### PR TITLE
Unify session breakdown optimization data

### DIFF
--- a/docs/reference/session-breakdown.md
+++ b/docs/reference/session-breakdown.md
@@ -145,6 +145,11 @@ optimizations
 │   ├── backend
 │   ├── execution_mode
 │   ├── kernel_id
+│   ├── adopted_attempt_id
+│   ├── action
+│   ├── variant_name
+│   ├── fingerprint
+│   ├── scope
 │   ├── gain_pct
 │   ├── cumulative_gain_pct
 │   ├── throughput_before
@@ -155,7 +160,16 @@ optimizations
 │   ├── provenance
 │   ├── configuration
 │   └── artifacts[]
-└── summary_by_source
+├── backend_attempts[]
+│   ├── attempt_id
+│   ├── kernel_id
+│   ├── backend
+│   ├── decision
+│   ├── sequence
+│   ├── duration_sec
+│   ├── error_class
+│   └── error
+├── summary_by_source
     ├── warm_replay
     ├── explore
     ├── framework_agent
@@ -165,17 +179,47 @@ optimizations
     │       ├── forge
     │       └── unattributed
     └── unattributed
+├── summary_by_kind
+├── validation
+│   ├── method
+│   ├── validated_total_gain_pct
+│   ├── attributed_total_gain_pct
+│   ├── attribution_gap_pct
+│   ├── notes
+│   ├── phase_breakdown
+│   └── domain_attribution
+└── gemm_tuning_runs[]
 ```
 
 `source` is one of `warm_replay`, `explore`, `framework_agent`,
 `kernel_agent`, or `unattributed`. Kernel entries additionally identify
 `backend=geak|forge` and `execution_mode=whole_pipeline|per_kernel`.
-Only validated entries contribute to `summary_by_source`.
+Only validated entries contribute to `summary_by_source` and
+`summary_by_kind`. The former answers which agent or phase produced the
+gain; the latter groups the same entries by `optimization_kind`. These
+summaries are alternate views of the same gains and must not be added
+together.
+
+`backend_attempts` retains adopted and non-adopted GEAK/Forge attempts,
+including KEEP, PARTIAL, REVERT, and FAILED outcomes. `sequence` is ordered
+within each kernel. Adopted kernel entries link back through
+`adopted_attempt_id`.
+
+`validation` carries the attribution lineage and reconciliation diagnostics
+previously available only through the legacy attribution projection.
+`gemm_tuning_runs` retains the complete tuning run records; the corresponding
+adopted gain remains represented exactly once by a `gemm_tuning` entry.
 
 The historical `optimization_stack`, attribution, GEAK invocation, Forge
 invocation, and GEMM-tuning result projections are not emitted in the new wire
-shape. Raw actions remain in `action_timeline`, while kernel attempt evidence
-remains in `kernel_lifecycle`; neither is an optimization display API.
+shape. Their required downstream evidence is instead normalized into the
+canonical fields above.
+
+When Warm Replay uses a donor recipe, `kb_provenance.warm_replay` also
+preserves the available `donor_canonical_id`, `donor_model`,
+`donor_session_id`, `donor_family_tags`, `donor_gain_pct`, and
+`donor_breakdown_link`. Fields absent from the source recipe remain absent
+rather than being inferred.
 
 ## `session` — `SessionMeta`
 

--- a/docs/reference/session-breakdown.md
+++ b/docs/reference/session-breakdown.md
@@ -150,6 +150,11 @@ optimizations
 │   ├── variant_name
 │   ├── fingerprint
 │   ├── scope
+│   ├── source_phase
+│   ├── gain_method
+│   ├── accepted_heads
+│   ├── extra_server_args_is_invariant
+│   ├── candidate_flags
 │   ├── gain_pct
 │   ├── cumulative_gain_pct
 │   ├── throughput_before
@@ -182,10 +187,12 @@ optimizations
 ├── summary_by_kind
 ├── validation
 │   ├── method
+│   ├── validated_at_stack_len
 │   ├── validated_total_gain_pct
 │   ├── attributed_total_gain_pct
 │   ├── attribution_gap_pct
 │   ├── notes
+│   ├── source_breakdown
 │   ├── phase_breakdown
 │   └── domain_attribution
 └── gemm_tuning_runs[]
@@ -203,12 +210,25 @@ together.
 `backend_attempts` retains adopted and non-adopted GEAK/Forge attempts,
 including KEEP, PARTIAL, REVERT, and FAILED outcomes. `sequence` is ordered
 within each kernel. Adopted kernel entries link back through
-`adopted_attempt_id`.
+`adopted_attempt_id`. Missing producer attempt IDs receive a stable
+session/kernel/backend/sequence ID. When multiple KEEP attempts match the
+same entry and the producer did not identify the adopted one, the link stays
+`null` and a warning is emitted rather than guessing.
 
 `validation` carries the attribution lineage and reconciliation diagnostics
 previously available only through the legacy attribution projection.
+`validation.source_breakdown` retains non-entry gain categories such as
+Sweep, params, and backend exploration without treating `sweep`,
+`conc_sweep`, or `validate_stack` as adopted optimizations.
 `gemm_tuning_runs` retains the complete tuning run records; the corresponding
 adopted gain remains represented exactly once by a `gemm_tuning` entry.
+
+`gain_method` is `ledger`, `legacy_ledger_derived`, `reconstructed`,
+`throughput_derived`, or `missing`; `source_phase` and
+`validated_at_stack_len` preserve the evidence needed to audit historical
+source, validation, and gain inference. V4 conversion reconstructs backend
+attempts and GEMM runs from canonical operation streams when that evidence is
+present, and marks validation as synthesized from validated adoptions.
 
 The historical `optimization_stack`, attribution, GEAK invocation, Forge
 invocation, and GEMM-tuning result projections are not emitted in the new wire

--- a/docs/reference/session-breakdown.md
+++ b/docs/reference/session-breakdown.md
@@ -30,27 +30,18 @@ This page describes the contract from a consumer's perspective.
 
 ## Versioning
 
-The top-level `schema_version` field is a stable string. The producer
-emits one of two version strings depending on the aggregation path:
+The top-level `schema_version` field is a stable string. New exports use the
+unified optimization wire shape:
 
 ```json
-"schema_version": "hyperloom.session_breakdown.v2"     // legacy collector-only fallback
-"schema_version": "hyperloom.session_breakdown.v3.0"   // when author-time recorder fragments are present
+"schema_version": "hyperloom.session_breakdown.v5.0"
 ```
 
-When the session has author-time recorder fragments (the "new way"
-write-side spool), the exporter aggregates from them and stamps
-`v3.0`; sessions without fragments (historical runs, recorder-disabled
-runs) fall back to the legacy collectors and keep the `v2` stamp. Both
-strings can therefore appear in production today.
-
-`v3.0` is the same additive wire shape as `v2` — the recorder path
-captures facts the collectors can miss (pre-dispatch / infra failures,
-pruned robustness signals) but adds no breaking field changes. A reader
-written for `v2` parses a `v3.0` file unchanged by ignoring unknown keys.
-`v2` is itself additive over `v1`: it only adds sections (for example,
-`specialist_runs`, `action_timeline`, `kernel_optimization_summary`,
-`conc_sweep_summary`).
+V5 is a breaking cutover for optimization results: consumers read only
+`optimizations`; the old `optimization_stack`, attribution, GEAK invocation,
+Forge invocation, and GEMM-tuning result projections are no longer emitted.
+Archived V2/V3/V4 documents require a downstream migration before V5 readers
+consume them.
 
 Compatibility rules:
 
@@ -82,7 +73,7 @@ The following JSON structure shows all top-level fields in `session_breakdown.js
 
 ```text
 {
-  "schema_version": "hyperloom.session_breakdown.v2",
+  "schema_version": "hyperloom.session_breakdown.v5.0",
   "exported_at_utc": "2026-05-17T12:34:56.789Z",
   "exporter_version": "session-breakdown-1.0.0",
 
@@ -92,14 +83,12 @@ The following JSON structure shows all top-level fields in `session_breakdown.js
   "final":              { /* §6  Final state — SaFE contract core */ },
   "phase_timeline":     [ /* §7  PhaseEvent[] */ ],
   "capability_summary": { /* §8  Capability cards */ },
-  "geak_invocations":   [ /* §9  Invocation[] */ ],
-  "forge_invocations":  [ /* §10 Invocation[] */ ],
   "kernel_lifecycle":   { /* §11 4+1-stage kernel lifecycle */ },
   "param_search":       { /* §12 ParamSearch */ },
   "sweep":              { /* §13 Sweep */ },
   "critic_robustness":  { /* §14 Critic iterations + Robustness signals */ },
   "telemetry":          { /* §15 Telemetry artefact paths */ },
-  "attribution":        { /* §16 Gain attribution per stack entry */ },
+  "optimizations":      { /* canonical adopted-optimization API */ },
 
   "warnings":           [ /* string[] — non-fatal collector warnings */ ],
   "source_files":       { /* §17 SourceFiles — raw artefact paths */ },
