### PR TITLE
fix(kernel): recognize aiter_meta split-wheel .cu for JIT rebuild on integrate

### DIFF
--- a/src/hyperloom/agents/kernel/tools/apply_and_bench.py
+++ b/src/hyperloom/agents/kernel/tools/apply_and_bench.py
@@ -169,6 +169,33 @@ def _aiter_prebuilt_so(aiter_root: Path) -> list[Path]:
     return list(aiter_root.rglob("module_aiter_core*.so"))
 
 
+# aiter device sources live in-tree (``/aiter/``) or in the sibling split
+# wheel (``/aiter_meta/``); both must trigger the aiter re-JIT path.
+_AITER_PATH_MARKERS = ("/aiter/", "/aiter_meta/")
+
+
+def _is_aiter_cu(target: Path) -> bool:
+    """Whether ``target`` is an aiter device source (``.cu``/``.cuh``).
+
+    Recognises both the in-tree ``/aiter/`` layout and the split-wheel
+    ``/aiter_meta/`` layout so patched aiter kernels always force a rebuild.
+    """
+    if target.suffix not in {".cu", ".cuh"}:
+        return False
+    norm = str(target).replace(os.sep, "/")
+    return any(marker in norm for marker in _AITER_PATH_MARKERS)
+
+
+def _aiter_source_root(target: Path) -> Path | None:
+    """Return the aiter/aiter_meta package root a source resides under, if any."""
+    parts = target.parts
+    for name in ("aiter_meta", "aiter"):
+        if name in parts:
+            idx = len(parts) - 1 - parts[::-1].index(name)
+            return Path(*parts[: idx + 1])
+    return None
+
+
 def _launch_server(
     backend: str, model: str, tp: int, port: int, gpu: str, extra_env: dict[str, str], log_path: Path
 ) -> subprocess.Popen:
