### PR TITLE
Fix pre-baseline enablement attribution

### DIFF
--- a/src/hyperloom/inference_optimizer/breakdown/collectors/attribution.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/attribution.py
@@ -61,12 +61,10 @@ _ACTION_FAMILY_TABLE: tuple[tuple[Callable[[str], bool], str], ...] = (
     # instead of vanishing into the non-emitted ``other`` family. The label may
     # carry a tier suffix (``replay_warm_recipe:exact``), so match the base token.
     (lambda s: s.split(":", 1)[0] == "replay_warm_recipe", "replay_warm_recipe"),
-    # FRAMEWORK: own headline row so per-source totals reconcile against
-    # validated_total_pct (else these KEEPs fell into ``other`` and vanished).
-    # Framework-PR integration is emitted as ``integrate_patch`` (distinct from
-    # the legacy kernel ``integrate`` above), so credit it to ``framework``
-    # rather than letting it fall through to ``other``/``unattributed``.
-    (lambda s: s == "framework" or s.startswith("integrate_patch"), "framework"),
+    # FRAMEWORK: exact legacy action label. ``integrate_patch`` is phase-generic
+    # (FRAMEWORK_AGENT, EXPLORE, and pre-baseline enablement), so it is resolved
+    # from entry metadata by ``_entry_family`` rather than blanket-credited here.
+    (lambda s: s == "framework", "framework"),
     # GEMM_TUNING: deterministic FP8 tuner KEEPs, bucketed apart from generic
     # ``kernel`` so the dashboard can split tuner vs source-level rewrite gain.
     (lambda s: s == "gemm_tuning", "gemm_tuning"),
@@ -92,6 +90,28 @@ def _action_family(action: str) -> str:
     for predicate, family in _ACTION_FAMILY_TABLE:
         if predicate(s):
             return family
+    return "other"
+
+
+def _entry_family(entry: dict[str, Any]) -> str:
+    """Resolve attribution family using phase/ownership metadata when needed.
+
+    ``integrate_patch`` is not intrinsically a Framework action. Framework
+    authoring owns explicitly marked or FRAMEWORK_AGENT entries; EXPLORE owns
+    its own patch applications; PRELUDE baseline-enablement entries are
+    configuration prerequisites and remain non-attributable.
+    """
+
+    action = str(entry.get("action") or "").strip().lower()
+    if not action.startswith("integrate_patch"):
+        return _action_family(action)
+    if entry.get("attribution_eligible") is False or entry.get("baseline_enablement"):
+        return "other"
+    phase = str(entry.get("source_phase") or entry.get("phase") or "").strip().upper()
+    if phase in {"FRAMEWORK", "FRAMEWORK_AGENT"} or entry.get("framework_agent_authoring"):
+        return "framework"
+    if phase == "EXPLORE":
+        return "explore"
     return "other"
 
 
@@ -142,6 +162,15 @@ def _promote_legacy_gain_entries(
         prov = str(se.get("provenance") or "").strip()
         if prov:
             promoted["provenance"] = prov
+        for key in (
+            "source_phase",
+            "phase",
+            "framework_agent_authoring",
+            "baseline_enablement",
+            "attribution_eligible",
+        ):
+            if key in se:
+                promoted[key] = se.get(key)
         out.append(promoted)
         if cum_after is not None:
             prev_cum = cum_after
@@ -220,10 +249,12 @@ def collect_attribution(
     for e in entries:
         if not isinstance(e, dict):
             continue
+        if e.get("attribution_eligible") is False or e.get("baseline_enablement"):
+            continue
         delta = _to_float(e.get("delta_pct"))
         if delta is None:
             continue
-        fam = _action_family(str(e.get("action") or ""))
+        fam = _entry_family(e)
         family_totals[fam] = family_totals.get(fam, 0.0) + max(delta, 0.0)
 
     # Split "kernel_agent" between backends based on adopted KEEP entries.
@@ -374,6 +405,8 @@ def _collect_phase_breakdown(
     for e in entries:
         if not isinstance(e, dict):
             continue
+        if e.get("attribution_eligible") is False or e.get("baseline_enablement"):
+            continue
         delta = _to_float(e.get("delta_pct"))
         if delta is None or delta <= 0:
             continue
@@ -399,7 +432,7 @@ def _collect_phase_breakdown(
         if phase == "framework_agent":
             phase = "framework"
         action = str(e.get("action") or "").lower()
-        fam = _action_family(action)
+        fam = _entry_family(e)
         # gemm_tuning runs inside KERNEL but is bucketed separately.
         if fam == "gemm_tuning":
             phase = "gemm_tuning"

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/attribution.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/attribution.py
@@ -12,6 +12,7 @@ recorded in ``warnings`` and the section returns a best-effort partial.
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import datetime
 from typing import Any
 
 
@@ -93,7 +94,60 @@ def _action_family(action: str) -> str:
     return "other"
 
 
-def _entry_family(entry: dict[str, Any]) -> str:
+def _phase_timeline(state: dict[str, Any]) -> list[tuple[float, str]]:
+    """Return normalized phase boundaries ordered by timestamp."""
+
+    history = state.get("phase_history") or []
+    if not isinstance(history, list):
+        return []
+    timeline: list[tuple[float, str]] = []
+    for row in history:
+        if not isinstance(row, dict):
+            continue
+        try:
+            ts = float(row.get("ts_unix") or 0.0)
+        except (TypeError, ValueError):
+            ts = 0.0
+        phase = str(row.get("to_phase") or "").strip().upper()
+        if phase:
+            timeline.append((ts, phase))
+    timeline.sort(key=lambda item: item[0])
+    return timeline
+
+
+def _entry_ts(entry: dict[str, Any]) -> float | None:
+    """Return an entry timestamp suitable for phase-history lookup."""
+
+    value = entry.get("ts_unix")
+    if value is not None:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            pass
+    text = str(entry.get("ts") or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def _phase_at(ts_unix: float | None, timeline: list[tuple[float, str]]) -> str:
+    """Return the phase active at ``ts_unix``, if one can be inferred."""
+
+    if ts_unix is None:
+        return ""
+    current = ""
+    for ts, phase in timeline:
+        if ts <= ts_unix:
+            current = phase
+        else:
+            break
+    return current
+
+
+def _entry_family(entry: dict[str, Any], *, inferred_phase: str = "") -> str:
     """Resolve attribution family using phase/ownership metadata when needed.
 
     ``integrate_patch`` is not intrinsically a Framework action. Framework
@@ -106,13 +160,19 @@ def _entry_family(entry: dict[str, Any]) -> str:
     if not action.startswith("integrate_patch"):
         return _action_family(action)
     if entry.get("attribution_eligible") is False or entry.get("baseline_enablement"):
-        return "other"
-    phase = str(entry.get("source_phase") or entry.get("phase") or "").strip().upper()
-    if phase in {"FRAMEWORK", "FRAMEWORK_AGENT"} or entry.get("framework_agent_authoring"):
+        return "unattributed"
+    if entry.get("framework_agent_authoring"):
         return "framework"
-    if phase == "EXPLORE":
-        return "explore"
-    return "other"
+    phase = str(
+        entry.get("source_phase") or entry.get("phase") or inferred_phase or ""
+    ).strip().upper()
+    return {
+        "FRAMEWORK": "framework",
+        "FRAMEWORK_AGENT": "framework",
+        "EXPLORE": "explore",
+        "KERNEL": "kernel_agent",
+        "KERNEL_AGENT": "kernel_agent",
+    }.get(phase, "unattributed")
 
 
 def _promote_legacy_gain_entries(
@@ -236,6 +296,7 @@ def collect_attribution(
         "kernel_agent": 0.0,
         "sweep": 0.0,
         "other": 0.0,
+        "unattributed": 0.0,
         # Legacy buckets for archived (pre-merge) sessions.
         "backends": 0.0,
         "params": 0.0,
@@ -246,6 +307,8 @@ def collect_attribution(
         "gemm_tuning": 0.0,
         "geak": 0.0,
     }
+    timeline = _phase_timeline(state)
+    unattributed_actions: set[str] = set()
     for e in entries:
         if not isinstance(e, dict):
             continue
@@ -254,8 +317,13 @@ def collect_attribution(
         delta = _to_float(e.get("delta_pct"))
         if delta is None:
             continue
-        fam = _entry_family(e)
+        fam = _entry_family(
+            e,
+            inferred_phase=_phase_at(_entry_ts(e), timeline),
+        )
         family_totals[fam] = family_totals.get(fam, 0.0) + max(delta, 0.0)
+        if fam in {"other", "unattributed"} and delta > 0:
+            unattributed_actions.add(str(e.get("action") or "<missing>"))
 
     # Split "kernel_agent" between backends based on adopted KEEP entries.
     forge_kept_kids = {inv.get("kernel_id") for inv in forge_invocations if inv.get("decision") == "KEEP"}
@@ -270,6 +338,10 @@ def collect_attribution(
     # not tied to a Forge KEEP stays unattributed instead of being reverse-
     # inferred onto Forge (which may not have run at all this session).
     kernel_unattributed = max(kernel_total - forge_total, 0.0)
+    unattributed_total = (
+        family_totals.get("unattributed", 0.0)
+        + family_totals.get("other", 0.0)
+    )
 
     notes: list[str] = []
     if not state_provided:
@@ -284,6 +356,15 @@ def collect_attribution(
             "optimization_stack (delta_pct computed as diff vs prior entry's "
             "cum_gain_after)."
         )
+    if unattributed_total > 0:
+        actions = ", ".join(sorted(unattributed_actions))
+        note = (
+            f"{unattributed_total:.2f}% validated gain could not be assigned "
+            f"to a known source family (actions: {actions}); reported as "
+            "unattributed."
+        )
+        notes.append(note)
+        warnings.append(f"attribution: {note}")
 
     # Per-phase gain breakdown (buckets each KEEP by its active phase).
     phase_breakdown = _collect_phase_breakdown(state, entries, warnings)
@@ -296,6 +377,7 @@ def collect_attribution(
             # Kernel-lane gain with no Forge KEEP evidence; surfaced honestly
             # instead of being credited to a backend that produced no KEEP.
             "kernel_unattributed_pct_of_total": round(kernel_unattributed, 2),
+            "unattributed_pct_of_total": round(unattributed_total, 2),
             "explore_pct_of_total": round(family_totals.get("explore", 0.0), 2),
             "replay_warm_recipe_pct_of_total": round(family_totals.get("replay_warm_recipe", 0.0), 2),
             "framework_pct_of_total": round(family_totals.get("framework", 0.0), 2),
@@ -336,41 +418,7 @@ def _collect_phase_breakdown(
         sub-breakdowns.
     """
     # Phase timeline: for an entry ts, pick the latest row with ts_unix <= ts.
-    history = state.get("phase_history") or []
-    if not isinstance(history, list):
-        history = []
-    timeline: list[tuple[float, str]] = []
-    for row in history:
-        if not isinstance(row, dict):
-            continue
-        try:
-            ts = float(row.get("ts_unix") or 0.0)
-        except (TypeError, ValueError):
-            ts = 0.0
-        phase = str(row.get("to_phase") or "").strip().upper()
-        if phase:
-            timeline.append((ts, phase))
-    timeline.sort(key=lambda r: r[0])
-
-    def _phase_for(ts_unix: float) -> str:
-        """Resolve which phase owned a given timestamp.
-
-        Args:
-            ts_unix (float): Unix timestamp of a gain-ledger entry.
-
-        Returns:
-            str: The latest phase whose boundary is ``<= ts_unix``, or ``""``
-            when the timeline is empty.
-        """
-        if not timeline:
-            return ""
-        current = ""
-        for ts, ph in timeline:
-            if ts <= ts_unix:
-                current = ph
-            else:
-                break
-        return current
+    timeline = _phase_timeline(state)
 
     # Explore provenance: map fingerprint -> provenance from winners_history.
     # ``scope_by_fp`` carries the specialist dial as an additive analytics tag.
@@ -410,21 +458,7 @@ def _collect_phase_breakdown(
         delta = _to_float(e.get("delta_pct"))
         if delta is None or delta <= 0:
             continue
-        ts = e.get("ts_unix")
-        if ts is None:
-            ts_str = str(e.get("ts") or "")
-            if ts_str:
-                try:
-                    from datetime import datetime as _dt
-
-                    ts = _dt.fromisoformat(ts_str.replace("Z", "+00:00")).timestamp()
-                except (TypeError, ValueError):
-                    ts = 0.0
-        try:
-            ts_f = float(ts or 0.0)
-        except (TypeError, ValueError):
-            ts_f = 0.0
-        phase = _phase_for(ts_f).lower()
+        phase = _phase_at(_entry_ts(e), timeline).lower()
         # ``phase_history`` records the phase as ``FRAMEWORK_AGENT`` but the
         # attribution bucket is named ``framework``; normalize so framework-phase
         # KEEPs land in the framework bucket instead of missing the bucket key and
@@ -432,7 +466,7 @@ def _collect_phase_breakdown(
         if phase == "framework_agent":
             phase = "framework"
         action = str(e.get("action") or "").lower()
-        fam = _entry_family(e)
+        fam = _entry_family(e, inferred_phase=phase)
         # gemm_tuning runs inside KERNEL but is bucketed separately.
         if fam == "gemm_tuning":
             phase = "gemm_tuning"

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/optimizations.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/optimizations.py
@@ -502,6 +502,12 @@ def collect_optimizations(
             warnings.append(f"optimizations: stack entry {stack_index} is not an object")
             continue
         raw = dict(raw_value)
+        # A pre-baseline enablement patch is part of the reproducible launch
+        # configuration, not a measured optimization. Keep it in SharedState's
+        # stack, but omit it from the canonical optimization projection and do
+        # not advance the throughput chain used by the next attributable entry.
+        if raw.get("baseline_enablement") or raw.get("attribution_eligible") is False:
+            continue
         if str(raw.get("action") or "").strip().lower() in _NON_OPTIMIZATION_ACTIONS:
             anchor_tput = _to_float(raw.get("tput"))
             if anchor_tput is not None:

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/optimizations.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/optimizations.py
@@ -397,6 +397,7 @@ def _validation_summary(
         _to_float(entry.get("gain_pct")) or 0.0
         for entry in entries
         if entry.get("validated") is True
+        and entry.get("source") != "unattributed"
     )
     phase_breakdown = attribution.get("phase_breakdown")
     if not isinstance(phase_breakdown, dict):
@@ -423,6 +424,10 @@ def _validation_summary(
         ),
         "gemm_tuning_gain_pct": round(
             _to_float(source_breakdown.get("gemm_tuning_pct_of_total")) or 0.0,
+            6,
+        ),
+        "unattributed_gain_pct": round(
+            _to_float(source_breakdown.get("unattributed_pct_of_total")) or 0.0,
             6,
         ),
     }

--- a/src/hyperloom/inference_optimizer/breakdown/schema.py
+++ b/src/hyperloom/inference_optimizer/breakdown/schema.py
@@ -1203,6 +1203,9 @@ class SourceBreakdown(TypedDict, total=False):
         kernel_unattributed_pct_of_total (float): Kernel-lane gain that could
             not be tied to any backend KEEP (e.g. no Forge/GEAK KEEP evidence);
             kept unattributed rather than credited to a backend.
+        unattributed_pct_of_total (float): Gain whose owning source could not
+            be resolved from explicit ownership, recorded phase, or phase
+            history.
         backends_pct_of_total (float): Gain share from backend exploration.
         params_pct_of_total (float): Gain share from param exploration.
         sweep_pct_of_total (float): Gain share attributed to the sweep.
@@ -1220,6 +1223,8 @@ class SourceBreakdown(TypedDict, total=False):
     gemm_tuning_pct_of_total: float
     # Kernel-lane gain with no backend KEEP evidence; unattributed on purpose.
     kernel_unattributed_pct_of_total: float
+    # Gain whose owning source could not be resolved.
+    unattributed_pct_of_total: float
     backends_pct_of_total: float
     params_pct_of_total: float
     sweep_pct_of_total: float

--- a/src/hyperloom/inference_optimizer/tests/test_promote_shared_state_lock.py
+++ b/src/hyperloom/inference_optimizer/tests/test_promote_shared_state_lock.py
@@ -407,6 +407,42 @@ async def test_promote_integrate_patch_kept_lifts_and_clears_pending(session_dir
 
 
 @pytest.mark.asyncio
+async def test_prebaseline_enablement_patch_is_config_only_not_gain(session_dir):
+    """A patch required to establish baseline stays reproducible but has no gain."""
+    coord = _coord(session_dir)
+    s = coord.shared_state
+    s.baseline_tput = 0.0
+    s.pending_integrate = {"task_id": "t-enable"}
+
+    await coord._promote_to_shared_state(
+        "integrate_patch",
+        {
+            "status": "kept",
+            "enablement": True,
+            "output_throughput": 140.0,
+            "specialist_task_id": "spec-enable",
+            "extra_server_args_applied": "--mem-fraction-static 0.95",
+            "workspace": "/w",
+        },
+        task=_task(
+            "integrate_patch",
+            task_id="t-enable",
+            params={"enablement": True},
+        ),
+    )
+
+    assert len(s.optimization_stack) == 1
+    entry = s.optimization_stack[0]
+    assert entry["action"] == "integrate_patch"
+    assert entry["baseline_enablement"] is True
+    assert entry["attribution_eligible"] is False
+    assert s.gain_per_stack_entry == [None]
+    assert s.cumulative_gain == 0.0
+    assert s.cumulative_gain_validated == 0.0
+    assert s.pending_integrate == {}
+
+
+@pytest.mark.asyncio
 async def test_promote_integrate_patch_reverted_keeps_current_best(session_dir):
     coord = _coord(session_dir)
     s = coord.shared_state

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py
@@ -68,6 +68,10 @@ def test_collect_optimizations_unifies_warm_framework_and_explore():
     assert summary["warm_replay"] == {"keeps": 1, "total_gain_pct": 50.0}
     assert summary["framework_agent"] == {"keeps": 1, "total_gain_pct": 10.0}
     assert summary["explore"] == {"keeps": 1, "total_gain_pct": 10.0}
+    source_breakdown = attribution["source_breakdown"]
+    assert source_breakdown["framework_pct_of_total"] == 10.0
+    assert source_breakdown["explore_pct_of_total"] == 10.0
+    assert source_breakdown["unattributed_pct_of_total"] == 0.0
 
 
 def test_prebaseline_enablement_is_not_framework_gain_before_warm_replay():
@@ -111,6 +115,69 @@ def test_prebaseline_enablement_is_not_framework_gain_before_warm_replay():
     assert [entry["source"] for entry in result["entries"]] == ["warm_replay"]
     assert result["entries"][0]["throughput_before"] == 100.0
     assert result["entries"][0]["gain_pct"] == 10.0
+
+
+def test_integrate_patch_with_unknown_phase_is_visible_as_unattributed():
+    state = {
+        "session_id": "unknown-integrate-owner",
+        "baseline_tput": 100.0,
+        "cumulative_gain_validated": 10.0,
+        "cumulative_gain_validated_stack_len": 1,
+        "optimization_stack": [
+            {
+                "action": "integrate_patch",
+                "source_phase": "",
+                "variant_name": "unknown-owner",
+                "tput": 110.0,
+                "ts": "1970-01-01T00:00:10+00:00",
+            },
+        ],
+        "gain_per_stack_entry": [10.0],
+    }
+    warnings: list[str] = []
+
+    attribution = collect_attribution(state, [], [], warnings)
+    result = collect_optimizations(state, attribution, [], [], warnings)
+
+    assert attribution["source_breakdown"]["unattributed_pct_of_total"] == 10.0
+    assert any("reported as unattributed" in note for note in attribution["notes"])
+    assert any("reported as unattributed" in warning for warning in warnings)
+    assert result["entries"][0]["source"] == "unattributed"
+    assert result["summary_by_source"]["unattributed"] == {
+        "keeps": 1,
+        "total_gain_pct": 10.0,
+    }
+    assert result["validation"]["attributed_total_gain_pct"] == 0.0
+    assert result["validation"]["attribution_gap_pct"] == 10.0
+
+
+def test_integrate_patch_from_kernel_phase_is_not_silently_dropped():
+    state = {
+        "session_id": "kernel-integrate-owner",
+        "baseline_tput": 100.0,
+        "cumulative_gain_validated": 10.0,
+        "cumulative_gain_validated_stack_len": 1,
+        "optimization_stack": [
+            {
+                "action": "integrate_patch",
+                "source_phase": "KERNEL_AGENT",
+                "variant_name": "kernel-owned",
+                "tput": 110.0,
+                "ts": "1970-01-01T00:00:10+00:00",
+            },
+        ],
+        "gain_per_stack_entry": [10.0],
+    }
+    warnings: list[str] = []
+
+    attribution = collect_attribution(state, [], [], warnings)
+    result = collect_optimizations(state, attribution, [], [], warnings)
+
+    assert attribution["source_breakdown"]["kernel_unattributed_pct_of_total"] == 10.0
+    assert attribution["source_breakdown"]["unattributed_pct_of_total"] == 0.0
+    assert result["entries"][0]["source"] == "kernel_agent"
+    assert result["validation"]["attributed_total_gain_pct"] == 10.0
+    assert result["validation"]["attribution_gap_pct"] == 0.0
 
 
 def test_collect_optimizations_splits_kernel_backend():

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py
@@ -70,6 +70,49 @@ def test_collect_optimizations_unifies_warm_framework_and_explore():
     assert summary["explore"] == {"keeps": 1, "total_gain_pct": 10.0}
 
 
+def test_prebaseline_enablement_is_not_framework_gain_before_warm_replay():
+    """A runnable-baseline patch is config provenance, not a Framework gain."""
+    state = {
+        "session_id": "enablement-before-warm",
+        "baseline_tput": 100.0,
+        "cumulative_gain_validated": 10.0,
+        "cumulative_gain_validated_stack_len": 2,
+        "optimization_stack": [
+            {
+                "action": "integrate_patch",
+                "source_phase": "PRELUDE",
+                "baseline_enablement": True,
+                "attribution_eligible": False,
+                "variant_name": "make-model-runnable",
+                "tput": 100.0,
+                "ts": "1970-01-01T00:00:10+00:00",
+            },
+            {
+                "action": "replay_warm_recipe",
+                "source_phase": "PRELUDE",
+                "variant_name": "warm",
+                "tput": 110.0,
+                "ts": "1970-01-01T00:00:20+00:00",
+            },
+        ],
+        "gain_per_stack_entry": [None, 10.0],
+        "phase_history": [
+            {"to_phase": "PRELUDE", "ts_unix": 0.0},
+        ],
+    }
+    warnings: list[str] = []
+
+    attribution = collect_attribution(state, [], [], warnings)
+    result = collect_optimizations(state, attribution, [], [], warnings)
+
+    assert attribution["gain_per_stack_entry"][1]["cum_gain_before"] == 0.0
+    assert attribution["source_breakdown"]["framework_pct_of_total"] == 0.0
+    assert attribution["source_breakdown"]["replay_warm_recipe_pct_of_total"] == 10.0
+    assert [entry["source"] for entry in result["entries"]] == ["warm_replay"]
+    assert result["entries"][0]["throughput_before"] == 100.0
+    assert result["entries"][0]["gain_pct"] == 10.0
+
+
 def test_collect_optimizations_splits_kernel_backend():
     state = {
         "session_id": "s2",

--- a/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
+++ b/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
@@ -53,22 +53,6 @@ class _StubSharedState:
     def save(self, *args, **kwargs):  # noqa: D401 — stub
         pass
 
-    def append_stack_gain_entry(
-        self,
-        *,
-        action,
-        variant_name,
-        new_tput,
-        extra_server_args="",
-        ts=None,
-    ):
-        gain = round(
-            (float(new_tput) / float(self.baseline_tput) - 1.0) * 100.0,
-            3,
-        )
-        self.gain_per_stack_entry.append(gain)
-        return gain
-
 
 class _StubTaskRegistry:
     """Captures ``create_or_return_existing`` calls so tests can assert."""
@@ -462,36 +446,6 @@ def test_promote_warm_replay_keeps_prebaseline_enablement_as_zero_gain_anchor(
     assert coord.shared_state.gain_per_stack_entry == [None, 23.0]
     assert coord.shared_state.cumulative_gain == 23.0
     assert coord.shared_state.cumulative_gain_validated_stack_len == 2
-
-
-def test_promote_warm_replay_skips_after_validated_optimization(tmp_path):
-    """Standalone warm replay must not overwrite an existing validated stack."""
-    coord = _make_coord(tmp_path, warm_start_recipe=_warm_recipe_t1())
-    coord.shared_state.optimization_stack = [
-        {"action": "integrate_patch", "tput": 660.0}
-    ]
-    coord.shared_state.gain_per_stack_entry = [10.0]
-    coord.shared_state.cumulative_gain = 10.0
-    coord.shared_state.cumulative_gain_validated = 10.0
-    coord.shared_state.cumulative_gain_validated_stack_len = 1
-    coord.shared_state.warm_replay_outcome = {
-        "status": "in_flight",
-        "expected_gain_pct": 25.0,
-    }
-
-    coord._promote_warm_replay(
-        {"status": "succeeded", "output_throughput": 738.0},
-        task=_StubTask(params={"extra_server_args": "--attention-backend AITER"}),
-    )
-
-    assert coord.shared_state.warm_replay_outcome["status"] == "skipped"
-    assert (
-        coord.shared_state.warm_replay_outcome["reason"]
-        == "preexisting_validated_stack_requires_combined_rebench"
-    )
-    assert len(coord.shared_state.optimization_stack) == 1
-    assert coord.shared_state.gain_per_stack_entry == [10.0]
-    assert coord.shared_state.cumulative_gain == 10.0
 
 
 def test_promote_warm_replay_rejected_by_failed_quality_gate(tmp_path):

--- a/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
+++ b/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
@@ -53,6 +53,22 @@ class _StubSharedState:
     def save(self, *args, **kwargs):  # noqa: D401 — stub
         pass
 
+    def append_stack_gain_entry(
+        self,
+        *,
+        action,
+        variant_name,
+        new_tput,
+        extra_server_args="",
+        ts=None,
+    ):
+        gain = round(
+            (float(new_tput) / float(self.baseline_tput) - 1.0) * 100.0,
+            3,
+        )
+        self.gain_per_stack_entry.append(gain)
+        return gain
+
 
 class _StubTaskRegistry:
     """Captures ``create_or_return_existing`` calls so tests can assert."""
@@ -413,6 +429,69 @@ def test_promote_warm_replay_reproduced_pushes_stack_and_updates_gain(
     assert coord.shared_state.cumulative_gain_validated_stack_len == 1
     assert coord.shared_state.current_best["action"] == "warm_replay"
     assert coord.shared_state.current_best["tput"] == 738.0
+
+
+def test_promote_warm_replay_keeps_prebaseline_enablement_as_zero_gain_anchor(
+    tmp_path,
+):
+    """A PRELUDE enablement config stays reproducible but contributes no gain."""
+    coord = _make_coord(tmp_path, warm_start_recipe=_warm_recipe_t1())
+    coord.shared_state.optimization_stack = [
+        {
+            "action": "integrate_patch",
+            "baseline_enablement": True,
+            "attribution_eligible": False,
+            "tput": 600.0,
+        }
+    ]
+    coord.shared_state.gain_per_stack_entry = [None]
+    coord.shared_state.warm_replay_outcome = {
+        "status": "in_flight",
+        "expected_gain_pct": 25.0,
+    }
+
+    coord._promote_warm_replay(
+        {"status": "succeeded", "output_throughput": 738.0},
+        task=_StubTask(params={"extra_server_args": "--attention-backend AITER"}),
+    )
+
+    assert [entry["action"] for entry in coord.shared_state.optimization_stack] == [
+        "integrate_patch",
+        "replay_warm_recipe",
+    ]
+    assert coord.shared_state.gain_per_stack_entry == [None, 23.0]
+    assert coord.shared_state.cumulative_gain == 23.0
+    assert coord.shared_state.cumulative_gain_validated_stack_len == 2
+
+
+def test_promote_warm_replay_skips_after_validated_optimization(tmp_path):
+    """Standalone warm replay must not overwrite an existing validated stack."""
+    coord = _make_coord(tmp_path, warm_start_recipe=_warm_recipe_t1())
+    coord.shared_state.optimization_stack = [
+        {"action": "integrate_patch", "tput": 660.0}
+    ]
+    coord.shared_state.gain_per_stack_entry = [10.0]
+    coord.shared_state.cumulative_gain = 10.0
+    coord.shared_state.cumulative_gain_validated = 10.0
+    coord.shared_state.cumulative_gain_validated_stack_len = 1
+    coord.shared_state.warm_replay_outcome = {
+        "status": "in_flight",
+        "expected_gain_pct": 25.0,
+    }
+
+    coord._promote_warm_replay(
+        {"status": "succeeded", "output_throughput": 738.0},
+        task=_StubTask(params={"extra_server_args": "--attention-backend AITER"}),
+    )
+
+    assert coord.shared_state.warm_replay_outcome["status"] == "skipped"
+    assert (
+        coord.shared_state.warm_replay_outcome["reason"]
+        == "preexisting_validated_stack_requires_combined_rebench"
+    )
+    assert len(coord.shared_state.optimization_stack) == 1
+    assert coord.shared_state.gain_per_stack_entry == [10.0]
+    assert coord.shared_state.cumulative_gain == 10.0
 
 
 def test_promote_warm_replay_rejected_by_failed_quality_gate(tmp_path):

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -2143,6 +2143,9 @@ class WritebackCollaborator:
                         val = bv.get(_src_key)
                         if val:
                             stack_entry[_src_key] = str(val)
+                    for _attr_key in ("baseline_enablement", "attribution_eligible"):
+                        if _attr_key in bv:
+                            stack_entry[_attr_key] = bool(bv.get(_attr_key))
                 self.shared_state.optimization_stack.append(stack_entry)
                 # Mirror append into gain_per_stack_entry so the two lists stay index-aligned.
                 self.shared_state.append_stack_gain_entry(
@@ -3022,6 +3025,16 @@ class WritebackCollaborator:
         status = str(result.get("status") or "")
         new_tput = result.get("output_throughput")
         kept_flag = status == "kept" and isinstance(new_tput, (int, float)) and float(new_tput) > 0
+        task_params = (getattr(task, "params", None) or {}) if task is not None else {}
+        prebaseline_enablement = bool(
+            kept_flag
+            and float(getattr(self.shared_state, "baseline_tput", 0.0) or 0.0) <= 0.0
+            and (
+                result.get("enablement")
+                or task_params.get("enablement")
+                or task_params.get("enablement_landing")
+            )
+        )
         if kept_flag:
             specialist_task_id = str(result.get("specialist_task_id") or "")
             lift = {
@@ -3043,13 +3056,30 @@ class WritebackCollaborator:
                 "framework_root": result.get("framework_root") or "",
                 "base_sha": result.get("base_sha") or "",
             }
-            self._lift_to_current_best("integrate_patch", float(new_tput), lift)
-            if self.shared_state.baseline_tput > 0:
-                self._update_cumulative_gain_validated(new_tput)
-                self.shared_state.resume_pending_revalidation = False
-                await self._maybe_enqueue_watermark_roofline(
-                    reason="integrate_keep_watermark",
+            if prebaseline_enablement:
+                lift["baseline_enablement"] = True
+                lift["attribution_eligible"] = False
+            if prebaseline_enablement:
+                # This patch establishes the runnable baseline environment. Keep
+                # it in the configuration stack for reproducibility, but mark it
+                # ineligible for gain attribution because no runnable before
+                # measurement exists.
+                self._lift_to_current_best("integrate_patch", float(new_tput), lift)
+                log.info(
+                    "integrate_patch KEEP accepted as pre-baseline enablement; "
+                    "retained in config stack without gain attribution "
+                    "(task=%s specialist=%s)",
+                    str(getattr(task, "task_id", "") or ""),
+                    specialist_task_id,
                 )
+            else:
+                self._lift_to_current_best("integrate_patch", float(new_tput), lift)
+                if self.shared_state.baseline_tput > 0:
+                    self._update_cumulative_gain_validated(new_tput)
+                    self.shared_state.resume_pending_revalidation = False
+                    await self._maybe_enqueue_watermark_roofline(
+                        reason="integrate_keep_watermark",
+                    )
             changed = True
         # Clear the pending_integrate sentinel after the task outcome is observed.
         if isinstance(getattr(self.shared_state, "pending_integrate", None), dict):
@@ -3060,12 +3090,19 @@ class WritebackCollaborator:
             }:
                 self.shared_state.pending_integrate = {}
                 changed = True
-        audit_decision = "promoted" if kept_flag else "discarded"
+        audit_decision = (
+            "enablement_accepted"
+            if prebaseline_enablement
+            else "promoted"
+            if kept_flag
+            else "discarded"
+        )
         audit_extras = {
             "status": status,
             "specialist_task_id": result.get("specialist_task_id"),
             "output_throughput": new_tput,
             "delta_pct": result.get("delta_pct"),
+            "prebaseline_enablement": prebaseline_enablement,
             "accuracy_pass": result.get("accuracy_pass"),
             "patches_applied": result.get("patches_applied") or [],
             "patches_reverted": result.get("patches_reverted") or [],

--- a/src/hyperloom/orchestrator/phases/prelude.py
+++ b/src/hyperloom/orchestrator/phases/prelude.py
@@ -238,27 +238,6 @@ class PreludePhase(PhaseHandler):
         if state.warm_replay_attempted:
             # Resume safety: a previous boot already enqueued/ran the replay.
             return None
-        # Warm replay is a PRELUDE branch measured against baseline_tput.  It is
-        # only attribution-safe before any *validated* optimization layer has
-        # landed.  Pre-baseline enablement entries from older sessions may still
-        # be present with a zero validation watermark; those are part of the
-        # baseline environment and remain replayable.  A validated stack,
-        # however, requires a combined full-stack rebench rather than replaying
-        # a standalone recipe and crediting its full baseline-relative gain.
-        try:
-            validated_stack_len = int(
-                getattr(state, "cumulative_gain_validated_stack_len", 0) or 0
-            )
-        except (TypeError, ValueError):
-            validated_stack_len = 0
-        if validated_stack_len > 0:
-            state.warm_replay_outcome = {
-                "status": "skipped",
-                "reason": "preexisting_validated_stack_requires_combined_rebench",
-                "validated_stack_len": validated_stack_len,
-            }
-            state.warm_replay_attempted = True
-            return None
         warm = state.warm_start_recipe or {}
         if not isinstance(warm, dict) or not warm:
             state.warm_replay_outcome = {
@@ -501,27 +480,6 @@ class PreludePhase(PhaseHandler):
             state.save(self.session_dir)
             log.info("warm-replay REJECTED by quality gate: %s", qg)
             return
-        # Defense in depth for a stack layer that landed while the replay task
-        # was in flight.  The replay result is a standalone baseline-relative
-        # measurement; promoting it after a validated Framework/Explore layer
-        # would overwrite cumulative attribution and double-credit prior work.
-        try:
-            validated_stack_len = int(
-                getattr(state, "cumulative_gain_validated_stack_len", 0) or 0
-            )
-        except (TypeError, ValueError):
-            validated_stack_len = 0
-        if validated_stack_len > 0:
-            outcome["status"] = "skipped"
-            outcome["reason"] = "preexisting_validated_stack_requires_combined_rebench"
-            outcome["validated_stack_len"] = validated_stack_len
-            state.warm_replay_outcome = outcome
-            state.save(self.session_dir)
-            log.warning(
-                "warm-replay not promoted: validated stack len=%d requires a combined rebench",
-                validated_stack_len,
-            )
-            return
         measured_gain = (single_round_tput / baseline_tput - 1.0) * 100.0
         min_reproduce = float(
             getattr(self, "_warm_replay_min_reproduce_pct", 0.8) or 0.8,
@@ -589,16 +547,10 @@ class PreludePhase(PhaseHandler):
                 state.save(self.session_dir)
                 return
             state.optimization_stack.append(stack_entry)
-            # Keep the authoritative cumulative ledger index-aligned with the
-            # stack.  This helper records absolute gain vs baseline; attribution
-            # derives the marginal delta from the preceding cumulative row.
-            state.append_stack_gain_entry(
-                action="replay_warm_recipe",
-                variant_name="warm_replay",
-                new_tput=single_round_tput,
-                extra_server_args=warm_args,
-                ts=stack_entry["ts"],
-            )
+            # gain_per_stack_entry runs in lock-step with optimization_stack.
+            gp = list(getattr(state, "gain_per_stack_entry", []) or [])
+            gp.append(round(measured_gain, 3))
+            state.gain_per_stack_entry = gp
             # Cumulative gain is absolute tput vs baseline, not additive deltas.
             total_gain = (single_round_tput / baseline_tput - 1.0) * 100.0
             state.cumulative_gain = round(total_gain, 3)

--- a/src/hyperloom/orchestrator/phases/prelude.py
+++ b/src/hyperloom/orchestrator/phases/prelude.py
@@ -238,6 +238,27 @@ class PreludePhase(PhaseHandler):
         if state.warm_replay_attempted:
             # Resume safety: a previous boot already enqueued/ran the replay.
             return None
+        # Warm replay is a PRELUDE branch measured against baseline_tput.  It is
+        # only attribution-safe before any *validated* optimization layer has
+        # landed.  Pre-baseline enablement entries from older sessions may still
+        # be present with a zero validation watermark; those are part of the
+        # baseline environment and remain replayable.  A validated stack,
+        # however, requires a combined full-stack rebench rather than replaying
+        # a standalone recipe and crediting its full baseline-relative gain.
+        try:
+            validated_stack_len = int(
+                getattr(state, "cumulative_gain_validated_stack_len", 0) or 0
+            )
+        except (TypeError, ValueError):
+            validated_stack_len = 0
+        if validated_stack_len > 0:
+            state.warm_replay_outcome = {
+                "status": "skipped",
+                "reason": "preexisting_validated_stack_requires_combined_rebench",
+                "validated_stack_len": validated_stack_len,
+            }
+            state.warm_replay_attempted = True
+            return None
         warm = state.warm_start_recipe or {}
         if not isinstance(warm, dict) or not warm:
             state.warm_replay_outcome = {
@@ -480,6 +501,27 @@ class PreludePhase(PhaseHandler):
             state.save(self.session_dir)
             log.info("warm-replay REJECTED by quality gate: %s", qg)
             return
+        # Defense in depth for a stack layer that landed while the replay task
+        # was in flight.  The replay result is a standalone baseline-relative
+        # measurement; promoting it after a validated Framework/Explore layer
+        # would overwrite cumulative attribution and double-credit prior work.
+        try:
+            validated_stack_len = int(
+                getattr(state, "cumulative_gain_validated_stack_len", 0) or 0
+            )
+        except (TypeError, ValueError):
+            validated_stack_len = 0
+        if validated_stack_len > 0:
+            outcome["status"] = "skipped"
+            outcome["reason"] = "preexisting_validated_stack_requires_combined_rebench"
+            outcome["validated_stack_len"] = validated_stack_len
+            state.warm_replay_outcome = outcome
+            state.save(self.session_dir)
+            log.warning(
+                "warm-replay not promoted: validated stack len=%d requires a combined rebench",
+                validated_stack_len,
+            )
+            return
         measured_gain = (single_round_tput / baseline_tput - 1.0) * 100.0
         min_reproduce = float(
             getattr(self, "_warm_replay_min_reproduce_pct", 0.8) or 0.8,
@@ -547,10 +589,16 @@ class PreludePhase(PhaseHandler):
                 state.save(self.session_dir)
                 return
             state.optimization_stack.append(stack_entry)
-            # gain_per_stack_entry runs in lock-step with optimization_stack.
-            gp = list(getattr(state, "gain_per_stack_entry", []) or [])
-            gp.append(round(measured_gain, 3))
-            state.gain_per_stack_entry = gp
+            # Keep the authoritative cumulative ledger index-aligned with the
+            # stack.  This helper records absolute gain vs baseline; attribution
+            # derives the marginal delta from the preceding cumulative row.
+            state.append_stack_gain_entry(
+                action="replay_warm_recipe",
+                variant_name="warm_replay",
+                new_tput=single_round_tput,
+                extra_server_args=warm_args,
+                ts=stack_entry["ts"],
+            )
             # Cumulative gain is absolute tput vs baseline, not additive deltas.
             total_gain = (single_round_tput / baseline_tput - 1.0) * 100.0
             state.cumulative_gain = round(total_gain, 3)


### PR DESCRIPTION
## Summary
- keep pre-baseline enablement patches in the reproducible config stack while marking them ineligible for optimization gain attribution
- classify `integrate_patch` from phase and ownership metadata instead of crediting every patch to Framework Agent
- omit baseline-enablement entries from the canonical optimization projection so warm replay remains the first measured gain

## Test plan
- [x] Run focused warm replay and SBD attribution regressions (4 passed)
- [x] Verify pre-baseline enablement promotion through an async manual regression
- [x] Compile all changed Python files
- [ ] Run the complete async test selection in CI (local environment lacks `pytest-asyncio`)