@@ -112,8 +101,6 @@ The following JSON structure shows all top-level fields in `session_breakdown.js
   "perfskills":                  { /* perf-skill telemetry */ },
   "kb_provenance":               { /* KB read/write provenance */ },
   "specialist_runs":             [ /* specialist sub-agent runs */ ],
-  "optimization_stack":          { /* accepted KEEP stack */ },
-  "gemm_tuning":                 { /* FP8 GEMM tuning results */ },
   "kernel_roofline":             { /* kernel roofline snapshot */ },
   "kernel_optimization_summary": { /* kernel-opt rollup */ },
   "conc_sweep_summary":          { /* post-run concurrency sweep */ },
@@ -137,6 +124,58 @@ ended early (`baseline_failed`, `time_exhausted` before kernel-opt
 started, …).
 
 ---
+
+## `optimizations` — canonical adopted optimizations
+
+`optimizations` is the only section downstream dashboards need to read for
+formally adopted optimization results. It normalizes Warm Replay, Explore,
+Framework Agent, and Kernel Agent KEEPs without exposing internal action names
+such as `integrate_patch`.
+
+```text
+optimizations
+├── schema_version
+├── entries[]
+│   ├── id
+│   ├── stack_index
+│   ├── source
+│   ├── source_method
+│   ├── optimization_kind
+│   ├── name
+│   ├── backend
+│   ├── execution_mode
+│   ├── kernel_id
+│   ├── gain_pct
+│   ├── cumulative_gain_pct
+│   ├── throughput_before
+│   ├── throughput_after
+│   ├── validated
+│   ├── task_id
+│   ├── ts
+│   ├── provenance
+│   ├── configuration
+│   └── artifacts[]
+└── summary_by_source
+    ├── warm_replay
+    ├── explore
+    ├── framework_agent
+    ├── kernel_agent
+    │   └── by_backend
+    │       ├── geak
+    │       ├── forge
+    │       └── unattributed
+    └── unattributed
+```
+
+`source` is one of `warm_replay`, `explore`, `framework_agent`,
+`kernel_agent`, or `unattributed`. Kernel entries additionally identify
+`backend=geak|forge` and `execution_mode=whole_pipeline|per_kernel`.
+Only validated entries contribute to `summary_by_source`.
+
+The historical `optimization_stack`, attribution, GEAK invocation, Forge
+invocation, and GEMM-tuning result projections are not emitted in the new wire
+shape. Raw actions remain in `action_timeline`, while kernel attempt evidence
+remains in `kernel_lifecycle`; neither is an optimization display API.
 
 ## `session` — `SessionMeta`
 
@@ -238,14 +277,6 @@ One card per live capability (`geak`, `forge`, `explore`, `sweep`,
 `best_gain_pct`, `reason`. Legacy `backends`, `params`, and
 `validate_stack` rows can appear when archived sessions are rebuilt.
 Drives the per-session UI cards in Primus-Claw.
-
----
-
-## `geak_invocations` / `forge_invocations` — `Invocation[]`
-
-Same `Invocation` shape across both lists; `backend` distinguishes
-(`geak` / `forge`). One entry per attempt-on-a-kernel. The `decision` enum is
-`KEEP` / `PARTIAL` / `REVERT` / `FAILED`.
 
 ---
 
@@ -468,7 +499,7 @@ The following example shows a complete `session_breakdown.json` for a finished G
 
 ```text
 {
-  "schema_version": "hyperloom.session_breakdown.v2",
+  "schema_version": "hyperloom.session_breakdown.v5.0",
   "exported_at_utc": "2026-05-17T14:02:15.001Z",
   "exporter_version": "session-breakdown-1.0.0",
 

--- a/docs/reference/session-breakdown.md
+++ b/docs/reference/session-breakdown.md
@@ -215,6 +215,13 @@ session/kernel/backend/sequence ID. When multiple KEEP attempts match the
 same entry and the producer did not identify the adopted one, the link stays
 `null` and a warning is emitted rather than guessing.
 
+GEAK's candidate-time `kernel_journey.e2e` values are provisional until the
+orchestrator rebench completes. If the measured candidate does not beat
+`current_best`, the journey row is rewritten with `validated=false`,
+`decision=REVERT`, and `integrated=false`. The original claimed gain remains
+available only as `self_reported_e2e_gain_pct`, alongside the measured and
+comparison throughput used by the rejection.
+
 `validation` carries the attribution lineage and reconciliation diagnostics
 previously available only through the legacy attribution projection.
 `validation.source_breakdown` retains non-entry gain categories such as

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/__init__.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/__init__.py
@@ -134,6 +134,11 @@ from .attribution import (
     _collect_phase_breakdown as _collect_phase_breakdown,
     _reconstruct_gain_ledger as _reconstruct_gain_ledger,
 )
+from .optimizations import (
+    OPTIMIZATIONS_SCHEMA_VERSION as OPTIMIZATIONS_SCHEMA_VERSION,
+    collect_optimizations as collect_optimizations,
+    collect_v4_optimizations as collect_v4_optimizations,
+)
 from .decision import (
     _TOKEN_IN_KEY as _TOKEN_IN_KEY,
     _TOKEN_OUT_KEY as _TOKEN_OUT_KEY,
@@ -202,4 +207,6 @@ __all__ = [
     "collect_token_usage",
     "collect_workload",
     "collect_model_info",
+    "collect_optimizations",
+    "collect_v4_optimizations",
 ]

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
@@ -1301,6 +1301,16 @@ def collect_gemm_tuning(state: dict[str, Any]) -> dict[str, Any]:
             "decision": str(raw.get("decision") or ""),
             "source": str(raw.get("source") or ""),
             "ts": str(raw.get("ts") or ""),
+            "duration_sec": next(
+                (
+                    _to_float(raw.get(field))
+                    for field in ("duration_sec", "elapsed_sec", "elapsed")
+                    if _to_float(raw.get(field)) is not None
+                ),
+                None,
+            ),
+            "error_class": str(raw.get("error_class") or ""),
+            "error": str(raw.get("error") or raw.get("reason") or ""),
             "precision": str(raw.get("precision") or precision),
             "framework": str(raw.get("framework") or framework),
             "gpu_type": str(raw.get("gpu_type") or gpu_type),
@@ -1330,6 +1340,10 @@ def collect_gemm_tuning(state: dict[str, Any]) -> dict[str, Any]:
             run["tuners_skipped"] = raw["tuners_skipped"]
         if isinstance(raw.get("summary"), dict):
             run["summary"] = raw["summary"]
+        if isinstance(raw.get("parameters"), dict):
+            run["parameters"] = raw["parameters"]
+        if isinstance(raw.get("candidates"), list):
+            run["candidates"] = raw["candidates"]
         if isinstance(raw.get("shapes"), list):
             run["shapes"] = raw["shapes"]
         runs.append(run)

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
@@ -1205,6 +1205,12 @@ def _normalize_optimization_stack_entry(
         out["provenance"] = str(raw.get("provenance") or "")
     if "task_id" in raw:
         out["task_id"] = str(raw.get("task_id") or "")
+    if "source_phase" in raw:
+        out["source_phase"] = str(raw.get("source_phase") or "")
+    if "operation_kind" in raw:
+        out["operation_kind"] = str(raw.get("operation_kind") or "")
+    if "scope" in raw:
+        out["scope"] = str(raw.get("scope") or "")
     return out
 
 

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/optimizations.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/optimizations.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from typing import Any
 
 
-OPTIMIZATIONS_SCHEMA_VERSION = 1
+OPTIMIZATIONS_SCHEMA_VERSION = 2
 
 _SOURCES = (
     "warm_replay",
@@ -267,12 +267,130 @@ def _empty_summary() -> dict[str, Any]:
     return summary
 
 
+def _collect_backend_attempts(
+    geak_invocations: list[dict[str, Any]],
+    forge_invocations: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Normalize every backend invocation into one chronological attempt list."""
+
+    attempts: list[dict[str, Any]] = []
+    for default_backend, invocations in (
+        ("geak", geak_invocations),
+        ("forge", forge_invocations),
+    ):
+        for raw in invocations:
+            if not isinstance(raw, dict):
+                continue
+            duration = next(
+                (
+                    _to_float(raw.get(field))
+                    for field in (
+                        "duration_sec",
+                        "elapsed_sec",
+                        "elapsed_time_sec",
+                        "elapsed",
+                    )
+                    if _to_float(raw.get(field)) is not None
+                ),
+                None,
+            )
+            attempts.append(
+                {
+                    "attempt_id": str(raw.get("attempt_id") or raw.get("run_id") or ""),
+                    "run_id": str(raw.get("run_id") or ""),
+                    "kernel_id": str(raw.get("kernel_id") or ""),
+                    "backend": str(raw.get("backend") or default_backend),
+                    "decision": str(raw.get("decision") or "").upper(),
+                    "ts": str(raw.get("ts") or ""),
+                    "duration_sec": duration,
+                    "micro_speedup": _to_float(raw.get("micro_speedup")),
+                    "compile_passed": raw.get("compile_passed"),
+                    "correctness_passed": raw.get("correctness_passed"),
+                    "error_class": (
+                        str(raw.get("error_class")) if raw.get("error_class") else None
+                    ),
+                    "error": str(raw.get("error")) if raw.get("error") else None,
+                    "result_path": (
+                        str(raw.get("result_path")) if raw.get("result_path") else None
+                    ),
+                    "verification_path": (
+                        str(raw.get("verification_path"))
+                        if raw.get("verification_path")
+                        else None
+                    ),
+                }
+            )
+
+    attempts.sort(
+        key=lambda row: (
+            str(row.get("kernel_id") or ""),
+            _parse_ts(row.get("ts")) if _parse_ts(row.get("ts")) is not None else float("inf"),
+            str(row.get("backend") or ""),
+            str(row.get("attempt_id") or ""),
+        )
+    )
+    sequence_by_kernel: dict[str, int] = {}
+    for attempt in attempts:
+        kernel_id = str(attempt.get("kernel_id") or "")
+        sequence_by_kernel[kernel_id] = sequence_by_kernel.get(kernel_id, 0) + 1
+        attempt["sequence"] = sequence_by_kernel[kernel_id]
+    return attempts
+
+
+def _empty_kind_summary() -> dict[str, Any]:
+    return {"keeps": 0, "total_gain_pct": 0.0}
+
+
+def _validation_summary(
+    state: dict[str, Any],
+    attribution: dict[str, Any],
+    entries: list[dict[str, Any]],
+) -> dict[str, Any]:
+    source_breakdown = attribution.get("source_breakdown")
+    if not isinstance(source_breakdown, dict):
+        source_breakdown = {}
+    validated_total = _to_float(source_breakdown.get("validated_total_pct"))
+    if validated_total is None:
+        validated_total = _to_float(state.get("cumulative_gain_validated"))
+    attributed_total = sum(
+        _to_float(entry.get("gain_pct")) or 0.0
+        for entry in entries
+        if entry.get("validated") is True
+    )
+    phase_breakdown = attribution.get("phase_breakdown")
+    if not isinstance(phase_breakdown, dict):
+        phase_breakdown = {}
+    explore = phase_breakdown.get("explore")
+    domain_attribution = (
+        dict(explore.get("by_domain") or {})
+        if isinstance(explore, dict) and isinstance(explore.get("by_domain"), dict)
+        else {}
+    )
+    notes = attribution.get("notes")
+    return {
+        "method": str(attribution.get("method") or "missing"),
+        "validated_total_gain_pct": (
+            round(validated_total, 6) if validated_total is not None else None
+        ),
+        "attributed_total_gain_pct": round(attributed_total, 6),
+        "attribution_gap_pct": (
+            round(validated_total - attributed_total, 6)
+            if validated_total is not None
+            else None
+        ),
+        "notes": [str(note) for note in notes] if isinstance(notes, list) else [],
+        "phase_breakdown": phase_breakdown,
+        "domain_attribution": domain_attribution,
+    }
+
+
 def collect_optimizations(
     state: dict[str, Any],
     attribution: dict[str, Any],
     geak_invocations: list[dict[str, Any]],
     forge_invocations: list[dict[str, Any]],
     warnings: list[str],
+    gemm_tuning: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the single canonical optimization read model.
 
@@ -301,6 +419,18 @@ def collect_optimizations(
     baseline_tput = _to_float(state.get("baseline_tput"))
     session_id = str(state.get("session_id") or "session")
     timeline = _phase_timeline(state)
+    backend_attempts = _collect_backend_attempts(
+        geak_invocations,
+        forge_invocations,
+    )
+    kept_attempts = {
+        (
+            str(attempt.get("kernel_id") or ""),
+            str(attempt.get("backend") or ""),
+        ): str(attempt.get("attempt_id") or "")
+        for attempt in backend_attempts
+        if str(attempt.get("decision") or "").upper() == "KEEP"
+    }
     entries: list[dict[str, Any]] = []
     previous_tput = baseline_tput
 
@@ -356,6 +486,11 @@ def collect_optimizations(
             "backend": backend,
             "execution_mode": _execution_mode(raw, backend),
             "kernel_id": kernel_id or None,
+            "adopted_attempt_id": kept_attempts.get((kernel_id, str(backend or ""))) or None,
+            "action": str(raw.get("action") or ""),
+            "variant_name": str(raw.get("variant_name") or ""),
+            "fingerprint": str(raw.get("fingerprint") or ""),
+            "scope": str(raw.get("scope") or ""),
             "gain_pct": round(delta, 6) if delta is not None else None,
             "cumulative_gain_pct": (
                 round(cumulative, 6) if cumulative is not None else None
@@ -382,6 +517,7 @@ def collect_optimizations(
             previous_tput = throughput_after
 
     summary = _empty_summary()
+    summary_by_kind: dict[str, dict[str, Any]] = {}
     for entry in entries:
         if not entry["validated"]:
             continue
@@ -396,6 +532,24 @@ def collect_optimizations(
                 backend = "unattributed"
             bucket["by_backend"][backend]["keeps"] += 1
             bucket["by_backend"][backend]["total_gain_pct"] += gain
+        kind = str(entry.get("optimization_kind") or "unknown")
+        kind_bucket = summary_by_kind.setdefault(kind, _empty_kind_summary())
+        kind_bucket["keeps"] += 1
+        kind_bucket["total_gain_pct"] += gain
+        if source == "kernel_agent":
+            by_backend = kind_bucket.setdefault(
+                "by_backend",
+                {
+                    "geak": _empty_kind_summary(),
+                    "forge": _empty_kind_summary(),
+                    "unattributed": _empty_kind_summary(),
+                },
+            )
+            backend = str(entry.get("backend") or "unattributed")
+            if backend not in by_backend:
+                backend = "unattributed"
+            by_backend[backend]["keeps"] += 1
+            by_backend[backend]["total_gain_pct"] += gain
 
     for bucket in summary.values():
         bucket["total_gain_pct"] = round(float(bucket["total_gain_pct"]), 6)
@@ -404,11 +558,28 @@ def collect_optimizations(
                 float(backend_bucket["total_gain_pct"]),
                 6,
             )
+    for bucket in summary_by_kind.values():
+        bucket["total_gain_pct"] = round(float(bucket["total_gain_pct"]), 6)
+        for backend_bucket in bucket.get("by_backend", {}).values():
+            backend_bucket["total_gain_pct"] = round(
+                float(backend_bucket["total_gain_pct"]),
+                6,
+            )
+
+    gemm_tuning_runs = []
+    if isinstance(gemm_tuning, dict) and isinstance(gemm_tuning.get("runs"), list):
+        gemm_tuning_runs = [
+            dict(run) for run in gemm_tuning["runs"] if isinstance(run, dict)
+        ]
 
     return {
         "schema_version": OPTIMIZATIONS_SCHEMA_VERSION,
         "entries": entries,
+        "backend_attempts": backend_attempts,
         "summary_by_source": summary,
+        "summary_by_kind": summary_by_kind,
+        "validation": _validation_summary(state, attribution, entries),
+        "gemm_tuning_runs": gemm_tuning_runs,
     }
 
 

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/optimizations.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/optimizations.py
@@ -268,6 +268,7 @@ def _empty_summary() -> dict[str, Any]:
 
 
 def _collect_backend_attempts(
+    session_id: str,
     geak_invocations: list[dict[str, Any]],
     forge_invocations: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -296,7 +297,7 @@ def _collect_backend_attempts(
             )
             attempts.append(
                 {
-                    "attempt_id": str(raw.get("attempt_id") or raw.get("run_id") or ""),
+                    "attempt_id": str(raw.get("attempt_id") or ""),
                     "run_id": str(raw.get("run_id") or ""),
                     "kernel_id": str(raw.get("kernel_id") or ""),
                     "backend": str(raw.get("backend") or default_backend),
@@ -334,7 +335,47 @@ def _collect_backend_attempts(
         kernel_id = str(attempt.get("kernel_id") or "")
         sequence_by_kernel[kernel_id] = sequence_by_kernel.get(kernel_id, 0) + 1
         attempt["sequence"] = sequence_by_kernel[kernel_id]
+        if not attempt.get("attempt_id"):
+            attempt["attempt_id"] = (
+                f"{session_id}:kernel-attempt:"
+                f"{kernel_id or 'unknown'}:{attempt.get('backend') or 'unknown'}:"
+                f"{attempt['sequence']}"
+            )
     return attempts
+
+
+def _adopted_attempt_id(
+    raw: dict[str, Any],
+    *,
+    kernel_id: str,
+    backend: str | None,
+    backend_attempts: list[dict[str, Any]],
+    warnings: list[str],
+) -> str | None:
+    explicit = str(
+        raw.get("adopted_attempt_id")
+        or raw.get("best_attempt_id")
+        or raw.get("attempt_id")
+        or ""
+    ).strip()
+    if explicit:
+        return explicit
+    matches = [
+        str(attempt.get("attempt_id") or "")
+        for attempt in backend_attempts
+        if str(attempt.get("kernel_id") or "") == kernel_id
+        and str(attempt.get("backend") or "") == str(backend or "")
+        and str(attempt.get("decision") or "").upper() == "KEEP"
+    ]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        warnings.append(
+            "optimizations: multiple KEEP attempts match "
+            f"kernel={kernel_id!r} backend={backend!r}; "
+            "adopted_attempt_id requires explicit producer evidence"
+        )
+    return None
 
 
 def _empty_kind_summary() -> dict[str, Any]:
@@ -367,8 +408,33 @@ def _validation_summary(
         else {}
     )
     notes = attribution.get("notes")
+    canonical_source_breakdown = {
+        "sweep_gain_pct": round(
+            _to_float(source_breakdown.get("sweep_pct_of_total")) or 0.0,
+            6,
+        ),
+        "params_gain_pct": round(
+            _to_float(source_breakdown.get("params_pct_of_total")) or 0.0,
+            6,
+        ),
+        "backends_gain_pct": round(
+            _to_float(source_breakdown.get("backends_pct_of_total")) or 0.0,
+            6,
+        ),
+        "gemm_tuning_gain_pct": round(
+            _to_float(source_breakdown.get("gemm_tuning_pct_of_total")) or 0.0,
+            6,
+        ),
+    }
+    try:
+        validated_at_stack_len = int(
+            state.get("cumulative_gain_validated_stack_len") or 0
+        )
+    except (TypeError, ValueError):
+        validated_at_stack_len = 0
     return {
         "method": str(attribution.get("method") or "missing"),
+        "validated_at_stack_len": validated_at_stack_len,
         "validated_total_gain_pct": (
             round(validated_total, 6) if validated_total is not None else None
         ),
@@ -379,6 +445,7 @@ def _validation_summary(
             else None
         ),
         "notes": [str(note) for note in notes] if isinstance(notes, list) else [],
+        "source_breakdown": canonical_source_breakdown,
         "phase_breakdown": phase_breakdown,
         "domain_attribution": domain_attribution,
     }
@@ -406,6 +473,9 @@ def collect_optimizations(
     gain_rows = attribution.get("gain_per_stack_entry") or []
     if not isinstance(gain_rows, list):
         gain_rows = []
+    state_gain_rows = state.get("gain_per_stack_entry")
+    if not isinstance(state_gain_rows, list):
+        state_gain_rows = []
     if gain_rows and len(gain_rows) != len(raw_stack):
         warnings.append(
             "optimizations: gain_per_stack_entry length does not match "
@@ -420,17 +490,10 @@ def collect_optimizations(
     session_id = str(state.get("session_id") or "session")
     timeline = _phase_timeline(state)
     backend_attempts = _collect_backend_attempts(
+        session_id,
         geak_invocations,
         forge_invocations,
     )
-    kept_attempts = {
-        (
-            str(attempt.get("kernel_id") or ""),
-            str(attempt.get("backend") or ""),
-        ): str(attempt.get("attempt_id") or "")
-        for attempt in backend_attempts
-        if str(attempt.get("decision") or "").upper() == "KEEP"
-    }
     entries: list[dict[str, Any]] = []
     previous_tput = baseline_tput
 
@@ -465,8 +528,24 @@ def collect_optimizations(
         throughput_before = previous_tput
         delta = _to_float(gain.get("delta_pct"))
         cumulative = _to_float(gain.get("cum_gain_after"))
+        original_gain = (
+            state_gain_rows[stack_index]
+            if stack_index < len(state_gain_rows)
+            else None
+        )
+        if isinstance(original_gain, dict) and _to_float(
+            original_gain.get("delta_pct")
+        ) is not None:
+            gain_method = "ledger"
+        elif isinstance(original_gain, (int, float)):
+            gain_method = "legacy_ledger_derived"
+        elif delta is not None:
+            gain_method = "reconstructed"
+        else:
+            gain_method = "missing"
         if delta is None and throughput_before and throughput_after is not None:
             delta = (throughput_after / throughput_before - 1.0) * 100.0
+            gain_method = "throughput_derived"
         if cumulative is None and baseline_tput and throughput_after is not None:
             cumulative = (throughput_after / baseline_tput - 1.0) * 100.0
 
@@ -486,11 +565,42 @@ def collect_optimizations(
             "backend": backend,
             "execution_mode": _execution_mode(raw, backend),
             "kernel_id": kernel_id or None,
-            "adopted_attempt_id": kept_attempts.get((kernel_id, str(backend or ""))) or None,
+            "adopted_attempt_id": _adopted_attempt_id(
+                raw,
+                kernel_id=kernel_id,
+                backend=backend,
+                backend_attempts=backend_attempts,
+                warnings=warnings,
+            ),
             "action": str(raw.get("action") or ""),
             "variant_name": str(raw.get("variant_name") or ""),
             "fingerprint": str(raw.get("fingerprint") or ""),
             "scope": str(raw.get("scope") or ""),
+            "source_phase": str(
+                raw.get("source_phase")
+                or gain.get("source_phase")
+                or raw.get("phase")
+                or gain.get("phase")
+                or ""
+            ),
+            "gain_method": gain_method,
+            "accepted_heads": (
+                list(raw.get("accepted_heads") or [])
+                if isinstance(raw.get("accepted_heads"), list)
+                else []
+            ),
+            "extra_server_args_is_invariant": (
+                raw.get("extra_server_args_is_invariant")
+                if isinstance(raw.get("extra_server_args_is_invariant"), bool)
+                else None
+            ),
+            "candidate_flags": (
+                raw.get("candidate_flags")
+                if raw.get("candidate_flags") is not None
+                else raw.get("flags")
+                if raw.get("flags") is not None
+                else str(raw.get("candidate_extra_server_args") or "")
+            ),
             "gain_pct": round(delta, 6) if delta is not None else None,
             "cumulative_gain_pct": (
                 round(cumulative, 6) if cumulative is not None else None
@@ -581,6 +691,222 @@ def collect_optimizations(
         "validation": _validation_summary(state, attribution, entries),
         "gemm_tuning_runs": gemm_tuning_runs,
     }
+
+
+def _duration_between(started_at: Any, ended_at: Any) -> float | None:
+    started = _parse_ts(started_at)
+    ended = _parse_ts(ended_at)
+    if started is None or ended is None or ended < started:
+        return None
+    return round(ended - started, 6)
+
+
+def _collect_v4_backend_invocations(
+    operations: list[dict[str, Any]],
+    measurements: list[dict[str, Any]],
+    adoptions: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    validated_operation_ids = {
+        str(adoption.get("operation_id") or "")
+        for adoption in adoptions
+        if isinstance(adoption, dict)
+        and adoption.get("validated") is True
+        and str(adoption.get("decision") or "").upper()
+        in {"KEEP", "ADOPT", "ADOPTED"}
+    }
+    micro_speedup_by_attempt = {
+        str((measurement.get("dimensions") or {}).get("attempt_id") or ""): _to_float(
+            measurement.get("value")
+        )
+        for measurement in measurements
+        if isinstance(measurement, dict)
+        and str(measurement.get("name") or "") == "micro_speedup"
+        and isinstance(measurement.get("dimensions"), dict)
+        and (measurement.get("dimensions") or {}).get("attempt_id")
+    }
+    geak: list[dict[str, Any]] = []
+    forge: list[dict[str, Any]] = []
+    for operation in operations:
+        if not isinstance(operation, dict):
+            continue
+        operation_id = str(operation.get("operation_id") or "")
+        subject = (
+            operation.get("subject")
+            if isinstance(operation.get("subject"), dict)
+            else {}
+        )
+        kernel_id = str(subject.get("name") or operation.get("name") or "")
+        outputs = (
+            operation.get("outputs")
+            if isinstance(operation.get("outputs"), dict)
+            else {}
+        )
+        verification = (
+            outputs.get("verification")
+            if isinstance(outputs.get("verification"), dict)
+            else {}
+        )
+        proposal = (
+            outputs.get("proposal")
+            if isinstance(outputs.get("proposal"), dict)
+            else {}
+        )
+        best_attempt_id = str(verification.get("best_attempt_id") or "")
+        operation_decision = str(
+            outputs.get("decision")
+            or proposal.get("decision")
+            or ""
+        ).upper()
+        for index, attempt_value in enumerate(operation.get("attempts") or []):
+            if not isinstance(attempt_value, dict):
+                continue
+            attempt = dict(attempt_value)
+            attempt_outputs = (
+                attempt.get("outputs")
+                if isinstance(attempt.get("outputs"), dict)
+                else {}
+            )
+            attempt_id = str(attempt.get("attempt_id") or "")
+            backend = str(
+                attempt.get("backend")
+                or attempt_outputs.get("backend")
+                or operation.get("strategy")
+                or ""
+            ).lower()
+            if "geak" in backend:
+                backend = "geak"
+                lane = geak
+            elif "forge" in backend:
+                backend = "forge"
+                lane = forge
+            else:
+                continue
+            status = str(attempt.get("status") or "").upper()
+            decision = str(attempt_outputs.get("decision") or "").upper()
+            if not decision and operation_id in validated_operation_ids:
+                if not best_attempt_id or attempt_id == best_attempt_id:
+                    decision = "KEEP"
+            if not decision and status in {"FAILED", "ERROR", "CANCELLED"}:
+                decision = "FAILED"
+            error = attempt.get("error")
+            error_class = None
+            error_message = None
+            if isinstance(error, dict):
+                error_class = str(
+                    error.get("class")
+                    or error.get("error_class")
+                    or error.get("type")
+                    or ""
+                ) or None
+                error_message = str(
+                    error.get("message") or error.get("error") or ""
+                ) or None
+            elif error:
+                error_message = str(error)
+            lane.append(
+                {
+                    "attempt_id": attempt_id,
+                    "run_id": operation_id,
+                    "kernel_id": kernel_id,
+                    "backend": backend,
+                    "decision": decision or operation_decision,
+                    "ts": str(
+                        attempt.get("started_at")
+                        or operation.get("started_at")
+                        or ""
+                    ),
+                    "sequence": attempt.get("sequence") or index + 1,
+                    "duration_sec": _duration_between(
+                        attempt.get("started_at"),
+                        attempt.get("ended_at"),
+                    ),
+                    "micro_speedup": _to_float(
+                        attempt_outputs.get("micro_speedup")
+                        or attempt_outputs.get("speedup")
+                    )
+                    or micro_speedup_by_attempt.get(attempt_id),
+                    "compile_passed": attempt_outputs.get("compile_passed"),
+                    "correctness_passed": attempt_outputs.get(
+                        "correctness_passed"
+                    ),
+                    "error_class": error_class,
+                    "error": error_message,
+                }
+            )
+    return geak, forge
+
+
+def _collect_v4_gemm_tuning_runs(
+    operations: list[dict[str, Any]],
+    adoptions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    adoption_by_operation = {
+        str(adoption.get("operation_id") or ""): adoption
+        for adoption in adoptions
+        if isinstance(adoption, dict) and adoption.get("operation_id")
+    }
+    runs: list[dict[str, Any]] = []
+    for operation in operations:
+        if not isinstance(operation, dict) or operation.get("kind") != "gemm_tuning":
+            continue
+        extensions = (
+            operation.get("extensions")
+            if isinstance(operation.get("extensions"), dict)
+            else {}
+        )
+        gemm_extension = (
+            extensions.get("gemm")
+            if isinstance(extensions.get("gemm"), dict)
+            else {}
+        )
+        result = (
+            dict(gemm_extension.get("result"))
+            if isinstance(gemm_extension.get("result"), dict)
+            else {}
+        )
+        outputs = (
+            operation.get("outputs")
+            if isinstance(operation.get("outputs"), dict)
+            else {}
+        )
+        adoption = adoption_by_operation.get(
+            str(operation.get("operation_id") or ""),
+            {},
+        )
+        result.setdefault(
+            "engine",
+            outputs.get("engine") or operation.get("strategy") or "",
+        )
+        result.setdefault("status", operation.get("status") or "")
+        result.setdefault("decision", outputs.get("decision") or "")
+        result.setdefault("source", operation.get("producer") or "")
+        result.setdefault(
+            "ts",
+            operation.get("ended_at") or operation.get("started_at") or "",
+        )
+        result.setdefault(
+            "duration_sec",
+            _duration_between(
+                operation.get("started_at"),
+                operation.get("ended_at"),
+            ),
+        )
+        result.setdefault(
+            "adopted",
+            adoption.get("validated") is True
+            and str(adoption.get("decision") or "").upper()
+            in {"KEEP", "ADOPT", "ADOPTED"},
+        )
+        if result.get("gain_pct") is None:
+            result["gain_pct"] = _to_float(adoption.get("gain_pct"))
+        if "candidates" not in result:
+            result["candidates"] = [
+                dict(attempt.get("outputs") or {})
+                for attempt in operation.get("attempts") or []
+                if isinstance(attempt, dict)
+            ]
+        runs.append(result)
+    return runs
 
 
 def collect_v4_optimizations(
@@ -736,14 +1062,34 @@ def collect_v4_optimizations(
         "baseline_tput": baseline_tput,
         "optimization_stack": stack,
         "gain_per_stack_entry": gains,
+        "cumulative_gain_validated": cumulative,
         "cumulative_gain_validated_stack_len": len(stack),
         "phase_history": [],
     }
+    geak_invocations, forge_invocations = _collect_v4_backend_invocations(
+        operations,
+        measurements,
+        adoptions,
+    )
+    synthetic_attribution = {
+        "gain_per_stack_entry": gains,
+        "method": "validated" if gains else "missing",
+        "source_breakdown": {
+            "validated_total_pct": cumulative,
+        },
+        "phase_breakdown": {},
+        "notes": [
+            "Attribution synthesized from validated V4 adoption streams."
+        ],
+    }
     return collect_optimizations(
         synthetic_state,
-        {"gain_per_stack_entry": gains},
-        [],
-        [],
+        synthetic_attribution,
+        geak_invocations,
+        forge_invocations,
         warnings,
+        gemm_tuning={
+            "runs": _collect_v4_gemm_tuning_runs(operations, adoptions),
+        },
     )
 

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/optimizations.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/optimizations.py
@@ -1,0 +1,578 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Canonical optimization projection for ``session_breakdown.json``.
+
+The historical breakdown contract exposes successful optimizations through
+several parallel sections (``optimization_stack``, attribution, Explore,
+GEAK, and Forge).  This module projects those records into one stable,
+phase-aware read model while leaving the historical sections available as
+audit and compatibility data.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+
+OPTIMIZATIONS_SCHEMA_VERSION = 1
+
+_SOURCES = (
+    "warm_replay",
+    "explore",
+    "framework_agent",
+    "kernel_agent",
+    "unattributed",
+)
+
+_NON_OPTIMIZATION_ACTIONS = {
+    "baseline",
+    "profile",
+    "roofline",
+    "sweep",
+    "conc_sweep",
+    "validate",
+    "validate_stack",
+    "target_analysis",
+    "trace_analyze",
+}
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_ts(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def _normalized_phase(value: Any) -> str:
+    phase = str(value or "").strip().upper()
+    return {
+        "FRAMEWORK": "framework_agent",
+        "FRAMEWORK_AGENT": "framework_agent",
+        "EXPLORE": "explore",
+        "KERNEL": "kernel_agent",
+        "KERNEL_AGENT": "kernel_agent",
+    }.get(phase, "")
+
+
+def _phase_timeline(state: dict[str, Any]) -> list[tuple[float, str]]:
+    timeline: list[tuple[float, str]] = []
+    history = state.get("phase_history") or []
+    if not isinstance(history, list):
+        return timeline
+    for row in history:
+        if not isinstance(row, dict):
+            continue
+        phase = _normalized_phase(row.get("to_phase"))
+        ts = _parse_ts(row.get("ts_unix"))
+        if ts is None:
+            ts = _parse_ts(row.get("ts"))
+        if phase and ts is not None:
+            timeline.append((ts, phase))
+    timeline.sort(key=lambda item: item[0])
+    return timeline
+
+
+def _phase_at(ts: float | None, timeline: list[tuple[float, str]]) -> str:
+    if ts is None:
+        return ""
+    current = ""
+    for boundary, phase in timeline:
+        if boundary > ts:
+            break
+        current = phase
+    return current
+
+
+def _kernel_backend(
+    raw: dict[str, Any],
+    *,
+    kernel_id: str,
+    geak_invocations: list[dict[str, Any]],
+    forge_invocations: list[dict[str, Any]],
+) -> str | None:
+    values = (
+        raw.get("backend"),
+        raw.get("engine"),
+        raw.get("source"),
+        raw.get("action"),
+    )
+    joined = " ".join(str(value or "").lower() for value in values)
+    if "forge" in joined:
+        return "forge"
+    if "geak" in joined:
+        return "geak"
+
+    if kernel_id:
+        for backend, invocations in (
+            ("forge", forge_invocations),
+            ("geak", geak_invocations),
+        ):
+            if any(
+                str(inv.get("kernel_id") or "") == kernel_id
+                and str(inv.get("decision") or "").upper() == "KEEP"
+                for inv in invocations
+                if isinstance(inv, dict)
+            ):
+                return backend
+    return None
+
+
+def _resolve_source(
+    raw: dict[str, Any],
+    gain: dict[str, Any],
+    *,
+    timeline: list[tuple[float, str]],
+) -> tuple[str, str]:
+    action = str(raw.get("action") or gain.get("action") or "").strip().lower()
+    if action in {"replay_warm_recipe", "warm_replay"} or "warm_replay" in action:
+        return "warm_replay", "action_family"
+
+    kernel_markers = (
+        raw.get("kernel_id"),
+        raw.get("backend"),
+        raw.get("engine"),
+        raw.get("tuned_file"),
+        raw.get("final_overlay"),
+    )
+    if (
+        any(value not in (None, "", [], {}) for value in kernel_markers)
+        or action in {"geak_e2e", "gemm_tuning", "fusion", "integrate"}
+        or action.startswith("kernel_opt")
+    ):
+        return "kernel_agent", "action_family"
+
+    explicit = _normalized_phase(
+        raw.get("source_phase")
+        or gain.get("source_phase")
+        or raw.get("phase")
+        or gain.get("phase")
+    )
+    if explicit:
+        return explicit, "recorded"
+
+    ts = _parse_ts(gain.get("ts_unix"))
+    if ts is None:
+        ts = _parse_ts(gain.get("ts") or raw.get("ts"))
+    inferred = _phase_at(ts, timeline)
+    if inferred:
+        return inferred, "phase_history_ts"
+
+    if action in {"explore", "backends", "params"}:
+        return "explore", "action_family"
+    if action == "framework_agent":
+        return "framework_agent", "action_family"
+    return "unattributed", "unknown"
+
+
+def _optimization_kind(
+    raw: dict[str, Any],
+    *,
+    source: str,
+) -> str:
+    action = str(raw.get("action") or "").strip().lower()
+    operation_kind = str(raw.get("operation_kind") or "").strip().lower()
+    if source == "warm_replay":
+        return "serving_config"
+    if source == "kernel_agent":
+        if action == "gemm_tuning":
+            return "gemm_tuning"
+        if action == "fusion":
+            return "kernel_fusion"
+        return "kernel_patch"
+    if source == "framework_agent":
+        patch_evidence = (
+            raw.get("patch_path"),
+            raw.get("target_file"),
+            raw.get("source_snapshot"),
+            raw.get("framework_root"),
+            raw.get("base_sha"),
+        )
+        return (
+            "framework_patch"
+            if any(value not in (None, "") for value in patch_evidence)
+            else "serving_config"
+        )
+    if source == "explore":
+        return operation_kind if operation_kind in {"backend", "param", "env"} else "serving_config"
+    return operation_kind or "unknown"
+
+
+def _artifacts(raw: dict[str, Any]) -> list[dict[str, str]]:
+    fields = (
+        ("patch", "patch_path"),
+        ("target_file", "target_file"),
+        ("tuned_file", "tuned_file"),
+        ("report", "final_report_path"),
+        ("report", "report_path"),
+        ("overlay", "final_overlay"),
+    )
+    out = [
+        {"kind": str(item.get("kind") or ""), "path": str(item.get("path") or "")}
+        for item in raw.get("artifacts") or []
+        if isinstance(item, dict) and item.get("path")
+    ]
+    seen: set[tuple[str, str]] = set()
+    seen.update((item["kind"], item["path"]) for item in out)
+    for kind, field in fields:
+        path = str(raw.get(field) or "").strip()
+        key = (kind, path)
+        if not path or key in seen:
+            continue
+        seen.add(key)
+        out.append({"kind": kind, "path": path})
+    return out
+
+
+def _execution_mode(raw: dict[str, Any], backend: str | None) -> str | None:
+    explicit = str(raw.get("execution_mode") or "").strip()
+    if explicit in {"whole_pipeline", "per_kernel"}:
+        return explicit
+    action = str(raw.get("action") or "").strip().lower()
+    if action == "geak_e2e":
+        return "whole_pipeline"
+    if action in {"gemm_tuning", "fusion", "integrate"} or action.startswith("kernel_opt"):
+        return "per_kernel"
+    if backend == "forge":
+        return "per_kernel"
+    if backend == "geak":
+        return "whole_pipeline"
+    return None
+
+
+def _empty_summary() -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        source: {"keeps": 0, "total_gain_pct": 0.0}
+        for source in _SOURCES
+    }
+    summary["kernel_agent"]["by_backend"] = {
+        "geak": {"keeps": 0, "total_gain_pct": 0.0},
+        "forge": {"keeps": 0, "total_gain_pct": 0.0},
+        "unattributed": {"keeps": 0, "total_gain_pct": 0.0},
+    }
+    return summary
+
+
+def collect_optimizations(
+    state: dict[str, Any],
+    attribution: dict[str, Any],
+    geak_invocations: list[dict[str, Any]],
+    forge_invocations: list[dict[str, Any]],
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Build the single canonical optimization read model.
+
+    Only records in ``state.optimization_stack`` are projected: attempts,
+    REVERTs, and ``no_promote`` events remain in the action timeline.  The
+    legacy sections are intentionally not mutated.
+    """
+
+    raw_stack = state.get("optimization_stack") or []
+    if not isinstance(raw_stack, list):
+        warnings.append("optimizations: state.optimization_stack is not a list")
+        raw_stack = []
+    gain_rows = attribution.get("gain_per_stack_entry") or []
+    if not isinstance(gain_rows, list):
+        gain_rows = []
+    if gain_rows and len(gain_rows) != len(raw_stack):
+        warnings.append(
+            "optimizations: gain_per_stack_entry length does not match "
+            "optimization_stack; missing rows use throughput fallback"
+        )
+    try:
+        validated_len = int(state.get("cumulative_gain_validated_stack_len") or 0)
+    except (TypeError, ValueError):
+        validated_len = 0
+
+    baseline_tput = _to_float(state.get("baseline_tput"))
+    session_id = str(state.get("session_id") or "session")
+    timeline = _phase_timeline(state)
+    entries: list[dict[str, Any]] = []
+    previous_tput = baseline_tput
+
+    for stack_index, raw_value in enumerate(raw_stack):
+        if not isinstance(raw_value, dict):
+            warnings.append(f"optimizations: stack entry {stack_index} is not an object")
+            continue
+        raw = dict(raw_value)
+        if str(raw.get("action") or "").strip().lower() in _NON_OPTIMIZATION_ACTIONS:
+            anchor_tput = _to_float(raw.get("tput"))
+            if anchor_tput is not None:
+                previous_tput = anchor_tput
+            continue
+        gain = (
+            dict(gain_rows[stack_index])
+            if stack_index < len(gain_rows) and isinstance(gain_rows[stack_index], dict)
+            else {}
+        )
+        source, source_method = _resolve_source(raw, gain, timeline=timeline)
+        kernel_id = str(raw.get("kernel_id") or raw.get("action_kernel_id") or "").strip()
+        backend = (
+            _kernel_backend(
+                raw,
+                kernel_id=kernel_id,
+                geak_invocations=geak_invocations,
+                forge_invocations=forge_invocations,
+            )
+            if source == "kernel_agent"
+            else None
+        )
+        throughput_after = _to_float(raw.get("tput"))
+        throughput_before = previous_tput
+        delta = _to_float(gain.get("delta_pct"))
+        cumulative = _to_float(gain.get("cum_gain_after"))
+        if delta is None and throughput_before and throughput_after is not None:
+            delta = (throughput_after / throughput_before - 1.0) * 100.0
+        if cumulative is None and baseline_tput and throughput_after is not None:
+            cumulative = (throughput_after / baseline_tput - 1.0) * 100.0
+
+        name = str(
+            raw.get("name")
+            or raw.get("variant_name")
+            or kernel_id
+            or _optimization_kind(raw, source=source)
+        )
+        entry = {
+            "id": f"{session_id}:optimization:{stack_index}",
+            "stack_index": stack_index,
+            "source": source,
+            "source_method": source_method,
+            "optimization_kind": _optimization_kind(raw, source=source),
+            "name": name,
+            "backend": backend,
+            "execution_mode": _execution_mode(raw, backend),
+            "kernel_id": kernel_id or None,
+            "gain_pct": round(delta, 6) if delta is not None else None,
+            "cumulative_gain_pct": (
+                round(cumulative, 6) if cumulative is not None else None
+            ),
+            "throughput_before": throughput_before,
+            "throughput_after": throughput_after,
+            "validated": stack_index < validated_len,
+            "task_id": str(raw.get("task_id") or gain.get("task_id") or ""),
+            "ts": str(gain.get("ts") or raw.get("ts") or ""),
+            "provenance": str(raw.get("provenance") or ""),
+            "configuration": {
+                "extra_server_args": str(
+                    raw.get("extra_server_args")
+                    or raw.get("candidate_extra_server_args")
+                    or gain.get("extra_server_args")
+                    or ""
+                ),
+                "extra_envs": dict(raw.get("extra_envs") or {}),
+            },
+            "artifacts": _artifacts(raw),
+        }
+        entries.append(entry)
+        if throughput_after is not None:
+            previous_tput = throughput_after
+
+    summary = _empty_summary()
+    for entry in entries:
+        if not entry["validated"]:
+            continue
+        source = str(entry["source"])
+        bucket = summary[source]
+        bucket["keeps"] += 1
+        gain = _to_float(entry.get("gain_pct")) or 0.0
+        bucket["total_gain_pct"] += gain
+        if source == "kernel_agent":
+            backend = str(entry.get("backend") or "unattributed")
+            if backend not in bucket["by_backend"]:
+                backend = "unattributed"
+            bucket["by_backend"][backend]["keeps"] += 1
+            bucket["by_backend"][backend]["total_gain_pct"] += gain
+
+    for bucket in summary.values():
+        bucket["total_gain_pct"] = round(float(bucket["total_gain_pct"]), 6)
+        for backend_bucket in bucket.get("by_backend", {}).values():
+            backend_bucket["total_gain_pct"] = round(
+                float(backend_bucket["total_gain_pct"]),
+                6,
+            )
+
+    return {
+        "schema_version": OPTIMIZATIONS_SCHEMA_VERSION,
+        "entries": entries,
+        "summary_by_source": summary,
+    }
+
+
+def collect_v4_optimizations(
+    run: dict[str, Any],
+    operations: list[dict[str, Any]],
+    measurements: list[dict[str, Any]],
+    adoptions: list[dict[str, Any]],
+    artifacts: list[dict[str, Any]],
+    warnings: list[str],
+) -> dict[str, Any]:
+    """Project canonical v4 adoption streams through the same read model.
+
+    V4 never reads business-state files, so a small synthetic stack is built
+    exclusively from recorder operations, validated adoptions, measurements,
+    and artifact references before delegating to :func:`collect_optimizations`.
+    """
+
+    operation_by_id = {
+        str(operation.get("operation_id") or ""): operation
+        for operation in operations
+        if isinstance(operation, dict) and operation.get("operation_id")
+    }
+    measurement_by_id = {
+        str(measurement.get("measurement_id") or ""): measurement
+        for measurement in measurements
+        if isinstance(measurement, dict) and measurement.get("measurement_id")
+    }
+    artifact_by_id = {
+        str(artifact.get("artifact_id") or ""): artifact
+        for artifact in artifacts
+        if isinstance(artifact, dict) and artifact.get("artifact_id")
+    }
+
+    stack: list[dict[str, Any]] = []
+    gains: list[dict[str, Any]] = []
+    cumulative = 0.0
+    for adoption in adoptions:
+        if not isinstance(adoption, dict):
+            continue
+        decision = str(adoption.get("decision") or "").upper()
+        if decision not in {"KEEP", "ADOPT", "ADOPTED"}:
+            continue
+        if adoption.get("validated") is not True:
+            continue
+        operation_id = str(adoption.get("operation_id") or "")
+        operation = operation_by_id.get(operation_id, {})
+        strategy = str(operation.get("strategy") or "")
+        subject = adoption.get("subject") if isinstance(adoption.get("subject"), dict) else {}
+        if not subject:
+            subject = operation.get("subject") if isinstance(operation.get("subject"), dict) else {}
+        kernel_id = str(subject.get("name") or "") if "kernel" in str(subject.get("kind") or "").lower() else ""
+        artifact_rows = [
+            artifact_by_id[artifact_id]
+            for artifact_id in adoption.get("artifact_ids") or []
+            if artifact_id in artifact_by_id
+        ]
+        raw: dict[str, Any] = {
+            "action": str(operation.get("kind") or adoption.get("kind") or ""),
+            "variant_name": str(
+                operation.get("name")
+                or subject.get("name")
+                or adoption.get("adoption_id")
+                or ""
+            ),
+            "name": str(
+                operation.get("name")
+                or subject.get("name")
+                or adoption.get("kind")
+                or ""
+            ),
+            "task_id": operation_id,
+            "source_phase": str(operation.get("phase") or ""),
+            "backend": strategy,
+            "execution_mode": (
+                "whole_pipeline"
+                if strategy == "geak"
+                else "per_kernel"
+                if "forge" in strategy
+                else None
+            ),
+            "kernel_id": kernel_id,
+            "operation_kind": str(operation.get("kind") or adoption.get("kind") or ""),
+            "extra_server_args": str((adoption.get("configuration") or {}).get("extra_server_args") or ""),
+            "extra_envs": dict((adoption.get("configuration") or {}).get("extra_envs") or {}),
+            "ts": str(adoption.get("adopted_at") or operation.get("ended_at") or ""),
+            "provenance": str(adoption.get("producer") or operation.get("producer") or ""),
+        }
+        for artifact in artifact_rows:
+            kind = str(artifact.get("kind") or "").lower()
+            path = str(artifact.get("path") or artifact.get("uri") or "")
+            if not path:
+                continue
+            if "patch" in kind:
+                raw.setdefault("patch_path", path)
+            elif "tuned" in kind:
+                raw.setdefault("tuned_file", path)
+            elif "target" in kind or "source" in kind:
+                raw.setdefault("target_file", path)
+            elif "overlay" in kind:
+                raw.setdefault("final_overlay", path)
+            else:
+                raw.setdefault("report_path", path)
+        raw["artifacts"] = [
+            {
+                "kind": str(artifact.get("kind") or ""),
+                "path": str(artifact.get("path") or artifact.get("uri") or ""),
+            }
+            for artifact in artifact_rows
+            if artifact.get("path") or artifact.get("uri")
+        ]
+
+        throughput_after = None
+        throughput_before = None
+        for measurement_id in adoption.get("measurement_ids") or []:
+            measurement = measurement_by_id.get(str(measurement_id), {})
+            name = str(measurement.get("name") or "").lower()
+            value = _to_float(measurement.get("value"))
+            if value is None:
+                continue
+            if name in {"throughput_after", "final_throughput", "output_throughput"}:
+                throughput_after = value
+            elif name in {"throughput_before", "baseline_throughput"}:
+                throughput_before = value
+        if throughput_after is not None:
+            raw["tput"] = throughput_after
+
+        delta = _to_float(adoption.get("gain_pct"))
+        cumulative += delta or 0.0
+        gain_row: dict[str, Any] = {
+            "action": raw["action"],
+            "variant_name": raw["variant_name"],
+            "delta_pct": delta,
+            "cum_gain_after": cumulative,
+            "ts": raw["ts"],
+            "task_id": operation_id,
+            "source_phase": raw["source_phase"],
+        }
+        if throughput_before is not None:
+            gain_row["throughput_before"] = throughput_before
+        stack.append(raw)
+        gains.append(gain_row)
+
+    baseline_tput = next(
+        (
+            _to_float(gain.get("throughput_before"))
+            for gain in gains
+            if _to_float(gain.get("throughput_before")) is not None
+        ),
+        None,
+    )
+    synthetic_state = {
+        "session_id": str(run.get("session_id") or run.get("claw_session_id") or "session"),
+        "baseline_tput": baseline_tput,
+        "optimization_stack": stack,
+        "gain_per_stack_entry": gains,
+        "cumulative_gain_validated_stack_len": len(stack),
+        "phase_history": [],
+    }
+    return collect_optimizations(
+        synthetic_state,
+        {"gain_per_stack_entry": gains},
+        [],
+        [],
+        warnings,
+    )
+

--- a/src/hyperloom/inference_optimizer/breakdown/exporter.py
+++ b/src/hyperloom/inference_optimizer/breakdown/exporter.py
@@ -362,6 +362,12 @@ def build(
         ),
         warnings,
     )
+    gemm_tuning = _safe_collect(
+        "gemm_tuning",
+        lambda: collectors.collect_gemm_tuning(state),
+        warnings,
+        default={},
+    )
     # Canonical optimization read model.  This is the single downstream entry
     # point for adopted warm-replay, Explore, Framework Agent, and Kernel Agent
     # changes; the historical sections below remain compatibility/audit data.
@@ -373,12 +379,17 @@ def build(
             geak_invocations,
             forge_invocations,
             warnings,
+            gemm_tuning=gemm_tuning,
         ),
         warnings,
         default={
-            "schema_version": 1,
+            "schema_version": 2,
             "entries": [],
+            "backend_attempts": [],
             "summary_by_source": {},
+            "summary_by_kind": {},
+            "validation": {},
+            "gemm_tuning_runs": [],
         },
     )
     kb_provenance = _pick(
@@ -1732,9 +1743,13 @@ def build_v4_live(session_dir: Path | str) -> dict[str, Any]:
         ),
         warnings,
         default={
-            "schema_version": 1,
+            "schema_version": 2,
             "entries": [],
+            "backend_attempts": [],
             "summary_by_source": {},
+            "summary_by_kind": {},
+            "validation": {},
+            "gemm_tuning_runs": [],
         },
     )
     compat = _v4_compat_projection(

--- a/src/hyperloom/inference_optimizer/breakdown/exporter.py
+++ b/src/hyperloom/inference_optimizer/breakdown/exporter.py
@@ -22,7 +22,7 @@ from hyperloom.common.jsonio import read_json
 from hyperloom.common.timeutil import iso_z
 
 from . import collectors
-from .schema import SCHEMA_VERSION, SCHEMA_VERSION_V3, SCHEMA_VERSION_V4
+from .schema import SCHEMA_VERSION_V5
 from ..session.session_paths import manifest_path, state_path
 
 log = logging.getLogger(__name__)
@@ -220,8 +220,9 @@ def build(
     # the source of truth for their section; when absent the collectors are used
     # as fallback.
     assembled = _load_assembled(sd, warnings)
-    # v3.0 when any recorder fragments are present; else the collector-only v2.
-    schema_version = SCHEMA_VERSION_V3 if assembled else SCHEMA_VERSION
+    # V5 is the hard-cutover wire shape regardless of whether recorder
+    # fragments or collector fallbacks supplied the underlying evidence.
+    schema_version = SCHEMA_VERSION_V5
 
     def _pick(section: str, collector_value: Any) -> Any:
         """Fragment value if recorded and non-empty, else the collector value.
@@ -343,16 +344,6 @@ def build(
         _safe_collect("explore_search", lambda: collectors.collect_explore_search(state, warnings), warnings),
     )
     sweep = _pick("sweep", _safe_collect("sweep", lambda: collectors.collect_sweep(sd, state, warnings), warnings))
-    # GEAK e2e KERNEL-phase section. Empty {} on native sessions.
-    geak = _pick(
-        "geak",
-        _safe_collect(
-            "geak",
-            lambda: collectors.collect_geak(sd, state, warnings),
-            warnings,
-            default={},
-        ),
-    )
     critic_robustness = _pick(
         "critic_robustness",
         _safe_collect("critic_robustness", lambda: collectors.collect_critic_robustness(sd, warnings), warnings),
@@ -370,6 +361,25 @@ def build(
             forge_invocations,
         ),
         warnings,
+    )
+    # Canonical optimization read model.  This is the single downstream entry
+    # point for adopted warm-replay, Explore, Framework Agent, and Kernel Agent
+    # changes; the historical sections below remain compatibility/audit data.
+    optimizations = _safe_collect(
+        "optimizations",
+        lambda: collectors.collect_optimizations(
+            state,
+            attribution,
+            geak_invocations,
+            forge_invocations,
+            warnings,
+        ),
+        warnings,
+        default={
+            "schema_version": 1,
+            "entries": [],
+            "summary_by_source": {},
+        },
     )
     kb_provenance = _pick(
         "kb_provenance",
@@ -398,16 +408,6 @@ def build(
             warnings,
             default=[],
         ),
-    )
-    # Raw ``state.optimization_stack[]`` passthrough.
-    optimization_stack = _pick(
-        "optimization_stack",
-        _safe_collect("optimization_stack", lambda: collectors.collect_optimization_stack(state), warnings, default=[]),
-    )
-    # Fixed FP8 GEMM-tuning stage, engine-tagged; empty {} on non-fp8/sglang.
-    gemm_tuning = _pick(
-        "gemm_tuning",
-        _safe_collect("gemm_tuning", lambda: collectors.collect_gemm_tuning(state), warnings, default={}),
     )
     # Hot-kernel roofline table from ``<sd>/reports/kernel_roofline.json``.
     kernel_roofline = _pick(
@@ -540,27 +540,18 @@ def build(
         # v1-reader alias mirroring the flat per-action timeline.
         "action_timeline": phase_timeline,
         "capability_summary": capability_summary,
-        "geak_invocations": geak_invocations,
-        "forge_invocations": forge_invocations,
         "kernel_lifecycle": kernel_lifecycle,
         "param_search": explore_search,
         # v2-native name for the merged ledger; mirrors ``param_search``.
         "explore_search": explore_search,
         "sweep": sweep,
-        # GEAK e2e KERNEL section; empty {} → hidden on native sessions.
-        "geak": geak,
         "critic_robustness": critic_robustness,
         "telemetry": telemetry,
-        "attribution": attribution,
+        # Canonical downstream optimization API.
+        "optimizations": optimizations,
         # Recipe KB integration audit.
         "kb_provenance": kb_provenance,
         "specialist_runs": specialist_runs,
-        # Raw KEEP ledger passthrough mirroring ``state.optimization_stack[]``.
-        "optimization_stack": optimization_stack,
-        # Fixed FP8 GEMM-tuning stage (KERNEL entry), engine-tagged. Gain
-        # mirrored here; ``attribution`` stays authoritative. Empty {} on
-        # non-fp8/sglang.
-        "gemm_tuning": gemm_tuning,
         # Hot-kernel roofline table; empty → hidden.
         "kernel_roofline": kernel_roofline,
         # Kernel-agent attempt outcome summary; empty → hides Block 1.
@@ -1729,6 +1720,23 @@ def build_v4_live(session_dir: Path | str) -> dict[str, Any]:
     artifacts = _rows("artifacts")
     trace_events = _rows("trace_events")
     integrity = _v4_integrity(assembled, warnings)
+    optimizations = _safe_collect(
+        "optimizations",
+        lambda: collectors.collect_v4_optimizations(
+            run,
+            operations,
+            measurements,
+            adoptions,
+            artifacts,
+            warnings,
+        ),
+        warnings,
+        default={
+            "schema_version": 1,
+            "entries": [],
+            "summary_by_source": {},
+        },
+    )
     compat = _v4_compat_projection(
         run=run,
         workload=workload,
@@ -1743,8 +1751,21 @@ def build_v4_live(session_dir: Path | str) -> dict[str, Any]:
         outcome=outcome,
         integrity=integrity,
     )
+    compat["optimizations"] = optimizations
+    # Hard cutover: these legacy optimization projections are used only while
+    # constructing ``optimizations`` and are no longer part of the public SBD
+    # wire shape. Canonical operations/adoptions remain available for audit.
+    for legacy_field in (
+        "optimization_stack",
+        "attribution",
+        "geak",
+        "geak_invocations",
+        "forge_invocations",
+        "gemm_tuning",
+    ):
+        compat.pop(legacy_field, None)
     breakdown: dict[str, Any] = {
-        "schema_version": SCHEMA_VERSION_V4,
+        "schema_version": SCHEMA_VERSION_V5,
         "exported_at_utc": datetime.now(timezone.utc).isoformat(timespec="seconds"),
         "exporter_version": EXPORTER_VERSION,
         "run": run,
@@ -1756,6 +1777,7 @@ def build_v4_live(session_dir: Path | str) -> dict[str, Any]:
         "operations": operations,
         "measurements": measurements,
         "adoptions": adoptions,
+        "optimizations": optimizations,
         "outcome": outcome,
         "artifacts": artifacts,
         "trace": {"events": trace_events},

--- a/src/hyperloom/inference_optimizer/breakdown/recorder/instrument.py
+++ b/src/hyperloom/inference_optimizer/breakdown/recorder/instrument.py
@@ -2918,9 +2918,11 @@ def record_kernel_e2e(
     validation_tier: str = "",
     producer: str = PRODUCER_KERNEL_AGENT,
 ) -> None:
-    """Record the end-to-end integrate outcome for one kernel (stage 4).
+    """Record the latest end-to-end integrate outcome for one kernel (stage 4).
 
-    Idempotent per ``kernel_id``. ``e2e_gain_pct`` is the validated end-to-end
+    Idempotent per ``kernel_id`` using overwrite-on-rewrite semantics: a later
+    final-validation verdict replaces the provisional candidate verdict rather
+    than appending a duplicate. ``e2e_gain_pct`` is the validated end-to-end
     gain at integrate (negative => regressed and reverted).
 
     Args:

--- a/src/hyperloom/inference_optimizer/breakdown/recorder/instrument.py
+++ b/src/hyperloom/inference_optimizer/breakdown/recorder/instrument.py
@@ -2941,6 +2941,7 @@ def record_kernel_e2e(
     if not session_dir or not kernel_id:
         return
     try:
+        evidence = dict(result or {})
         payload = {
             "kernel_id": str(kernel_id),
             "integrated": bool(integrated),
@@ -2952,6 +2953,15 @@ def record_kernel_e2e(
             "extra_server_args": str(extra_server_args or ""),
             "ts": _now_iso_safe(),
         }
+        for field in (
+            "self_reported_e2e_gain_pct",
+            "revalidation_measured_tput",
+            "revalidation_current_best_tput",
+            "revalidation_provenance",
+            "rejection_reason",
+        ):
+            if evidence.get(field) is not None:
+                payload[field] = evidence[field]
         if validation_tier:
             payload["validation_tier"] = validation_tier
         _recorder(session_dir, producer).record_item(
@@ -2959,7 +2969,6 @@ def record_kernel_e2e(
             payload,
             key=str(kernel_id),
         )
-        evidence = dict(result or {})
         if str(route_strategy or "") == "legacy_only":
             return
         if str(route_strategy or "") == "geak_internal":

--- a/src/hyperloom/inference_optimizer/breakdown/reporters/_renderers/attribution.py
+++ b/src/hyperloom/inference_optimizer/breakdown/reporters/_renderers/attribution.py
@@ -25,8 +25,9 @@ def render(breakdown: dict[str, Any]) -> RenderedSection:
         RenderedSection: The rendered section, marked skipped when there is no
             per-source split to show.
     """
-    a = breakdown.get("attribution") or {}
-    sb = a.get("source_breakdown") or {}
+    optimizations = breakdown.get("optimizations") or {}
+    validation = optimizations.get("validation") or {}
+    a = validation or breakdown.get("attribution") or {}
     notes = a.get("notes") or []
     # Render ``attribution.method`` verbatim; never substitute a different label.
     method_raw = a.get("method")
@@ -36,15 +37,48 @@ def render(breakdown: dict[str, Any]) -> RenderedSection:
     else:
         method_display = method
 
-    total_v = sb.get("validated_total_pct")
-    rows = [
-        ["explore", sb.get("explore_pct_of_total"), sb.get("explore_share_pct")],
-        ["replay_warm_recipe", sb.get("replay_warm_recipe_pct_of_total"), sb.get("replay_warm_recipe_share_pct")],
-        ["backends", sb.get("backends_pct_of_total"), sb.get("backends_share_pct")],
-        ["params", sb.get("params_pct_of_total"), sb.get("params_share_pct")],
-        ["sweep", sb.get("sweep_pct_of_total"), sb.get("sweep_share_pct")],
-        ["geak", sb.get("geak_pct_of_total"), sb.get("geak_share_pct")],
-    ]
+    if validation:
+        total_v = validation.get("validated_total_gain_pct")
+        summary = optimizations.get("summary_by_source") or {}
+        canonical_rows = [
+            [source, bucket.get("total_gain_pct")]
+            for source, bucket in summary.items()
+            if isinstance(bucket, dict)
+        ]
+        share_total = total_v
+        if not isinstance(share_total, (int, float)) or not share_total:
+            share_total = sum(
+                float(gain)
+                for _source, gain in canonical_rows
+                if isinstance(gain, (int, float))
+            )
+        rows = [
+            [
+                source,
+                gain,
+                (
+                    float(gain) / float(share_total) * 100.0
+                    if isinstance(gain, (int, float)) and share_total
+                    else None
+                ),
+            ]
+            for source, gain in canonical_rows
+        ]
+    else:
+        sb = a.get("source_breakdown") or {}
+        total_v = sb.get("validated_total_pct")
+        rows = [
+            ["explore", sb.get("explore_pct_of_total"), sb.get("explore_share_pct")],
+            [
+                "replay_warm_recipe",
+                sb.get("replay_warm_recipe_pct_of_total"),
+                sb.get("replay_warm_recipe_share_pct"),
+            ],
+            ["backends", sb.get("backends_pct_of_total"), sb.get("backends_share_pct")],
+            ["params", sb.get("params_pct_of_total"), sb.get("params_share_pct")],
+            ["sweep", sb.get("sweep_pct_of_total"), sb.get("sweep_share_pct")],
+            ["geak", sb.get("geak_pct_of_total"), sb.get("geak_share_pct")],
+        ]
 
     facts: list[str] = []
     if total_v is not None:

--- a/src/hyperloom/inference_optimizer/breakdown/reporters/_renderers/optimizations.py
+++ b/src/hyperloom/inference_optimizer/breakdown/reporters/_renderers/optimizations.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Canonical optimization renderer."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..base import Decision, RenderedSection, fmt_pct, md_table, register_renderer
+
+
+@register_renderer("optimizations")
+def render(breakdown: dict[str, Any]) -> RenderedSection:
+    """Render adopted optimizations from the single canonical read model."""
+
+    optimizations = breakdown.get("optimizations") or {}
+    entries = [
+        entry
+        for entry in optimizations.get("entries") or []
+        if isinstance(entry, dict)
+    ]
+    summary = optimizations.get("summary_by_source") or {}
+    rows: list[list[Any]] = []
+    decisions: list[Decision] = []
+    for source, bucket in summary.items():
+        if not isinstance(bucket, dict):
+            continue
+        keeps = int(bucket.get("keeps") or 0)
+        gain = bucket.get("total_gain_pct")
+        rows.append([source, keeps, gain])
+        if keeps > 0:
+            decisions.append(
+                Decision(
+                    kind="kept",
+                    subject=f"optimizations:{source}",
+                    metric_pct=float(gain or 0.0),
+                    rationale=f"{keeps} validated optimization(s)",
+                )
+            )
+
+    facts = [
+        f"{len(entries)} adopted optimization entr"
+        f"{'y' if len(entries) == 1 else 'ies'} recorded."
+    ]
+    validated = [entry for entry in entries if entry.get("validated") is True]
+    facts.append(f"{len(validated)} entr{'y is' if len(validated) == 1 else 'ies are'} validated.")
+    positive = [
+        bucket
+        for bucket in summary.values()
+        if isinstance(bucket, dict) and bucket.get("total_gain_pct")
+    ]
+    if positive:
+        facts.append(
+            "Validated gain represented in canonical source summaries: "
+            + fmt_pct(
+                sum(float(bucket.get("total_gain_pct") or 0.0) for bucket in positive),
+                plus=True,
+            )
+            + "."
+        )
+
+    return RenderedSection(
+        section_id="optimizations",
+        title="Adopted Optimizations",
+        key_facts=facts,
+        markdown_block=md_table(
+            ["source", "validated_keeps", "total_gain_pct"],
+            rows,
+        ),
+        decisions=decisions,
+        warnings=[],
+        skipped=not entries,
+    )
+

--- a/src/hyperloom/inference_optimizer/breakdown/reporters/compose.py
+++ b/src/hyperloom/inference_optimizer/breakdown/reporters/compose.py
@@ -35,6 +35,7 @@ from ._renderers import (  # noqa: F401  (side-effect imports)
     sweep as _r_sweep,
     critic_robustness as _r_critic_robustness,
     attribution as _r_attribution,
+    optimizations as _r_optimizations,
     source_files as _r_source_files,
     data_provenance as _r_data_provenance,
 )
@@ -43,7 +44,7 @@ from ._renderers import (  # noqa: F401  (side-effect imports)
 # Final report layout ``(group_title, [section_id, ...])``. ``telemetry`` is dropped.
 SECTION_GROUPS: list[tuple[str, list[str]]] = [
     ("Session & Workload", ["session", "workload"]),
-    ("Performance Results", ["baseline", "final", "roofline", "attribution"]),
+    ("Performance Results", ["baseline", "final", "roofline", "optimizations"]),
     ("Capability Search", ["capability_summary", "param_search", "decision_journal", "sweep"]),
     (
         "Kernel Optimization",
@@ -51,8 +52,6 @@ SECTION_GROUPS: list[tuple[str, list[str]]] = [
             "kernel_lifecycle",
             "kernel_profiling",
             "kernel_decision_path",
-            "geak_invocations",
-            "forge_invocations",
             "critic_robustness",
         ],
     ),
@@ -81,6 +80,7 @@ __all__ = [
     "_r_sweep",
     "_r_critic_robustness",
     "_r_attribution",
+    "_r_optimizations",
     "_r_source_files",
     "_r_data_provenance",
 ]

--- a/src/hyperloom/inference_optimizer/breakdown/reporters/cross_section.py
+++ b/src/hyperloom/inference_optimizer/breakdown/reporters/cross_section.py
@@ -85,6 +85,7 @@ def _gain_attribution_lines(
     """
     optimizations = breakdown.get("optimizations") or {}
     summary = optimizations.get("summary_by_source") or {}
+    validation = optimizations.get("validation") or {}
     canonical_sources = {
         source: to_float(bucket.get("total_gain_pct"))
         for source, bucket in summary.items()
@@ -106,7 +107,8 @@ def _gain_attribution_lines(
                 key=lambda item: -item[1],
             )
         ]
-        return lines, "canonical optimizations"
+        method = validation.get("method")
+        return lines, str(method) if isinstance(method, str) and method else "missing"
 
     attribution = breakdown.get("attribution") or {}
     sb = attribution.get("source_breakdown") or {}
@@ -211,8 +213,12 @@ def _data_quality_flags(
         for w in sec.warnings:
             _push(f"[{sec.section_id}] {w}")
 
-    if (breakdown.get("attribution") or {}).get("notes"):
-        for n in breakdown["attribution"]["notes"]:
+    optimizations = breakdown.get("optimizations") or {}
+    validation = optimizations.get("validation") or {}
+    attribution = breakdown.get("attribution") or {}
+    notes = validation.get("notes") or attribution.get("notes") or []
+    if notes:
+        for n in notes:
             _push(f"[attribution] {n}")
     cap = breakdown.get("capability_summary") or {}
     val = cap.get("validate_stack") or {}

--- a/src/hyperloom/inference_optimizer/breakdown/reporters/cross_section.py
+++ b/src/hyperloom/inference_optimizer/breakdown/reporters/cross_section.py
@@ -72,10 +72,9 @@ def _gain_attribution_lines(
 ) -> tuple[list[str], str]:
     """Compute per-source gain attribution + the method used.
 
-    Priority: validated ``source_breakdown`` split. When that is absent we do
-    NOT reverse-infer a KEEP from ``final.action_path`` / ``optimization_stack``
-    (those can be seeded, not real this-session KEEPs); the gain is reported as
-    ``unattributed`` with stack entries listed for reference only.
+    Priority: canonical ``optimizations.summary_by_source``. Legacy
+    ``attribution.source_breakdown`` remains a read-only fallback for archived
+    breakdowns supplied directly to the reporter.
 
     Args:
         breakdown: The full ``session_breakdown.json`` dict.
@@ -84,6 +83,31 @@ def _gain_attribution_lines(
         A tuple of the human-readable attribution lines and a label
         describing the method used to derive them.
     """
+    optimizations = breakdown.get("optimizations") or {}
+    summary = optimizations.get("summary_by_source") or {}
+    canonical_sources = {
+        source: to_float(bucket.get("total_gain_pct"))
+        for source, bucket in summary.items()
+        if isinstance(bucket, dict)
+    }
+    canonical_nonzero = {
+        source: gain
+        for source, gain in canonical_sources.items()
+        if gain and gain != 0
+    }
+    canonical_total = sum(canonical_nonzero.values())
+    if canonical_nonzero and canonical_total:
+        lines = [
+            f"{source}: {gain:.2f}% of total "
+            f"(={(gain / canonical_total * 100):.0f}% share of "
+            f"{canonical_total:.2f}%)"
+            for source, gain in sorted(
+                canonical_nonzero.items(),
+                key=lambda item: -item[1],
+            )
+        ]
+        return lines, "canonical optimizations"
+
     attribution = breakdown.get("attribution") or {}
     sb = attribution.get("source_breakdown") or {}
     total = to_float(sb.get("validated_total_pct"))

--- a/src/hyperloom/inference_optimizer/breakdown/schema.py
+++ b/src/hyperloom/inference_optimizer/breakdown/schema.py
@@ -803,6 +803,11 @@ class KernelE2E(TypedDict, total=False):
     patch_path: str | None
     target_file: str | None
     extra_server_args: str
+    self_reported_e2e_gain_pct: float | None
+    revalidation_measured_tput: float
+    revalidation_current_best_tput: float
+    revalidation_provenance: str
+    rejection_reason: str
     ts: str
 
 

--- a/src/hyperloom/inference_optimizer/breakdown/schema.py
+++ b/src/hyperloom/inference_optimizer/breakdown/schema.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 
 from typing import Any, Literal, TypedDict
 
-#: breakdown schema version. Emitted on the legacy fallback path (no recorder fragments).
-SCHEMA_VERSION = "hyperloom.session_breakdown.v2"
+#: Historical collector-only schema retained for archived-reader identification.
+SCHEMA_VERSION_V2 = "hyperloom.session_breakdown.v2"
 
 #: breakdown schema version stamped when the file was assembled from the
 #: author-time recorder fragments. Same wire shape as v2 plus recorder-only
@@ -26,6 +26,13 @@ SCHEMA_VERSION_V3 = "hyperloom.session_breakdown.v3.0"
 #: exclusively from recorder SDK fragments and never reconstructed from session
 #: business files.
 SCHEMA_VERSION_V4 = "hyperloom.session_breakdown.v4.0"
+
+#: Unified optimization schema. This is a breaking wire-shape cutover: adopted
+#: optimizations are emitted only through ``optimizations``.
+SCHEMA_VERSION_V5 = "hyperloom.session_breakdown.v5.0"
+
+#: Current breakdown schema version.
+SCHEMA_VERSION = SCHEMA_VERSION_V5
 
 
 # Session metadata
@@ -1602,10 +1609,83 @@ class OptimizationStackEntry(TypedDict, total=False):
     fingerprint: str
     provenance: str
     task_id: str
+    source_phase: str
     # filter label for the kind of optimization (backend / param / env on
     # explore KEEPs); specialist dial.
     operation_kind: str
     scope: str
+
+
+# Canonical optimizations — single downstream read model
+OptimizationSource = Literal[
+    "warm_replay",
+    "explore",
+    "framework_agent",
+    "kernel_agent",
+    "unattributed",
+]
+OptimizationSourceMethod = Literal[
+    "recorded",
+    "phase_history_ts",
+    "action_family",
+    "unknown",
+]
+KernelOptimizationBackend = Literal["geak", "forge"]
+KernelExecutionMode = Literal["whole_pipeline", "per_kernel"]
+
+
+class OptimizationArtifact(TypedDict, total=False):
+    """One artifact attached to a canonical optimization entry."""
+
+    kind: str
+    path: str
+
+
+class OptimizationConfiguration(TypedDict, total=False):
+    """Effective serving configuration carried by one optimization."""
+
+    extra_server_args: str
+    extra_envs: dict[str, str]
+
+
+class OptimizationEntry(TypedDict, total=False):
+    """One adopted optimization, independent of its internal action name."""
+
+    id: str
+    stack_index: int
+    source: OptimizationSource
+    source_method: OptimizationSourceMethod
+    optimization_kind: str
+    name: str
+    backend: KernelOptimizationBackend | None
+    execution_mode: KernelExecutionMode | None
+    kernel_id: str | None
+    gain_pct: float | None
+    cumulative_gain_pct: float | None
+    throughput_before: float | None
+    throughput_after: float | None
+    validated: bool
+    task_id: str
+    ts: str
+    provenance: str
+    configuration: OptimizationConfiguration
+    artifacts: list[OptimizationArtifact]
+
+
+class OptimizationSourceSummary(TypedDict, total=False):
+    """Validated KEEP count and gain for one canonical source."""
+
+    keeps: int
+    total_gain_pct: float
+    by_backend: dict[str, "OptimizationSourceSummary"]
+
+
+class Optimizations(TypedDict, total=False):
+    """Canonical downstream optimization API."""
+
+    schema_version: int
+    entries: list[OptimizationEntry]
+    summary_by_source: dict[OptimizationSource, OptimizationSourceSummary]
 
 
 # GEMM tuning — fixed FP8 block-scale GEMM tuning stage that runs at KERNEL
@@ -2436,6 +2516,7 @@ class SessionBreakdownV4(TypedDict, total=False):
     operations: list[Operation]
     measurements: list[Measurement]
     adoptions: list[Adoption]
+    optimizations: Optimizations
     outcome: dict[str, Any]
     artifacts: list[ArtifactRef]
     trace: dict[str, Any]
@@ -2468,20 +2549,17 @@ class SessionBreakdown(TypedDict, total=False):
         phase_segments (list[PhaseSegment]): Phase-boundary view (M2).
         action_timeline (list[PhaseEvent]): v2 canonical flat per-action timeline.
         capability_summary (CapabilitySummary): Per-capability roll-up.
-        geak_invocations (list[Invocation]): GEAK backend invocations.
-        forge_invocations (list[Invocation]): Forge backend invocations.
         kernel_lifecycle (KernelLifecycle): Kernels grouped by lifecycle stage.
         param_search (ParamSearch): v1-reader compat alias for ``explore_search``.
         explore_search (ParamSearch): Merged explore-search ledger.
         sweep (Sweep): Concurrency/shape sweep results.
         critic_robustness (CriticRobustness): Critic reviews and robustness signals.
         telemetry (Telemetry): Telemetry artifacts and aggregated metrics.
-        attribution (Attribution): Gain attribution across stack/source/phase.
+        optimizations (Optimizations): Canonical adopted-optimization read
+            model spanning Warm Replay, Explore, Framework Agent, and Kernel
+            Agent.
         kb_provenance (KBProvenance): Recipe KB integration audit.
         specialist_runs (list[SpecialistRound]): Specialist sub-agent dispatch records.
-        optimization_stack (list[OptimizationStackEntry]): Raw KEEP ledger passthrough.
-        gemm_tuning (GemmTuning): Fixed FP8 GEMM-tuning stage, engine-tagged
-            (geak today, forge later); empty {} on non-fp8/sglang or old sessions.
         kernel_roofline (KernelRoofline): Hot-kernel table for the dashboard.
         roofline (list[dict[str, Any]]): Per-snapshot roofline comparison list for
             the markdown report's ``## Roofline`` section.
@@ -2508,24 +2586,17 @@ class SessionBreakdown(TypedDict, total=False):
     # flat-list alias for older readers.
     action_timeline: list[PhaseEvent]
     capability_summary: CapabilitySummary
-    geak_invocations: list[Invocation]
-    forge_invocations: list[Invocation]
     kernel_lifecycle: KernelLifecycle
     # explore_search is the native merged ledger; param_search is a v1 alias.
     param_search: ParamSearch
     explore_search: ParamSearch
     sweep: Sweep
-    # GEAK e2e KERNEL-phase section; ``{}`` on native sessions.
-    geak: Geak
     critic_robustness: CriticRobustness
     telemetry: Telemetry
-    attribution: Attribution
+    # Single downstream read model for every formally adopted optimization.
+    optimizations: Optimizations
     kb_provenance: KBProvenance  # Recipe KB audit
     specialist_runs: list[SpecialistRound]
-    # Raw KEEP ledger passthrough mirroring ``state.optimization_stack[]``.
-    optimization_stack: list["OptimizationStackEntry"]
-    # Fixed FP8 block-scale GEMM-tuning stage (KERNEL entry), engine-tagged; {} when absent.
-    gemm_tuning: GemmTuning
     # Hot-kernel table, mirror of ``reports/kernel_roofline.json``.
     kernel_roofline: KernelRoofline
     # Kernel-agent attempt outcome summary; empty → dashboard hides Block 1.
@@ -2555,8 +2626,10 @@ class SessionBreakdown(TypedDict, total=False):
 
 __all__ = [
     "SCHEMA_VERSION",
+    "SCHEMA_VERSION_V2",
     "SCHEMA_VERSION_V3",
     "SCHEMA_VERSION_V4",
+    "SCHEMA_VERSION_V5",
     "Adoption",
     "AdoptedKernel",
     "ArtifactRef",
@@ -2597,6 +2670,13 @@ __all__ = [
     "OperationGate",
     "OperationRelation",
     "OperationSubstep",
+    "OptimizationArtifact",
+    "OptimizationConfiguration",
+    "OptimizationEntry",
+    "Optimizations",
+    "OptimizationSource",
+    "OptimizationSourceMethod",
+    "OptimizationSourceSummary",
     "Final",
     "GpuMonitorAggregate",
     "Invocation",
@@ -2609,6 +2689,8 @@ __all__ = [
     "KernelLifecycle",
     "KernelMetadata",
     "KernelOptimizationSummary",
+    "KernelExecutionMode",
+    "KernelOptimizationBackend",
     "OptimizedKernel",
     "ParamSearch",
     "ParamSearchEntry",

--- a/src/hyperloom/inference_optimizer/breakdown/schema.py
+++ b/src/hyperloom/inference_optimizer/breakdown/schema.py
@@ -1378,6 +1378,14 @@ class WarmReplayOutcome(TypedDict, total=False):
     throughput_after: float
     warm_recipe_tier: str
     warm_recipe_conf: float
+    config_source: str
+    config_donor_tier: str
+    donor_canonical_id: str
+    donor_model: str
+    donor_session_id: str
+    donor_family_tags: list[str]
+    donor_gain_pct: float
+    donor_breakdown_link: str
     replay_task_id: str
     error_class: str
     reason: str
@@ -1660,6 +1668,11 @@ class OptimizationEntry(TypedDict, total=False):
     backend: KernelOptimizationBackend | None
     execution_mode: KernelExecutionMode | None
     kernel_id: str | None
+    adopted_attempt_id: str | None
+    action: str
+    variant_name: str
+    fingerprint: str
+    scope: str
     gain_pct: float | None
     cumulative_gain_pct: float | None
     throughput_before: float | None
@@ -1680,12 +1693,48 @@ class OptimizationSourceSummary(TypedDict, total=False):
     by_backend: dict[str, "OptimizationSourceSummary"]
 
 
+class OptimizationBackendAttempt(TypedDict, total=False):
+    """One ordered backend attempt, including non-adopted outcomes."""
+
+    attempt_id: str
+    run_id: str
+    kernel_id: str
+    backend: str
+    decision: str
+    sequence: int
+    ts: str
+    duration_sec: float | None
+    micro_speedup: float | None
+    compile_passed: bool | None
+    correctness_passed: bool | None
+    error_class: str | None
+    error: str | None
+    result_path: str | None
+    verification_path: str | None
+
+
+class OptimizationValidation(TypedDict, total=False):
+    """Attribution trust, reconciliation, and diagnostic metadata."""
+
+    method: str
+    validated_total_gain_pct: float | None
+    attributed_total_gain_pct: float
+    attribution_gap_pct: float | None
+    notes: list[str]
+    phase_breakdown: dict[str, Any]
+    domain_attribution: dict[str, Any]
+
+
 class Optimizations(TypedDict, total=False):
     """Canonical downstream optimization API."""
 
     schema_version: int
     entries: list[OptimizationEntry]
+    backend_attempts: list[OptimizationBackendAttempt]
     summary_by_source: dict[OptimizationSource, OptimizationSourceSummary]
+    summary_by_kind: dict[str, OptimizationSourceSummary]
+    validation: OptimizationValidation
+    gemm_tuning_runs: list["GemmTuningRun"]
 
 
 # GEMM tuning — fixed FP8 block-scale GEMM tuning stage that runs at KERNEL
@@ -1734,6 +1783,9 @@ class GemmTuningRun(TypedDict, total=False):
     decision: str
     source: str
     ts: str
+    duration_sec: float | None
+    error_class: str
+    error: str
     precision: str
     framework: str
     gpu_type: str
@@ -1751,6 +1803,8 @@ class GemmTuningRun(TypedDict, total=False):
     workspace: str
     adopted: bool
     summary: dict[str, Any]
+    parameters: dict[str, Any]
+    candidates: list[dict[str, Any]]
     shapes: list[dict[str, Any]]
 
 
@@ -2671,12 +2725,14 @@ __all__ = [
     "OperationRelation",
     "OperationSubstep",
     "OptimizationArtifact",
+    "OptimizationBackendAttempt",
     "OptimizationConfiguration",
     "OptimizationEntry",
     "Optimizations",
     "OptimizationSource",
     "OptimizationSourceMethod",
     "OptimizationSourceSummary",
+    "OptimizationValidation",
     "Final",
     "GpuMonitorAggregate",
     "Invocation",

--- a/src/hyperloom/inference_optimizer/breakdown/schema.py
+++ b/src/hyperloom/inference_optimizer/breakdown/schema.py
@@ -1622,6 +1622,9 @@ class OptimizationStackEntry(TypedDict, total=False):
     # explore KEEPs); specialist dial.
     operation_kind: str
     scope: str
+    accepted_heads: list[Any]
+    extra_server_args_is_invariant: bool
+    candidate_flags: Any
 
 
 # Canonical optimizations — single downstream read model
@@ -1673,6 +1676,11 @@ class OptimizationEntry(TypedDict, total=False):
     variant_name: str
     fingerprint: str
     scope: str
+    source_phase: str
+    gain_method: str
+    accepted_heads: list[Any]
+    extra_server_args_is_invariant: bool | None
+    candidate_flags: Any
     gain_pct: float | None
     cumulative_gain_pct: float | None
     throughput_before: float | None
@@ -1717,10 +1725,12 @@ class OptimizationValidation(TypedDict, total=False):
     """Attribution trust, reconciliation, and diagnostic metadata."""
 
     method: str
+    validated_at_stack_len: int
     validated_total_gain_pct: float | None
     attributed_total_gain_pct: float
     attribution_gap_pct: float | None
     notes: list[str]
+    source_breakdown: dict[str, float]
     phase_breakdown: dict[str, Any]
     domain_attribution: dict[str, Any]
 

--- a/src/hyperloom/inference_optimizer/tests/test_breakdown_v4_core.py
+++ b/src/hyperloom/inference_optimizer/tests/test_breakdown_v4_core.py
@@ -41,6 +41,7 @@ from hyperloom.inference_optimizer.breakdown.schema import (
     ArtifactRef,
     Measurement,
     SCHEMA_VERSION_V4,
+    SCHEMA_VERSION_V5,
     Operation,
     SessionBreakdownV4,
 )
@@ -105,7 +106,7 @@ def test_v4_missing_streams_are_unavailable_and_poison_files_are_ignored(tmp_pat
     monkeypatch.setattr(exporter, "collectors", RejectCollectors())
     out = exporter.build_v4_live(tmp_path)
 
-    assert out["schema_version"] == SCHEMA_VERSION_V4
+    assert out["schema_version"] == SCHEMA_VERSION_V5
     assert out["operations"] == []
     assert out["measurements"] == []
     assert out["artifacts"] == []
@@ -281,11 +282,15 @@ def test_write_breakdown_json_uses_v4_feature_flag(tmp_path, monkeypatch):
     record_operation(tmp_path, operation_id="op-flag", status="succeeded")
     monkeypatch.setenv("INFERENCE_OPTIMIZER_BREAKDOWN_V4", "1")
     target = exporter.write_breakdown_json(tmp_path)
-    assert json.loads(target.read_text())["schema_version"] == SCHEMA_VERSION_V4
+    flagged = json.loads(target.read_text())
+    assert flagged["schema_version"] == SCHEMA_VERSION_V5
+    assert "run" in flagged
 
     monkeypatch.delenv("INFERENCE_OPTIMIZER_BREAKDOWN_V4")
     target = exporter.write_breakdown_json(tmp_path)
-    assert json.loads(target.read_text())["schema_version"] != SCHEMA_VERSION_V4
+    fallback = json.loads(target.read_text())
+    assert fallback["schema_version"] == SCHEMA_VERSION_V5
+    assert "session" in fallback
 
 
 def test_v4_helpers_reject_invalid_producer_without_raising(tmp_path):
@@ -478,7 +483,7 @@ def test_v4_state_snapshot_does_not_infer_canonical_entities_from_stack(tmp_path
     assert out["measurements"] == []
     assert out["artifacts"] == []
     assert out["adoptions"] == []
-    assert out["optimization_stack"] == []
+    assert out["optimizations"]["entries"] == []
     assert len(assemble_parts(tmp_path)["optimization_stack"]) == 3
 
 
@@ -629,7 +634,8 @@ def test_v4_geak_final_validation_creates_validated_adoption(tmp_path):
     )
     assert final["value"] == 111.0
     assert final["metric_basis"] == "output"
-    assert out["geak"]["final_validation_precedence"] == "orchestrator_final_validation"
+    assert out["optimizations"]["entries"][0]["source"] == "kernel_agent"
+    assert out["optimizations"]["entries"][0]["backend"] == "geak"
 
 
 def test_v4_forge_operation_carries_correctness_evidence(tmp_path):
@@ -726,8 +732,9 @@ def test_v4_gemm_adoption_is_keep_only(tmp_path):
     assert [adoption["decision"] for adoption in keep["adoptions"]] == ["KEEP"]
     assert revert["adoptions"][0]["status"] == "revoked"
     assert revert["adoptions"][0]["validated"] is False
-    assert revert["optimization_stack"] == []
-    assert keep["gemm_tuning"]["operations"][0].get("parent_operation_id") is None
+    assert revert["optimizations"]["entries"] == []
+    assert keep["optimizations"]["entries"][0]["backend"] == "forge"
+    assert keep["optimizations"]["entries"][0]["optimization_kind"] == "gemm_tuning"
 
 
 def test_v4_kernel_keep_then_revert_revokes_adoption(tmp_path):
@@ -762,8 +769,11 @@ def test_v4_kernel_keep_then_revert_revokes_adoption(tmp_path):
     assert out["adoptions"][0]["status"] == "revoked"
     assert out["adoptions"][0]["decision"] == "REVERT"
     assert out["adoptions"][0]["validated"] is False
-    assert out["optimization_stack"] == []
-    assert out["attribution"]["by_strategy"] == {}
+    assert out["optimizations"]["entries"] == []
+    assert all(
+        summary["keeps"] == 0
+        for summary in out["optimizations"]["summary_by_source"].values()
+    )
 
 
 def test_v4_warm_replay_keep_then_revert_revokes_same_adoption(tmp_path):
@@ -803,7 +813,7 @@ def test_v4_warm_replay_keep_then_revert_revokes_same_adoption(tmp_path):
     assert len(out["adoptions"]) == 1
     assert out["adoptions"][0]["status"] == "revoked"
     assert out["adoptions"][0]["validated"] is False
-    assert out["optimization_stack"] == []
+    assert out["optimizations"]["entries"] == []
 
 
 def test_v4_geak_final_validation_failure_revokes_prior_keep(tmp_path):
@@ -844,7 +854,7 @@ def test_v4_geak_final_validation_failure_revokes_prior_keep(tmp_path):
     assert len(out["adoptions"]) == 1
     assert out["adoptions"][0]["status"] == "revoked"
     assert out["adoptions"][0]["validated"] is False
-    assert out["optimization_stack"] == []
+    assert out["optimizations"]["entries"] == []
 
 
 def test_v4_gemm_micro_keep_is_provisional_until_e2e_keep(tmp_path):

--- a/src/hyperloom/inference_optimizer/tests/test_breakdown_v4_core.py
+++ b/src/hyperloom/inference_optimizer/tests/test_breakdown_v4_core.py
@@ -693,6 +693,15 @@ def test_v4_forge_operation_carries_correctness_evidence(tmp_path):
     )
     assert operation["parent_operation_id"] == native_route["operation_id"]
     assert operation["attempts"][0]["outputs"]["correctness_source"] == "generated_harness"
+    assert out["optimizations"]["backend_attempts"][0]["attempt_id"] == "attempt-1"
+    assert out["optimizations"]["backend_attempts"][0]["kernel_id"] == "k001"
+    assert out["optimizations"]["backend_attempts"][0]["backend"] == "forge"
+    assert out["optimizations"]["backend_attempts"][0]["micro_speedup"] == 1.25
+    assert out["optimizations"]["backend_attempts"][0]["compile_passed"] is True
+    assert (
+        out["optimizations"]["backend_attempts"][0]["correctness_passed"]
+        is True
+    )
     gate_names = {gate["name"] for gate in operation["gates"]}
     assert {"compile", "correctness", "kernel_verification"} <= gate_names
     measurement = next(item for item in out["measurements"] if item["name"] == "micro_speedup")
@@ -735,6 +744,10 @@ def test_v4_gemm_adoption_is_keep_only(tmp_path):
     assert revert["optimizations"]["entries"] == []
     assert keep["optimizations"]["entries"][0]["backend"] == "forge"
     assert keep["optimizations"]["entries"][0]["optimization_kind"] == "gemm_tuning"
+    assert keep["optimizations"]["gemm_tuning_runs"][0]["engine"] == "forge"
+    assert keep["optimizations"]["gemm_tuning_runs"][0]["adopted"] is True
+    assert keep["optimizations"]["validation"]["method"] == "validated"
+    assert keep["optimizations"]["validation"]["validated_total_gain_pct"] == 5.0
 
 
 def test_v4_kernel_keep_then_revert_revokes_adoption(tmp_path):

--- a/src/hyperloom/inference_optimizer/tests/test_geak_breakdown_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_breakdown_unit.py
@@ -510,17 +510,18 @@ def test_parse_isl_osl() -> None:
     assert _parse_isl_osl("") == (1024, 1024)
 
 
-def test_schema_has_geak_contract() -> None:
-    # The wire schema must declare the top-level ``geak`` section the exporter emits.
+def test_schema_has_optimizations_contract() -> None:
+    # V5 exposes adopted GEAK results through the canonical optimizations section.
     from hyperloom.inference_optimizer.breakdown import schema
 
-    assert hasattr(schema, "Geak")
-    assert "geak" in schema.SessionBreakdown.__annotations__
+    assert hasattr(schema, "Optimizations")
+    assert "optimizations" in schema.SessionBreakdown.__annotations__
     # ``from __future__ import annotations`` stores the type as a string ref.
-    assert "Geak" in str(schema.SessionBreakdown.__annotations__["geak"])
+    assert "Optimizations" in str(schema.SessionBreakdown.__annotations__["optimizations"])
+    assert "geak" not in schema.SessionBreakdown.__annotations__
     # A few representative fields must be part of the declared shape.
-    for field in ("engaged", "status", "error_class", "throughput_speedup", "accepted_kernels"):
-        assert field in schema.Geak.__annotations__
+    for field in ("entries", "backend_attempts", "summary_by_source", "validation"):
+        assert field in schema.Optimizations.__annotations__
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/inference_optimizer/tests/test_geak_gain_alignment.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_gain_alignment.py
@@ -18,10 +18,12 @@ consistent with GEAK's own e2e speedup:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
+from hyperloom.inference_optimizer.breakdown.recorder import assemble_parts
 from hyperloom.inference_optimizer.breakdown.reporters._renderers.final import render as render_final
 from hyperloom.orchestrator.loop.coordinator import Coordinator
 from hyperloom.orchestrator.loop.coordinator_helpers import (
@@ -240,6 +242,30 @@ async def test_geak_harness_fallback_no_promote_below_current_best(
         "validated_regimes": [{"isl": 1024, "osl": 1024, "conc": 64}],
         "alignment_metrics": {"cold_geak_speedup": 1.088, "final_basis": "cold"},
     }
+    journey_path = tmp_path / "kernel_journey.json"
+    journey_path.write_text(
+        json.dumps(
+            {
+                "kernels": [
+                    {
+                        "kernel_id": "candidate-kernel",
+                        "e2e": {
+                            "integrated": True,
+                            "e2e_gain_pct": 1.686,
+                            "validated": True,
+                            "decision": "KEEP",
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    coord.shared_state.geak_result["kernel_journey_path"] = str(journey_path)
+    coord._record_geak_kernel_journey(coord.shared_state.geak_result)
+    provisional = assemble_parts(tmp_path)["kernel_journey"]["kernels"][0]["e2e"]
+    assert provisional["decision"] == "KEEP"
+    assert provisional["validated"] is True
 
     async def _fake_sweep(**_kwargs):
         return {"status": "succeeded", "best_for_each_conc": {"64": {"output_throughput": measured}}}
@@ -256,6 +282,19 @@ async def test_geak_harness_fallback_no_promote_below_current_best(
     assert not any(e.get("action") == "geak_e2e" for e in ss.optimization_stack)
     assert ss.cumulative_gain_validated == pytest.approx(0.0)
     assert not ss.geak_pending
+    rejected = assemble_parts(tmp_path)
+    e2e = rejected["kernel_journey"]["kernels"][0]["e2e"]
+    assert e2e["decision"] == "REVERT"
+    assert e2e["validated"] is False
+    assert e2e["integrated"] is False
+    assert e2e["e2e_gain_pct"] is None
+    assert e2e["self_reported_e2e_gain_pct"] == pytest.approx(1.686)
+    assert e2e["revalidation_measured_tput"] == pytest.approx(measured)
+    assert e2e["revalidation_current_best_tput"] == pytest.approx(current_best)
+    assert e2e["rejection_reason"] == "rebench_did_not_beat_current_best"
+    adoption = rejected["adoptions"][0]
+    assert adoption["decision"] == "REVERT"
+    assert adoption["validated"] is False
 
 
 # ── Fix B: report renders a PROVISIONAL gain honestly (not "+0.00% validated") ─

--- a/src/hyperloom/inference_optimizer/tests/test_geak_gain_alignment.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_gain_alignment.py
@@ -255,7 +255,16 @@ async def test_geak_harness_fallback_no_promote_below_current_best(
                             "validated": True,
                             "decision": "KEEP",
                         },
-                    }
+                    },
+                    {
+                        "kernel_id": "already-reverted",
+                        "e2e": {
+                            "integrated": False,
+                            "e2e_gain_pct": -1.0,
+                            "validated": False,
+                            "decision": "REVERT",
+                        },
+                    },
                 ]
             }
         ),
@@ -263,7 +272,11 @@ async def test_geak_harness_fallback_no_promote_below_current_best(
     )
     coord.shared_state.geak_result["kernel_journey_path"] = str(journey_path)
     coord._record_geak_kernel_journey(coord.shared_state.geak_result)
-    provisional = assemble_parts(tmp_path)["kernel_journey"]["kernels"][0]["e2e"]
+    provisional_rows = {
+        row["kernel_id"]: row
+        for row in assemble_parts(tmp_path)["kernel_journey"]["kernels"]
+    }
+    provisional = provisional_rows["candidate-kernel"]["e2e"]
     assert provisional["decision"] == "KEEP"
     assert provisional["validated"] is True
 
@@ -283,7 +296,10 @@ async def test_geak_harness_fallback_no_promote_below_current_best(
     assert ss.cumulative_gain_validated == pytest.approx(0.0)
     assert not ss.geak_pending
     rejected = assemble_parts(tmp_path)
-    e2e = rejected["kernel_journey"]["kernels"][0]["e2e"]
+    rejected_rows = {
+        row["kernel_id"]: row for row in rejected["kernel_journey"]["kernels"]
+    }
+    e2e = rejected_rows["candidate-kernel"]["e2e"]
     assert e2e["decision"] == "REVERT"
     assert e2e["validated"] is False
     assert e2e["integrated"] is False
@@ -292,6 +308,19 @@ async def test_geak_harness_fallback_no_promote_below_current_best(
     assert e2e["revalidation_measured_tput"] == pytest.approx(measured)
     assert e2e["revalidation_current_best_tput"] == pytest.approx(current_best)
     assert e2e["rejection_reason"] == "rebench_did_not_beat_current_best"
+    untouched = rejected_rows["already-reverted"]["e2e"]
+    assert untouched["decision"] == "REVERT"
+    assert untouched["e2e_gain_pct"] == pytest.approx(-1.0)
+    assert "rejection_reason" not in untouched
+
+    coord.phase_kernel._reject_geak_kernel_journey(
+        coord.shared_state.geak_result,
+        measured_tput=measured,
+        current_best_tput=current_best,
+        provenance="geak_same_harness_geak",
+    )
+    repeated = assemble_parts(tmp_path)["kernel_journey"]["kernels"]
+    assert len(repeated) == 2
     adoption = rejected["adoptions"][0]
     assert adoption["decision"] == "REVERT"
     assert adoption["validated"] is False

--- a/src/hyperloom/inference_optimizer/tests/test_kb_unified_interface.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kb_unified_interface.py
@@ -222,12 +222,22 @@ def test_recipe_is_actionable() -> None:
 
 def test_build_warm_start_context_hit() -> None:
     recipe = {
+        "canonical_id": "inference:donor:h:f:v:p",
+        "model": "donor-model",
+        "family_tags": ["moe", "mla"],
         "best_config": {
             "extra_server_args": "--cuda-graph-max-bs 256",
             "extra_envs": {"FOO": "1"},
         },
         "best_throughput": 5430.9,
         "validated_gain_pct": 7.8,
+        "sessions": [
+            {
+                "session_id": "donor-session",
+                "gain_pct": 7.8,
+                "breakdown_link": "https://example.test/session/donor-session",
+            }
+        ],
         "what_worked": [{"id": "w1"}],
         "what_failed": [{"id": "f1"}],
         "lessons": [{"attrs": {"statement": "x"}}],
@@ -246,6 +256,15 @@ def test_build_warm_start_context_hit() -> None:
     assert ctx["recommended_replay"]["extra_server_args"] == "--cuda-graph-max-bs 256"
     assert ctx["recommended_replay"]["extra_envs"] == {"FOO": "1"}
     assert ctx["recommended_replay"]["expected_gain_pct"] == 7.8
+    assert ctx["recommended_replay"]["donor_canonical_id"] == "inference:donor:h:f:v:p"
+    assert ctx["recommended_replay"]["donor_model"] == "donor-model"
+    assert ctx["recommended_replay"]["donor_session_id"] == "donor-session"
+    assert ctx["recommended_replay"]["donor_family_tags"] == ["moe", "mla"]
+    assert ctx["recommended_replay"]["donor_gain_pct"] == 7.8
+    assert (
+        ctx["recommended_replay"]["donor_breakdown_link"]
+        == "https://example.test/session/donor-session"
+    )
     assert ctx["proven_prior"] == [{"id": "w1"}]
     assert ctx["do_not_repeat"] == [{"id": "f1"}]
     assert ctx["lessons"] == [{"attrs": {"statement": "x"}}]

--- a/src/hyperloom/inference_optimizer/tests/test_reporters_smoke.py
+++ b/src/hyperloom/inference_optimizer/tests/test_reporters_smoke.py
@@ -359,6 +359,43 @@ def test_attribution_method_renders_from_field() -> None:
     assert not any("single-source" in fact and "single_source" not in fact for fact in sec.key_facts), sec.key_facts
 
 
+def test_v5_attribution_method_and_notes_render_from_validation() -> None:
+    bd = _fixture_breakdown()
+    bd.pop("attribution", None)
+    bd["optimizations"] = {
+        "entries": [
+            {
+                "id": "opt-1",
+                "source": "explore",
+                "gain_pct": 10.99,
+                "validated": True,
+            }
+        ],
+        "summary_by_source": {
+            "explore": {"keeps": 1, "total_gain_pct": 10.99},
+        },
+        "validation": {
+            "method": "reconstructed",
+            "validated_total_gain_pct": 10.99,
+            "notes": ["gain ledger reconstructed from throughput"],
+        },
+    }
+
+    r = render_session_report(bd)
+
+    assert r.global_facts.attribution_method == "reconstructed"
+    assert any(
+        "gain ledger reconstructed from throughput" in flag
+        for flag in r.global_facts.data_quality_flags
+    )
+    sec = next(s for s in r.sections if s.section_id == "attribution")
+    assert any("reconstructed" in fact for fact in sec.key_facts)
+    assert any(
+        "gain ledger reconstructed from throughput" in fact
+        for fact in sec.key_facts
+    )
+
+
 def test_invocation_section_renders_when_present() -> None:
     """Baseline/final renderers surface an ``### Invocation`` block; secret-shaped envs are filtered out."""
     bd = _fixture_breakdown()

--- a/src/hyperloom/inference_optimizer/tests/test_reporters_smoke.py
+++ b/src/hyperloom/inference_optimizer/tests/test_reporters_smoke.py
@@ -133,6 +133,7 @@ def test_all_renderers_register_in_stable_order() -> None:
         "sweep",
         "critic_robustness",
         "attribution",
+        "optimizations",
         "source_files",
         "data_provenance",
     ]

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py
@@ -60,7 +60,8 @@ def test_collect_optimizations_unifies_warm_framework_and_explore():
         "explore",
     ]
     assert [entry["gain_pct"] for entry in result["entries"]] == [50.0, 10.0, 10.0]
-    assert "action" not in result["entries"][1]
+    assert result["entries"][1]["action"] == "integrate_patch"
+    assert result["entries"][1]["variant_name"] == "framework-patch"
     assert result["entries"][1]["optimization_kind"] == "framework_patch"
     assert result["entries"][2]["optimization_kind"] == "env"
     summary = result["summary_by_source"]
@@ -73,6 +74,7 @@ def test_collect_optimizations_splits_kernel_backend():
     state = {
         "session_id": "s2",
         "baseline_tput": 100.0,
+        "cumulative_gain_validated": 20.0,
         "cumulative_gain_validated_stack_len": 2,
         "optimization_stack": [
             {
@@ -95,16 +97,104 @@ def test_collect_optimizations_splits_kernel_backend():
         "phase_history": [{"to_phase": "KERNEL_AGENT", "ts_unix": 0.0}],
     }
     attribution = collect_attribution(state, [], [], [])
+    geak_invocations = [
+        {
+            "attempt_id": "geak-failed",
+            "kernel_id": "k0",
+            "backend": "geak",
+            "decision": "FAILED",
+            "ts": "1970-01-01T00:00:05+00:00",
+            "duration_sec": 3.0,
+            "error_class": "CompileError",
+            "error": "compile failed",
+        }
+    ]
+    forge_invocations = [
+        {
+            "attempt_id": "forge-kept",
+            "kernel_id": "k1",
+            "backend": "forge",
+            "decision": "KEEP",
+            "ts": "1970-01-01T00:00:15+00:00",
+            "elapsed_sec": 7.5,
+        }
+    ]
 
-    result = collect_optimizations(state, attribution, [], [], [])
+    result = collect_optimizations(
+        state,
+        attribution,
+        geak_invocations,
+        forge_invocations,
+        [],
+        gemm_tuning={
+            "runs": [
+                {
+                    "engine": "forge",
+                    "status": "succeeded",
+                    "decision": "KEEP",
+                    "adopted": True,
+                }
+            ]
+        },
+    )
 
     assert result["entries"][0]["backend"] == "geak"
     assert result["entries"][0]["execution_mode"] == "whole_pipeline"
     assert result["entries"][1]["backend"] == "forge"
     assert result["entries"][1]["execution_mode"] == "per_kernel"
+    assert result["entries"][1]["adopted_attempt_id"] == "forge-kept"
+    assert result["backend_attempts"] == [
+        {
+            "attempt_id": "geak-failed",
+            "run_id": "",
+            "kernel_id": "k0",
+            "backend": "geak",
+            "decision": "FAILED",
+            "ts": "1970-01-01T00:00:05+00:00",
+            "duration_sec": 3.0,
+            "micro_speedup": None,
+            "compile_passed": None,
+            "correctness_passed": None,
+            "error_class": "CompileError",
+            "error": "compile failed",
+            "result_path": None,
+            "verification_path": None,
+            "sequence": 1,
+        },
+        {
+            "attempt_id": "forge-kept",
+            "run_id": "",
+            "kernel_id": "k1",
+            "backend": "forge",
+            "decision": "KEEP",
+            "ts": "1970-01-01T00:00:15+00:00",
+            "duration_sec": 7.5,
+            "micro_speedup": None,
+            "compile_passed": None,
+            "correctness_passed": None,
+            "error_class": None,
+            "error": None,
+            "result_path": None,
+            "verification_path": None,
+            "sequence": 1,
+        },
+    ]
     by_backend = result["summary_by_source"]["kernel_agent"]["by_backend"]
     assert by_backend["geak"] == {"keeps": 1, "total_gain_pct": 10.0}
     assert by_backend["forge"] == {"keeps": 1, "total_gain_pct": 10.0}
+    assert result["summary_by_kind"]["gemm_tuning"] == {
+        "keeps": 1,
+        "total_gain_pct": 10.0,
+        "by_backend": {
+            "geak": {"keeps": 0, "total_gain_pct": 0.0},
+            "forge": {"keeps": 1, "total_gain_pct": 10.0},
+            "unattributed": {"keeps": 0, "total_gain_pct": 0.0},
+        },
+    }
+    assert result["validation"]["method"] == "reconstructed"
+    assert result["validation"]["validated_total_gain_pct"] == 20.0
+    assert result["validation"]["attribution_gap_pct"] == 0.0
+    assert result["gemm_tuning_runs"][0]["engine"] == "forge"
 
 
 def test_collect_optimizations_excludes_non_optimization_stack_anchors():
@@ -146,6 +236,7 @@ def test_exporter_emits_canonical_optimizations(tmp_path):
     state = {
         "session_id": "export",
         "baseline_tput": 100.0,
+        "cumulative_gain_validated": 10.0,
         "cumulative_gain_validated_stack_len": 1,
         "optimization_stack": [
             {
@@ -156,6 +247,18 @@ def test_exporter_emits_canonical_optimizations(tmp_path):
             }
         ],
         "gain_per_stack_entry": [10.0],
+        "gemm_tuning_attempts": [
+            {
+                "engine": "geak",
+                "status": "failed",
+                "decision": "FAILED",
+                "duration_sec": 4.5,
+                "error_class": "TuningError",
+                "error": "no valid candidate",
+                "parameters": {"libtype": "ck"},
+                "candidates": [{"name": "candidate-1", "status": "eliminated"}],
+            }
+        ],
     }
     (tmp_path / "state.json").write_text(json.dumps(state), encoding="utf-8")
     (tmp_path / "manifest.json").write_text("{}", encoding="utf-8")
@@ -163,8 +266,17 @@ def test_exporter_emits_canonical_optimizations(tmp_path):
     result = exporter.build(tmp_path)
 
     assert result["schema_version"] == "hyperloom.session_breakdown.v5.0"
-    assert result["optimizations"]["schema_version"] == 1
+    assert result["optimizations"]["schema_version"] == 2
     assert result["optimizations"]["entries"][0]["source"] == "warm_replay"
+    assert result["optimizations"]["validation"]["validated_total_gain_pct"] == 10.0
+    assert result["optimizations"]["gemm_tuning_runs"][0]["duration_sec"] == 4.5
+    assert result["optimizations"]["gemm_tuning_runs"][0]["error_class"] == "TuningError"
+    assert result["optimizations"]["gemm_tuning_runs"][0]["parameters"] == {
+        "libtype": "ck"
+    }
+    assert result["optimizations"]["gemm_tuning_runs"][0]["candidates"] == [
+        {"name": "candidate-1", "status": "eliminated"}
+    ]
     assert "optimization_stack" not in result
     assert "attribution" not in result
     assert "geak_invocations" not in result

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py
@@ -90,6 +90,10 @@ def test_collect_optimizations_splits_kernel_backend():
                 "tput": 120.0,
                 "backend": "forge",
                 "kernel_id": "k1",
+                "source_phase": "KERNEL_AGENT",
+                "accepted_heads": ["mla"],
+                "extra_server_args_is_invariant": True,
+                "candidate_flags": {"fast_math": True},
                 "ts": "1970-01-01T00:00:20+00:00",
             },
         ],
@@ -143,6 +147,11 @@ def test_collect_optimizations_splits_kernel_backend():
     assert result["entries"][1]["backend"] == "forge"
     assert result["entries"][1]["execution_mode"] == "per_kernel"
     assert result["entries"][1]["adopted_attempt_id"] == "forge-kept"
+    assert result["entries"][1]["source_phase"] == "KERNEL_AGENT"
+    assert result["entries"][1]["gain_method"] == "legacy_ledger_derived"
+    assert result["entries"][1]["accepted_heads"] == ["mla"]
+    assert result["entries"][1]["extra_server_args_is_invariant"] is True
+    assert result["entries"][1]["candidate_flags"] == {"fast_math": True}
     assert result["backend_attempts"] == [
         {
             "attempt_id": "geak-failed",
@@ -194,6 +203,7 @@ def test_collect_optimizations_splits_kernel_backend():
     assert result["validation"]["method"] == "reconstructed"
     assert result["validation"]["validated_total_gain_pct"] == 20.0
     assert result["validation"]["attribution_gap_pct"] == 0.0
+    assert result["validation"]["validated_at_stack_len"] == 2
     assert result["gemm_tuning_runs"][0]["engine"] == "forge"
 
 
@@ -202,11 +212,13 @@ def test_collect_optimizations_excludes_non_optimization_stack_anchors():
         "session_id": "anchors",
         "optimization_stack": [
             {"action": "baseline", "tput": 100.0},
-            {"action": "validate_stack", "tput": 110.0},
+            {"action": "sweep", "tput": 110.0},
+            {"action": "validate_stack", "tput": 115.0},
             {"action": "explore", "variant_name": "kept", "tput": 120.0},
         ],
-        "gain_per_stack_entry": [0.0, 10.0, 20.0],
-        "cumulative_gain_validated_stack_len": 3,
+        "gain_per_stack_entry": [0.0, 10.0, 15.0, 20.0],
+        "cumulative_gain_validated": 20.0,
+        "cumulative_gain_validated_stack_len": 4,
         "phase_history": [{"to_phase": "EXPLORE", "ts_unix": 0.0}],
     }
     attribution = collect_attribution(state, [], [], [])
@@ -214,6 +226,68 @@ def test_collect_optimizations_excludes_non_optimization_stack_anchors():
     result = collect_optimizations(state, attribution, [], [], [])
 
     assert [entry["name"] for entry in result["entries"]] == ["kept"]
+    assert result["validation"]["source_breakdown"]["sweep_gain_pct"] == 10.0
+
+
+def test_collect_optimizations_generates_stable_attempt_ids_and_rejects_ambiguous_keep():
+    state = {
+        "session_id": "stable",
+        "baseline_tput": 100.0,
+        "cumulative_gain_validated": 10.0,
+        "cumulative_gain_validated_stack_len": 1,
+        "optimization_stack": [
+            {
+                "action": "kernel_optimize",
+                "kernel_id": "k1",
+                "backend": "forge",
+                "tput": 110.0,
+            }
+        ],
+        "gain_per_stack_entry": [
+            {
+                "delta_pct": 10.0,
+                "cum_gain_after": 10.0,
+            }
+        ],
+    }
+    attribution = collect_attribution(state, [], [], [])
+
+    single = collect_optimizations(
+        state,
+        attribution,
+        [],
+        [{"kernel_id": "k1", "backend": "forge", "decision": "KEEP"}],
+        [],
+    )
+
+    generated = "stable:kernel-attempt:k1:forge:1"
+    assert single["backend_attempts"][0]["attempt_id"] == generated
+    assert single["entries"][0]["adopted_attempt_id"] == generated
+
+    warnings: list[str] = []
+    ambiguous = collect_optimizations(
+        state,
+        attribution,
+        [],
+        [
+            {
+                "attempt_id": "keep-1",
+                "kernel_id": "k1",
+                "backend": "forge",
+                "decision": "KEEP",
+            },
+            {
+                "attempt_id": "keep-2",
+                "kernel_id": "k1",
+                "backend": "forge",
+                "decision": "KEEP",
+            },
+        ],
+        warnings,
+    )
+
+    assert ambiguous["entries"][0]["adopted_attempt_id"] is None
+    assert any("multiple KEEP attempts" in warning for warning in warnings)
 
 
 def test_collect_optimizations_keeps_unknown_source_honest():

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import json
+
+from hyperloom.inference_optimizer.breakdown import exporter
+from hyperloom.inference_optimizer.breakdown.collectors import (
+    collect_attribution,
+    collect_optimizations,
+    collect_v4_optimizations,
+)
+
+
+def test_collect_optimizations_unifies_warm_framework_and_explore():
+    state = {
+        "session_id": "s1",
+        "baseline_tput": 100.0,
+        "cumulative_gain_validated": 70.0,
+        "cumulative_gain_validated_stack_len": 3,
+        "optimization_stack": [
+            {
+                "action": "replay_warm_recipe",
+                "variant_name": "warm",
+                "tput": 150.0,
+                "ts": "1970-01-01T00:00:10+00:00",
+            },
+            {
+                "action": "integrate_patch",
+                "variant_name": "framework-patch",
+                "tput": 160.0,
+                "ts": "1970-01-01T00:00:20+00:00",
+                "patch_path": "/tmp/framework.patch",
+            },
+            {
+                "action": "integrate_patch",
+                "variant_name": "explore-config",
+                "tput": 170.0,
+                "ts": "1970-01-01T00:00:30+00:00",
+                "operation_kind": "env",
+            },
+        ],
+        # Legacy cumulative ledger: the attribution collector promotes it.
+        "gain_per_stack_entry": [50.0, 60.0, 70.0],
+        "phase_history": [
+            {"to_phase": "PRELUDE", "ts_unix": 0.0},
+            {"to_phase": "FRAMEWORK_AGENT", "ts_unix": 15.0},
+            {"to_phase": "EXPLORE", "ts_unix": 25.0},
+        ],
+    }
+    warnings: list[str] = []
+    attribution = collect_attribution(state, [], [], warnings)
+
+    result = collect_optimizations(state, attribution, [], [], warnings)
+
+    assert [entry["source"] for entry in result["entries"]] == [
+        "warm_replay",
+        "framework_agent",
+        "explore",
+    ]
+    assert [entry["gain_pct"] for entry in result["entries"]] == [50.0, 10.0, 10.0]
+    assert "action" not in result["entries"][1]
+    assert result["entries"][1]["optimization_kind"] == "framework_patch"
+    assert result["entries"][2]["optimization_kind"] == "env"
+    summary = result["summary_by_source"]
+    assert summary["warm_replay"] == {"keeps": 1, "total_gain_pct": 50.0}
+    assert summary["framework_agent"] == {"keeps": 1, "total_gain_pct": 10.0}
+    assert summary["explore"] == {"keeps": 1, "total_gain_pct": 10.0}
+
+
+def test_collect_optimizations_splits_kernel_backend():
+    state = {
+        "session_id": "s2",
+        "baseline_tput": 100.0,
+        "cumulative_gain_validated_stack_len": 2,
+        "optimization_stack": [
+            {
+                "action": "geak_e2e",
+                "variant_name": "geak",
+                "tput": 110.0,
+                "source": "geak_e2e",
+                "ts": "1970-01-01T00:00:10+00:00",
+            },
+            {
+                "action": "gemm_tuning",
+                "variant_name": "forge-gemm",
+                "tput": 120.0,
+                "backend": "forge",
+                "kernel_id": "k1",
+                "ts": "1970-01-01T00:00:20+00:00",
+            },
+        ],
+        "gain_per_stack_entry": [10.0, 20.0],
+        "phase_history": [{"to_phase": "KERNEL_AGENT", "ts_unix": 0.0}],
+    }
+    attribution = collect_attribution(state, [], [], [])
+
+    result = collect_optimizations(state, attribution, [], [], [])
+
+    assert result["entries"][0]["backend"] == "geak"
+    assert result["entries"][0]["execution_mode"] == "whole_pipeline"
+    assert result["entries"][1]["backend"] == "forge"
+    assert result["entries"][1]["execution_mode"] == "per_kernel"
+    by_backend = result["summary_by_source"]["kernel_agent"]["by_backend"]
+    assert by_backend["geak"] == {"keeps": 1, "total_gain_pct": 10.0}
+    assert by_backend["forge"] == {"keeps": 1, "total_gain_pct": 10.0}
+
+
+def test_collect_optimizations_excludes_non_optimization_stack_anchors():
+    state = {
+        "session_id": "anchors",
+        "optimization_stack": [
+            {"action": "baseline", "tput": 100.0},
+            {"action": "validate_stack", "tput": 110.0},
+            {"action": "explore", "variant_name": "kept", "tput": 120.0},
+        ],
+        "gain_per_stack_entry": [0.0, 10.0, 20.0],
+        "cumulative_gain_validated_stack_len": 3,
+        "phase_history": [{"to_phase": "EXPLORE", "ts_unix": 0.0}],
+    }
+    attribution = collect_attribution(state, [], [], [])
+
+    result = collect_optimizations(state, attribution, [], [], [])
+
+    assert [entry["name"] for entry in result["entries"]] == ["kept"]
+
+
+def test_collect_optimizations_keeps_unknown_source_honest():
+    state = {
+        "session_id": "legacy",
+        "optimization_stack": [{"action": "integrate_patch", "tput": 10.0}],
+        "gain_per_stack_entry": [3.0],
+        "cumulative_gain_validated_stack_len": 1,
+    }
+    attribution = collect_attribution(state, [], [], [])
+
+    result = collect_optimizations(state, attribution, [], [], [])
+
+    assert result["entries"][0]["source"] == "unattributed"
+    assert result["entries"][0]["source_method"] == "unknown"
+    assert result["summary_by_source"]["unattributed"]["keeps"] == 1
+
+
+def test_exporter_emits_canonical_optimizations(tmp_path):
+    state = {
+        "session_id": "export",
+        "baseline_tput": 100.0,
+        "cumulative_gain_validated_stack_len": 1,
+        "optimization_stack": [
+            {
+                "action": "replay_warm_recipe",
+                "variant_name": "warm",
+                "tput": 110.0,
+                "ts": "2026-01-01T00:00:00+00:00",
+            }
+        ],
+        "gain_per_stack_entry": [10.0],
+    }
+    (tmp_path / "state.json").write_text(json.dumps(state), encoding="utf-8")
+    (tmp_path / "manifest.json").write_text("{}", encoding="utf-8")
+
+    result = exporter.build(tmp_path)
+
+    assert result["schema_version"] == "hyperloom.session_breakdown.v5.0"
+    assert result["optimizations"]["schema_version"] == 1
+    assert result["optimizations"]["entries"][0]["source"] == "warm_replay"
+    assert "optimization_stack" not in result
+    assert "attribution" not in result
+    assert "geak_invocations" not in result
+    assert "forge_invocations" not in result
+    assert "geak" not in result
+    assert "gemm_tuning" not in result
+
+
+def test_v4_optimizations_derive_from_validated_adoptions():
+    run = {"session_id": "v4"}
+    operations = [
+        {
+            "operation_id": "op1",
+            "kind": "kernel_optimization",
+            "name": "k1",
+            "phase": "KERNEL_AGENT",
+            "strategy": "kernel_agent_forge",
+            "subject": {"kind": "kernel", "name": "k1"},
+        }
+    ]
+    measurements = [
+        {
+            "measurement_id": "m1",
+            "name": "final_throughput",
+            "value": 125.0,
+        }
+    ]
+    adoptions = [
+        {
+            "adoption_id": "a1",
+            "operation_id": "op1",
+            "decision": "KEEP",
+            "validated": True,
+            "gain_pct": 25.0,
+            "measurement_ids": ["m1"],
+            "artifact_ids": ["p1"],
+            "subject": {"kind": "kernel", "name": "k1"},
+        }
+    ]
+    artifacts = [
+        {
+            "artifact_id": "p1",
+            "kind": "patch",
+            "path": "/tmp/k1.patch",
+        }
+    ]
+
+    result = collect_v4_optimizations(
+        run,
+        operations,
+        measurements,
+        adoptions,
+        artifacts,
+        [],
+    )
+
+    entry = result["entries"][0]
+    assert entry["source"] == "kernel_agent"
+    assert entry["backend"] == "forge"
+    assert entry["kernel_id"] == "k1"
+    assert entry["artifacts"] == [{"kind": "patch", "path": "/tmp/k1.patch"}]
+

--- a/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
+++ b/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
@@ -330,6 +330,12 @@ async def test_warm_replay_prefers_warm_start_context_recommended_replay(tmp_pat
             "extra_envs": {"VLLM_ROCM_USE_AITER": "1"},
             "expected_gain_pct": 25.0,
             "best_throughput": 5430.9,
+            "donor_canonical_id": "inference:donor:h:f:v:p",
+            "donor_model": "donor-model",
+            "donor_session_id": "donor-session",
+            "donor_family_tags": ["moe"],
+            "donor_gain_pct": 25.0,
+            "donor_breakdown_link": "https://example.test/session/donor-session",
         },
     }
     coord = _make_coord(
@@ -342,6 +348,9 @@ async def test_warm_replay_prefers_warm_start_context_recommended_replay(tmp_pat
     params = coord.tasks.calls[0]["params"]
     assert params["extra_server_args"] == "--from-context --cuda-graph-max-bs 256"
     assert params["extra_envs"] == {"VLLM_ROCM_USE_AITER": "1"}
+    assert coord.shared_state.warm_replay_outcome["donor_model"] == "donor-model"
+    assert coord.shared_state.warm_replay_outcome["donor_session_id"] == "donor-session"
+    assert coord.shared_state.warm_replay_outcome["donor_family_tags"] == ["moe"]
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/inference_optimizer/tools/dump_session_breakdown.py
+++ b/src/hyperloom/inference_optimizer/tools/dump_session_breakdown.py
@@ -133,7 +133,12 @@ def _summary_line(breakdown: dict) -> str:
     """
     sess = breakdown.get("session") or {}
     final = breakdown.get("final") or {}
-    geak_n = len(breakdown.get("geak_invocations") or [])
+    optimization_entries = (breakdown.get("optimizations") or {}).get("entries") or []
+    geak_n = sum(
+        1
+        for entry in optimization_entries
+        if isinstance(entry, dict) and entry.get("backend") == "geak"
+    )
     lifecycle = breakdown.get("kernel_lifecycle") or {}
     sweep = breakdown.get("sweep") or {}
     warnings = breakdown.get("warnings") or []

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb_t0.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb_t0.py
@@ -458,7 +458,19 @@ def _build_warm_start_context(
                 expected_gain = 0.0
             if expected_gain <= 0:
                 expected_gain = _max_session_gain(donor)
-            ctx["recommended_replay"] = {
+            donor_session: Mapping[str, Any] | None = None
+            donor_session_gain = float("-inf")
+            for session in donor.get("sessions") or []:
+                if not isinstance(session, Mapping):
+                    continue
+                try:
+                    session_gain = float(session.get("gain_pct") or 0.0)
+                except (TypeError, ValueError):
+                    continue
+                if session_gain > donor_session_gain:
+                    donor_session = session
+                    donor_session_gain = session_gain
+            recommended_replay: dict[str, Any] = {
                 "extra_server_args": args,
                 "extra_envs": envs,
                 "expected_gain_pct": expected_gain,
@@ -467,6 +479,35 @@ def _build_warm_start_context(
                 "config_tier": config_donor_tier or "self",
                 "config_confidence": float(config_donor_confidence or confidence),
             }
+            donor_canonical_id = str(donor.get("canonical_id") or "")
+            donor_model = str(donor.get("model") or "")
+            family_tags = donor.get("family_tags") or donor.get("model_architectures")
+            breakdown_link = str(donor.get("breakdown_link") or "")
+            if donor_session is not None:
+                breakdown_link = str(
+                    donor_session.get("breakdown_link")
+                    or donor_session.get("session_breakdown_url")
+                    or breakdown_link
+                )
+            recommended_replay.update(
+                {
+                    "donor_canonical_id": donor_canonical_id,
+                    "donor_model": donor_model,
+                    "donor_session_id": (
+                        str(donor_session.get("session_id") or "")
+                        if donor_session is not None
+                        else ""
+                    ),
+                    "donor_family_tags": (
+                        [str(tag) for tag in family_tags]
+                        if isinstance(family_tags, (list, tuple, set))
+                        else []
+                    ),
+                    "donor_gain_pct": expected_gain,
+                    "donor_breakdown_link": breakdown_link,
+                }
+            )
+            ctx["recommended_replay"] = recommended_replay
     # Extract replayable code patches from prs_tested (positive + negative).
     _extract_patches_from_prs_tested(ctx, recipe, model_architectures)
     # KG enhancement (best-effort, degradable).

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -277,6 +277,7 @@ class WritebackCollaborator:
                         break
         entry = {
             "action": "integrate",
+            "source_phase": str(getattr(self.shared_state, "phase", "") or "KERNEL_AGENT"),
             "integration_id": result.get("integration_id"),
             "kernel_id": result.get("kernel_id"),
             "task_group_key": result.get("task_group_key"),
@@ -2080,6 +2081,7 @@ class WritebackCollaborator:
             if key not in existing:
                 stack_entry: dict[str, Any] = {
                     "action": task_kind,
+                    "source_phase": str(getattr(self.shared_state, "phase", "") or ""),
                     "variant_name": variant_name,
                     "candidate_extra_server_args": candidate_args,
                     "extra_server_args": full_args,

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -1392,6 +1392,9 @@ class KernelPhase(PhaseHandler):
             e2e = kernel.get("e2e")
             if not kernel_id or not isinstance(e2e, dict):
                 continue
+            decision = str(e2e.get("decision") or "").upper()
+            if decision not in {"KEEP", "ADOPTED"}:
+                continue
             evidence = dict(e2e)
             evidence.update(
                 {

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -1135,6 +1135,39 @@ class KernelPhase(PhaseHandler):
                 measured,
                 float(cb_tput),
             )
+            self._reject_geak_kernel_journey(
+                result,
+                measured_tput=measured,
+                current_best_tput=float(cb_tput),
+                provenance=provenance,
+            )
+            try:
+                from hyperloom.inference_optimizer.breakdown.recorder import instrument
+
+                rejected_result = dict(result)
+                rejected_result["final_validation"] = {
+                    "decision": "REJECTED",
+                    "reason": "rebench_did_not_beat_current_best",
+                    "measured_tput": measured,
+                    "current_best_tput": float(cb_tput),
+                }
+                instrument.record_geak_operation(
+                    self.session_dir,
+                    stage="final_validation_failed",
+                    macro_cycle=int(
+                        getattr(self.shared_state, "macro_cycle", 0) or 0
+                    ),
+                    result=rejected_result,
+                    status="failed",
+                    validated=False,
+                    measured_tput=measured,
+                    validation_source=provenance,
+                )
+            except Exception:  # noqa: BLE001
+                log.debug(
+                    "geak v4 final validation rejection recording failed",
+                    exc_info=True,
+                )
             self.shared_state.geak_pending = {}
             self.shared_state.resume_pending_revalidation = False
             return
@@ -1323,6 +1356,74 @@ class KernelPhase(PhaseHandler):
                 )
             except Exception:  # noqa: BLE001
                 pass
+
+    def _reject_geak_kernel_journey(
+        self,
+        result: dict[str, Any],
+        *,
+        measured_tput: float,
+        current_best_tput: float,
+        provenance: str,
+    ) -> None:
+        """Replace provisional GEAK e2e KEEPs after a failed final rebench."""
+
+        if not isinstance(result, dict):
+            return
+        kj_path = str(result.get("kernel_journey_path") or "")
+        if not kj_path:
+            eval_dir = str(result.get("eval_dir") or "")
+            if eval_dir:
+                kj_path = str(Path(eval_dir) / "kernel_journey.json")
+        if not kj_path or not Path(kj_path).is_file():
+            return
+        try:
+            journey = json.loads(Path(kj_path).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return
+        if not isinstance(journey, dict):
+            return
+
+        from hyperloom.inference_optimizer.breakdown.recorder import instrument
+
+        for kernel in journey.get("kernels") or []:
+            if not isinstance(kernel, dict):
+                continue
+            kernel_id = str(kernel.get("kernel_id") or "")
+            e2e = kernel.get("e2e")
+            if not kernel_id or not isinstance(e2e, dict):
+                continue
+            evidence = dict(e2e)
+            evidence.update(
+                {
+                    "self_reported_e2e_gain_pct": e2e.get("e2e_gain_pct"),
+                    "revalidation_measured_tput": measured_tput,
+                    "revalidation_current_best_tput": current_best_tput,
+                    "revalidation_provenance": provenance,
+                    "rejection_reason": "rebench_did_not_beat_current_best",
+                }
+            )
+            try:
+                instrument.record_kernel_e2e(
+                    self.session_dir,
+                    kernel_id=kernel_id,
+                    integrated=False,
+                    e2e_gain_pct=None,
+                    validated=False,
+                    decision="REVERT",
+                    patch_path=e2e.get("patch_path"),
+                    target_file=e2e.get("target_file"),
+                    extra_server_args=str(
+                        e2e.get("extra_server_args") or ""
+                    ),
+                    result=evidence,
+                    route_strategy="legacy_only",
+                )
+            except Exception:  # noqa: BLE001
+                log.debug(
+                    "geak kernel_journey rejection replay failed for %s",
+                    kernel_id,
+                    exc_info=True,
+                )
 
     def _merge_gemm_candidate_with_runtime(
         self, env_var: str, candidate_csv_path: str

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -1174,6 +1174,7 @@ class KernelPhase(PhaseHandler):
         if not self._geak_win_already_recorded():
             entry = {
                 "action": "geak_e2e",
+                "source_phase": "KERNEL_AGENT",
                 "variant_name": "geak_e2e",
                 "tput": measured,
                 "candidate_extra_server_args": accepted_flags,
@@ -1879,6 +1880,7 @@ class KernelPhase(PhaseHandler):
 
         entry = {
             "action": "gemm_tuning",
+            "source_phase": "KERNEL_AGENT",
             "variant_name": variant_name,
             "tuned_file": tuned_file,
             "final_report_path": final_report,
@@ -2118,6 +2120,7 @@ class KernelPhase(PhaseHandler):
 
                 entry = {
                     "action": "gemm_tuning",
+                    "source_phase": "KERNEL_AGENT",
                     "variant_name": f"forge_{tuner_name}",
                     "tuned_file": (
                         env.get(cand["env_var"])
@@ -2465,6 +2468,7 @@ class KernelPhase(PhaseHandler):
         extra_args = str(integrate_result.get("extra_server_args") or "")
         entry = {
             "action": "fusion",
+            "source_phase": "KERNEL_AGENT",
             "variant_name": "forge_fusion",
             "backend": "forge",
             "engine": "forge_fusion",

--- a/src/hyperloom/orchestrator/phases/prelude.py
+++ b/src/hyperloom/orchestrator/phases/prelude.py
@@ -501,6 +501,7 @@ class PreludePhase(PhaseHandler):
             # Push warm best_config onto the stack (schema mirrors explore-KEEP).
             stack_entry = {
                 "action": "replay_warm_recipe",
+                "source_phase": "PRELUDE",
                 "name": "warm_replay",
                 "variant_name": "warm_replay",
                 "task_id": str(getattr(task, "task_id", "") or ""),

--- a/src/hyperloom/orchestrator/phases/prelude.py
+++ b/src/hyperloom/orchestrator/phases/prelude.py
@@ -289,6 +289,18 @@ class PreludePhase(PhaseHandler):
             config_source = str(recipe.get("canonical_id") or "")
             config_tier = "self"
             donor_expected_gain = 0.0
+        donor_metadata = {
+            field: replay.get(field)
+            for field in (
+                "donor_canonical_id",
+                "donor_model",
+                "donor_session_id",
+                "donor_family_tags",
+                "donor_gain_pct",
+                "donor_breakdown_link",
+            )
+            if replay.get(field) not in (None, "", [])
+        }
         # Gate on the config-transfer confidence.
         if replay_conf < min_conf:
             state.warm_replay_outcome = {
@@ -298,6 +310,7 @@ class PreludePhase(PhaseHandler):
                 "warm_recipe_conf": conf,
                 "config_donor_tier": config_tier,
                 "config_source": config_source,
+                **donor_metadata,
             }
             state.warm_replay_attempted = True
             return None
@@ -313,6 +326,7 @@ class PreludePhase(PhaseHandler):
                 "reason": "best_config_empty",
                 "warm_recipe_tier": tier,
                 "warm_recipe_conf": conf,
+                **donor_metadata,
             }
             state.warm_replay_attempted = True
             return None
@@ -382,6 +396,7 @@ class PreludePhase(PhaseHandler):
             "config_source": config_source,
             "expected_gain_pct": expected_gain,
             "replay_task_id": task.task_id,
+            **donor_metadata,
         }
         return task
 


### PR DESCRIPTION
## Summary
- introduce the SBD V5 `optimizations` contract as the single source for adopted Warm Replay, Explore, Framework Agent, and Kernel Agent results
- normalize per-entry gains, source attribution, throughput, artifacts, and GEAK/Forge backend metadata, with source summaries for downstream dashboards
- remove legacy optimization result projections from the V5 wire shape while retaining action and kernel lifecycle audit data

## Test plan
- [x] `python3 -m pytest -q src/hyperloom/inference_optimizer/tests/test_breakdown*.py src/hyperloom/inference_optimizer/tests/test_reporters*.py src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py src/hyperloom/inference_optimizer/tests/test_phase_state_plateau.py`
- [x] `python3 -m compileall -q src/hyperloom/inference_optimizer/breakdown src/hyperloom/inference_optimizer/tools/dump_session_breakdown.py src/hyperloom/orchestrator`
- [ ] deploy downstream dual-read support before merging this breaking producer change
- [ ] validate historical backfill output against legacy KEEP counts and validated gain

Made with [Cursor](https://cursor.com)