### PR TITLE
fix(benchmark): prevent API key leakage into session artifacts

### DIFF
--- a/src/hyperloom/common/env_safety.py
+++ b/src/hyperloom/common/env_safety.py
@@ -54,6 +54,40 @@ BLOCKED_CHILD_ENV_NAMES: frozenset[str] = frozenset(
     }
 )
 
+BENCHMARK_SECRET_ENV_NAMES: frozenset[str] = frozenset(
+    {
+        "AMD_API_KEY",
+        "AMD_LLM_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_CUSTOM_HEADERS",
+        "CLAW_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "GEAK_API_KEY",
+        "LLM_API_KEY",
+        "LLM_GATEWAY_KEY",
+        "LLM_PROXY_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENAI_CUSTOM_HEADERS",
+        "SAFE_API_KEY",
+    }
+)
+
+_SECRET_REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(?i)(bearer\s+)[A-Za-z0-9\-_.=]{8,}"), r"\1[REDACTED]"),
+    (re.compile(r"\b((?:ak|sk|pk)-(?:lf-)?)[A-Za-z0-9\-_]{6,}"), r"\1[REDACTED]"),
+    (re.compile(r"\b(gh[pousr]_|github_pat_)[A-Za-z0-9_]{10,}"), r"\1[REDACTED]"),
+    (
+        re.compile(
+            r"(?i)\b([A-Z0-9_]*"
+            r"(?:API_?KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)"
+            r"[A-Z0-9_]*\s*[=:]\s*)"
+            r"[^\s,;'\"]+"
+        ),
+        r"\1[REDACTED]",
+    ),
+)
+
 DOTENV_EXACT_ALLOWLIST: frozenset[str] = frozenset(
     {
         "ANTHROPIC_API_KEY",
@@ -206,13 +240,47 @@ def scrub_child_process_env(env: dict[str, str]) -> dict[str, str]:
     return env
 
 
+def scrub_benchmark_process_env(env: dict[str, str]) -> dict[str, str]:
+    """Remove control-plane credentials from a benchmark environment in place.
+
+    Serving benchmarks target the local model server and do not need LLM-agent
+    credentials. Keeping those values out of the process tree also prevents
+    shell tracing and lm-eval command/result serialization from persisting them.
+    """
+    scrub_child_process_env(env)
+    for name in BENCHMARK_SECRET_ENV_NAMES:
+        env.pop(name, None)
+    return env
+
+
+def filter_benchmark_env_mapping(envs: Mapping[str, object] | None) -> dict[str, str]:
+    """Return benchmark env overrides without control-plane credentials."""
+    return {
+        str(name): str(value)
+        for name, value in (envs or {}).items()
+        if str(name).strip().upper() not in BENCHMARK_SECRET_ENV_NAMES
+    }
+
+
+def redact_secret_values(text: str) -> str:
+    """Mask recognizable credential values before diagnostic text is persisted."""
+    out = str(text or "")
+    for pattern, replacement in _SECRET_REDACTION_PATTERNS:
+        out = pattern.sub(replacement, out)
+    return out
+
+
 __all__ = [
+    "BENCHMARK_SECRET_ENV_NAMES",
     "BLOCKED_CHILD_ENV_NAMES",
     "BLOCKED_UNTRUSTED_ENV_NAMES",
+    "filter_benchmark_env_mapping",
     "filter_untrusted_env_mapping",
     "is_allowed_dotenv_key",
     "is_allowed_kernel_agent_env_key",
     "is_python_package_root",
+    "redact_secret_values",
+    "scrub_benchmark_process_env",
     "scrub_child_process_env",
     "valid_env_key",
 ]

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_param_overrides.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_param_overrides.py
@@ -643,7 +643,9 @@ def test_baseline_executor_falls_back_to_ctx_extra_shared_state_model_path(tmp_p
     assert captured["cfg"]["benchmark"]["model"] == "/path/models/PrimeIntellect-Qwen3-1.7B"
 
 
-def test_baseline_executor_defaults_result_dir_to_workspace(tmp_path):
+def test_baseline_executor_defaults_result_dir_to_workspace(tmp_path, monkeypatch):
+    monkeypatch.setenv("SAFE_API_KEY", "must-not-reach-benchmark")
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-reach-benchmark")
     base = tmp_path / "base.yaml"
     _write_yaml(base)
     output_dir = tmp_path / "ws"
@@ -674,6 +676,8 @@ def test_baseline_executor_defaults_result_dir_to_workspace(tmp_path):
     # benchmark_script so the cold-start double-run is not eligible and the
     # single-round path runs directly in output_dir.
     assert captured["env"]["RESULT_DIR"] == str(output_dir)
+    assert "SAFE_API_KEY" not in captured["env"]
+    assert "OPENAI_API_KEY" not in captured["env"]
 
 
 def test_baseline_executor_pins_magpie_inferencex_path(tmp_path, monkeypatch):

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
@@ -522,7 +522,8 @@ def test_baseline_invalid_measurement_with_server_death_marker_is_dead(
         (slot / "benchmark_vllm_20260602_010101").mkdir(parents=True)
         (slot / "server.log").write_text(
             "(APIServer pid=42) RuntimeError: Engine core initialization "
-            "failed. See root cause above. Failed core proc(s): {}\n",
+            "failed. See root cause above. Failed core proc(s): {} "
+            "SAFE_API_KEY=ak-invalid-measurement-secret\n",
             encoding="utf-8",
         )
         # Classification must be driven by the server.log marker, not returncode.
@@ -546,6 +547,8 @@ def test_baseline_invalid_measurement_with_server_death_marker_is_dead(
     assert result["status"] == "failed"
     assert result["error_class"] == "server_init_dead", result
     assert "Engine core initialization failed" in result["error"]
+    assert "invalid-measurement-secret" not in result["error"]
+    assert "[REDACTED]" in result["error"]
 
 
 def test_baseline_clears_stale_server_log_before_run(tmp_path, monkeypatch):

--- a/src/hyperloom/inference_optimizer/tests/test_bypass_backend.py
+++ b/src/hyperloom/inference_optimizer/tests/test_bypass_backend.py
@@ -402,7 +402,7 @@ def test_bypass_run_end_to_end(tmp_path, monkeypatch):
     monkeypatch.setattr(bypass_runner, "_terminate_server", lambda proc: None)
     monkeypatch.setattr(bypass_engine, "wait_for_server_ready", lambda *a, **k: True)
 
-    def fake_run(cmd, capture_output=True, text=True, timeout=None):
+    def fake_run(cmd, capture_output=True, text=True, timeout=None, env=None):
         # The client writes inferencex_result.json into --result-dir.
         result_dir = Path(cmd[cmd.index("--result-dir") + 1])
         raw = {
@@ -512,7 +512,7 @@ def test_bypass_eval_env_passthrough(tmp_path, monkeypatch):
 
     monkeypatch.setattr(bypass_engine, "build_eval_command", fake_eval_cmd)
 
-    def fake_run(cmd, capture_output=True, text=True, timeout=None):
+    def fake_run(cmd, capture_output=True, text=True, timeout=None, env=None):
         if "--result-dir" in cmd:
             rd = Path(cmd[cmd.index("--result-dir") + 1])
             rd.mkdir(parents=True, exist_ok=True)
@@ -564,7 +564,7 @@ def test_bypass_eval_limit_absent_is_none(tmp_path, monkeypatch):
 
     monkeypatch.setattr(bypass_engine, "build_eval_command", fake_eval_cmd)
 
-    def fake_run(cmd, capture_output=True, text=True, timeout=None):
+    def fake_run(cmd, capture_output=True, text=True, timeout=None, env=None):
         if "--result-dir" in cmd:
             rd = Path(cmd[cmd.index("--result-dir") + 1])
             rd.mkdir(parents=True, exist_ok=True)
@@ -721,7 +721,7 @@ def test_client_phase_reuses_healthy_server(tmp_path, monkeypatch):
 
     monkeypatch.setattr(sl, "teardown_lifecycle_server", lambda **k: teardown.__setitem__("called", True))
 
-    def fake_run(cmd, capture_output=True, text=True, timeout=None):
+    def fake_run(cmd, capture_output=True, text=True, timeout=None, env=None):
         if "--result-dir" in cmd:
             rd = Path(cmd[cmd.index("--result-dir") + 1])
             rd.mkdir(parents=True, exist_ok=True)
@@ -803,7 +803,7 @@ def _write_cfg_lifecycle(tmp_path, inferencex, cleanup, pid_dir):
 
 
 def _fake_client_run(monkeypatch, tput=700.0):
-    def fake_run(cmd, capture_output=True, text=True, timeout=None):
+    def fake_run(cmd, capture_output=True, text=True, timeout=None, env=None):
         if "--result-dir" in cmd:
             rd = Path(cmd[cmd.index("--result-dir") + 1])
             rd.mkdir(parents=True, exist_ok=True)
@@ -963,7 +963,7 @@ def test_remote_multinode_client_no_server(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_run(cmd, capture_output=True, text=True, timeout=None):
+    def fake_run(cmd, capture_output=True, text=True, timeout=None, env=None):
         if "--result-dir" in cmd:
             captured["base_url"] = cmd[cmd.index("--base-url") + 1] if "--base-url" in cmd else None
             rd = Path(cmd[cmd.index("--result-dir") + 1])
@@ -1267,7 +1267,7 @@ def test_num_prompts_warmups_passthrough(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_run(cmd, capture_output=True, text=True, timeout=None):
+    def fake_run(cmd, capture_output=True, text=True, timeout=None, env=None):
         if "--num-prompts" in cmd:
             captured["num_prompts"] = cmd[cmd.index("--num-prompts") + 1]
             captured["num_warmups"] = cmd[cmd.index("--num-warmups") + 1]
@@ -1291,9 +1291,11 @@ def test_num_prompts_warmups_passthrough(tmp_path, monkeypatch):
     assert captured.get("num_warmups") == "3"
 
 
-def test_server_env_injects_rocr_visible_devices():
+def test_server_env_injects_rocr_visible_devices(monkeypatch):
+    monkeypatch.setenv("SAFE_API_KEY", "must-not-reach-benchmark")
     env = bypass_runner._server_env(False, None, {"ROCR_VISIBLE_DEVICES": "0,1,2,3"})
     assert env["ROCR_VISIBLE_DEVICES"] == "0,1,2,3"
+    assert "SAFE_API_KEY" not in env
     env2 = bypass_runner._server_env(False, None, {})
     # No pin in bench_envs: whatever the parent env had (may be unset).
     assert env2.get("ROCR_VISIBLE_DEVICES") == os.environ.get("ROCR_VISIBLE_DEVICES")
@@ -1608,9 +1610,11 @@ def test_write_report_emits_magpie_compat_artifacts(tmp_path):
 def test_run_subprocess_timeout_writes_log(tmp_path, monkeypatch):
     """Timeouts return 124 and leave a phase stderr log for debugging."""
 
-    def fake_run(cmd, capture_output=True, text=True, timeout=None):
+    def fake_run(cmd, capture_output=True, text=True, timeout=None, env=None):
+        assert "SAFE_API_KEY" not in (env or {})
         raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
 
+    monkeypatch.setenv("SAFE_API_KEY", "must-not-reach-benchmark")
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     rc = bypass_runner._run_subprocess(["client"], 0.01, tmp_path, "client")

--- a/src/hyperloom/inference_optimizer/tests/test_env_safety.py
+++ b/src/hyperloom/inference_optimizer/tests/test_env_safety.py
@@ -106,3 +106,35 @@ def test_common_env_safety_filters_dotenv_and_kernel_agent_keys_only():
     env = {"LD_PRELOAD": "evil.so", "PATH": "/bin", "SAFE": "1"}
     assert common_env_safety.scrub_child_process_env(env) is env
     assert env == {"PATH": "/bin", "SAFE": "1"}
+
+
+def test_scrub_benchmark_process_env_removes_control_plane_credentials():
+    env = {
+        "AMD_API_KEY": "amd-secret",
+        "AMD_LLM_API_KEY": "amd-llm-secret",
+        "ANTHROPIC_API_KEY": "anthropic-secret",
+        "LLM_GATEWAY_KEY": "gateway-secret",
+        "LLM_PROXY_API_KEY": "proxy-secret",
+        "OPENAI_API_KEY": "openai-secret",
+        "SAFE_API_KEY": "safe-secret",
+        "HF_TOKEN": "model-download-token",
+        "PATH": "/bin",
+        "RUN_EVAL": "true",
+    }
+
+    assert common_env_safety.scrub_benchmark_process_env(env) is env
+    assert env == {
+        "HF_TOKEN": "model-download-token",
+        "PATH": "/bin",
+        "RUN_EVAL": "true",
+    }
+
+
+def test_redact_secret_values_masks_assignments_and_bearer_tokens():
+    text = "SAFE_API_KEY=ak-sensitive-value Authorization: Bearer sensitive-token"
+
+    redacted = common_env_safety.redact_secret_values(text)
+
+    assert "sensitive-value" not in redacted
+    assert "sensitive-token" not in redacted
+    assert redacted.count("[REDACTED]") == 2

--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner.py
@@ -719,6 +719,34 @@ def test_run_magpie_default_result_dir_is_output_dir(tmp_path, monkeypatch):
     assert captured["env"]["RESULT_DIR"] == str(tmp_path / "slot")
 
 
+def test_run_magpie_does_not_forward_llm_credentials(tmp_path, monkeypatch):
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "skip-kill")
+    monkeypatch.setenv("SAFE_API_KEY", "must-not-reach-benchmark")
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-reach-benchmark")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "must-not-reach-benchmark")
+    captured: dict = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        captured["env"] = dict(kwargs.get("env") or {})
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    with patch(
+        "hyperloom.orchestrator.actions.executors._grid_runner.run_with_session_kill",
+        side_effect=fake_run,
+    ):
+        _run_magpie(
+            magpie_python="/opt/venv/bin/python",
+            config_path=tmp_path / "config.yaml",
+            output_dir=tmp_path / "slot",
+            timeout_sec=5,
+            cwd=str(tmp_path),
+        )
+
+    assert "SAFE_API_KEY" not in captured["env"]
+    assert "OPENAI_API_KEY" not in captured["env"]
+    assert "ANTHROPIC_API_KEY" not in captured["env"]
+
+
 def test_run_magpie_explicit_result_dir_overrides_default(tmp_path, monkeypatch):
     monkeypatch.setenv("PYTEST_CURRENT_TEST", "skip-kill")
     captured: dict = {}

--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner_behavior_lock.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner_behavior_lock.py
@@ -425,7 +425,12 @@ class TestAutoWarmupTeardown:
             state["n"] += 1
             if state["n"] == 1:
                 # Warmup round fails (nonzero, no workspace).
-                return subprocess.CompletedProcess(cmd, 1, "", "warmup boom")
+                return subprocess.CompletedProcess(
+                    cmd,
+                    1,
+                    "",
+                    "warmup boom SAFE_API_KEY=ak-warmup-secret-value",
+                )
             out_idx = cmd.index("--output-dir")
             _valid_workspace(Path(cmd[out_idx + 1]))
             return subprocess.CompletedProcess(cmd, 0, "ok", "")
@@ -433,6 +438,11 @@ class TestAutoWarmupTeardown:
         results, teardown_calls = self._run_capture_teardown(_run, base, tmp_path / "out")
         assert results[0].status == "failed"
         assert results[0].error_class == "warmup_round_failed"
+        assert "warmup-secret-value" not in results[0].error
+        assert "[REDACTED]" in results[0].error
+        marker_path = next((tmp_path / "out").glob("variant_*/abort_reason.json"))
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+        assert "warmup-secret-value" not in marker["error"]
         # The measured round never ran — only the warmup call was made.
         assert state["n"] == 1
         # Exactly one teardown, from the warmup-failure branch.

--- a/src/hyperloom/inference_optimizer/tests/test_ray_backend_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_ray_backend_unit.py
@@ -70,6 +70,8 @@ def test_merge_worker_env_preserves_ray_visible_devices(monkeypatch: pytest.Monk
     monkeypatch.setenv("ROCR_VISIBLE_DEVICES", "2,3")
     monkeypatch.setenv("HIP_VISIBLE_DEVICES", "2,3")
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3")
+    monkeypatch.setenv("SAFE_API_KEY", "must-not-reach-benchmark")
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-reach-benchmark")
     merged = rb._merge_worker_env(
         {
             "ROCR_VISIBLE_DEVICES": "0",  # must be ignored
@@ -82,6 +84,8 @@ def test_merge_worker_env_preserves_ray_visible_devices(monkeypatch: pytest.Monk
     assert merged["HIP_VISIBLE_DEVICES"] == "2,3"
     assert merged["CUDA_VISIBLE_DEVICES"] == "2,3"
     assert merged["MY_FLAG"] == "1"
+    assert "SAFE_API_KEY" not in merged
+    assert "OPENAI_API_KEY" not in merged
 
 
 def test_merge_worker_env_none():
@@ -491,8 +495,14 @@ class _FakeGpuActor:
         self.exit_code = _FakeActorMethodP2(lambda: self._exit)
         self.stop = _FakeActorMethodP2(self._stop)
 
-    def _start(self, cmd, env=None, cwd=None, log_path=None):
-        self.started_with = {"cmd": cmd, "env": env, "cwd": cwd, "log_path": log_path}
+    def _start(self, cmd, env=None, cwd=None, log_path=None, scrub_benchmark_env=False):
+        self.started_with = {
+            "cmd": cmd,
+            "env": env,
+            "cwd": cwd,
+            "log_path": log_path,
+            "scrub_benchmark_env": scrub_benchmark_env,
+        }
         return 4242
 
     def _stop(self):
@@ -547,6 +557,7 @@ def test_gpu_specialist_lease_lifecycle(monkeypatch: pytest.MonkeyPatch):
     assert lease.poll_started() == 4242
     assert lease.pid() == 4242
     assert actor.started_with["log_path"] == "/tmp/p.log"
+    assert actor.started_with["scrub_benchmark_env"] is False
     assert lease.is_alive() is True
     assert lease.exit_code() is None
     lease.stop()
@@ -777,6 +788,7 @@ def test_serving_group_manager_lifecycle(monkeypatch: pytest.MonkeyPatch):
     assert pg_calls == {"nodes": 2, "gpus": 8.0, "serving_slot": True}
     assert [m[0] for m in made] == [0, 1]  # one rank pinned per bundle index
     assert all(m[1] == 8.0 for m in made)  # num_gpus per rank
+    assert all(m[3].started_with["scrub_benchmark_env"] is True for m in made)
     assert sgm.ranks_alive() == [True, True]
     assert sgm.is_alive() is True
 
@@ -1034,6 +1046,35 @@ def test_serving_actor_body_methods_drive_real_subprocess(monkeypatch: pytest.Mo
     rc, out, err = actor2.run_blocking(["echo", "hello-actor"], timeout=30)
     assert rc == 0 and "hello-actor" in out
     actor2.stop()
+
+
+def test_serving_actor_scrubs_benchmark_credentials_when_requested(monkeypatch: pytest.MonkeyPatch):
+    """Serving ranks must scrub inherited control-plane credentials."""
+    captured_env: dict[str, str] = {}
+
+    class _CaptureEnvProcess:
+        def start(self, cmd, *, env=None, cwd=None, log_path=None):
+            del cmd, cwd, log_path
+            captured_env.update(env or {})
+            return 4321
+
+    monkeypatch.setitem(sys.modules, "ray", _PassthroughRay())
+    monkeypatch.setattr(rs, "ManagedServerProcess", _CaptureEnvProcess)
+    monkeypatch.setenv("ROCR_VISIBLE_DEVICES", "2")
+    monkeypatch.setenv("SAFE_API_KEY", "must-not-reach-benchmark")
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-reach-benchmark")
+
+    actor = rs._serving_actor_body()()
+    actor.start(
+        ["python", "-m", "server"],
+        env={"ROCR_VISIBLE_DEVICES": "caller", "WORKLOAD_FLAG": "1"},
+        scrub_benchmark_env=True,
+    )
+
+    assert captured_env["ROCR_VISIBLE_DEVICES"] == "2"
+    assert captured_env["WORKLOAD_FLAG"] == "1"
+    assert "SAFE_API_KEY" not in captured_env
+    assert "OPENAI_API_KEY" not in captured_env
 
 
 def test_serving_actor_run_blocking_timeout_sentinel(monkeypatch: pytest.MonkeyPatch):

--- a/src/hyperloom/inference_optimizer/tests/test_shared_state_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_shared_state_units.py
@@ -394,6 +394,27 @@ def test_record_action_attempt_subprocess_failure_captures_stderr_tail():
     assert attempt["stderr_log_path"] == "/runs/baseline/t-oom/baseline_stderr.log"
 
 
+def test_record_action_attempt_redacts_secrets_from_persisted_errors():
+    s = SharedState()
+    secret = "ak-sensitive-value"
+    s.record_action_attempt(
+        action="baseline",
+        task_id="t-secret",
+        status="failed",
+        decision="no_promote",
+        result={
+            "error_class": "subprocess_nonzero",
+            "error": f"SAFE_API_KEY={secret} Authorization: Bearer {secret}",
+        },
+    )
+
+    attempt = s.baseline_attempts[-1]
+    assert secret not in attempt["error_excerpt"]
+    assert secret not in attempt["stderr_tail"]
+    assert "[REDACTED]" in attempt["error_excerpt"]
+    assert "[REDACTED]" in attempt["stderr_tail"]
+
+
 def test_attempts_history_caps_at_default():
     s = SharedState()
     for i in range(_DEFAULT_ATTEMPTS_HISTORY + 5):

--- a/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
@@ -95,7 +95,7 @@ def test_materialize_remove_args_and_string_unset_env(tmp_path, monkeypatch):
     assert envs["SGLANG_REMOVE_ME"] == "override"
 
 
-def test_materialize_preserves_valid_workload_env_keys(tmp_path, monkeypatch):
+def test_materialize_drops_credentials_but_preserves_workload_env_keys(tmp_path, monkeypatch):
     _clear_env(monkeypatch)
     _stub_server_arg_injectors(monkeypatch)
     src = tmp_path / "base.yaml"
@@ -106,6 +106,7 @@ def test_materialize_preserves_valid_workload_env_keys(tmp_path, monkeypatch):
         extra_envs={
             "ANTHROPIC_API_KEY": "anthropic-secret",
             "LD_PRELOAD": "/tmp/evil.so",
+            "LLM_GATEWAY_KEY": "gateway-secret",
             "OPENAI_API_KEY": "secret",
             "PYTHONSTARTUP": "/tmp/pwn.py",
             "SAFE_API_KEY": "safe-secret",
@@ -114,6 +115,7 @@ def test_materialize_preserves_valid_workload_env_keys(tmp_path, monkeypatch):
             "BAD-NAME": "dropped",
         },
         reference_envs={
+            "DEEPSEEK_API_KEY": "deepseek-secret",
             "PYTHONPATH": "/tmp/evil",
             "REFERENCE_ONLY_KNOB": "1",
             "VLLM_ROCM_USE_AITER": "1",
@@ -121,12 +123,14 @@ def test_materialize_preserves_valid_workload_env_keys(tmp_path, monkeypatch):
         },
     )
     envs = bench["envs"]
-    assert envs["ANTHROPIC_API_KEY"] == "anthropic-secret"
+    assert "ANTHROPIC_API_KEY" not in envs
     assert envs["LD_PRELOAD"] == "/tmp/evil.so"
-    assert envs["OPENAI_API_KEY"] == "secret"
+    assert "LLM_GATEWAY_KEY" not in envs
+    assert "OPENAI_API_KEY" not in envs
     assert envs["PYTHONSTARTUP"] == "/tmp/pwn.py"
     assert envs["PYTHONPATH"] == "/tmp/evil"
-    assert envs["SAFE_API_KEY"] == "safe-secret"
+    assert "SAFE_API_KEY" not in envs
+    assert "DEEPSEEK_API_KEY" not in envs
     assert "BAD-NAME" not in envs
     assert "bad key" not in envs
     assert envs["REFERENCE_ONLY_KNOB"] == "1"

--- a/src/hyperloom/orchestrator/actions/executors/_geak_sweep.py
+++ b/src/hyperloom/orchestrator/actions/executors/_geak_sweep.py
@@ -21,7 +21,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-from hyperloom.common.env_safety import scrub_child_process_env
+from hyperloom.common.env_safety import scrub_benchmark_process_env
 from hyperloom.common.jsonio import read_json
 from ._grid_base import pareto_front
 
@@ -163,7 +163,7 @@ async def sweep_via_geak(
             variant_idx += 1
             out_dir = output_root / variant_name
             out_dir.mkdir(parents=True, exist_ok=True)
-            env = scrub_child_process_env(dict(os.environ))
+            env = scrub_benchmark_process_env(dict(os.environ))
             env.update(
                 {
                     "BACKEND": backend,

--- a/src/hyperloom/orchestrator/actions/executors/_grid_base.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_base.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from hyperloom.common.coerce import to_str_list
+from hyperloom.common.env_safety import filter_benchmark_env_mapping
 from ._canonical_fingerprint import canonical_fingerprint
 
 log = logging.getLogger(__name__)
@@ -123,7 +124,7 @@ class GridVariant:
         """
         self.name = name
         self.extra_server_args = extra_server_args
-        self.extra_envs = dict(extra_envs) if extra_envs is not None else {}
+        self.extra_envs = filter_benchmark_env_mapping(extra_envs)
         self.remove_args = to_str_list(remove_args)
         self.unset_envs = to_str_list(unset_envs)
         mode = str(args_mode or "append").strip().lower()

--- a/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
@@ -28,7 +28,8 @@ from hyperloom.common.env_safety import (
     BLOCKED_CHILD_ENV_NAMES,
     _ENV_KEY_RE,
     is_python_package_root,
-    scrub_child_process_env,
+    redact_secret_values,
+    scrub_benchmark_process_env,
 )
 
 from ...roles.robustness_pulse import pulse as _robustness_pulse
@@ -905,7 +906,7 @@ def _run_magpie(
     if preclean and not os.environ.get("PYTEST_CURRENT_TEST"):
         _kill_stale_servers()
 
-    env = scrub_child_process_env(os.environ.copy())
+    env = scrub_benchmark_process_env(os.environ.copy())
     env["PATH"] = f"/opt/venv/bin:{env.get('PATH', '')}"
     magpie_dir = os.environ.get("MAGPIE_PATH") or ""
     if magpie_dir:
@@ -1410,7 +1411,7 @@ async def run_grid(
                     port=int(lifecycle.get("port") or 0),
                 )
                 warmup_error = (
-                    (warmup_stderr or warmup_stdout)[-2000:]
+                    redact_secret_values((warmup_stderr or warmup_stdout)[-2000:])
                     if warmup_rc != 0
                     else "warmup benchmark_report missing valid throughput/completed requests"
                 )
@@ -1815,7 +1816,11 @@ async def run_grid(
             )
         if not candidates:
             harvest_tags = [f"harvested_leaked_artifact:{src}" for src, _ in harvested]
-            no_ws_error_summary = (stderr or stdout)[-2000:] if rc != 0 else "no benchmark_* workspace produced"
+            no_ws_error_summary = (
+                redact_secret_values((stderr or stdout)[-2000:])
+                if rc != 0
+                else "no benchmark_* workspace produced"
+            )
             log.warning(
                 "grid_runner: variant %d/%d name=%s aborted: no_benchmark_workspace (rc=%s)",
                 i + 1,
@@ -1866,7 +1871,7 @@ async def run_grid(
 
         if not measurement.get("valid_measurement"):
             if rc != 0:
-                error = (stderr or stdout)[-2000:]
+                error = redact_secret_values((stderr or stdout)[-2000:])
                 invalid_class = "magpie_nonzero_invalid_measurement"
             elif not report:
                 error = "benchmark_report missing"
@@ -1932,7 +1937,7 @@ async def run_grid(
                 reported_success=measurement.get("reported_success"),
                 returncode=rc,
                 nonfatal_warnings=warnings,
-                error=(stderr or stdout)[-2000:] if rc != 0 else None,
+                error=redact_secret_values((stderr or stdout)[-2000:]) if rc != 0 else None,
                 note=variant.note,
                 runtime_sec=round(
                     max(0.0, time.time() - variant_started_unix),

--- a/src/hyperloom/orchestrator/actions/executors/_ray_backend.py
+++ b/src/hyperloom/orchestrator/actions/executors/_ray_backend.py
@@ -14,6 +14,8 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from hyperloom.common.env_safety import scrub_benchmark_process_env
+
 log = logging.getLogger(__name__)
 
 # Env vars Ray owns inside its workers; never let a caller override them.
@@ -169,7 +171,7 @@ def _merge_worker_env(caller_env: dict[str, str] | None) -> dict[str, str]:
         if key in _RAY_OWNED_VISIBLE_DEVICE_VARS:
             continue
         merged[key] = value
-    return merged
+    return scrub_benchmark_process_env(merged)
 
 
 def _run_subprocess_worker(

--- a/src/hyperloom/orchestrator/actions/executors/_ray_serving.py
+++ b/src/hyperloom/orchestrator/actions/executors/_ray_serving.py
@@ -12,6 +12,8 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
+from hyperloom.common.env_safety import scrub_benchmark_process_env
+
 log = logging.getLogger(__name__)
 
 # Sentinel returncodes (distinct from -909..-912 watchdog sentinels).
@@ -188,8 +190,19 @@ def _serving_actor_body() -> Any:
         def __init__(self) -> None:
             self._mgr = ManagedServerProcess()
 
-        def start(self, cmd, *, env=None, cwd=None, log_path=None) -> int:
+        def start(
+            self,
+            cmd,
+            *,
+            env=None,
+            cwd=None,
+            log_path=None,
+            scrub_benchmark_env=False,
+        ) -> int:
             """Launch the serving subprocess; Ray has set visible devices.
+
+            GPU specialist actors retain control-plane credentials by default;
+            benchmark serving ranks opt into scrubbing at their call site.
 
             Returns:
                 The launched pid.
@@ -199,6 +212,8 @@ def _serving_actor_body() -> Any:
                 if key in ("ROCR_VISIBLE_DEVICES", "HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"):
                     continue
                 merged[key] = value
+            if scrub_benchmark_env:
+                scrub_benchmark_process_env(merged)
             return self._mgr.start(cmd, env=merged, cwd=cwd, log_path=log_path)
 
         def run_blocking(
@@ -803,6 +818,7 @@ class ServingGroupManager:
                         env=(envs[i] if envs else None),
                         cwd=(cwds[i] if cwds else None),
                         log_path=(log_paths[i] if log_paths else None),
+                        scrub_benchmark_env=True,
                     )
                 )
             )

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -30,6 +30,7 @@ import yaml
 
 from hyperloom.common.coerce import to_str_list
 from hyperloom.common.env_safety import (
+    filter_benchmark_env_mapping,
     filter_untrusted_env_mapping,
     valid_env_key,
 )
@@ -1041,6 +1042,15 @@ def materialize_config_with_envs(
     for key in unset_list:
         if isinstance(extra_envs, dict) and key in extra_envs:
             envs[str(key)] = str(extra_envs[key])
+    filtered_envs = filter_benchmark_env_mapping(envs)
+    dropped_credentials = sorted(set(envs) - set(filtered_envs))
+    if dropped_credentials:
+        log.warning(
+            "Dropping control-plane credentials from benchmark envs: %s",
+            ", ".join(dropped_credentials),
+        )
+        envs.clear()
+        envs.update(filtered_envs)
     output_dir.mkdir(parents=True, exist_ok=True)
     materialized = output_dir / out_name
     with materialized.open("w", encoding="utf-8") as f:

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -30,7 +30,7 @@ from typing import Any
 import yaml
 
 from hyperloom.common.env import is_truthy
-from hyperloom.common.env_safety import scrub_child_process_env
+from hyperloom.common.env_safety import redact_secret_values, scrub_benchmark_process_env
 from hyperloom.inference_optimizer.session.session_paths import runs_dir
 from ...loop.sub_agent_runner import RunnerContext
 from . import _server_lifecycle as _lifecycle
@@ -2402,7 +2402,7 @@ class BaselineExecutor:
             config_path=config_path,
             output_dir=output_dir,
         )
-        env = scrub_child_process_env(os.environ.copy())
+        env = scrub_benchmark_process_env(os.environ.copy())
         # Put the venv first in PATH so the benchmark script's `python3`
         # resolves to one with torch+rocm (defense in depth vs Magpie YAML).
         env["PATH"] = f"/opt/venv/bin:{env.get('PATH', '')}"
@@ -2690,7 +2690,7 @@ class BaselineExecutor:
             # Magpie never created a benchmark_* workspace, so the wrapper never
             # wrote server.log. Persist captured stderr/stdout so the failure
             # survives the NFS clone and S3 archive.
-            captured = (proc_stderr or "") + (proc_stdout or "")
+            captured = redact_secret_values((proc_stderr or "") + (proc_stdout or ""))
             stderr_log_path: str | None = None
             if captured.strip():
                 try:
@@ -2711,7 +2711,9 @@ class BaselineExecutor:
                     "status": "failed",
                     "error_class": "cuda_graph_capture_failed",
                     "returncode": proc_returncode,
-                    "error": server_init_dead_error if server_init_dead else (proc_stderr or proc_stdout or "")[-2000:],
+                    "error": redact_secret_values(
+                        server_init_dead_error if server_init_dead else (proc_stderr or proc_stdout or "")[-2000:]
+                    ),
                     **failure_extras,
                 }
             if server_init_dead:
@@ -2719,11 +2721,11 @@ class BaselineExecutor:
                     "status": "failed",
                     "error_class": "server_init_dead",
                     "returncode": proc_returncode,
-                    "error": server_init_dead_error,
+                    "error": redact_secret_values(server_init_dead_error),
                     **failure_extras,
                 }
             if proc_returncode != 0:
-                tail = (proc_stderr or proc_stdout or "")[-2000:]
+                tail = redact_secret_values((proc_stderr or proc_stdout or "")[-2000:])
                 err_class = _classify_subprocess_error(
                     subprocess_runtime_sec,
                     tail,
@@ -2786,6 +2788,7 @@ class BaselineExecutor:
             else:
                 error_class = "invalid_measurement"
                 error = "benchmark report did not contain positive throughput and completed requests"
+            error = redact_secret_values(error)
             return {
                 "status": "failed",
                 "error_class": error_class,

--- a/src/hyperloom/orchestrator/actions/executors/bypass_runner.py
+++ b/src/hyperloom/orchestrator/actions/executors/bypass_runner.py
@@ -34,7 +34,7 @@ from typing import Any
 
 import yaml
 
-from hyperloom.common.env_safety import scrub_child_process_env
+from hyperloom.common.env_safety import scrub_benchmark_process_env
 
 from . import bypass_analysis
 from . import bypass_engine
@@ -834,7 +834,7 @@ def _server_env(
     bench_envs: dict | None = None,
 ) -> dict[str, str]:
     """Build the server subprocess env (parent + profiler dirs + GPU pin)."""
-    env = scrub_child_process_env(os.environ.copy())
+    env = scrub_benchmark_process_env(os.environ.copy())
     # GPU pin: the materializer writes ROCR_VISIBLE_DEVICES into benchmark.envs
     # (reconciled against TP). Inject it so the server binds the same cards
     # Magpie would; missing on single-GPU pods (harmless).
@@ -895,7 +895,13 @@ def _terminate_server(proc: subprocess.Popen | None) -> None:
 def _run_subprocess(cmd: list[str], timeout_s: float, workspace: Path, tag: str) -> int:
     """Run a client/eval subprocess, appending logs; return its exit code."""
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s)
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            env=scrub_benchmark_process_env(os.environ.copy()),
+        )
     except subprocess.TimeoutExpired:
         _append_log(workspace, tag, "", f"{tag} timed out after {timeout_s}s")
         return 124

--- a/src/hyperloom/orchestrator/actions/executors/bypass_scriptable.py
+++ b/src/hyperloom/orchestrator/actions/executors/bypass_scriptable.py
@@ -23,7 +23,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-from hyperloom.common.env_safety import scrub_child_process_env
+from hyperloom.common.env_safety import scrub_benchmark_process_env
 
 
 def _scriptable_script_name(framework: str, runner_type: str) -> str:
@@ -77,7 +77,7 @@ def build_scriptable_env(
     Returns:
         The environment mapping for the scriptable subprocess.
     """
-    env = scrub_child_process_env(os.environ.copy())
+    env = scrub_benchmark_process_env(os.environ.copy())
     env["MODEL"] = str(bench.get("model") or env.get("MODEL", ""))
     if bench.get("precision"):
         env["PRECISION"] = str(bench["precision"])
@@ -95,7 +95,7 @@ def build_scriptable_env(
         if profile_dir:
             env["VLLM_TORCH_PROFILER_DIR"] = profile_dir
             env["SGLANG_TORCH_PROFILER_DIR"] = profile_dir
-    return env
+    return scrub_benchmark_process_env(env)
 
 
 def run_scriptable(

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -49,6 +49,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from hyperloom.common.env_safety import redact_secret_values
 from hyperloom.common.io import atomic_write_json
 from hyperloom.common.profile_args import sanitize_profile_server_args
 
@@ -2039,7 +2040,7 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
         """
         if value is None:
             return None
-        text = str(value)
+        text = redact_secret_values(str(value))
         if not text:
             return None
         if len(text) <= limit:
@@ -2061,7 +2062,7 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
         """
         if value is None:
             return None
-        text = str(value)
+        text = redact_secret_values(str(value))
         if not text:
             return None
         return text[-limit:] if len(text) > limit else text


### PR DESCRIPTION
## Summary
- remove control-plane credentials from benchmark subprocess environments and materialized workload configs
- redact credential values before benchmark failures and diagnostics are persisted
- cover baseline, grid, warmup, bypass, and GEAK execution paths with regression tests

## Test plan
- [x] Run 392 affected benchmark and state tests
- [x] Run IDE lint checks on changed files
- [x] Run `git diff --check`