### PR TITLE
fix(kernel): tune the GEMM shapes the workload actually runs

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -3162,6 +3162,69 @@ class TestRunGemmTuningHandler:
             {"M": 3126, "N": 3072, "K": 512},
         ]
 
+    @staticmethod
+    def _mixed_dtype_candidates(path: Path) -> None:
+        path.write_text(
+            json.dumps(
+                {
+                    "hot_kernels": [
+                        {
+                            "name": "aiter::gemm_a8w8_blockscale_ck",
+                            "input_shapes": [
+                                {"call_num": 360, "shape": "(64,3072) fp8"},
+                                {"call_num": 360, "shape": "(8704,3072) fp8"},
+                            ],
+                        },
+                        {
+                            # BF16 router head: most-called, so without dtype
+                            # scoping it displaces the FP8 shape being tuned.
+                            "name": "vllm::rocm_unquantized_gemm",
+                            "input_shapes": [
+                                {"call_num": 1440, "shape": "(64,3072) bf16"},
+                                {"call_num": 1440, "shape": "(256,3072) bf16"},
+                            ],
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_extract_gemm_shapes_scopes_to_tuned_precision(self, tmp_path):
+        candidates = tmp_path / "kernel_candidates.json"
+        self._mixed_dtype_candidates(candidates)
+
+        out = krh._extract_gemm_shapes_from_candidates(
+            str(candidates), tmp_path, precision="fp8"
+        )
+
+        assert json.loads(Path(out).read_text(encoding="utf-8")) == [
+            {"M": 64, "N": 8704, "K": 3072}
+        ]
+
+    def test_extract_gemm_shapes_scopes_to_bf16_precision(self, tmp_path):
+        candidates = tmp_path / "kernel_candidates.json"
+        self._mixed_dtype_candidates(candidates)
+
+        out = krh._extract_gemm_shapes_from_candidates(
+            str(candidates), tmp_path, precision="bf16"
+        )
+
+        assert json.loads(Path(out).read_text(encoding="utf-8")) == [
+            {"M": 64, "N": 256, "K": 3072}
+        ]
+
+    def test_extract_gemm_shapes_keeps_every_dtype_without_precision(self, tmp_path):
+        candidates = tmp_path / "kernel_candidates.json"
+        self._mixed_dtype_candidates(candidates)
+
+        out = krh._extract_gemm_shapes_from_candidates(str(candidates), tmp_path)
+
+        assert json.loads(Path(out).read_text(encoding="utf-8")) == [
+            {"M": 64, "N": 256, "K": 3072},
+            {"M": 64, "N": 8704, "K": 3072},
+        ]
+
 
 # _default_kernel_batch_parallel — adaptive batch fanout scaling with visible GPUs.
 class TestDefaultKernelBatchParallel:

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -3293,6 +3293,176 @@ class TestRunGemmTuningHandler:
             {"M": 64, "N": 8704, "K": 3072},
         ]
 
+    @pytest.mark.parametrize(
+        ("precision", "traced"),
+        [
+            ("fp8", "fp8_e4m3"),
+            ("fp8", "e4m3fnuz"),
+            ("fp8", "torch.float8_e4m3fn"),
+            ("fp16", "f16"),          # what this repo's _TRACE_DTYPE_SUFFIX emits
+            ("bf16", "b16"),
+            ("mxfp4", "fp4x2"),
+            ("fp4", "mxfp4"),
+        ],
+    )
+    def test_extract_gemm_shapes_matches_dtype_aliases(self, tmp_path, precision, traced):
+        """A precision and a traced token spell the same dtype many ways; exact
+        string matching would drop shapes that do belong to the tuned family."""
+        candidates = tmp_path / "kernel_candidates.json"
+        candidates.write_text(
+            json.dumps(
+                {
+                    "hot_kernels": [
+                        {
+                            "name": "aiter::gemm",
+                            "input_shapes": [
+                                {"call_num": 8, "shape": f"(64,3072) {traced}"},
+                                {"call_num": 8, "shape": f"(8704,3072) {traced}"},
+                            ],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        out = krh._extract_gemm_shapes_from_candidates(
+            str(candidates), tmp_path, precision=precision
+        )
+
+        assert out, f"{precision!r} rejected the equivalent traced token {traced!r}"
+        assert json.loads(Path(out).read_text(encoding="utf-8")) == [
+            {"M": 64, "N": 8704, "K": 3072}
+        ]
+
+    def test_extract_gemm_shapes_keeps_the_highest_call_count(self, tmp_path):
+        """The same (M,N,K) can be reported by several kernels; the hot sighting
+        must win, otherwise a rare first one buries the real decode hotspot."""
+        candidates = tmp_path / "kernel_candidates.json"
+        candidates.write_text(
+            json.dumps(
+                {
+                    "hot_kernels": [
+                        {
+                            "name": "aiter::gemm_cold_first",
+                            "input_shapes": [
+                                {"call_num": 10, "shape": "(64,3072) fp8"},
+                                {"call_num": 10, "shape": "(8704,3072) fp8"},
+                            ],
+                        },
+                        {
+                            "name": "aiter::gemm_other",
+                            "input_shapes": [
+                                {"call_num": 100, "shape": "(64,3072) fp8"},
+                                {"call_num": 100, "shape": "(10240,3072) fp8"},
+                            ],
+                        },
+                        {
+                            "name": "aiter::gemm_same_shape_hot",
+                            "input_shapes": [
+                                {"call_num": 1000, "shape": "(64,3072) fp8"},
+                                {"call_num": 1000, "shape": "(8704,3072) fp8"},
+                            ],
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        out = krh._extract_gemm_shapes_from_candidates(str(candidates), tmp_path)
+
+        assert json.loads(Path(out).read_text(encoding="utf-8")) == [
+            {"M": 64, "N": 8704, "K": 3072},   # 1000, not the first sighting's 10
+            {"M": 64, "N": 10240, "K": 3072},  # 100
+        ]
+
+    @pytest.mark.parametrize("sep", ["<br>", "<br/>", "<BR/>", "<BR>"])
+    def test_extract_gemm_shapes_accepts_legacy_separator_spellings(self, tmp_path, sep):
+        candidates = tmp_path / "kernel_candidates.json"
+        candidates.write_text(
+            json.dumps(
+                {
+                    "hot_kernels": [
+                        {
+                            "name": "aiter::gemm_a8w8_blockscale",
+                            "input_shapes": [
+                                {"shape": f"(1024, 5120) fp8{sep}(34816, 5120) fp8"}
+                            ],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        out = krh._extract_gemm_shapes_from_candidates(str(candidates), tmp_path)
+
+        assert out, f"separator {sep!r} was not recognised"
+        assert json.loads(Path(out).read_text(encoding="utf-8")) == [
+            {"M": 1024, "N": 34816, "K": 5120}
+        ]
+
+    def test_resolve_forge_shapes_prefers_scoped_candidates_over_untyped_artifact(
+        self, tmp_path
+    ):
+        """A pre-rendered shapes artifact carries no dtype, so it must not win
+        over candidates that were actually scoped to the tuned precision."""
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        artifact = tmp_path / "shapes.json"  # recorded from the BF16 head
+        artifact.write_text(
+            json.dumps([{"M": 64, "N": 256, "K": 3072}]), encoding="utf-8"
+        )
+        candidates = tmp_path / "kernel_candidates.json"
+        candidates.write_text(
+            json.dumps(
+                {
+                    "hot_kernels": [
+                        {
+                            "name": "aiter::gemm_a8w8_blockscale_ck",
+                            "input_shapes": [
+                                {"call_num": 360, "shape": "(64,3072) fp8"},
+                                {"call_num": 360, "shape": "(8704,3072) fp8"},
+                            ],
+                        },
+                        {
+                            "name": "vllm::rocm_unquantized_gemm",
+                            "input_shapes": [
+                                {"call_num": 1440, "shape": "(64,3072) bf16"},
+                                {"call_num": 1440, "shape": "(256,3072) bf16"},
+                            ],
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        state = SharedState(
+            last_trace_analyze={
+                "shapes_json": str(artifact),
+                "candidates_path": str(candidates),
+            }
+        )
+
+        resolved = krh._resolve_forge_shapes(state, session_dir, precision="fp8")
+
+        assert json.loads(Path(resolved).read_text(encoding="utf-8")) == [
+            {"M": 64, "N": 8704, "K": 3072}
+        ]
+
+    def test_resolve_forge_shapes_still_uses_artifact_when_unscoped(self, tmp_path):
+        """Without a precision to scope by, the explicit artifact keeps priority."""
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        artifact = tmp_path / "shapes.json"
+        artifact.write_text(
+            json.dumps([{"M": 64, "N": 256, "K": 3072}]), encoding="utf-8"
+        )
+        state = SharedState(last_trace_analyze={"shapes_json": str(artifact)})
+
+        assert krh._resolve_forge_shapes(state, session_dir) == str(artifact)
+
 
 # _default_kernel_batch_parallel — adaptive batch fanout scaling with visible GPUs.
 class TestDefaultKernelBatchParallel:

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -3108,6 +3108,60 @@ class TestRunGemmTuningHandler:
             {"M": 1024, "N": 34816, "K": 5120}
         ]
 
+    def test_extract_gemm_shapes_parses_per_tensor_input_shapes(self, tmp_path):
+        # Current TraceLens emits one entry per tensor ({"call_num": .., "shape":
+        # "(M,K) fp8"}) instead of a single <br>-joined string. The old parser
+        # skipped every such entry and returned no shapes, so GEMM tuning fell
+        # back to a lossy profile capture that recorded only a large prefill M
+        # and missed the throughput-dominant decode M (observed on
+        # Qwen3.5-122B-A10B-FP8: tuned M=2095 only -> -18.45% E2E).
+        candidates = tmp_path / "kernel_candidates.json"
+        candidates.write_text(
+            json.dumps(
+                {
+                    "hot_kernels": [
+                        {
+                            "name": "aiter::gemm_a8w8_blockscale_ck",
+                            "input_shapes": [
+                                {"call_num": 48, "shape": "(3126,512) fp8"},
+                                {"call_num": 48, "shape": "(3072,512) fp8"},
+                                {"call_num": 48, "shape": "(0,) fp32"},
+                            ],
+                        },
+                        {
+                            "name": "aiter::gemm_a8w8_blockscale_ck",
+                            "input_shapes": [
+                                {"call_num": 1440, "shape": "(64,3072) fp8"},
+                                {"call_num": 1440, "shape": "(10240,3072) fp8"},
+                                {"call_num": 1440, "shape": "(0,) fp32"},
+                            ],
+                        },
+                        {
+                            # Matrix-vector head: highest call count, but N==1 is
+                            # not a tunable GEMM tile and must be dropped.
+                            "name": "vllm::rocm_unquantized_gemm",
+                            "input_shapes": [
+                                {"call_num": 9999, "shape": "(64,3072) bf16"},
+                                {"call_num": 9999, "shape": "(1,3072) bf16"},
+                            ],
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        out = krh._extract_gemm_shapes_from_candidates(str(candidates), tmp_path)
+
+        assert out, "per-tensor input_shapes yielded no GEMM shapes"
+        shapes = json.loads(Path(out).read_text(encoding="utf-8"))
+        # The decode shape is present (it was dropped entirely before) and, being
+        # the most-called, is tuned first when the tuner runs out of budget.
+        assert shapes == [
+            {"M": 64, "N": 10240, "K": 3072},
+            {"M": 3126, "N": 3072, "K": 512},
+        ]
+
 
 # _default_kernel_batch_parallel — adaptive batch fanout scaling with visible GPUs.
 class TestDefaultKernelBatchParallel:

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -861,6 +861,74 @@ class TestForgeGemmHelperCoverage:
         assert result["backend"] == "forge"
 
     @pytest.mark.asyncio
+    async def test_vllm_block_fp8_prefers_traced_shapes_over_profile_capture(
+        self, tmp_path, monkeypatch
+    ):
+        """vLLM block-FP8 must tune the device-side traced shapes.
+
+        Decode steps replay inside a CUDA Graph, so they emit no Kineto op
+        events and the block-FP8 profile capture can only ever report prefill M
+        (it reported M=2095 alone on the session that then lost 18.45% E2E).
+        The TraceLens candidates carry the decode M, so they win and the capture
+        pass is not needed at all.
+        """
+        candidates = tmp_path / "kernel_candidates.json"
+        candidates.write_text(
+            json.dumps(
+                {
+                    "hot_kernels": [
+                        {
+                            "name": "aiter::gemm_a8w8_blockscale_ck",
+                            "input_shapes": [
+                                {"call_num": 1440, "shape": "(64,3072) fp8"},
+                                {"call_num": 1440, "shape": "(10240,3072) fp8"},
+                            ],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        state = SharedState(
+            precision="fp8",
+            framework="vllm",
+            model_path="/models/qwen",
+            gpu_type="mi355x",
+            tp=1,
+            conc=64,
+            last_trace_analyze={"candidates_path": str(candidates)},
+        )
+        state.save(tmp_path)
+        monkeypatch.setattr(krh, "_forge_gemm_tune_available", lambda: True)
+        monkeypatch.setattr(krh, "_profile_shapes_are_fresh", lambda _state: True)
+
+        captured = {"ran": False}
+
+        async def _record_capture(**_kwargs):
+            captured["ran"] = True
+            return {"status": "failed"}
+
+        monkeypatch.setattr(krh, "_capture_vllm_tunableop_shapes", _record_capture)
+
+        async def _fake_subprocess(cmd, *, timeout_sec):
+            return 1, "", ""
+
+        monkeypatch.setattr(krh, "_run_subprocess", _fake_subprocess)
+
+        # task_id keeps the workspace deterministic (it otherwise falls back to
+        # a wall-clock suffix, which the assertion below could not re-derive).
+        payload = {"precision": "fp8", "quant_type": "blockscale", "task_id": "gemm-1"}
+        await krh._run_forge_gemm_tuning(payload, session_dir=tmp_path)
+
+        assert captured["ran"] is False, "profile capture ran despite traced shapes"
+        workspace = krh._gemm_tuning_workspace(payload, session_dir=tmp_path)
+        written = json.loads(
+            (workspace / "forge_gemm_tuning_input.json").read_text(encoding="utf-8")
+        )
+        shapes = json.loads(Path(written["shapes_json"]).read_text(encoding="utf-8"))
+        assert shapes == [{"M": 64, "N": 10240, "K": 3072}]
+
+    @pytest.mark.asyncio
     async def test_run_forge_gemm_tuning_tags_engine_forge(self, tmp_path, monkeypatch):
         """Forge runs must carry ``engine='forge'`` so the breakdown attributes them correctly."""
         state = SharedState(

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -1971,8 +1971,38 @@ def _extract_gemm_shapes_from_candidates(
     if not isinstance(hot_kernels, list):
         return ""
 
-    shapes: list[dict[str, int]] = []
+    # Tolerate whitespace after the comma ("(1024, 5120)") and any leading token
+    # before the tuple; TraceLens formats vary. .search() rather than .match() so
+    # a leading dtype/name does not defeat it.
+    dim_pattern = _re.compile(r"\((\d+)\s*,\s*(\d+)\)")
+
+    def _mnk(a_text: str, b_text: str) -> tuple[int, int, int] | None:
+        """Derive (M, N, K) from the A ``(M,K)`` and B tensor texts."""
+        m0 = dim_pattern.search(a_text)
+        m1 = dim_pattern.search(b_text)
+        if not m0 or not m1:
+            return None
+        M, K = int(m0.group(1)), int(m0.group(2))
+        b0, b1 = int(m1.group(1)), int(m1.group(2))
+        # B is stored either (N,K) or (K,N); pick the orientation whose
+        # contracted dim matches K, else keep the legacy first-dim reading.
+        N = b0 if b1 == K else (b1 if b0 == K else b0)
+        # ``N == 1`` is a matrix-vector head (e.g. a scalar projection), not a
+        # tunable GEMM tile; it would otherwise sort first on call count and
+        # burn a tuning slot.
+        return (M, N, K) if min(M, K) > 0 and N > 1 else None
+
+    # ``weight`` is the observed call count: decode GEMMs are invoked far more
+    # often than prefill ones, so ordering by it puts the throughput-dominant
+    # shapes first and they still get tuned when the tuner runs out of budget.
+    weighted: list[tuple[int, tuple[int, int, int]]] = []
     seen: set[tuple[int, int, int]] = set()
+
+    def _record(key: tuple[int, int, int] | None, weight: int) -> None:
+        if key is None or key in seen:
+            return
+        seen.add(key)
+        weighted.append((weight, key))
 
     for kernel in hot_kernels:
         name = str(kernel.get("name", ""))
@@ -1981,32 +2011,30 @@ def _extract_gemm_shapes_from_candidates(
         input_shapes = kernel.get("input_shapes", [])
         if not isinstance(input_shapes, list):
             continue
-        for entry in input_shapes:
-            shape_str = entry.get("shape", "") if isinstance(entry, dict) else ""
-            if not shape_str:
-                continue
-            # Parse "(M,K) dtype<br>(N,K) dtype<br>..." — first two tensors give M,N,K
-            parts = [p.strip() for p in shape_str.split("<br>") if p.strip()]
+        entries = [e for e in input_shapes if isinstance(e, dict) and e.get("shape")]
+
+        # Legacy format: one entry carries every tensor, "<br>"-joined.
+        matched_joined = False
+        for entry in entries:
+            parts = [p.strip() for p in str(entry["shape"]).split("<br>") if p.strip()]
             if len(parts) < 2:
                 continue
-            # Tolerate whitespace after the comma ("(1024, 5120)") and any
-            # leading token before the tuple; TraceLens formats vary. .search()
-            # rather than .match() so a leading dtype/name does not defeat it.
-            dim_pattern = _re.compile(r"\((\d+)\s*,\s*(\d+)\)")
-            m0 = dim_pattern.search(parts[0])
-            m1 = dim_pattern.search(parts[1])
-            if not m0 or not m1:
-                continue
-            M = int(m0.group(1))
-            K = int(m0.group(2))
-            N = int(m1.group(1))
-            key = (M, N, K)
-            if key not in seen:
-                seen.add(key)
-                shapes.append({"M": M, "N": N, "K": K})
+            matched_joined = True
+            _record(_mnk(parts[0], parts[1]), int(entry.get("call_num") or 0))
+        if matched_joined or len(entries) < 2:
+            continue
 
-    if not shapes:
+        # Current format: one entry per tensor, so A and B are the first two.
+        weight = max(int(e.get("call_num") or 0) for e in entries[:2])
+        _record(_mnk(str(entries[0]["shape"]), str(entries[1]["shape"])), weight)
+
+    if not weighted:
         return ""
+
+    # Most-called first; ties keep discovery order so output stays deterministic.
+    order = {key: i for i, (_, key) in enumerate(weighted)}
+    weighted.sort(key=lambda item: (-item[0], order[item[1]]))
+    shapes = [{"M": M, "N": N, "K": K} for _, (M, N, K) in weighted]
 
     out_path = cand_file.parent / "traced_gemm_shapes.json"
     try:

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -3103,6 +3103,27 @@ async def _run_forge_gemm_tuning(
         dry_run=bool(payload.get("dry_run")),
     )
     if block_fp8_profile_capture:
+        # Decode steps replay inside a CUDA Graph and therefore emit no Kineto
+        # *op* events, so every profile-derived block-FP8 shape set structurally
+        # carries prefill M only -- measured on a real capture, the decode-only
+        # trace split yields zero block-FP8 events while the prefill splits yield
+        # M=2095. Tuning that alone optimizes an operating point the workload
+        # barely uses. TraceLens candidates are built from the device kernel
+        # timeline, which does see through the graph and carries the decode M
+        # that dominates throughput, so prefer them. ``require_fresh_profile``
+        # keeps the vLLM rule that shapes must be workload-matched, and
+        # ``precision`` keeps BF16 heads out of an FP8 tuner's input.
+        traced_shapes = _resolve_forge_shapes(
+            state,
+            session_dir,
+            require_fresh_profile=True,
+            precision=precision,
+        )
+        if traced_shapes:
+            shapes_json = traced_shapes
+            untuned_csv = ""
+            block_fp8_profile_capture = False
+    if block_fp8_profile_capture:
         shape_capture = _reuse_vllm_block_fp8_roofline_shapes(
             state,
             workspace=workspace,

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -1889,12 +1889,17 @@ def _resolve_forge_shapes(
     session_dir: Path,
     *,
     require_fresh_profile: bool = False,
+    precision: str = "",
 ) -> str:
     """Find TraceLens shapes JSON if available and in forge-compatible format.
 
     Forge dense tuners expect: [{"M": int, "N": int, "K": int}, ...]
     Only passes files that match this schema; incompatible formats are
     silently skipped so forge falls back to config.json shape derivation.
+
+    ``precision`` scopes the traced shapes to the dtype the tuner will actually
+    tune (a trace carries every GEMM dtype the model runs, e.g. FP8 projections
+    alongside BF16 router heads). Empty means "no dtype scoping".
     """
     if require_fresh_profile and not _profile_shapes_are_fresh(state):
         log.info(
@@ -1937,6 +1942,7 @@ def _resolve_forge_shapes(
     extracted = _extract_gemm_shapes_from_candidates(
         str(last_trace.get("candidates_path") or ""),
         session_dir,
+        precision=precision,
     )
     if extracted:
         return extracted
@@ -1944,14 +1950,29 @@ def _resolve_forge_shapes(
     return ""
 
 
+def _dtype_token_for_precision(precision: str) -> str:
+    """Map a tuning precision onto the dtype token TraceLens renders in shapes.
+
+    Returns "" when the precision does not scope to a single traced dtype, which
+    the caller treats as "keep every dtype" (the historical behaviour).
+    """
+    normalized = str(precision or "").strip().lower()
+    return {"fp8": "fp8", "bf16": "bf16", "fp16": "fp16"}.get(normalized, "")
+
+
 def _extract_gemm_shapes_from_candidates(
-    candidates_path_str: str, session_dir: Path
+    candidates_path_str: str, session_dir: Path, *, precision: str = ""
 ) -> str:
     """Extract M,N,K from kernel_candidates.json hot_kernels input_shapes.
 
-    Parses the TraceLens shape format "(M,K) fp8<br>(N,K) fp8<br>..." to derive
-    the actual GEMM dimensions observed during serving. Writes a forge-compatible
-    shapes JSON beside the candidates file and returns its path.
+    Derives the GEMM dimensions actually observed during serving and writes a
+    forge-compatible shapes JSON beside the candidates file, returning its path.
+
+    ``precision`` scopes the result to one traced dtype. A trace records every
+    GEMM the model runs, so an FP8 tuner would otherwise also receive the BF16
+    router/head shapes; those rows are never looked up at serve time and they
+    displace real FP8 shapes in the call-count ordering below. Empty keeps every
+    dtype (historical behaviour).
     """
     import json as _json
     import re as _re
@@ -1975,9 +1996,21 @@ def _extract_gemm_shapes_from_candidates(
     # before the tuple; TraceLens formats vary. .search() rather than .match() so
     # a leading dtype/name does not defeat it.
     dim_pattern = _re.compile(r"\((\d+)\s*,\s*(\d+)\)")
+    # TraceLens renders the dtype right after the dims: "(64,3072) fp8".
+    dtype_pattern = _re.compile(r"\)\s*([A-Za-z][A-Za-z0-9_]*)")
+    wanted_dtype = _dtype_token_for_precision(precision)
+
+    def _dtype_matches(a_text: str) -> bool:
+        """Whether the A tensor's traced dtype is the one being tuned."""
+        if not wanted_dtype:
+            return True
+        found = dtype_pattern.search(a_text)
+        return bool(found) and found.group(1).lower() == wanted_dtype
 
     def _mnk(a_text: str, b_text: str) -> tuple[int, int, int] | None:
         """Derive (M, N, K) from the A ``(M,K)`` and B tensor texts."""
+        if not _dtype_matches(a_text):
+            return None
         m0 = dim_pattern.search(a_text)
         m1 = dim_pattern.search(b_text)
         if not m0 or not m1:
@@ -3043,6 +3076,7 @@ async def _run_forge_gemm_tuning(
             state,
             session_dir,
             require_fresh_profile=True,
+            precision=precision,
         )
         if not shapes_json:
             untuned_csv = _resolve_forge_untuned_csv(

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -1900,6 +1900,13 @@ def _resolve_forge_shapes(
     ``precision`` scopes the traced shapes to the dtype the tuner will actually
     tune (a trace carries every GEMM dtype the model runs, e.g. FP8 projections
     alongside BF16 router heads). Empty means "no dtype scoping".
+
+    When scoping is requested the candidate extraction runs first, because it is
+    the only source whose dtype can be checked: a pre-rendered shapes artifact is
+    a bare ``[{M,N,K}]`` list carrying no dtype or provenance, so an artifact
+    recorded for another dtype would otherwise be handed to the tuner ahead of
+    correctly-scoped shapes. Artifacts stay the fallback for the unscoped case
+    and for when the trace yields nothing for this precision.
     """
     if require_fresh_profile and not _profile_shapes_are_fresh(state):
         log.info(
@@ -1932,32 +1939,56 @@ def _resolve_forge_shapes(
             shapes_file = cand_file.parent / "shapes.json"
             candidates.append(str(shapes_file))
 
+    # Extract the GEMM shapes observed by the latest TraceLens analysis. Older
+    # traces can describe a backend that is no longer active.
+    def _extracted() -> str:
+        return _extract_gemm_shapes_from_candidates(
+            str(last_trace.get("candidates_path") or ""),
+            session_dir,
+            precision=precision,
+        )
+
+    if _canonical_dtype(precision):
+        scoped = _extracted()
+        if scoped:
+            return scoped
+
     for candidate in candidates:
         p = Path(candidate)
         if p.is_file() and _is_forge_compatible_shapes_json(p):
             return str(p)
 
-    # Final fallback: extract the GEMM shapes observed by the latest TraceLens
-    # analysis. Older traces can describe a backend that is no longer active.
-    extracted = _extract_gemm_shapes_from_candidates(
-        str(last_trace.get("candidates_path") or ""),
-        session_dir,
-        precision=precision,
-    )
-    if extracted:
-        return extracted
-
-    return ""
+    return _extracted()
 
 
-def _dtype_token_for_precision(precision: str) -> str:
-    """Map a tuning precision onto the dtype token TraceLens renders in shapes.
+# TraceLens has spelled the tensor separator <br>, <br/> and <BR/> over time.
+_BR_SPLIT_RE = re.compile(r"<\s*br\s*/?\s*>", re.IGNORECASE)
 
-    Returns "" when the precision does not scope to a single traced dtype, which
-    the caller treats as "keep every dtype" (the historical behaviour).
+
+def _canonical_dtype(raw: str) -> str:
+    """Fold a precision name or traced dtype token onto one canonical family.
+
+    Both sides of the comparison spell the same dtype many ways: a tuning
+    precision arrives as ``fp8`` / ``mxfp4``, while TraceLens renders whatever
+    the framework reported -- ``fp8_e4m3``, ``e4m3fnuz``, ``fp4x2``, and
+    ``_TRACE_DTYPE_SUFFIX`` in this repo emits ``f16`` for float16. Matching the
+    raw strings drops shapes that do belong to the tuned precision, so both are
+    folded onto a family first.
+
+    Returns "" for anything unrecognised, which callers treat as "do not scope".
     """
-    normalized = str(precision or "").strip().lower()
-    return {"fp8": "fp8", "bf16": "bf16", "fp16": "fp16"}.get(normalized, "")
+    token = str(raw or "").strip().lower().removeprefix("torch.")
+    if not token:
+        return ""
+    if token.startswith(("fp4", "mxfp4", "float4")) or "e2m1" in token:
+        return "fp4"
+    if token.startswith(("fp8", "float8")) or token == "f8" or "e4m3" in token or "e5m2" in token:
+        return "fp8"
+    if token.startswith(("bf16", "bfloat16")) or token == "b16":
+        return "bf16"
+    if token.startswith(("fp16", "float16")) or token in {"f16", "half"}:
+        return "fp16"
+    return ""
 
 
 def _extract_gemm_shapes_from_candidates(
@@ -1997,15 +2028,17 @@ def _extract_gemm_shapes_from_candidates(
     # a leading dtype/name does not defeat it.
     dim_pattern = _re.compile(r"\((\d+)\s*,\s*(\d+)\)")
     # TraceLens renders the dtype right after the dims: "(64,3072) fp8".
-    dtype_pattern = _re.compile(r"\)\s*([A-Za-z][A-Za-z0-9_]*)")
-    wanted_dtype = _dtype_token_for_precision(precision)
+    # Dots are allowed so a fully-qualified spelling ("torch.float8_e4m3fn") is
+    # captured whole rather than truncated at "torch".
+    dtype_pattern = _re.compile(r"\)\s*([A-Za-z][A-Za-z0-9_.]*)")
+    wanted_dtype = _canonical_dtype(precision)
 
     def _dtype_matches(a_text: str) -> bool:
-        """Whether the A tensor's traced dtype is the one being tuned."""
+        """Whether the A tensor's traced dtype is the family being tuned."""
         if not wanted_dtype:
             return True
         found = dtype_pattern.search(a_text)
-        return bool(found) and found.group(1).lower() == wanted_dtype
+        return bool(found) and _canonical_dtype(found.group(1)) == wanted_dtype
 
     def _mnk(a_text: str, b_text: str) -> tuple[int, int, int] | None:
         """Derive (M, N, K) from the A ``(M,K)`` and B tensor texts."""
@@ -2028,14 +2061,17 @@ def _extract_gemm_shapes_from_candidates(
     # ``weight`` is the observed call count: decode GEMMs are invoked far more
     # often than prefill ones, so ordering by it puts the throughput-dominant
     # shapes first and they still get tuned when the tuner runs out of budget.
-    weighted: list[tuple[int, tuple[int, int, int]]] = []
-    seen: set[tuple[int, int, int]] = set()
+    # The same (M,N,K) can be reported by several kernels; keep the largest
+    # count, otherwise a rare first sighting would outrank the hot one.
+    weights: dict[tuple[int, int, int], int] = {}
+    order: dict[tuple[int, int, int], int] = {}
 
     def _record(key: tuple[int, int, int] | None, weight: int) -> None:
-        if key is None or key in seen:
+        if key is None:
             return
-        seen.add(key)
-        weighted.append((weight, key))
+        if key not in order:
+            order[key] = len(order)
+        weights[key] = max(weights.get(key, 0), weight)
 
     for kernel in hot_kernels:
         name = str(kernel.get("name", ""))
@@ -2046,10 +2082,11 @@ def _extract_gemm_shapes_from_candidates(
             continue
         entries = [e for e in input_shapes if isinstance(e, dict) and e.get("shape")]
 
-        # Legacy format: one entry carries every tensor, "<br>"-joined.
+        # Legacy format: one entry carries every tensor, "<br>"-joined. The tag
+        # is spelled several ways across TraceLens versions (<br>, <br/>, <BR/>).
         matched_joined = False
         for entry in entries:
-            parts = [p.strip() for p in str(entry["shape"]).split("<br>") if p.strip()]
+            parts = [p.strip() for p in _BR_SPLIT_RE.split(str(entry["shape"])) if p.strip()]
             if len(parts) < 2:
                 continue
             matched_joined = True
@@ -2061,13 +2098,12 @@ def _extract_gemm_shapes_from_candidates(
         weight = max(int(e.get("call_num") or 0) for e in entries[:2])
         _record(_mnk(str(entries[0]["shape"]), str(entries[1]["shape"])), weight)
 
-    if not weighted:
+    if not weights:
         return ""
 
     # Most-called first; ties keep discovery order so output stays deterministic.
-    order = {key: i for i, (_, key) in enumerate(weighted)}
-    weighted.sort(key=lambda item: (-item[0], order[item[1]]))
-    shapes = [{"M": M, "N": N, "K": K} for _, (M, N, K) in weighted]
+    ranked = sorted(weights, key=lambda key: (-weights[key], order[key]))
+    shapes = [{"M": M, "N": N, "K": K} for M, N, K in ranked]
 
     out_path = cand_file.parent / "traced_gemm_shapes.json"
     try:


### PR DESCRIPTION
## Summary

GEMM tuning was optimizing an operating point the workload barely uses. On a Qwen3.5-122B-A10B-FP8 session it tuned a single large prefill `M=2095`, won the micro benchmark 2.89-3.29x, and lost **-18.45% E2E** (immediate revert, 738 s of tuning wasted).

The shapes it should have tuned were already recorded. Three independent defects kept them from reaching the tuner.

### 1. Decode shapes are invisible to the vLLM block-FP8 route

That route derives shapes from Kineto **op** events. Decode steps replay inside a CUDA Graph and emit no such events, so the route structurally reports prefill `M` only. Measured on the capture behind the regression:

| trace split | block-FP8 shapes | M |
|---|---|---|
| `decode_only_..._bs64` | **0** | — |
| `mixed_..._bs126` | 3 | 2095 |
| `prefilldecode_..._bs2095` | 3 | 2095 |

TraceLens candidates are built from the **device kernel timeline**, which does see through the graph — the same session recorded the decode shapes at `M=64` with ~30x the call count of prefill. The block-FP8 branch now consults them before falling back to the profile capture. `require_fresh_profile` preserves the vLLM rule that shapes must be workload-matched.

The change stays surgical: only the block-FP8 branch consults the traced shapes, so the vLLM TunableOp recording pass keeps its current behaviour.

### 2. The candidate parser read the current TraceLens format as empty

`_extract_gemm_shapes_from_candidates` only understood the legacy rendering, where one `input_shapes` entry carried every tensor joined by `<br>`. Current TraceLens emits **one entry per tensor**:

```json
"input_shapes": [
  {"call_num": 1440, "shape": "(64,3072) fp8"},
  {"call_num": 1440, "shape": "(10240,3072) fp8"}
]
```

Every entry hit the `len(parts) < 2` guard. Measured on the real session: **22 GEMM kernels, 88 entries, 0 shapes extracted** — which is what made the sglang path fall through to its own config-derived fallback, and what would have made fix 1 a no-op.

Now parses the per-tensor layout (`A = entry[0]` `(M,K)`, `B = entry[1]`, oriented by matching the contracted dim `K`); the legacy `<br>` path is byte-identical. Shapes are ordered by observed `call_num` so decode is tuned first when the tuner runs out of budget, and `N == 1` matrix-vector heads are dropped — they are not tunable GEMM tiles yet would sort first on call count.

### 3. Traced shapes were not scoped to the tuned dtype

A capture records every GEMM dtype the model runs: here 15 FP8 projections plus 4 BF16 router/head shapes. Feeding BF16 shapes to an FP8 tuner is not a miscompile — aiter looks the config up by `(M,N,K)`, so those rows are never hit — but it burns budget and distorts the ordering above: the BF16 head is invoked 1440 times and outranks the real FP8 decode shapes. The tuning precision is now threaded through `_resolve_forge_shapes` into the extractor. Both FP8 and BF16 dense tuners consume this file, so the filter is parameterised, and an empty precision keeps every dtype (existing callers unchanged).

## Effect on the capture behind the regression

- Extracted shapes: **0 → 19**, or **15** scoped to `precision="fp8"`.
- Coverage: `M=64` (decode) alongside `M=1084`/`3126` (prefill), with the FP8 decode shapes ranked first.
- The lossy block-FP8 profile capture no longer runs.

Complements KernelForge #91, which added a consumer-side decode-coverage floor. With real shapes flowing again that floor becomes a no-op and stays as defense-in-depth for degraded paths.

## Test plan

- New handler-level regression test: vLLM block-FP8 with traced candidates available must not run the capture pass and must tune the decode `M`. Verified to fail without the fix.
- New extractor tests: per-tensor layout, call-count ordering, `N == 1` drop, and dtype scoping for FP8 / BF16 / unscoped.
- Both legacy `<br>` format tests pass unchanged.
- `pytest src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py` — 246 passed.
- `pytest src/hyperloom/inference_optimizer/tests/ -k "gemm or shape or kernel_request or forge or vllm"` — 709 passed. The 3 failures in `test_server_patcher_vllm_isolated_venv.py` reproduce on a clean `origin/main` and are unrelated.
- Replayed the real session's `kernel_candidates.json` and all three trace splits through the affected code paths to confirm the numbers quoted above.
