### PR TITLE
[FIX] Make optimization resource and plateau gates actionable

### DIFF
--- a/src/hyperloom/inference_optimizer/actions/specialist.md
+++ b/src/hyperloom/inference_optimizer/actions/specialist.md
@@ -134,9 +134,10 @@ Each specialist subprocess sees:
   fan-out is single-layer and stays within the parent's lane/GPU lease.
 * A 60s heartbeat protocol — the subprocess writes
   `runs/specialist/<task_id>/heartbeat.json`; SpecialistRunner reaps an agent
-  only after approximately 10 minutes without either heartbeat or process-log
-  activity. The staleness threshold is currently fixed and has no operator
-  override.
+  after approximately 5 minutes if neither heartbeat nor process-log activity
+  ever appears. Once either activity file has appeared, it reaps the agent
+  after approximately 10 minutes of subsequent silence. The staleness
+  threshold is currently fixed and has no operator override.
 * The exit contract:
   - one `specialist_done` intent (the SpecialistRunner harvests it from
     stdout's stream-json transcript) with payload schema

--- a/src/hyperloom/inference_optimizer/actions/specialist.md
+++ b/src/hyperloom/inference_optimizer/actions/specialist.md
@@ -133,8 +133,10 @@ Each specialist subprocess sees:
   parent specialist's visible devices and their tool set omits `Task`, so
   fan-out is single-layer and stays within the parent's lane/GPU lease.
 * A 60s heartbeat protocol — the subprocess writes
-  `runs/specialist/<task_id>/heartbeat.json`; SpecialistRunner reaps
-  stale agents after 5 minutes (`HEARTBEAT_STALE_THRESHOLD_S`).
+  `runs/specialist/<task_id>/heartbeat.json`; SpecialistRunner reaps an agent
+  only after approximately 10 minutes without either heartbeat or process-log
+  activity. The staleness threshold is currently fixed and has no operator
+  override.
 * The exit contract:
   - one `specialist_done` intent (the SpecialistRunner harvests it from
     stdout's stream-json transcript) with payload schema

--- a/src/hyperloom/inference_optimizer/cli/parser.py
+++ b/src/hyperloom/inference_optimizer/cli/parser.py
@@ -1247,7 +1247,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="EXPLORE plateau: required count of *consecutive* specialist "
         "rounds with empty proposal_set before the AND condition "
-        "fires. Default 3.",
+        "fires. Default 5.",
     )
     opt.add_argument(
         "--plateau-explore-lookback",

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_sync_helpers_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_sync_helpers_coverage_unit.py
@@ -59,6 +59,33 @@ def test_specialist_wall_budget_caps_at_4h(coord: Coordinator) -> None:
     assert coord._specialist_wall_budget_sec(needs_gpu=False) == 110 * 60
 
 
+def test_bench_specialist_budget_covers_rebench_timeout(coord: Coordinator) -> None:
+    """Bench-capable specialists receive enough time for their advertised rebench."""
+    from hyperloom.orchestrator.bus.gpu_pool import GPU_LEASE_TTL_GRACE
+    from hyperloom.orchestrator.specialists.rebench import DEFAULT_REBENCH_TIMEOUT_SEC
+
+    params = {"scope": "domain", "mode": "patch", "bench": True}
+    budget = coord._specialist_wall_budget_sec(
+        needs_gpu=True,
+        params=params,
+    )
+
+    assert budget == DEFAULT_REBENCH_TIMEOUT_SEC + 10 * 60
+    assert coord._gpu_lease_ttl_sec(params=params) == int(budget * (1.0 + GPU_LEASE_TTL_GRACE))
+
+
+def test_specialist_budget_does_not_outlast_session(coord: Coordinator, monkeypatch) -> None:
+    """A profile floor cannot extend a finite session's wall-clock budget."""
+    monkeypatch.setattr(coord.shared_state, "remaining_minutes", lambda: 30.0)
+
+    budget = coord._specialist_wall_budget_sec(
+        needs_gpu=True,
+        params={"scope": "domain", "mode": "patch", "bench": True},
+    )
+
+    assert budget == 30 * 60
+
+
 # -- WS2: GPU lease TTL re-source + structured-finally release --------------
 def test_gpu_lease_ttl_grace_over_wall_budget(coord: Coordinator) -> None:
     # TTL = wall_budget × (1 + grace); lease must outlive the kill.

--- a/src/hyperloom/inference_optimizer/tests/test_integrate_patch_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_integrate_patch_coverage_unit.py
@@ -22,6 +22,7 @@ from hyperloom.orchestrator.actions.executors.integrate_patch import (
     _detect_p_level,
     _read_done_payload,
 )
+from hyperloom.orchestrator.actions.executors._stack_rebench import StackRebenchResult
 from hyperloom.orchestrator.actions.executors._workload_envs import (
     FrameworkScriptMismatchError,
 )
@@ -271,6 +272,40 @@ def _stub_confirm(result: dict):
         return result
 
     return _c
+
+
+@pytest.mark.asyncio
+async def test_confirmation_rebench_floor_stays_below_keep_threshold(tmp_path, monkeypatch):
+    """A late-cycle confirmation cannot impose a stricter gain floor than KEEP."""
+    config_path = tmp_path / "base.yaml"
+    config_path.write_text("benchmark: {}\n", encoding="utf-8")
+    captured: dict[str, float] = {}
+
+    def _materialize(*_args, **_kwargs):
+        return config_path
+
+    async def _measure(**kwargs):
+        captured["stable_threshold_pct"] = kwargs["stable_threshold_pct"]
+        return StackRebenchResult(tput=None, workspace=None)
+
+    monkeypatch.setattr(ip, "materialize_config_with_envs", _materialize)
+    monkeypatch.setattr(ip, "measure_stack_rebench", _measure)
+
+    executor = IntegratePatchExecutor(session_dir=tmp_path)
+    await executor._confirm_stack_rebench(
+        params={
+            "config_path": str(config_path),
+            "keep_threshold_pct": 0.4,
+            "rebench_stable_threshold_pct": 0.5,
+        },
+        output_root=tmp_path / "output",
+        extra_server_args_applied="",
+        extra_envs_applied={},
+        specialist_task_id="spec",
+        base_tput=100.0,
+    )
+
+    assert captured["stable_threshold_pct"] == pytest.approx(0.2)
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/inference_optimizer/tests/test_phase_state_framework_agent.py
+++ b/src/hyperloom/inference_optimizer/tests/test_phase_state_framework_agent.py
@@ -166,25 +166,15 @@ def test_compute_plateau_framework_agent_returns_signal():
     """compute_plateau_framework_agent remains as a pure advisory."""
     batches = [
         {
-            "batch_id": "b1",
-            "max_gain_pct_observed_in_batch": 0.2,
-            "candidates": [{"id": "c1a"}],
-        },
-        {
-            "batch_id": "b2",
+            "batch_id": f"b{i}",
             "max_gain_pct_observed_in_batch": 0.0,
-            "candidates": [{"id": "c2a"}],
-        },
-        {
-            "batch_id": "b3",
-            "max_gain_pct_observed_in_batch": 0.5,
-            "candidates": [{"id": "c3a"}],
-        },
+            "candidates": [{"id": f"c{i}a"}],
+        }
+        for i in range(phase_state.DEFAULT_FRAMEWORK_PLATEAU_LOOKBACK)
     ]
     progress = [
-        {"batch_id": "b1", "candidate_id": "c1a", "status": "reject"},
-        {"batch_id": "b2", "candidate_id": "c2a", "status": "reject"},
-        {"batch_id": "b3", "candidate_id": "c3a", "status": "reject"},
+        {"batch_id": f"b{i}", "candidate_id": f"c{i}a", "status": "reject"}
+        for i in range(phase_state.DEFAULT_FRAMEWORK_PLATEAU_LOOKBACK)
     ]
     state = _State(
         framework_agent_batches=batches,
@@ -192,7 +182,7 @@ def test_compute_plateau_framework_agent_returns_signal():
     )
     triggered, ev = phase_state.compute_plateau_framework_agent(state)
     assert triggered is True
-    assert ev["lookback"] == 3
+    assert ev["lookback"] == phase_state.DEFAULT_FRAMEWORK_PLATEAU_LOOKBACK
 
 
 def test_framework_batch_plateau_ignores_prior_macro_cycle():

--- a/src/hyperloom/inference_optimizer/tests/test_phase_state_plateau.py
+++ b/src/hyperloom/inference_optimizer/tests/test_phase_state_plateau.py
@@ -647,6 +647,34 @@ def test_compute_next_phase_advances_on_plateau():
     assert triggered is True
 
 
+def test_compute_next_phase_honors_explore_plateau_overrides():
+    """CLI plateau overrides control the actual phase transition."""
+    state = SimpleNamespace(
+        phase="EXPLORE",
+        phase_started_unix=0.0,
+        max_minutes=0,
+        phase_budget_pct={},
+        explore_search={"winners_history": [{"gain_pct": 0.1}]},
+        specialist_rounds=[
+            {"proposals_total": 0, "proposals_kept": 0},
+            {"proposals_total": 0, "proposals_kept": 0},
+            {"proposals_total": 0, "proposals_kept": 0},
+        ],
+        params_no_promote_streak=0,
+        backends_search={},
+        optimization_stack=[],
+        pending_escalate_hint="",
+        stop_reason="",
+        plateau_overrides={"explore_empty_streak": 3},
+    )
+
+    target, reason, evidence = compute_next_phase(state, kernel_enabled=True)
+
+    assert target == "KERNEL_AGENT"
+    assert reason == "explore_no_more_leverage"
+    assert evidence["empty_streak_threshold"] == 3
+
+
 def test_collect_phase_breakdown_buckets_by_phase():
     from hyperloom.inference_optimizer.breakdown.collectors import collect_attribution
 

--- a/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
+++ b/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
@@ -3447,12 +3447,24 @@ class IntegratePatchExecutor:
         _rt_rb = params.get("runtime_override")
         if isinstance(_rt_rb, dict) and _rt_rb:
             variant.runtime_override = dict(_rt_rb)
+        # A confirmation rebench must remain a stability check, not become a
+        # stricter second discovery gate as the per-cycle KEEP threshold decays.
+        # An explicit lower per-task floor remains valid, but it cannot exceed
+        # half of the threshold that admitted this patch.
+        keep_threshold_pct = float(params.get("keep_threshold_pct", self.keep_threshold_pct))
+        requested_stable_threshold_pct = float(
+            params.get("rebench_stable_threshold_pct", DEFAULT_STACK_STABLE_PCT)
+        )
+        stable_threshold_pct = min(
+            requested_stable_threshold_pct,
+            max(0.0, keep_threshold_pct / 2.0),
+        )
         rebench = await measure_stack_rebench(
             config_path=config_path,
             base_extra_args=base_extra_args,
             variant=variant,
             base_tput=base_tput,
-            stable_threshold_pct=float(params.get("rebench_stable_threshold_pct", DEFAULT_STACK_STABLE_PCT)),
+            stable_threshold_pct=stable_threshold_pct,
             output_slot=output_root / "stack_rebench",
             variant_timeout_sec=int(params.get("variant_timeout_sec", self.variant_timeout_sec)),
             model_path=resolved_model or None,

--- a/src/hyperloom/orchestrator/loop/dispatcher.py
+++ b/src/hyperloom/orchestrator/loop/dispatcher.py
@@ -393,9 +393,10 @@ class DispatcherCollaborator:
                 params = task.params or {}
                 needs_gpu = coerce_needs_gpu(params.get("needs_gpu", False))
                 # Explicit wall-clock budget (lane-tiered base × macro_cycle,
-                # capped at 4h).
+                # with a benchmark-profile floor and capped by session time).
                 extra_context["wall_budget_sec"] = self._specialist_wall_budget_sec(
                     needs_gpu=needs_gpu,
+                    params=params,
                 )
                 extra_context["specialist_progress_cb"] = self._specialist_progress_publisher(task)
                 if needs_gpu:
@@ -469,7 +470,10 @@ class DispatcherCollaborator:
                     # TTL re-sourced to the wall budget. Iron law:
                     # kill <= gpu_lease TTL <= gpu_research_lane TTL. Both TTLs
                     # come from ``_gpu_lease_ttl_sec`` so they never drift apart.
-                    gpu_ttl_sec = self._gpu_lease_ttl_sec(int(task.lease_ttl_sec or 0))
+                    gpu_ttl_sec = self._gpu_lease_ttl_sec(
+                        int(task.lease_ttl_sec or 0),
+                        params=params,
+                    )
                     # §3.2: under single-node Ray the physical GPU mutex is Ray's
                     # ``num_gpus``, not this SQLite pool. Admit by a count-based
                     # pending limit so multiple specialists can queue on one
@@ -676,13 +680,23 @@ class DispatcherCollaborator:
 
         return _publish
 
-    def _specialist_wall_budget_sec(self, *, needs_gpu: bool) -> float:
+    def _specialist_wall_budget_sec(
+        self,
+        *,
+        needs_gpu: bool,
+        params: dict[str, Any] | None = None,
+    ) -> float:
         """Compute the explicit wall-clock budget for a specialist task.
 
         The budget is a lane-tiered base (cpu 10min / gpu 60min) amplified by the
-        macro-cycle count and hard-capped at 4h::
+        macro-cycle count and hard-capped at 4h. Bench-capable patch specialists
+        are floored at the rebench helper's timeout plus a 10-minute startup
+        allowance. Any finite session budget remains an upper bound::
 
-            budget_min = min(base × (macro_cycle + 1), 240)
+            budget_sec = min(base × (macro_cycle + 1), 240 min)
+            if profile.bench:
+                budget_sec = max(budget_sec, rebench_timeout + 10 min)
+            budget_sec = min(budget_sec, session_remaining)
 
         ``macro_cycle`` grows whenever a new macro-cycle opens, including short
         bounded runs. As cycles progress, specialists get more room to complete
@@ -691,6 +705,8 @@ class DispatcherCollaborator:
         Args:
             needs_gpu: Whether the specialist holds a GPU lease (selects the
                 60min GPU lane base vs the 10min cpu base).
+            params: Specialist dispatch parameters, used to identify
+                bench-capable patch specialists.
 
         Returns:
             float: The wall-clock budget in seconds.
@@ -698,7 +714,17 @@ class DispatcherCollaborator:
         base_min = 60.0 if needs_gpu else 10.0
         macro_cycle = int(getattr(self.shared_state, "macro_cycle", 0) or 0)
         budget_min = min(base_min * (macro_cycle + 1), 240.0)
-        return budget_min * 60.0
+        budget_sec = budget_min * 60.0
+        from ..specialists.profile import resolve_specialist_profile
+        from ..specialists.rebench import DEFAULT_REBENCH_TIMEOUT_SEC
+
+        profile = resolve_specialist_profile(params or {})
+        if profile.reserves_benchmark_lane:
+            budget_sec = max(budget_sec, float(DEFAULT_REBENCH_TIMEOUT_SEC + 10 * 60))
+        session_remaining_min = self.shared_state.remaining_minutes()
+        if session_remaining_min is not None:
+            budget_sec = min(budget_sec, session_remaining_min * 60.0)
+        return max(0.0, budget_sec)
 
     def _resolve_serving_tp(self) -> int:
         """Resolve the live serving process's TP size (cards it holds).
@@ -720,7 +746,12 @@ class DispatcherCollaborator:
         except ValueError:
             return 0
 
-    def _gpu_lease_ttl_sec(self, floor_ttl_sec: int = 0) -> int:
+    def _gpu_lease_ttl_sec(
+        self,
+        floor_ttl_sec: int = 0,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> int:
         """Single source for the GPU-specialist lease / ``gpu_research_lane`` TTL.
 
         The iron law is ``kill ≤ gpu_lease TTL ≤ gpu_research_lane TTL`` — both the
@@ -732,13 +763,21 @@ class DispatcherCollaborator:
         Args:
             floor_ttl_sec: A lower bound (e.g. the registry / existing
                 ``lease_ttl_sec``) the computed TTL is raised to.
+            params: Specialist dispatch parameters used to derive the same
+                profile-aware wall budget as the subprocess reaper.
 
         Returns:
             int: ``max(floor_ttl_sec, wall_budget × (1 + grace))``.
         """
         return max(
             int(floor_ttl_sec or 0),
-            int(self._specialist_wall_budget_sec(needs_gpu=True) * (1.0 + GPU_LEASE_TTL_GRACE)),
+            int(
+                self._specialist_wall_budget_sec(
+                    needs_gpu=True,
+                    params=params,
+                )
+                * (1.0 + GPU_LEASE_TTL_GRACE)
+            ),
         )
 
     async def _reap_dispatched_task(

--- a/src/hyperloom/orchestrator/loop/intent_router.py
+++ b/src/hyperloom/orchestrator/loop/intent_router.py
@@ -454,7 +454,10 @@ class IntentRouter:
                     lanes = tuple(dict.fromkeys((*lanes, "gpu_research_lane")))
                     try:
                         # Shared with the GPU-pool lease so the two TTLs never drift.
-                        ttl = self._coord._gpu_lease_ttl_sec(int(ttl or 0))
+                        ttl = self._coord._gpu_lease_ttl_sec(
+                            int(ttl or 0),
+                            params=params,
+                        )
                     except Exception:  # noqa: BLE001 — fall back to registry ttl
                         log.exception(
                             "WS2: failed to re-source gpu_research_lane TTL; using registry default",

--- a/src/hyperloom/orchestrator/phases/explore.py
+++ b/src/hyperloom/orchestrator/phases/explore.py
@@ -804,7 +804,10 @@ class ExplorePhase(PhaseHandler):
         if needs_gpu:
             lanes = list(dict.fromkeys((*lanes, "gpu_research_lane")))
             try:
-                ttl = self._gpu_lease_ttl_sec(int(ttl or 0))
+                ttl = self._gpu_lease_ttl_sec(
+                    int(ttl or 0),
+                    params=retry_params,
+                )
             except Exception:  # noqa: BLE001
                 log.exception("specialist auto-retry: gpu_research_lane TTL re-source failed; using registry default")
 

--- a/src/hyperloom/orchestrator/phases/framework.py
+++ b/src/hyperloom/orchestrator/phases/framework.py
@@ -1069,7 +1069,7 @@ class FrameworkPhase(PhaseHandler):
         if self._coerce_needs_gpu(params.get("needs_gpu")):
             lanes.append("gpu_research_lane")
             try:
-                ttl = self._gpu_lease_ttl_sec(ttl)
+                ttl = self._gpu_lease_ttl_sec(ttl, params=params)
             except Exception:  # noqa: BLE001 — fall back to the base TTL
                 log.exception(
                     "framework GPU: gpu_research_lane TTL re-source failed; using base TTL",

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -373,7 +373,7 @@ DEFAULT_EXPLORE_FORCE_EXIT_HOURS_REMAINING: float = 3.0
 DEFAULT_EXPLORE_FORCE_EXIT_BUDGET_PCT: float = 0.20
 
 # FRAMEWORK plateau/force-exit knobs: plateau when each LOOKBACK batch < KEEP_GAIN_PCT; force-exit when remaining < RATIO * max_hours.
-DEFAULT_FRAMEWORK_PLATEAU_LOOKBACK: int = 3
+DEFAULT_FRAMEWORK_PLATEAU_LOOKBACK: int = 5
 DEFAULT_FRAMEWORK_PLATEAU_KEEP_GAIN_PCT: float = 1.0
 import os as _os_fw_ratio  # noqa: E402
 
@@ -1632,6 +1632,9 @@ def exit_normal_explore(
     *,
     budget_pct: dict[str, float] | None = None,
     now_unix: float | None = None,
+    plateau_lookback: int = DEFAULT_PLATEAU_EXPLORE_LOOKBACK,
+    plateau_keep_gain_threshold_pct: float = DEFAULT_PLATEAU_EXPLORE_KEEP_GAIN_PCT,
+    plateau_empty_streak_threshold: int = DEFAULT_PLATEAU_EXPLORE_EMPTY_STREAK,
     force_exit_hours_remaining: float = DEFAULT_EXPLORE_FORCE_EXIT_HOURS_REMAINING,
     force_exit_budget_pct: float = DEFAULT_EXPLORE_FORCE_EXIT_BUDGET_PCT,
 ) -> tuple[str, dict[str, Any]] | None:
@@ -1647,6 +1650,11 @@ def exit_normal_explore(
         budget_pct (dict[str, float] | None): Phase-budget overrides; defaults
             to ``state.phase_budget_pct`` when None.
         now_unix (float | None): Override for the current time.
+        plateau_lookback: Number of EXPLORE KEEP results to inspect.
+        plateau_keep_gain_threshold_pct: Cumulative KEEP-gain threshold below
+            which the plateau gain arm is active.
+        plateau_empty_streak_threshold: Consecutive empty specialist rounds
+            required for the plateau streak arm.
         force_exit_hours_remaining (float): Session-hours-remaining force-exit
             threshold.
         force_exit_budget_pct (float): Phase-budget-fraction force-exit
@@ -1682,7 +1690,12 @@ def exit_normal_explore(
         }
     # A detected EXPLORE plateau is not terminal: switch lever (→ KERNEL_AGENT)
     # and flag that the next macro-cycle should steer off the bottleneck.
-    plateaued, plateau_ev = compute_plateau_explore(state)
+    plateaued, plateau_ev = compute_plateau_explore(
+        state,
+        lookback=plateau_lookback,
+        keep_gain_threshold_pct=plateau_keep_gain_threshold_pct,
+        empty_streak_threshold=plateau_empty_streak_threshold,
+    )
     if plateaued:
         return "explore_no_more_leverage", {
             "evidence": "plateau_explore",
@@ -2194,6 +2207,24 @@ def compute_next_phase(
             state,
             budget_pct=budget_pct,
             now_unix=now_unix,
+            plateau_lookback=int(
+                overrides.get(
+                    "explore_lookback",
+                    DEFAULT_PLATEAU_EXPLORE_LOOKBACK,
+                )
+            ),
+            plateau_keep_gain_threshold_pct=float(
+                overrides.get(
+                    "explore_keep_gain_pct",
+                    DEFAULT_PLATEAU_EXPLORE_KEEP_GAIN_PCT,
+                )
+            ),
+            plateau_empty_streak_threshold=int(
+                overrides.get(
+                    "explore_empty_streak",
+                    DEFAULT_PLATEAU_EXPLORE_EMPTY_STREAK,
+                )
+            ),
             force_exit_hours_remaining=float(
                 overrides.get(
                     "force_exit_hours_remaining",

--- a/src/hyperloom/orchestrator/specialists/subprocess_.py
+++ b/src/hyperloom/orchestrator/specialists/subprocess_.py
@@ -206,8 +206,13 @@ class SpecialistSubprocessConfig:
     """How often the reaper polls done.json / process exit / heartbeat."""
 
     heartbeat_stale_seconds: float = 300.0
-    """If the agent stops writing heartbeat.json for this long, treat
-    it as stale and kill the subprocess (matches Arbor's 5-min cap)."""
+    """Liveness window for heartbeat.json or process.log activity.
+
+    A process that never creates either file is reaped after this window.
+    After either file has appeared, its mtime can refresh the liveness clock
+    for one window before the subsequent stale window expires, yielding about
+    two windows of silence before reap.
+    """
 
 
 # Result


### PR DESCRIPTION

- Keep `integrate_patch` confirmation rebenches below the active KEEP threshold
  so late-cycle  confirmation remains a stability check rather than a stricter
  second discovery gate.
- Give only bench-capable GPU specialists enough wall-clock time for the
  advertised rebench helper, cap that budget by the remaining session time, and
  keep the GPU/lane lease TTLs derived from the same budget.
- Route EXPLORE plateau CLI settings into the actual phase transition, correct
  the empty-streak help text, and align the FRAMEWORK plateau advisory
  lookback with the five-round convention.
- Correct specialist heartbeat documentation to describe the fixed,
  approximately ten-minute staleness behavior and remove the nonexistent
  override.

## Test plan

- [x] `pytest src/hyperloom/inference_optimizer/tests/test_integrate_patch_coverage_unit.py -k 'confirmation_rebench_floor_stays_below_keep_threshold'`
- [x] `pytest src/hyperloom/inference_optimizer/tests/test_coordinator_sync_helpers_coverage_unit.py -k 'specialist_wall_budget or bench_specialist_budget or specialist_budget_does_not_outlast_session or gpu_lease_ttl'`
- [x] `pytest src/hyperloom/inference_optimizer/tests/test_gpu_research_lane_dispatch.py`
- [x] `pytest src/hyperloom/inference_optimizer/tests/test_phase_state_plateau.py src/hyperloom/inference_optimizer/tests/test_phase_force_exit.py src/hyperloom/inference_optimizer/tests/test_phase_state_framework_agent.py`
- [x] `pytest src/hyperloom/inference_optimizer/tests/test_cli_bootstrap.py src/hyperloom/inference_optimizer/tests/test_cli_bootstrap_coverage_unit.py`