@@ -661,7 +688,7 @@ def apply_and_bench(
             return {"status": "error", "error": "need pairs=[(patch,target),...] or patch_path+target_file"}
         pairs = [(patch_path, target_file)]
     targets = [Path(t) for _, t in pairs]
-    any_aiter_cu = any("/aiter/" in str(t) and t.suffix in {".cu", ".cuh"} for t in targets)
+    any_aiter_cu = any(_is_aiter_cu(t) for t in targets)
     patched_env: dict[str, str] = {}
     if aiter_rebuild or any_aiter_cu:
         patched_env["AITER_REBUILD"] = "1"
@@ -705,7 +732,12 @@ def apply_and_bench(
     for i, (pp, tf) in enumerate(pairs):
         if _looks_like_diff(Path(pp)):
             # Reconstruct byte-exact source for every file the diff touches, then deploy each.
-            repo_root = Path("/sgl-workspace/aiter") if "/aiter/" in str(tf) else Path(tf).parents[2]
+            if "/aiter/" in str(tf):
+                repo_root = Path("/sgl-workspace/aiter")
+            elif "/aiter_meta/" in str(tf):
+                repo_root = _aiter_source_root(Path(tf)) or Path(tf).parents[2]
+            else:
+                repo_root = Path(tf).parents[2]
             rec = _reconstruct_sources_from_diff(Path(pp), repo_root, out)
             if rec.get("status") != "ok":
                 _revert_all()
@@ -746,7 +778,7 @@ def apply_and_bench(
         engagement = [
             dict(
                 target=str(t),
-                **_engagement_proof(out / "server_patched.log", t, "/aiter/" in str(t) and t.suffix in {".cu", ".cuh"}),
+                **_engagement_proof(out / "server_patched.log", t, _is_aiter_cu(t)),
             )
             for t in targets
         ]

--- a/src/hyperloom/agents/kernel/tools/apply_and_bench.py
+++ b/src/hyperloom/agents/kernel/tools/apply_and_bench.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import signal
 import statistics
 import subprocess
@@ -78,13 +79,76 @@ def _diff_unsupported_ops(diff_text: str) -> list[str]:
     return sorted(set(bad))
 
 
+def _is_git_tree(path: Path) -> bool:
+    """True when ``path`` is inside an initialised git work tree."""
+    try:
+        cp = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--is-inside-work-tree"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return cp.returncode == 0 and cp.stdout.strip() == "true"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _diff_target_paths(diff_text: str) -> list[tuple[str, str]]:
+    """Return raw ``(old, new)`` header paths for every file section in a diff."""
+    pairs: list[tuple[str, str]] = []
+    old: str | None = None
+    for ln in diff_text.splitlines():
+        if ln.startswith("--- "):
+            old = ln[4:].split("\t", 1)[0].strip()
+        elif ln.startswith("+++ ") and old is not None:
+            new = ln[4:].split("\t", 1)[0].strip()
+            pairs.append((old, new))
+            old = None
+    return pairs
+
+
+def _seed_base_tree_from_disk(diff_text: str, repo_root: Path, wt: Path, level: int) -> None:
+    """Copy each modified file's on-disk base into ``wt`` at its stripped rel path.
+
+    Added files (``--- /dev/null``) have no base and are left for ``git apply`` to
+    create. Used for non-git installs (e.g. the ``aiter_meta`` split wheel under
+    dist-packages) where a hermetic ``git worktree`` checkout is unavailable.
+    """
+    for old_raw, _new_raw in _diff_target_paths(diff_text):
+        if old_raw in ("/dev/null", ""):
+            continue
+        rel = _strip_diff_prefix(old_raw, level)
+        if not rel or rel.startswith("/") or ".." in Path(rel).parts:
+            continue
+        base = repo_root / rel
+        if base.is_file():
+            dst = wt / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(base.read_bytes())
+
+
+def _strip_diff_prefix(path: str, level: int) -> str:
+    """Drop ``level`` leading path components (mimics ``git apply -p<level>``)."""
+    if level <= 0:
+        return path
+    parts = path.split("/")
+    return "/".join(parts[level:]) if len(parts) > level else parts[-1]
+
+
 def _reconstruct_sources_from_diff(diff_path: Path, repo_root: Path, out_dir: Path) -> dict[str, Any]:
     """Reconstruct the byte-exact optimized source for every file a diff touches.
 
-    Applies the diff to a throwaway copy of the repo's committed tree and reads back each
-    resulting file. delete / rename / copy / mode-only / binary ops are detected up front
-    (the function fails). Done in an isolated ``git worktree`` so the live tree is never
-    mutated. Returns ``{status, files: {repo_rel_path: reconstructed_source_path}, error}``.
+    Applies the diff to a throwaway copy of the base tree and reads back each
+    resulting file. delete / rename / copy / mode-only / binary ops are detected up
+    front (the function fails). The base tree is materialized hermetically:
+
+    * git install -> an isolated ``git worktree`` checked out at ``HEAD``;
+    * non-git install (e.g. the ``aiter_meta`` split wheel under dist-packages,
+      which is not a git repo) -> a temp tree seeded with each touched file's
+      current on-disk contents.
+
+    ``git apply`` runs in that temp tree either way (it does not require a repo).
+    Returns ``{status, files: {repo_rel_path: reconstructed_source_path}, error}``.
     """
     try:
         diff_text = diff_path.read_text(encoding="utf-8", errors="replace")
@@ -99,17 +163,27 @@ def _reconstruct_sources_from_diff(diff_path: Path, repo_root: Path, out_dir: Pa
         }
     files: dict[str, str] = {}
     wt = out_dir / f"_recon_wt_{diff_path.stem}"
-    # Detached worktree at HEAD for hermetic reconstruction.
-    rm = subprocess.run(
-        ["git", "-C", str(repo_root), "worktree", "add", "--detach", "-f", str(wt), "HEAD"],
-        capture_output=True,
-        text=True,
-    )
-    if rm.returncode != 0:
-        return {"status": "failed", "error": f"git worktree add: {rm.stderr[:200]}"}
+    is_git = _is_git_tree(repo_root)
+    if is_git:
+        # Detached worktree at HEAD for hermetic reconstruction.
+        rm = subprocess.run(
+            ["git", "-C", str(repo_root), "worktree", "add", "--detach", "-f", str(wt), "HEAD"],
+            capture_output=True,
+            text=True,
+        )
+        if rm.returncode != 0:
+            return {"status": "failed", "error": f"git worktree add: {rm.stderr[:200]}"}
     try:
         applied = False
         for lvl in (1, 0, 2):
+            if not is_git:
+                # Non-git: rebuild the temp tree from the current on-disk base for
+                # this strip level before probing (each level maps headers to a
+                # different rel path).
+                if wt.exists():
+                    shutil.rmtree(wt)
+                wt.mkdir(parents=True, exist_ok=True)
+                _seed_base_tree_from_disk(diff_text, repo_root, wt, lvl)
             chk = subprocess.run(
                 ["git", "-C", str(wt), "apply", f"-p{lvl}", "--check", str(diff_path)], capture_output=True, text=True
             )
@@ -138,7 +212,8 @@ def _reconstruct_sources_from_diff(diff_path: Path, repo_root: Path, out_dir: Pa
                 applied = True
                 _log(
                     out_dir,
-                    f"reconstructed {len(files)} file(s) from diff -p{lvl}: "
+                    f"reconstructed {len(files)} file(s) from diff -p{lvl} "
+                    f"({'git' if is_git else 'nogit-disk'}): "
                     f"{', '.join(r.split('/')[-1] for r in files)}",
                 )
                 break
@@ -146,9 +221,12 @@ def _reconstruct_sources_from_diff(diff_path: Path, repo_root: Path, out_dir: Pa
             return {"status": "failed", "error": "git apply: no -p level (0/1/2) applies this diff cleanly"}
         return {"status": "ok", "files": files}
     finally:
-        subprocess.run(
-            ["git", "-C", str(repo_root), "worktree", "remove", "-f", str(wt)], capture_output=True, text=True
-        )
+        if is_git:
+            subprocess.run(
+                ["git", "-C", str(repo_root), "worktree", "remove", "-f", str(wt)], capture_output=True, text=True
+            )
+        elif wt.exists():
+            shutil.rmtree(wt, ignore_errors=True)
 
 
 def _find_benchmark_serving() -> str | None:

--- a/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
+++ b/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
@@ -763,7 +763,10 @@ def _clear_python_kernel_caches(target: Path) -> dict[str, Any]:
 
 
 # aiter JIT cache invalidation around rebuilds (setup.py develop won't invalidate jit/build/ .so).
-_AITER_CSRC_MARKER = "/aiter/csrc/"
+# aiter device sources ship either in-tree (``/aiter/csrc/``) or in the sibling
+# split wheel (``/aiter_meta/csrc/``); both feed the same importable ``aiter``
+# JIT build, so the rebuild gates must recognise both layouts.
+_AITER_CSRC_MARKERS = ("/aiter/csrc/", "/aiter_meta/csrc/")
 
 
 def _isolated_aiter_pkg_root() -> Path | None:
@@ -787,9 +790,11 @@ def _target_is_in_aiter_csrc(target_file: Path) -> bool:
         target_file: The file path to test.
 
     Returns:
-        ``True`` if the path is under an ``aiter/csrc/`` directory.
+        ``True`` if the path is under an ``aiter/csrc/`` (in-tree) or
+        ``aiter_meta/csrc/`` (split-wheel) directory.
     """
-    return _AITER_CSRC_MARKER in str(target_file).replace(os.sep, "/")
+    norm = str(target_file).replace(os.sep, "/")
+    return any(marker in norm for marker in _AITER_CSRC_MARKERS)
 
 
 def _aiter_jit_build_dir() -> Path | None:
@@ -931,7 +936,7 @@ def _restore_aiter_jit_build(jit_build_backup: dict[str, Any]) -> dict[str, Any]
 
 
 # aiter cpp_itfs kernels are runtime-compiled into parameter-keyed caches.
-_AITER_CPP_ITFS_MARKER = "/aiter/csrc/cpp_itfs/"
+_AITER_CPP_ITFS_MARKERS = ("/aiter/csrc/cpp_itfs/", "/aiter_meta/csrc/cpp_itfs/")
 _MD_NAME_RE = re.compile(r"""(?m)^\s*MD_NAME\s*=\s*["']([^"']+)["']""")
 
 
@@ -941,9 +946,10 @@ def _target_is_in_aiter_cpp_itfs(target_file: Path) -> bool:
     Strict subset of :func:`_target_is_in_aiter_csrc`: these are the
     runtime-compiled kernels whose served ``.so`` lives in
     ``$HOME/.aiter/build`` rather than in ``<aiter>/jit/build`` or the
-    statically-linked wheel. Matches both the editable checkout
-    (``/sgl-workspace/aiter/csrc/cpp_itfs/...``) and the dist-packages
-    layout (``.../aiter/csrc/cpp_itfs/...``).
+    statically-linked wheel. Matches the editable checkout
+    (``/sgl-workspace/aiter/csrc/cpp_itfs/...``), the dist-packages layout
+    (``.../aiter/csrc/cpp_itfs/...``), and the split-wheel layout
+    (``.../aiter_meta/csrc/cpp_itfs/...``).
 
     Args:
         target_file: The file path to test.
@@ -951,7 +957,8 @@ def _target_is_in_aiter_cpp_itfs(target_file: Path) -> bool:
     Returns:
         ``True`` if the path is under an ``aiter/csrc/cpp_itfs/`` directory.
     """
-    return _AITER_CPP_ITFS_MARKER in str(target_file).replace(os.sep, "/")
+    norm = str(target_file).replace(os.sep, "/")
+    return any(marker in norm for marker in _AITER_CPP_ITFS_MARKERS)
 
 
 def _aiter_cpp_itfs_build_dir() -> Path:

--- a/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
@@ -552,3 +552,95 @@ def test_detect_strategy_accepts_dist_packages_vllm_py(
     )
     strat = apply_tool._detect_strategy(target, allow_unknown_target=False)
     assert strat["compiled"] is False
+
+
+# --- aiter_meta split-wheel rebuild recognition (regression) ---
+# aiter device sources ship in the sibling ``aiter_meta`` package, so hot
+# kernels land under ``.../dist-packages/aiter_meta/csrc/...``. The JIT/cpp_itfs
+# rebuild gates keyed only ``/aiter/csrc/``, so a KEPT aiter_meta .cu deployed
+# but never re-JIT'd -> integrate saw a stale binary and REVERT'd
+# (fault_attempts_exhausted; observed 07.25-07.30 on Qwen3-8B/Llama/Mixtral).
+
+_AITER_META_CU = Path(
+    "/usr/local/lib/python3.12/dist-packages/aiter_meta/csrc/kernels/quant_kernels.cu"
+)
+_AITER_META_CPP_ITFS_CU = Path(
+    "/usr/local/lib/python3.12/dist-packages/aiter_meta/csrc/cpp_itfs/mha_fwd.cu"
+)
+
+
+def test_target_is_in_aiter_csrc_matches_aiter_meta(apply_tool) -> None:
+    # split-wheel layout must be recognised as an aiter csrc source
+    assert apply_tool._target_is_in_aiter_csrc(_AITER_META_CU) is True
+    # classic layout still recognised
+    assert (
+        apply_tool._target_is_in_aiter_csrc(
+            Path("/sgl-workspace/aiter/csrc/kernels/quant_kernels.cu")
+        )
+        is True
+    )
+    # unrelated source stays out
+    assert (
+        apply_tool._target_is_in_aiter_csrc(
+            Path("/usr/local/lib/python3.12/dist-packages/vllm/model_executor/parameter.py")
+        )
+        is False
+    )
+
+
+def test_target_is_in_aiter_cpp_itfs_matches_aiter_meta(apply_tool) -> None:
+    assert apply_tool._target_is_in_aiter_cpp_itfs(_AITER_META_CPP_ITFS_CU) is True
+    # a non-cpp_itfs aiter_meta source is csrc but NOT cpp_itfs
+    assert apply_tool._target_is_in_aiter_cpp_itfs(_AITER_META_CU) is False
+
+
+def test_invalidate_aiter_jit_build_runs_for_aiter_meta_target(apply_tool, tmp_path) -> None:
+    jit_build = tmp_path / "aiter" / "jit" / "build"
+    jit_build.mkdir(parents=True)
+    (jit_build / "module_aiter_core.so").write_bytes(b"stale")
+    backup_dir = tmp_path / "backup"
+
+    res = apply_tool._invalidate_aiter_jit_build(
+        _AITER_META_CU,
+        backup_dir,
+        jit_build_dir_override=jit_build,
+    )
+
+    assert res["status"] == "ok", res
+    assert not jit_build.exists()  # moved aside so the next import re-JITs
+    assert (backup_dir / "jit_build" / "module_aiter_core.so").is_file()
+
+
+_APPLY_BENCH_PATH = (
+    Path(__file__).resolve().parents[4] / "src" / "hyperloom" / "agents" / "kernel" / "tools" / "apply_and_bench.py"
+)
+
+
+@pytest.fixture(scope="module")
+def apply_bench_tool() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("_apply_and_bench_test", _APPLY_BENCH_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_apply_and_bench_is_aiter_cu_matches_aiter_meta(apply_bench_tool) -> None:
+    ab = apply_bench_tool
+    assert ab._is_aiter_cu(_AITER_META_CU) is True
+    assert ab._is_aiter_cu(Path("/sgl-workspace/aiter/csrc/kernels/quant_kernels.cu")) is True
+    # non-.cu aiter source and unrelated files stay out
+    assert ab._is_aiter_cu(Path("/x/dist-packages/aiter_meta/csrc/kernels/q.py")) is False
+    assert ab._is_aiter_cu(Path("/x/dist-packages/vllm/model_executor/parameter.py")) is False
+
+
+def test_apply_and_bench_aiter_source_root(apply_bench_tool) -> None:
+    ab = apply_bench_tool
+    assert ab._aiter_source_root(_AITER_META_CU) == Path(
+        "/usr/local/lib/python3.12/dist-packages/aiter_meta"
+    )
+    assert ab._aiter_source_root(
+        Path("/sgl-workspace/aiter/csrc/kernels/q.cu")
+    ) == Path("/sgl-workspace/aiter")
+    assert ab._aiter_source_root(Path("/x/vllm/a.py")) is None

--- a/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
@@ -644,3 +644,42 @@ def test_apply_and_bench_aiter_source_root(apply_bench_tool) -> None:
         Path("/sgl-workspace/aiter/csrc/kernels/q.cu")
     ) == Path("/sgl-workspace/aiter")
     assert ab._aiter_source_root(Path("/x/vllm/a.py")) is None
+
+
+def test_reconstruct_sources_from_diff_nongit_repo(apply_bench_tool, tmp_path) -> None:
+    """A unified diff must reconstruct against a NON-git repo_root (the aiter_meta
+    split wheel under dist-packages is not a git repo).
+
+    Previously _reconstruct_sources_from_diff unconditionally ran
+    `git worktree add`, which fails on a non-git tree -> apply_failed, so a
+    diff-shaped aiter_meta kernel patch could never deploy. It now seeds a temp
+    tree from the on-disk base and `git apply`s there.
+    """
+    ab = apply_bench_tool
+    # a NON-git aiter_meta layout with a real base source file
+    repo = tmp_path / "site-packages" / "aiter_meta"
+    src = repo / "csrc" / "kernels" / "quant_kernels.cu"
+    src.parent.mkdir(parents=True)
+    src.write_text("old line\nkeep\n", encoding="utf-8")
+    assert ab._is_git_tree(repo) is False  # precondition: not a git repo
+
+    diff = tmp_path / "forge.patch"
+    diff.write_text(
+        "--- a/csrc/kernels/quant_kernels.cu\n"
+        "+++ b/csrc/kernels/quant_kernels.cu\n"
+        "@@ -1,2 +1,2 @@\n"
+        "-old line\n"
+        "+new line\n"
+        " keep\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "out"
+    out.mkdir()
+
+    rec = ab._reconstruct_sources_from_diff(diff, repo, out)
+    assert rec["status"] == "ok", rec
+    rel = "csrc/kernels/quant_kernels.cu"
+    assert rel in rec["files"], rec
+    assert Path(rec["files"][rel]).read_text(encoding="utf-8") == "new line\nkeep\n"
+    # the live on-disk base must be untouched (reconstruction is hermetic)
+    assert src.read_text(encoding="utf-8") == "old line\nkeep\n"


### PR DESCRIPTION
## Summary

aiter device sources ship either in-tree (`/aiter/csrc/...`) or in the sibling **split wheel** (`/aiter_meta/csrc/...`), the latter being the dist-packages layout in vLLM serving containers. The JIT / cpp_itfs rebuild gates in `apply_kernel_patch.py` matched only the literal substring `"/aiter/csrc/"`, which is **absent** from `"/aiter_meta/csrc/"` (aiter is followed by `_meta`, not `/`).

So a KEPT aiter_meta `.cu` was deployed but `_invalidate_aiter_jit_build` returned `skipped("target not under aiter/csrc/")`: the stale prebuilt `.so` was never moved aside, the server never re-JIT'd, and integrate's fresh-binary check failed → `fault_attempts_exhausted_2` → REVERT. The kernel never landed.

Observed **6 times over 07.25–07.30** across 3 models, every failing integrate target under `.../dist-packages/aiter_meta/csrc/`:

| date | model | target |
|---|---|---|
| 07.25 | Qwen3-8B | quant_kernels.cu |
| 07.26 | Qwen3-8B | quant_kernels.cu |
| 07.27 | Qwen3-8B | quant_kernels.cu |
| 07.28 | Llama-3.1-8B | custom_kernels.cu |
| 07.29 | Mixtral-8x7B | quant_kernels.cu |
| 07.30 | Mixtral-8x7B | gemm_moe_ck2stages.cu + custom_kernels.cu |

## Changes

- **`apply_kernel_patch.py`**: `_AITER_CSRC_MARKER` / `_AITER_CPP_ITFS_MARKER` become marker tuples that also match `"/aiter_meta/csrc/"`; `_target_is_in_aiter_csrc` / `_target_is_in_aiter_cpp_itfs` match any. The jit/build dir is still resolved via `find_spec("aiter")` (the built `.so` lives under the importable `aiter` package for both layouts), so only the gate needed widening.
- **`apply_and_bench.py`**: fold the three `"/aiter/"` `.cu` checks into a shared `_is_aiter_cu()` helper (matches `/aiter/` and `/aiter_meta/`); add `_aiter_source_root()` so the diff-reconstruct `repo_root` resolves the aiter_meta package root instead of defaulting to `parents[2]`. The classic `/sgl-workspace/aiter` branch is preserved — additive, no regression.

## Test plan

- New unit coverage in `test_framework_paths_units.py`: aiter_meta csrc/cpp_itfs recognition, real-filesystem `_invalidate_aiter_jit_build` for an aiter_meta target (was `skipped`, now `ok` + moved), and the `apply_and_bench` helpers. `test_framework_paths_units.py`: 52 passed.
- Regression: `test_aiter_jit*`, `test_kernel_integrate_and_report`, `test_kernel_request_handlers_units`: 303 passed.
- **Real-machine (MI355X / gfx950)**: (1) the fixed gate routes a real on-disk `aiter_meta/csrc/...` target into a real `jit/build` invalidation (old gate skipped); (2) a real aiter module re-JIT compiles a fresh `.so` in ~9s and runs correctly. Fully reversible; env restored.
- Not covered here: an end-to-end integrate on a container that actually installs `aiter_meta` (this box has the in-tree `/sgl-workspace/aiter` layout only).