### PR TITLE
fix(cli): register framework executor under the kind the phase enqueues

### DIFF
--- a/src/hyperloom/inference_optimizer/cli/executors.py
+++ b/src/hyperloom/inference_optimizer/cli/executors.py
@@ -285,8 +285,12 @@ def _register_executors(
     )
 
     # FRAMEWORK per-candidate executor — Coordinator-internal only.
+    # Key must match the kind the FRAMEWORK phase enqueues ("framework_agent",
+    # per action_surfaces.COORDINATOR_INTERNAL_ACTIONS and
+    # actions/_meta/framework_agent.yaml); registering it as "framework" left
+    # every discovered PR candidate stamped no_result_failed.
     coordinator.sub.register_executor(
-        "framework",
+        "framework_agent",
         FrameworkAgentExecutor(session_dir=session_dir),
     )
 

--- a/src/hyperloom/inference_optimizer/tests/test_cli_executors_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_executors_wiring.py
@@ -144,7 +144,10 @@ def test_register_executors_wires_full_set_and_kernel_noops():
         assert kind in reg
     assert "target_analysis" in reg
     assert "integrate_patch" in reg
-    assert "framework" in reg
+    # Must match the kind the FRAMEWORK phase enqueues; a stale "framework"
+    # key silently drops every discovered PR candidate.
+    assert "framework_agent" in reg
+    assert "framework" not in reg
     assert "roofline" in reg
     assert any(fn is _noop_prep for fn in reg.values())
 


### PR DESCRIPTION
## Summary

- The FRAMEWORK phase enqueues per-candidate work with kind `framework_agent` (matching `protocol/action_surfaces.py` `COORDINATOR_INTERNAL_ACTIONS` and `actions/_meta/framework_agent.yaml`), but `_register_executors` registered `FrameworkAgentExecutor` under the stale key `framework`.
- With no executor matching the enqueued kind, every PR candidate discovered by the framework agent was stamped `no_result_failed` instead of being benchmarked.
- Renames the registration key to `framework_agent` and tightens the wiring test to assert the new key is present and the stale `framework` key is gone, so the mismatch cannot silently come back.

## Test plan

- [ ] `pytest src/hyperloom/inference_optimizer/tests/test_cli_executors_wiring.py`
- [ ] Run a session with the framework agent enabled and confirm discovered PR candidates get real benchmark results rather than `no_result_failed`.


Made with [Cursor](https://cursor.com)