### PR TITLE
feat(trace): emit Explore spend telemetry and report failed LLM calls

### DIFF
--- a/src/hyperloom/agents/robustness/role/envelope.py
+++ b/src/hyperloom/agents/robustness/role/envelope.py
@@ -137,6 +137,7 @@ CORE_STATE_FIELDS: frozenset[str] = frozenset(
         "phase_started_unix",
         "phase_history",
         "phase_budget_pct",
+        "explore_elapsed_accum_s",
         # Cyclic phase-machine state; locked so an LLM update_state cannot forge
         # macro-cycle / convergence / per-cycle budget state.
         "macro_cycle",

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/decision.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/decision.py
@@ -44,6 +44,15 @@ _TOKEN_CACHE_CREATE_KEY = "cache_creation_input_tokens"
 _TOKEN_CACHE_READ_KEY = "cache_read_input_tokens"
 
 
+# Terminal-status key + its success value, re-declared for the same reason as the
+# token keys above. A ``status="error"`` row records a call that never returned,
+# so it carries no tokens and must stay out of every spend / call-count rollup.
+_STATUS_KEY = "status"
+
+
+_STATUS_OK = "ok"
+
+
 _TOKEN_KEYS_ALL: tuple[str, ...] = (
     _TOKEN_IN_KEY,
     _TOKEN_OUT_KEY,
@@ -105,12 +114,18 @@ def _load_llm_calls(
     session_dir: Path,
     warnings: list[str],
 ) -> list[dict[str, Any]]:
-    """Read every LLM-call row from the trace ledger and ext shards.
+    """Read every *successful* LLM-call row from the trace ledger and ext shards.
 
     Merges ``reports/trace/llm_calls.jsonl`` with every
     ``reports/trace/ext/*.jsonl`` shard written by out-of-process children.
     Best-effort: missing files / dirs yield ``[]``; malformed lines are
     skipped by :func:`_load_jsonl_safe`.
+
+    Rows whose ``status`` is not ``ok`` are dropped: they describe a call that
+    never returned, so counting them would inflate ``calls`` and skew the
+    per-decision spend attribution. Rows predating the ``status`` field have no
+    such key and are kept. Failure visibility is Langfuse's job (the emitter
+    maps them to ``level=ERROR``), not the spend rollup's.
 
     Args:
         session_dir (Path): Absolute session root.
@@ -118,8 +133,8 @@ def _load_llm_calls(
             failures).
 
     Returns:
-        list[dict[str, Any]]: Every well-formed LLM-call row across the ledger
-        and ext shards. Empty when no trace files exist.
+        list[dict[str, Any]]: Every well-formed successful LLM-call row across
+        the ledger and ext shards. Empty when no trace files exist.
     """
     trace_root = session_dir / "reports" / "trace"
     rows: list[dict[str, Any]] = list(_load_jsonl_safe(trace_root / "llm_calls.jsonl", warnings))
@@ -132,7 +147,11 @@ def _load_llm_calls(
             shards = []
         for shard in shards:
             rows.extend(_load_jsonl_safe(shard, warnings))
-    return [r for r in rows if isinstance(r, dict)]
+    return [
+        r
+        for r in rows
+        if isinstance(r, dict) and str(r.get(_STATUS_KEY) or _STATUS_OK).strip().lower() == _STATUS_OK
+    ]
 
 
 def _load_proposal_task_map(

--- a/src/hyperloom/inference_optimizer/tests/test_claude_backend.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_backend.py
@@ -9,6 +9,7 @@ All tests use SDK test seams so no real Claude API calls are made and no
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -21,7 +22,7 @@ from hyperloom.orchestrator.roles import (
     build_emit_intent_server,
     validate_emit_intent_input,
 )
-from hyperloom.orchestrator.roles.base import BackendError
+from hyperloom.orchestrator.roles.base import BackendError, LLMCallFailed, RetryPolicy
 from hyperloom.inference_optimizer.protocol.intent import (
     IntentType,
     IntentValidationError,
@@ -78,6 +79,49 @@ def _make_query_factory(messages: list[Any]):
             yield m
 
     return _q
+
+
+def _make_raising_query_factory(exc: BaseException):
+    async def _q(*, prompt, options):
+        raise exc
+        yield  # pragma: no cover — keeps this an async generator
+
+    return _q
+
+
+@pytest.mark.asyncio
+async def test_stream_api_error_is_marked_as_llm_call_failed():
+    """A non-timeout gateway error must be countable, not just a timeout.
+
+    The failure that motivated this telemetry is a gateway 400
+    (``litellm.BadRequestError: AnthropicException``) surfacing out of the SDK
+    stream. Left unmarked it reaches the Coordinator's "unexpected crash" path
+    and no error row is written, so the LLM error rate silently misses exactly
+    the case it was added for.
+    """
+    backend = ClaudeBackend(
+        sdk_query_factory=_make_raising_query_factory(
+            RuntimeError("litellm.BadRequestError: AnthropicException")
+        ),
+        sdk_options_cls=FakeOptions,
+        enable_mcp_emit_intent=False,
+        retry_policy=RetryPolicy(max_attempts=1),
+    )
+    with pytest.raises(LLMCallFailed, match="Claude backend call failed"):
+        await backend.run("hello")
+
+
+@pytest.mark.asyncio
+async def test_cancellation_is_not_marked_as_an_llm_failure():
+    """Cancellation is a BaseException and must pass through untouched."""
+    backend = ClaudeBackend(
+        sdk_query_factory=_make_raising_query_factory(asyncio.CancelledError()),
+        sdk_options_cls=FakeOptions,
+        enable_mcp_emit_intent=False,
+        retry_policy=RetryPolicy(max_attempts=1),
+    )
+    with pytest.raises(asyncio.CancelledError):
+        await backend.run("hello")
 
 
 @pytest.mark.parametrize(

--- a/src/hyperloom/inference_optimizer/tests/test_codex_backend.py
+++ b/src/hyperloom/inference_optimizer/tests/test_codex_backend.py
@@ -11,7 +11,7 @@ from typing import Any
 import pytest
 
 from hyperloom.orchestrator.roles import CodexBackend
-from hyperloom.orchestrator.roles.base import BackendError
+from hyperloom.orchestrator.roles.base import BackendError, LLMCallFailed
 from hyperloom.orchestrator.roles.codex import _extract_envelope, _extract_responses_output
 from hyperloom.inference_optimizer.protocol.intent import (
     IntentType,
@@ -227,6 +227,42 @@ async def test_run_records_call_metadata():
     assert res.metadata["finish_reason"] == "stop"
     assert b.calls[0]["prompt_chars"] > 0
     assert b.calls[0]["reply_chars"] == len(reply)
+
+
+@pytest.mark.asyncio
+async def test_api_failure_raises_llm_call_failed():
+    """A provider call that blows up must be distinguishable from a local fault.
+
+    Only ``LLMCallFailed`` is counted in the LLM error rate; a plain
+    ``BackendError`` here would let the reactor record a deterministic local
+    fault as a provider failure.
+    """
+
+    class _BoomCompletions(FakeChatCompletions):
+        async def create(self, **kwargs):
+            raise RuntimeError("gateway 400")
+
+    client = FakeOpenAIClient([])
+    client.completions = _BoomCompletions([])
+    client.chat = FakeChat(client.completions)
+    backend = CodexBackend(model="gpt-5.4", client_factory=lambda: client)
+
+    with pytest.raises(LLMCallFailed, match="Codex API call failed"):
+        await backend.run("p")
+
+
+@pytest.mark.asyncio
+async def test_responses_api_failure_raises_llm_call_failed():
+    class _BoomResponses(FakeResponses):
+        async def create(self, **kwargs):
+            raise RuntimeError("gateway 500")
+
+    client = FakeOpenAIClient([], responses_replies=[])
+    client.responses = _BoomResponses([])
+    backend = CodexBackend(model="gpt-5.5", web_search=True, client_factory=lambda: client)
+
+    with pytest.raises(LLMCallFailed, match="Codex Responses API call failed"):
+        await backend.run("p")
 
 
 def test_construct_without_creds_raises_backend_error(monkeypatch):

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
@@ -253,6 +253,69 @@ async def test_llm_call_failed_records_one_error_row_per_turn(session_dir):
         await c.stop()
 
 
+class _SelfTracingLLMFailingBackend(_LLMFailingBackend):
+    """A self-tracing backend (critic-shaped): writes its own row, then raises.
+
+    Having ``set_trace_context`` is the contract that marks a backend as owning
+    its trace rows, so the Coordinator must not add one of its own.
+    """
+
+    def __init__(self, name: str, session_dir: Path) -> None:
+        super().__init__(name)
+        self._session_dir = session_dir
+        self.trace_ctx_calls = 0
+
+    def set_trace_context(self, *, tick: int | None = None, phase: str | None = None) -> None:
+        self.trace_ctx_calls += 1
+
+    async def run(
+        self,
+        prompt: str,
+        *,
+        system_prompt: str | None = None,
+        tools: list[str] | None = None,
+        max_turns: int = 1,
+    ) -> "BackendTurnResult":  # noqa: F821 — protocol return type, raises before returning
+        from hyperloom.orchestrator.roles.base import LLMCallFailed
+        from hyperloom.orchestrator.trace.llm_trace import LLMCallRecord, append_llm_call
+
+        self.calls += 1
+        error = LLMCallFailed(f"simulated {self.name} gateway 400 #{self.calls}")
+        append_llm_call(
+            session_dir=self._session_dir,
+            record=LLMCallRecord.for_failure(
+                session_id=self._session_dir.name,
+                component="critic",
+                role="critic",
+                error=error,
+                model="claude-opus-4-7",
+            ),
+        )
+        raise error
+
+
+@pytest.mark.asyncio
+async def test_self_tracing_backend_failure_is_recorded_exactly_once(session_dir):
+    """One provider failure must produce one row, not one per writer.
+
+    The critic writes its own error row (carrying the review model) and then
+    raises; if the Coordinator also wrote one, Langfuse would count a single
+    critic failure twice, with disagreeing model/latency on the two rows.
+    """
+    backends = _build_backends({})
+    backends["critic"] = _SelfTracingLLMFailingBackend("critic", session_dir)
+    c = Coordinator(session_dir, backends=backends)
+    try:
+        await c.tick(2)
+        rows = _llm_error_rows(session_dir)
+        assert len(rows) == backends["critic"].calls
+        # The surviving row is the backend's richer one (real review model).
+        assert {r["model"] for r in rows} == {"claude-opus-4-7"}
+        assert {r["component"] for r in rows} == {"critic"}
+    finally:
+        await c.stop()
+
+
 class _AlwaysCrashingBackend(Backend):
     """Backend that raises an unexpected exception from ``run``."""
 

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
@@ -186,6 +186,73 @@ class _AlwaysFailingBackend(Backend):
         raise BackendError(f"simulated {self.name} subprocess crash #{self.calls}")
 
 
+class _LLMFailingBackend(Backend):
+    """Backend whose provider call fails (raises the ``LLMCallFailed`` marker)."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.calls = 0
+
+    async def run(
+        self,
+        prompt: str,
+        *,
+        system_prompt: str | None = None,
+        tools: list[str] | None = None,
+        max_turns: int = 1,
+    ) -> "BackendTurnResult":  # noqa: F821 — protocol return type, raises before returning
+        from hyperloom.orchestrator.roles.base import LLMCallFailed
+
+        self.calls += 1
+        raise LLMCallFailed(f"simulated {self.name} gateway 400 #{self.calls}")
+
+
+def _llm_error_rows(session_dir: Path) -> list[dict]:
+    from hyperloom.inference_optimizer.session.session_paths import llm_calls_path
+
+    path = llm_calls_path(session_dir)
+    if not path.exists():
+        return []
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    return [r for r in rows if r.get("status") == "error"]
+
+
+@pytest.mark.asyncio
+async def test_plain_backend_error_records_no_llm_error_row(session_dir):
+    """A deterministic local fault must not be counted as a provider failure.
+
+    ``BackendError`` covers unreadable ``emit.json``, a missing ``--review``
+    path, an absent SDK — none of which touched the model. Recording those
+    would make the Langfuse LLM error rate meaningless.
+    """
+    backends = _build_backends({})
+    backends["robustness"] = _AlwaysFailingBackend("robustness")
+    c = Coordinator(session_dir, backends=backends)
+    try:
+        await c.tick(2)
+        assert _llm_error_rows(session_dir) == []
+    finally:
+        await c.stop()
+
+
+@pytest.mark.asyncio
+async def test_llm_call_failed_records_one_error_row_per_turn(session_dir):
+    backends = _build_backends({})
+    backends["robustness"] = _LLMFailingBackend("robustness")
+    c = Coordinator(session_dir, backends=backends)
+    try:
+        await c.tick(2)
+        rows = _llm_error_rows(session_dir)
+        assert len(rows) == 2
+        row = rows[0]
+        assert row["component"] == "robustness"
+        assert row["error_type"] == "LLMCallFailed"
+        assert "gateway 400" in row["error_message"]
+        assert row["input_tokens"] is None and row["output_tokens"] is None
+    finally:
+        await c.stop()
+
+
 class _AlwaysCrashingBackend(Backend):
     """Backend that raises an unexpected exception from ``run``."""
 

--- a/src/hyperloom/inference_optimizer/tests/test_langfuse_emitter.py
+++ b/src/hyperloom/inference_optimizer/tests/test_langfuse_emitter.py
@@ -388,6 +388,100 @@ def test_token_and_conversation_pair_into_one_generation(tmp_path, monkeypatch):
     assert g.ended is True
 
 
+def test_failed_call_emits_immediately_with_error_level(tmp_path, monkeypatch):
+    """A failure has no response half, so it must not wait for a pair.
+
+    Buffering it would hide the failure until session end and let ``pair_key``
+    (status-blind) marry it to a neighbouring successful call.
+    """
+    _enable_env(monkeypatch)
+    client = _FakeClient()
+    _install_fake_sdk(monkeypatch, client)
+    em = lfe.LangfuseEmitter(tmp_path)
+
+    em.record_llm_call(
+        _llm_row(
+            status="error",
+            error_type="BackendError",
+            error_message="gateway returned 400",
+            input_tokens=None,
+            output_tokens=None,
+            cache_read_input_tokens=None,
+        )
+    )
+
+    assert len(client.generations) == 1
+    g = client.generations[0]
+    assert g.kwargs["level"] == lfmap.LEVEL_ERROR
+    assert g.kwargs["status_message"] == "BackendError: gateway returned 400"
+    assert g.kwargs["metadata"]["status"] == "error"
+    assert g.kwargs["metadata"]["error_type"] == "BackendError"
+    # No response half was ever buffered waiting for a partner.
+    assert em._pending == {}
+    assert em._counts["generations_failed"] == 1
+
+
+def test_successful_and_legacy_rows_stay_default_level(tmp_path, monkeypatch):
+    """Rows written before ``status`` existed must not all turn red on backfill."""
+    _enable_env(monkeypatch)
+    client = _FakeClient()
+    _install_fake_sdk(monkeypatch, client)
+    em = lfe.LangfuseEmitter(tmp_path)
+
+    legacy = _llm_row()
+    assert "status" not in legacy
+    em.record_llm_call(legacy)
+    em.record_conversation(_conv_row())
+
+    assert len(client.generations) == 1
+    g = client.generations[0]
+    assert g.kwargs["level"] == lfmap.LEVEL_DEFAULT
+    assert g.kwargs["status_message"] is None
+    assert em._counts["generations_failed"] == 0
+
+
+def test_start_obs_degrades_when_sdk_rejects_level(monkeypatch):
+    """An SDK predating ``level`` still gets the observation, minus the extras."""
+
+    class _OldParent:
+        def __init__(self):
+            self.calls: list[dict] = []
+
+        def start_observation(self, **kwargs):
+            self.calls.append(kwargs)
+            for unsupported in ("start_time", "level", "status_message"):
+                if unsupported in kwargs:
+                    raise TypeError(f"unexpected keyword argument {unsupported!r}")
+            return "observation"
+
+    parent = _OldParent()
+    got = lfe._start_obs(
+        parent,
+        name="gen",
+        as_type="generation",
+        start_time="T",
+        level="ERROR",
+        status_message="boom",
+    )
+
+    assert got == "observation"
+    # Ladder walked down to the signature the SDK accepts, without repeating one.
+    assert [sorted(c) for c in parent.calls] == [
+        ["as_type", "level", "name", "start_time", "status_message"],
+        ["as_type", "level", "name", "status_message"],
+        ["as_type", "name"],
+    ]
+
+
+def test_start_obs_reraises_when_even_minimal_signature_fails():
+    class _Hostile:
+        def start_observation(self, **_kwargs):
+            raise TypeError("nope")
+
+    with pytest.raises(TypeError):
+        lfe._start_obs(_Hostile(), name="gen", as_type="span")
+
+
 def test_conversation_first_then_token_also_pairs(tmp_path, monkeypatch):
     _enable_env(monkeypatch)
     client = _FakeClient()

--- a/src/hyperloom/inference_optimizer/tests/test_langfuse_emitter.py
+++ b/src/hyperloom/inference_optimizer/tests/test_langfuse_emitter.py
@@ -1378,6 +1378,36 @@ def test_record_status_throttles_unchanged_snapshots(tmp_path, monkeypatch):
     assert em._counts["status_updates_sent"] == 2
 
 
+def test_record_status_minute_buckets_runtime_clocks(tmp_path, monkeypatch):
+    _enable_env(monkeypatch)
+    client = _FakeClient()
+    _install_fake_sdk(monkeypatch, client)
+    sd = tmp_path / "SID"
+    _write_manifest(sd)
+    em = lfe.LangfuseEmitter(sd)
+
+    em.record_status(_status(
+        session_elapsed_s=121,
+        explore_elapsed_s=31,
+        explore_ratio=31 / 121,
+    ))
+    em.record_status(_status(
+        session_elapsed_s=139,
+        explore_elapsed_s=49,
+        explore_ratio=49 / 139,
+    ))
+    assert em._counts["status_updates_sent"] == 1
+
+    em.record_status(_status(
+        session_elapsed_s=181,
+        explore_elapsed_s=61,
+        explore_ratio=61 / 181,
+    ))
+    assert em._counts["status_updates_sent"] == 2
+    status_spans = [s for s in client.spans if s.kwargs.get("name") == "session_status"]
+    assert status_spans[-1].kwargs["output"]["session_elapsed_s"] == 181
+
+
 def test_record_status_refreshes_after_min_interval(tmp_path, monkeypatch):
     _enable_env(monkeypatch)
     client = _FakeClient()

--- a/src/hyperloom/inference_optimizer/tests/test_llm_trace_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_llm_trace_unit.py
@@ -76,6 +76,68 @@ def test_coerce_optional_str_list_variants():
     assert llm_trace._coerce_optional_str_list(["x", "", " y "]) == ["x", "y"]
 
 
+def test_for_failure_records_error_without_token_counters(tmp_path: Path, monkeypatch):
+    """A failed call lands in the ledger as an ``error`` row, tokens unmeasured."""
+    monkeypatch.setattr(llm_trace, "_now_iso", lambda **_: "2026-01-01T00:00:00Z")
+    monkeypatch.setattr(llm_trace, "get_emitter", lambda _session_dir: None, raising=False)
+
+    record = llm_trace.LLMCallRecord.for_failure(
+        session_id="s1",
+        component="orchestration",
+        role="orchestration",
+        error=RuntimeError("litellm.BadRequestError: AnthropicException"),
+        model="claude-opus-5",
+        tick=4,
+        phase="EXPLORE",
+        latency_ms=1200,
+    )
+    llm_trace.append_llm_call(session_dir=tmp_path, record=record)
+    row = json.loads((tmp_path / "reports" / "trace" / "llm_calls.jsonl").read_text())
+
+    assert row["status"] == llm_trace.LLM_STATUS_ERROR
+    assert row["error_type"] == "RuntimeError"
+    assert row["error_message"] == "litellm.BadRequestError: AnthropicException"
+    # Join keys survive so the failure lands on the same phase/agent as its peers.
+    assert (row["component"], row["tick"], row["phase"]) == ("orchestration", 4, "EXPLORE")
+    assert row["latency_ms"] == 1200
+    # Nothing was measured, so no counter may claim zero.
+    assert all(
+        row[k] is None
+        for k in (
+            "input_tokens",
+            "output_tokens",
+            "cache_creation_input_tokens",
+            "cache_read_input_tokens",
+        )
+    )
+
+
+def test_for_failure_accepts_plain_message_and_truncates(tmp_path: Path):
+    """A gateway body can be huge; the ledger keeps a bounded slice of it."""
+    record = llm_trace.LLMCallRecord.for_failure(
+        session_id="s1",
+        component="forge",
+        error="x" * 5000,
+    )
+    row = record.to_row()
+    assert row["error_type"] is None
+    assert len(row["error_message"]) == llm_trace._ERROR_MESSAGE_MAX
+
+
+def test_success_rows_default_to_ok_status(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(llm_trace, "_now_iso", lambda **_: "2026-01-01T00:00:00Z")
+    row = llm_trace.LLMCallRecord(session_id="s1", component="forge").to_row()
+    assert row["status"] == llm_trace.LLM_STATUS_OK
+    assert row["error_type"] is None and row["error_message"] is None
+
+
+def test_append_llm_call_rejects_unknown_status(tmp_path: Path):
+    record = llm_trace.LLMCallRecord(session_id="s1", component="forge")
+    record.status = "partially_ok"
+    with pytest.raises(llm_trace.LLMTraceRowError):
+        llm_trace.append_llm_call(session_dir=tmp_path, record=record)
+
+
 def test_llm_trace_langfuse_mirror_failure_swallowed(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(llm_trace, "_now_iso", lambda **_: "2026-01-01T00:00:00Z")
 

--- a/src/hyperloom/inference_optimizer/tests/test_llm_trace_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_llm_trace_unit.py
@@ -138,6 +138,20 @@ def test_append_llm_call_rejects_unknown_status(tmp_path: Path):
         llm_trace.append_llm_call(session_dir=tmp_path, record=record)
 
 
+def test_llm_call_failed_is_a_backend_error(tmp_path: Path):
+    """The marker must stay catchable as ``BackendError``.
+
+    Retry and error-streak accounting are written against ``BackendError``; if
+    the marker were a sibling type instead of a subclass, marking a call site
+    would silently change failure handling as well as tracing.
+    """
+    from hyperloom.orchestrator.roles.base import BackendError, LLMCallFailed
+
+    assert issubclass(LLMCallFailed, BackendError)
+    with pytest.raises(BackendError):
+        raise LLMCallFailed("gateway 400")
+
+
 def test_llm_trace_langfuse_mirror_failure_swallowed(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(llm_trace, "_now_iso", lambda **_: "2026-01-01T00:00:00Z")
 

--- a/src/hyperloom/inference_optimizer/tests/test_phase_state_machine.py
+++ b/src/hyperloom/inference_optimizer/tests/test_phase_state_machine.py
@@ -316,6 +316,51 @@ def test_record_phase_transition_writes_row_and_updates_phase():
     assert row2["from_phase"] == "PRELUDE"
 
 
+def test_explore_elapsed_accumulates_completed_and_live_segments():
+    s = SharedState()
+    s.record_phase_transition(
+        to_phase="EXPLORE",
+        reason="phase_entered",
+        evidence={},
+        ts="2026-05-19T00:00:00+00:00",
+        ts_unix=100.0,
+    )
+    s.record_phase_transition(
+        to_phase="KERNEL_AGENT",
+        reason="explore_done",
+        evidence={},
+        ts="2026-05-19T00:02:00+00:00",
+        ts_unix=220.0,
+    )
+    assert s.explore_elapsed_accum_s == 120.0
+    assert phase_state.explore_elapsed_seconds(s, now_unix=300.0) == 120.0
+
+    s.record_phase_transition(
+        to_phase="EXPLORE",
+        reason="sweep_reloop",
+        evidence={},
+        ts="2026-05-19T00:03:00+00:00",
+        ts_unix=280.0,
+    )
+    assert phase_state.explore_elapsed_seconds(s, now_unix=310.0) == 150.0
+
+
+def test_langfuse_status_includes_explore_runtime_and_kb_hit():
+    s = SharedState()
+    s.start_ts = "2026-05-19T00:00:00+00:00"
+    s.phase = "EXPLORE"
+    s.phase_started_unix = 100.0
+    s.explore_elapsed_accum_s = 120.0
+    s.warm_start_context = {"status": "hit"}
+
+    summary = s._langfuse_status_summary()
+
+    assert summary["kb_hit"] == "hit"
+    assert summary["explore_elapsed_s"] >= 120
+    assert "explore_ratio" in summary
+    assert "session_elapsed_s" in summary
+
+
 def test_core_state_fields_includes_phase_fields():
     for f in (
         "phase",
@@ -323,6 +368,7 @@ def test_core_state_fields_includes_phase_fields():
         "phase_started_unix",
         "phase_history",
         "phase_budget_pct",
+        "explore_elapsed_accum_s",
     ):
         assert f in CORE_STATE_FIELDS, f
 

--- a/src/hyperloom/inference_optimizer/tests/test_phase_state_machine.py
+++ b/src/hyperloom/inference_optimizer/tests/test_phase_state_machine.py
@@ -361,6 +361,36 @@ def test_langfuse_status_includes_explore_runtime_and_kb_hit():
     assert "session_elapsed_s" in summary
 
 
+def test_legacy_resume_keeps_explore_runtime_unknown():
+    raw = SharedState().to_dict()
+    raw.pop("explore_elapsed_accum_s")
+    raw.update(
+        {
+            "start_ts": "2026-05-19T00:00:00+00:00",
+            "phase": "EXPLORE",
+            "phase_started_unix": 100.0,
+        }
+    )
+
+    s = SharedState.from_dict(raw)
+    assert s.explore_elapsed_accum_s is None
+    assert phase_state.explore_elapsed_seconds(s, now_unix=220.0) is None
+
+    summary = s._langfuse_status_summary()
+    assert "session_elapsed_s" in summary
+    assert "explore_elapsed_s" not in summary
+    assert "explore_ratio" not in summary
+
+    s.record_phase_transition(
+        to_phase="KERNEL_AGENT",
+        reason="explore_done",
+        evidence={},
+        ts="2026-05-19T00:02:00+00:00",
+        ts_unix=220.0,
+    )
+    assert s.explore_elapsed_accum_s is None
+
+
 def test_core_state_fields_includes_phase_fields():
     for f in (
         "phase",

--- a/src/hyperloom/inference_optimizer/tests/test_proposal_scorer.py
+++ b/src/hyperloom/inference_optimizer/tests/test_proposal_scorer.py
@@ -201,6 +201,47 @@ async def test_scoring_call_writes_full_conversation_trace(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_failed_scoring_call_writes_an_error_row(tmp_path: Path):
+    """A model whose call blows up must still land in the ledger.
+
+    ``score()`` folds per-model exceptions into an ``errors`` map via
+    ``gather(return_exceptions=True)``, so without a row written inside
+    ``_score_one_model`` the failure never reaches the ledger or Langfuse — and
+    which model failed is the only thing that survives the fold.
+    """
+    session_dir = tmp_path / "SESSION"
+    session_dir.mkdir()
+
+    class _BoomClient:
+        def __init__(self):
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+
+        async def _create(self, **_kwargs):
+            raise RuntimeError("gateway 400")
+
+    scorer = ProposalScorer(
+        models=("claude-opus-4-7",),
+        client_factory=_BoomClient,
+        session_dir=session_dir,
+    )
+    out = await scorer.score(gap=_GAP, proposals=_PROPOSALS, task_id="spec-9")
+
+    # The scorer still degrades gracefully for its caller.
+    assert "claude-opus-4-7" in (out.get("errors") or {})
+
+    rows = [r for r in _read_jsonl(llm_calls_path(session_dir)) if r["component"] == "proposal_scorer"]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["status"] == "error"
+    assert row["error_type"] == "RuntimeError"
+    assert "gateway 400" in row["error_message"]
+    assert row["model"] == "claude-opus-4-7"
+    assert row["task_id"] == "spec-9"
+    # Nothing was measured, so no counter may claim zero.
+    assert row["input_tokens"] is None and row["output_tokens"] is None
+
+
+@pytest.mark.asyncio
 async def test_scoring_without_session_dir_writes_no_trace(tmp_path: Path):
     """The default (tests / no full-trace) path writes no conversation file."""
     scorer = _make_scorer({"m1": _scores_json(("cuda_graph_bs_512", 7.0, "x"))})

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -5576,6 +5576,15 @@ def _trace_kernel_attempt_usage(
         try:
             usage = parse_forge_usage(stdout_text)
             if not usage:
+                # No failure row is written here, deliberately. This is a
+                # post-hoc log scrape of an out-of-process child, and the child
+                # prints FORGE_LLM_USAGE only on success — so a missing marker
+                # cannot be told apart from "the child's LLM calls failed".
+                # The attempt dict carries only business outcomes (improved,
+                # best_ms), and synthesizing an LLM error from those is exactly
+                # the conflation that makes an error rate untrustworthy.
+                # Closing this gap needs the child (GEAK / KernelForge
+                # forge_submit) to emit a failure marker of its own.
                 continue
             record = LLMCallRecord(
                 session_id=session_dir.name,

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -54,7 +54,7 @@ from ..state.optimization_journal import Journal
 from hyperloom.inference_optimizer.session.paths import db_path_for
 from ..actions.registry import ActionRegistry
 from ..roles.agent_role import AgentRole, default_role_registry
-from ..roles.base import Backend, BackendError, BackendTurnResult
+from ..roles.base import Backend, BackendError, BackendTurnResult, LLMCallFailed
 from ..bus.cursor_store import CursorStore
 from ..bus.storage.connection import SqliteConnection
 from hyperloom.inference_optimizer.protocol.intent import NoIntentEmitted
@@ -1756,11 +1756,12 @@ class Coordinator(metaclass=_CoordinatorMeta):
                 outcome="backend_error",
                 error=exc,
             )
-            self._trace_reactor_llm_failure(
-                agent_name,
-                exc,
-                latency_ms=int((time.perf_counter() - _t0) * 1000),
-            )
+            if isinstance(exc, LLMCallFailed):
+                self._trace_reactor_llm_failure(
+                    agent_name,
+                    exc,
+                    latency_ms=int((time.perf_counter() - _t0) * 1000),
+                )
             await self._record_observation(
                 "coordinator",
                 "observation",
@@ -1972,7 +1973,7 @@ class Coordinator(metaclass=_CoordinatorMeta):
     def _trace_reactor_llm_failure(
         self,
         agent_name: str,
-        error: BaseException,
+        error: LLMCallFailed,
         *,
         latency_ms: int | None = None,
     ) -> None:
@@ -1983,9 +1984,14 @@ class Coordinator(metaclass=_CoordinatorMeta):
         Langfuse — has no trace of a turn whose model call never returned. The
         row carries no token counters; it exists to make the failure countable.
 
+        Only :class:`LLMCallFailed` reaches here. A plain ``BackendError`` can
+        come from a deterministic local fault (unreadable ``emit.json``, missing
+        ``--review`` path, absent SDK) that never touched the provider, and
+        recording those would make the Langfuse error rate meaningless.
+
         Args:
             agent_name: The reactor role; doubles as trace component and role.
-            error: The backend error that ended the turn.
+            error: The model-call failure that ended the turn.
             latency_ms: Time spent before failing, when measured.
         """
         try:

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -1727,9 +1727,13 @@ class Coordinator(metaclass=_CoordinatorMeta):
         sys_prompt = await self._load_system_prompt(agent_name)
         tools = self.policy.allowed_tools_for_agent(agent_name)
         # Stamp timeline keys onto backends that self-write their trace row.
-        # No-op for backends without the hook.
+        # No-op for backends without the hook. Presence of the hook is also what
+        # tells the failure path below to stay out of the way: such a backend
+        # records its own row, with the review model and its own latency, and a
+        # second row from here would count one provider failure twice.
         _set_trace_ctx = getattr(backend, "set_trace_context", None)
-        if callable(_set_trace_ctx):
+        backend_self_traces = callable(_set_trace_ctx)
+        if backend_self_traces:
             try:
                 _set_trace_ctx(
                     tick=int(self.shared_state.tick or 0),
@@ -1756,7 +1760,7 @@ class Coordinator(metaclass=_CoordinatorMeta):
                 outcome="backend_error",
                 error=exc,
             )
-            if isinstance(exc, LLMCallFailed):
+            if isinstance(exc, LLMCallFailed) and not backend_self_traces:
                 self._trace_reactor_llm_failure(
                     agent_name,
                     exc,
@@ -1984,10 +1988,13 @@ class Coordinator(metaclass=_CoordinatorMeta):
         Langfuse — has no trace of a turn whose model call never returned. The
         row carries no token counters; it exists to make the failure countable.
 
-        Only :class:`LLMCallFailed` reaches here. A plain ``BackendError`` can
-        come from a deterministic local fault (unreadable ``emit.json``, missing
+        Only :class:`LLMCallFailed` reaches here, and only from a backend that
+        does not trace itself. A plain ``BackendError`` can come from a
+        deterministic local fault (unreadable ``emit.json``, missing
         ``--review`` path, absent SDK) that never touched the provider, and
-        recording those would make the Langfuse error rate meaningless.
+        recording those would make the Langfuse error rate meaningless; a
+        self-tracing backend (the critic) has already written a richer row of
+        its own, so writing here too would double-count one failure.
 
         Args:
             agent_name: The reactor role; doubles as trace component and role.

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -1756,6 +1756,11 @@ class Coordinator(metaclass=_CoordinatorMeta):
                 outcome="backend_error",
                 error=exc,
             )
+            self._trace_reactor_llm_failure(
+                agent_name,
+                exc,
+                latency_ms=int((time.perf_counter() - _t0) * 1000),
+            )
             await self._record_observation(
                 "coordinator",
                 "observation",
@@ -1960,6 +1965,43 @@ class Coordinator(metaclass=_CoordinatorMeta):
         except Exception:  # noqa: BLE001 — trace must never break the loop
             log.debug(
                 "full-trace: reactor llm_call append failed for %s",
+                agent_name,
+                exc_info=True,
+            )
+
+    def _trace_reactor_llm_failure(
+        self,
+        agent_name: str,
+        error: BaseException,
+        *,
+        latency_ms: int | None = None,
+    ) -> None:
+        """Append one ``status="error"`` ``llm_calls.jsonl`` row for a failed turn.
+
+        The success path (:meth:`_trace_reactor_llm_call`) can only run once a
+        ``BackendTurnResult`` exists, so without this the ledger — and therefore
+        Langfuse — has no trace of a turn whose model call never returned. The
+        row carries no token counters; it exists to make the failure countable.
+
+        Args:
+            agent_name: The reactor role; doubles as trace component and role.
+            error: The backend error that ended the turn.
+            latency_ms: Time spent before failing, when measured.
+        """
+        try:
+            record = LLMCallRecord.for_failure(
+                session_id=self.session_dir.name,
+                component=agent_name,
+                role=agent_name,
+                error=error,
+                tick=int(self.shared_state.tick or 0),
+                phase=(self.shared_state.phase or "") or None,
+                latency_ms=latency_ms,
+            )
+            append_llm_call(session_dir=self.session_dir, record=record)
+        except Exception:  # noqa: BLE001 — trace must never break the loop
+            log.debug(
+                "full-trace: reactor llm_call failure append failed for %s",
                 agent_name,
                 exc_info=True,
             )

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -869,17 +869,21 @@ def phase_elapsed_seconds(state: Any, *, now_unix: float | None = None) -> float
     return max(0.0, now - started)
 
 
-def explore_elapsed_seconds(state: Any, *, now_unix: float | None = None) -> float:
+def explore_elapsed_seconds(state: Any, *, now_unix: float | None = None) -> float | None:
     """Return total Explore wall-clock seconds across all macro cycles.
 
     Completed Explore segments are accumulated at every transition out of
     EXPLORE. If the current phase is still EXPLORE, append the live segment at
-    read time so runtime telemetry remains current between transitions.
+    read time so runtime telemetry remains current between transitions. Returns
+    ``None`` when a legacy resumed state has no trustworthy historical total.
     """
+    raw_accumulated = getattr(state, "explore_elapsed_accum_s", 0.0)
+    if raw_accumulated is None:
+        return None
     try:
-        accumulated = float(getattr(state, "explore_elapsed_accum_s", 0.0) or 0.0)
+        accumulated = float(raw_accumulated or 0.0)
     except (TypeError, ValueError):
-        accumulated = 0.0
+        return None
     if (getattr(state, "phase", "") or "").strip().upper() == PHASE_EXPLORE:
         accumulated += phase_elapsed_seconds(state, now_unix=now_unix)
     return max(0.0, accumulated)
@@ -2549,14 +2553,17 @@ def record_phase_transition(
     now_unix = float(ts_unix if ts_unix is not None else _time.time())
     from_phase = (state.phase or "").strip().upper()
     if from_phase == PHASE_EXPLORE:
-        try:
-            accumulated = float(getattr(state, "explore_elapsed_accum_s", 0.0) or 0.0)
-        except (TypeError, ValueError):
-            accumulated = 0.0
-        state.explore_elapsed_accum_s = accumulated + phase_elapsed_seconds(
-            state,
-            now_unix=now_unix,
-        )
+        raw_accumulated = getattr(state, "explore_elapsed_accum_s", 0.0)
+        if raw_accumulated is not None:
+            try:
+                accumulated = float(raw_accumulated or 0.0)
+            except (TypeError, ValueError):
+                state.explore_elapsed_accum_s = None
+            else:
+                state.explore_elapsed_accum_s = accumulated + phase_elapsed_seconds(
+                    state,
+                    now_unix=now_unix,
+                )
     row = make_history_row(
         from_phase=from_phase,
         to_phase=to_phase,

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -869,6 +869,22 @@ def phase_elapsed_seconds(state: Any, *, now_unix: float | None = None) -> float
     return max(0.0, now - started)
 
 
+def explore_elapsed_seconds(state: Any, *, now_unix: float | None = None) -> float:
+    """Return total Explore wall-clock seconds across all macro cycles.
+
+    Completed Explore segments are accumulated at every transition out of
+    EXPLORE. If the current phase is still EXPLORE, append the live segment at
+    read time so runtime telemetry remains current between transitions.
+    """
+    try:
+        accumulated = float(getattr(state, "explore_elapsed_accum_s", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        accumulated = 0.0
+    if (getattr(state, "phase", "") or "").strip().upper() == PHASE_EXPLORE:
+        accumulated += phase_elapsed_seconds(state, now_unix=now_unix)
+    return max(0.0, accumulated)
+
+
 def _phase_budget_total_seconds(
     state: Any,
     *,
@@ -2531,8 +2547,18 @@ def record_phase_transition(
 
     now_ts = ts or _dt.now(_tz.utc).isoformat(timespec="seconds")
     now_unix = float(ts_unix if ts_unix is not None else _time.time())
+    from_phase = (state.phase or "").strip().upper()
+    if from_phase == PHASE_EXPLORE:
+        try:
+            accumulated = float(getattr(state, "explore_elapsed_accum_s", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            accumulated = 0.0
+        state.explore_elapsed_accum_s = accumulated + phase_elapsed_seconds(
+            state,
+            now_unix=now_unix,
+        )
     row = make_history_row(
-        from_phase=state.phase or "",
+        from_phase=from_phase,
         to_phase=to_phase,
         reason=reason,
         evidence=evidence,
@@ -2715,6 +2741,7 @@ __all__ = [
     "is_valid_stop_reason",
     "kernel_work_pending",
     "make_history_row",
+    "explore_elapsed_seconds",
     "normalize_budget_pct",
     "phase_budget_remaining_seconds",
     "phase_elapsed_seconds",

--- a/src/hyperloom/orchestrator/policy/gate.py
+++ b/src/hyperloom/orchestrator/policy/gate.py
@@ -527,6 +527,7 @@ CORE_STATE_FIELDS: frozenset[str] = frozenset(
         "phase_started_unix",
         "phase_history",
         "phase_budget_pct",
+        "explore_elapsed_accum_s",
         # Cyclic phase-machine state; Coordinator-only writers. Locked so an LLM
         # update_state cannot forge the macro-cycle counter, budget window, gain
         # anchor / no-gain streak, or bottleneck-switch handoff.

--- a/src/hyperloom/orchestrator/roles/base.py
+++ b/src/hyperloom/orchestrator/roles/base.py
@@ -86,6 +86,22 @@ class BackendError(RuntimeError):
     """Backend invocation failed (network, schema, etc.)."""
 
 
+class LLMCallFailed(BackendError):
+    """The model request itself failed — no usable response came back.
+
+    A :class:`BackendError` covers everything a backend can get wrong, most of
+    which never touches the provider: a missing ``--review`` path, an
+    unreadable ``emit.json``, an unsupported runtime phase, an absent SDK. Only
+    the subset raised around an actual provider call belongs in the LLM error
+    rate, so those sites raise this instead and the trace layer records an
+    ``error`` row for it alone. Counting every ``BackendError`` would let
+    deterministic local faults masquerade as provider failures.
+
+    Subclasses :class:`BackendError` so existing ``except BackendError``
+    handlers (retry, error-streak accounting) are unaffected.
+    """
+
+
 @dataclass(frozen=True)
 class RetryPolicy:
     """Bounded exponential-backoff policy for transient LLM call failures.
@@ -283,6 +299,7 @@ __all__ = [
     "Backend",
     "BackendError",
     "BackendTurnResult",
+    "LLMCallFailed",
     "RetryPolicy",
     "build_chat_messages",
     "parse_call_timeout_env",

--- a/src/hyperloom/orchestrator/roles/claude.py
+++ b/src/hyperloom/orchestrator/roles/claude.py
@@ -398,6 +398,17 @@ class ClaudeBackend:
             raise error from exc
         except BaseException as exc:
             self._finish_turn_diagnostic(outcome="backend_error", error=exc)
+            # Once retries are exhausted, anything the SDK stream raised is a
+            # provider call that produced nothing usable — including the gateway
+            # 400s (``litellm.BadRequestError: AnthropicException``) this
+            # telemetry exists to count. Marking it here matches what Codex
+            # already does for its own API errors, and keeps the failure out of
+            # the Coordinator's "unexpected crash" path. ``NoIntentEmitted`` is
+            # raised below, outside this block, so a call that succeeded with
+            # unusable output stays distinct. Cancellation is a BaseException
+            # and is re-raised untouched.
+            if isinstance(exc, Exception) and not isinstance(exc, LLMCallFailed):
+                raise LLMCallFailed(f"Claude backend call failed: {exc!r}") from exc
             raise
         if self._active_turn_diagnostic is not None:
             self._active_turn_diagnostic["session_id_hash"] = self._session_hash(session_id)

--- a/src/hyperloom/orchestrator/roles/claude.py
+++ b/src/hyperloom/orchestrator/roles/claude.py
@@ -32,6 +32,7 @@ from hyperloom.inference_optimizer.protocol.intent import (
 from .base import (
     BackendError,
     BackendTurnResult,
+    LLMCallFailed,
     RetryPolicy,
     parse_call_timeout_env,
     retry_with_backoff,
@@ -390,7 +391,7 @@ class ClaudeBackend:
                     ),
                 }
             )
-            error = BackendError(
+            error = LLMCallFailed(
                 f"Claude backend timed out: stream idle for >{self.call_timeout_s:.0f}s (likely upstream proxy stall)"
             )
             self._finish_turn_diagnostic(outcome="backend_error", error=error)

--- a/src/hyperloom/orchestrator/roles/codex.py
+++ b/src/hyperloom/orchestrator/roles/codex.py
@@ -36,7 +36,14 @@ from hyperloom.inference_optimizer.protocol.intent import (
     validate_envelope,
 )
 from .agent_role import DEFAULT_CODEX_MODEL
-from .base import BackendError, BackendTurnResult, build_chat_messages, parse_call_timeout_env, safe_int
+from .base import (
+    BackendError,
+    BackendTurnResult,
+    LLMCallFailed,
+    build_chat_messages,
+    parse_call_timeout_env,
+    safe_int,
+)
 
 
 _OUTPUT_INSTRUCTIONS = """
@@ -288,11 +295,11 @@ class CodexBackend:
                 timeout=self.call_timeout_s,
             )
         except asyncio.TimeoutError as exc:
-            raise BackendError(
+            raise LLMCallFailed(
                 f"Codex API call timed out after {self.call_timeout_s:.0f}s (likely upstream proxy stall)"
             ) from exc
         except Exception as exc:  # noqa: BLE001
-            raise BackendError(f"Codex API call failed: {exc!r}") from exc
+            raise LLMCallFailed(f"Codex API call failed: {exc!r}") from exc
 
         choice = resp.choices[0]
         text = choice.message.content or ""
@@ -342,11 +349,11 @@ class CodexBackend:
                 timeout=self.call_timeout_s,
             )
         except asyncio.TimeoutError as exc:
-            raise BackendError(
+            raise LLMCallFailed(
                 f"Codex Responses API call timed out after {self.call_timeout_s:.0f}s (likely upstream proxy stall)"
             ) from exc
         except Exception as exc:  # noqa: BLE001
-            raise BackendError(f"Codex Responses API call failed: {exc!r}") from exc
+            raise LLMCallFailed(f"Codex Responses API call failed: {exc!r}") from exc
 
         text, citations = _extract_responses_output(resp)
         finish = _field(resp, "status")

--- a/src/hyperloom/orchestrator/roles/critic_agent.py
+++ b/src/hyperloom/orchestrator/roles/critic_agent.py
@@ -39,7 +39,7 @@ from hyperloom.inference_optimizer.protocol.intent import (
 from hyperloom.inference_optimizer.session.session_paths import allocate_turn_workdir, manifest_path
 from ..trace.conversation_trace import ConversationRecord, append_conversation
 from ..trace.llm_trace import LLMCallRecord, append_llm_call
-from .base import BackendError, BackendTurnResult, build_chat_messages, parse_call_timeout_env
+from .base import BackendError, BackendTurnResult, LLMCallFailed, build_chat_messages, parse_call_timeout_env
 from ._runtime_bridge import RuntimeCall, RuntimeCaller, invoke_runtime_cli
 
 
@@ -999,8 +999,9 @@ class CriticAgentBackend:
         try:
             resp = await self._client.chat.completions.create(**kwargs)
         except Exception as exc:  # noqa: BLE001
-            raise BackendError(
+            raise self._llm_call_failed(
                 f"Codex API call failed (critic-agent reasoning): {exc!r}",
+                latency_ms=int((time.perf_counter() - _t0) * 1000),
             ) from exc
         latency_ms = int((time.perf_counter() - _t0) * 1000)
         self._accumulate_usage(usage_acc, getattr(resp, "usage", None))
@@ -1051,18 +1052,25 @@ class CriticAgentBackend:
         try:
             resp = await self._client.post("/v1/messages", json=payload)
         except Exception as exc:  # noqa: BLE001
-            raise BackendError(
+            raise self._llm_call_failed(
                 f"Anthropic API call failed (critic-agent reasoning): {exc!r}",
+                latency_ms=int((time.perf_counter() - _t0) * 1000),
             ) from exc
         latency_ms = int((time.perf_counter() - _t0) * 1000)
         status = int(getattr(resp, "status_code", 200) or 200)
         if status >= 400:
             body_txt = str(getattr(resp, "text", ""))[:200]
-            raise BackendError(f"Anthropic API call failed (critic-agent reasoning): status={status} body={body_txt}")
+            raise self._llm_call_failed(
+                f"Anthropic API call failed (critic-agent reasoning): status={status} body={body_txt}",
+                latency_ms=latency_ms,
+            )
         try:
             body = resp.json()
         except ValueError as exc:
-            raise BackendError(f"Anthropic API returned non-JSON body (critic-agent reasoning): {exc!r}") from exc
+            raise self._llm_call_failed(
+                f"Anthropic API returned non-JSON body (critic-agent reasoning): {exc!r}",
+                latency_ms=latency_ms,
+            ) from exc
         self._accumulate_anthropic_usage(usage_acc, body.get("usage") if isinstance(body, dict) else None)
         self._trace_critic_llm_call(usage_acc, latency_ms=latency_ms)
         text = _anthropic_text_from_content(body.get("content") if isinstance(body, dict) else None)
@@ -1181,6 +1189,47 @@ class CriticAgentBackend:
                 "full-trace: critic llm_call append failed",
                 exc_info=True,
             )
+
+    def _llm_call_failed(
+        self,
+        message: str,
+        *,
+        latency_ms: int | None = None,
+    ) -> LLMCallFailed:
+        """Record a failed review-model call and return the error to raise.
+
+        The critic self-writes its trace rows, so a review call that never
+        returned has to be recorded here — the Coordinator only sees the raised
+        error, and by then the token accounting the success path relies on does
+        not exist. Returning the exception (rather than raising) keeps each call
+        site a single ``raise ... from exc``.
+
+        Args:
+            message: The failure description carried by the raised error.
+            latency_ms: Time spent before failing, when measured.
+
+        Returns:
+            The :class:`LLMCallFailed` for the caller to raise.
+        """
+        error = LLMCallFailed(message)
+        try:
+            record = LLMCallRecord.for_failure(
+                session_id=self.session_dir.name,
+                component="critic",
+                role="critic",
+                error=error,
+                model=self._review_model,
+                tick=self._trace_tick,
+                phase=self._trace_phase,
+                latency_ms=latency_ms,
+            )
+            append_llm_call(session_dir=self.session_dir, record=record)
+        except Exception:  # noqa: BLE001 — trace must never break review
+            log.debug(
+                "full-trace: critic llm_call failure append failed",
+                exc_info=True,
+            )
+        return error
 
     def _record_critic_conversation(
         self,

--- a/src/hyperloom/orchestrator/scoring/proposal_scorer.py
+++ b/src/hyperloom/orchestrator/scoring/proposal_scorer.py
@@ -307,7 +307,29 @@ class ProposalScorer:
         try:
             text_parts, usage = await asyncio.wait_for(_read_stream(), timeout=self.call_timeout_s)
         except asyncio.TimeoutError as exc:
-            raise RuntimeError(f"timed out after {self.call_timeout_s:.0f}s") from exc
+            error = RuntimeError(f"timed out after {self.call_timeout_s:.0f}s")
+            self._trace_scorer_llm_failure(
+                model,
+                error,
+                latency_ms=int((time.perf_counter() - _t0) * 1000),
+                task_id=task_id,
+                tick=tick,
+                phase=phase,
+            )
+            raise error from exc
+        except Exception as exc:
+            # Anything else out of the stream (transport, proxy 5xx, malformed
+            # chunk) is still a model call that produced nothing usable.
+            # Cancellation is a BaseException and deliberately not caught.
+            self._trace_scorer_llm_failure(
+                model,
+                exc,
+                latency_ms=int((time.perf_counter() - _t0) * 1000),
+                task_id=task_id,
+                tick=tick,
+                phase=phase,
+            )
+            raise
         latency_ms = int((time.perf_counter() - _t0) * 1000)
         # Record this model's token spend before parsing (best-effort).
         self._trace_scorer_llm_call(
@@ -383,6 +405,53 @@ class ProposalScorer:
         except Exception:  # noqa: BLE001 — trace must never break scoring
             log.debug(
                 "full-trace: proposal_scorer llm_call append failed for model=%s",
+                model,
+                exc_info=True,
+            )
+
+    def _trace_scorer_llm_failure(
+        self,
+        model: str,
+        error: BaseException,
+        *,
+        latency_ms: int | None = None,
+        task_id: str | None = None,
+        tick: int | None = None,
+        phase: str | None = None,
+    ) -> None:
+        """Append one ``status="error"`` row for a scoring call that never returned.
+
+        Recorded here rather than at the caller because the per-model context
+        (model slug, task/tick/phase) is only known inside this coroutine — by
+        the time :func:`asyncio.gather` has folded the exception into the
+        ``errors`` map, which model failed is all that survives.
+
+        Args:
+            model: The model slug whose call failed.
+            error: The exception that ended the call.
+            latency_ms: Time spent before failing, when measured.
+            task_id: The specialist round this scoring spend is attributed to.
+            tick: Timeline tick threaded from the coordinator dispatch point.
+            phase: Optimization phase threaded from the coordinator dispatch point.
+        """
+        if self.session_dir is None:
+            return
+        try:
+            record = LLMCallRecord.for_failure(
+                session_id=self.session_dir.name,
+                component="proposal_scorer",
+                role="proposal_scorer",
+                error=error,
+                model=str(model),
+                task_id=task_id,
+                tick=tick,
+                phase=phase,
+                latency_ms=latency_ms,
+            )
+            append_llm_call(session_dir=self.session_dir, record=record)
+        except Exception:  # noqa: BLE001 — trace must never break scoring
+            log.debug(
+                "full-trace: proposal_scorer llm_call failure append failed for model=%s",
                 model,
                 exc_info=True,
             )

--- a/src/hyperloom/orchestrator/specialists/runner.py
+++ b/src/hyperloom/orchestrator/specialists/runner.py
@@ -27,7 +27,7 @@ from hyperloom.common import io as _common_io
 from hyperloom.common.timeutil import now_iso
 
 from hyperloom.inference_optimizer.session.session_paths import runs_dir, specialist_intel_path
-from ..roles.base import BackendError
+from ..roles.base import BackendError, LLMCallFailed
 from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
 from ..trace.conversation_trace import ConversationRecord, append_conversation
 from ..trace.llm_trace import LLMCallRecord, append_llm_call
@@ -720,6 +720,52 @@ class SpecialistRunner:
                 exc_info=True,
             )
 
+    def _trace_specialist_llm_failure(
+        self,
+        *,
+        task_id: str,
+        turn: int,
+        error: BaseException,
+        latency_ms: int | None = None,
+        tick: int | None = None,
+        phase: str | None = None,
+    ) -> None:
+        """Append one ``status="error"`` row for a specialist turn that never returned.
+
+        The turn loop swallows a failed ``backend.run`` and breaks, so nothing
+        propagates to the Coordinator; without a row written here the failed
+        turn is invisible to the ledger and to Langfuse.
+
+        Args:
+            task_id: The specialist task id.
+            turn: The turn index that failed.
+            error: The exception that ended the turn.
+            latency_ms: Time spent before failing, when measured.
+            tick: Timeline tick for this turn, when known.
+            phase: Optimization phase for this turn, when known.
+        """
+        if self.session_dir is None:
+            return
+        try:
+            record = LLMCallRecord.for_failure(
+                session_id=self.session_dir.name,
+                component="specialist",
+                task_id=task_id,
+                turn=turn,
+                error=error,
+                latency_ms=latency_ms,
+                tick=tick,
+                phase=phase,
+            )
+            append_llm_call(session_dir=self.session_dir, record=record)
+        except Exception:  # noqa: BLE001 — trace must never break the run
+            log.debug(
+                "full-trace: specialist llm_call failure append failed for task_id=%s turn=%s",
+                task_id,
+                turn,
+                exc_info=True,
+            )
+
     def _record_specialist_intel(
         self,
         *,
@@ -886,6 +932,16 @@ class SpecialistRunner:
                         "error": str(exc),
                     },
                 )
+                if isinstance(exc, LLMCallFailed):
+                    _tick, _phase = self._ctx_tick_phase(ctx)
+                    self._trace_specialist_llm_failure(
+                        task_id=ctx.task.task_id,
+                        turn=turn_idx,
+                        error=exc,
+                        latency_ms=int((time.perf_counter() - _t0) * 1000),
+                        tick=_tick,
+                        phase=_phase,
+                    )
                 break
             except Exception as exc:  # noqa: BLE001 — defensive
                 backend_error = f"backend_unexpected:{exc!r}"

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -800,10 +800,11 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
     phase_started_unix: float = 0.0
     # Append-only log of phase transitions (rows from machine_state.make_history_row; reason in PHASE_EXIT_REASONS). Capped at _PHASE_HISTORY_CAP.
     phase_history: list[dict[str, Any]] = field(default_factory=list)
-    # Durable sum of completed EXPLORE segments. The current active EXPLORE
+    # Durable sum of completed EXPLORE segments. None means a legacy resumed
+    # state whose pre-upgrade total is unknowable. The current active EXPLORE
     # segment is added at status-render time; accumulating completed segments
     # avoids undercounting long macro-cycle runs after phase_history is capped.
-    explore_elapsed_accum_s: float = 0.0
+    explore_elapsed_accum_s: float | None = 0.0
     # Append-only operator-facing lifecycle log. Each row (built by
     # :func:`machine_state.make_lifecycle_event`) records a phase/step boundary
     # plus artifact paths. Coordinator-only writer; capped at ``_LIFECYCLE_CAP``.
@@ -1181,6 +1182,12 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
         # Filter to known fields; unknown keys dropped, missing keys default.
         known = {f for f in cls.__dataclass_fields__}
         filtered = {k: v for k, v in raw.items() if k in known}
+        # A pre-telemetry state may already have completed EXPLORE segments,
+        # but their exact sum cannot be reconstructed once phase_history has
+        # been capped. Preserve "unknown" instead of reporting a misleading
+        # partial zero after resume. Fresh states still start from 0.0.
+        if "explore_elapsed_accum_s" not in raw:
+            filtered["explore_elapsed_accum_s"] = None
         if not isinstance(filtered.get("specialist_patch_verdicts"), dict):
             filtered["specialist_patch_verdicts"] = {}
         if not isinstance(filtered.get("kernel_opt_attempts"), dict):
@@ -1473,15 +1480,16 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
         try:
             from ..phases.machine_state import explore_elapsed_seconds
 
-            explore_elapsed_s = explore_elapsed_seconds(self)
             session_elapsed_s = max(0.0, self.elapsed_minutes() * 60.0)
-            summary["explore_elapsed_s"] = int(round(explore_elapsed_s))
             summary["session_elapsed_s"] = int(round(session_elapsed_s))
-            summary["explore_ratio"] = (
-                round(explore_elapsed_s / session_elapsed_s, 4)
-                if session_elapsed_s > 0.0
-                else 0.0
-            )
+            explore_elapsed_s = explore_elapsed_seconds(self)
+            if explore_elapsed_s is not None:
+                summary["explore_elapsed_s"] = int(round(explore_elapsed_s))
+                summary["explore_ratio"] = (
+                    round(explore_elapsed_s / session_elapsed_s, 4)
+                    if session_elapsed_s > 0.0
+                    else 0.0
+                )
         except Exception:  # noqa: BLE001 - status telemetry must stay best-effort
             log.debug("explore runtime telemetry derivation failed", exc_info=True)
         tput = cb.get("tput") if isinstance(cb, dict) else None

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -800,6 +800,10 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
     phase_started_unix: float = 0.0
     # Append-only log of phase transitions (rows from machine_state.make_history_row; reason in PHASE_EXIT_REASONS). Capped at _PHASE_HISTORY_CAP.
     phase_history: list[dict[str, Any]] = field(default_factory=list)
+    # Durable sum of completed EXPLORE segments. The current active EXPLORE
+    # segment is added at status-render time; accumulating completed segments
+    # avoids undercounting long macro-cycle runs after phase_history is capped.
+    explore_elapsed_accum_s: float = 0.0
     # Append-only operator-facing lifecycle log. Each row (built by
     # :func:`machine_state.make_lifecycle_event`) records a phase/step boundary
     # plus artifact paths. Coordinator-only writer; capped at ``_LIFECYCLE_CAP``.
@@ -1464,7 +1468,22 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
             "session_id": self.session_id or "",
             "model_name": self.model_name or "",
             "framework": self.framework or os.environ.get("FRAMEWORK", "") or "",
+            "kb_hit": str((self.warm_start_context or {}).get("status") or ""),
         }
+        try:
+            from ..phases.machine_state import explore_elapsed_seconds
+
+            explore_elapsed_s = explore_elapsed_seconds(self)
+            session_elapsed_s = max(0.0, self.elapsed_minutes() * 60.0)
+            summary["explore_elapsed_s"] = int(round(explore_elapsed_s))
+            summary["session_elapsed_s"] = int(round(session_elapsed_s))
+            summary["explore_ratio"] = (
+                round(explore_elapsed_s / session_elapsed_s, 4)
+                if session_elapsed_s > 0.0
+                else 0.0
+            )
+        except Exception:  # noqa: BLE001 - status telemetry must stay best-effort
+            log.debug("explore runtime telemetry derivation failed", exc_info=True)
         tput = cb.get("tput") if isinstance(cb, dict) else None
         if isinstance(tput, (int, float)) and not isinstance(tput, bool):
             summary["current_best_tput"] = round(float(tput), 1)

--- a/src/hyperloom/orchestrator/trace/langfuse_emitter.py
+++ b/src/hyperloom/orchestrator/trace/langfuse_emitter.py
@@ -169,19 +169,23 @@ def _start_obs(parent: Any, **kwargs: Any) -> Any:
     Raises:
         TypeError: If even the most reduced signature is rejected.
     """
-    last: TypeError | None = None
-    attempted: set[frozenset[str]] = set()
+    seen: set[frozenset[str]] = set()
+    attempts: list[dict[str, Any]] = []
     for drop in _OBS_KWARG_LADDER:
         attempt = {k: v for k, v in kwargs.items() if k not in drop}
         signature = frozenset(attempt)
-        if signature in attempted:
+        if signature in seen:
             continue
-        attempted.add(signature)
+        seen.add(signature)
+        attempts.append(attempt)
+    for attempt in attempts[:-1]:
         try:
             return parent.start_observation(**attempt)
-        except TypeError as exc:
-            last = exc
-    raise last  # type: ignore[misc]  # the ladder always runs at least once
+        except TypeError:
+            continue
+    # The final rung is not guarded, so a still-rejected signature surfaces its
+    # own TypeError instead of one synthesized from a saved exception.
+    return parent.start_observation(**attempts[-1])
 
 
 def _end_time_wants_int(obs: Any) -> bool:

--- a/src/hyperloom/orchestrator/trace/langfuse_emitter.py
+++ b/src/hyperloom/orchestrator/trace/langfuse_emitter.py
@@ -52,6 +52,29 @@ from .trace_env import (
 
 log = logging.getLogger(__name__)
 
+_STATUS_CLOCK_BUCKET_SEC = 60
+_STATUS_CLOCK_KEYS = frozenset({"explore_elapsed_s", "session_elapsed_s"})
+_STATUS_CLOCK_DERIVED_KEYS = frozenset({"explore_ratio"})
+
+
+def _status_signature(status: dict[str, Any]) -> tuple:
+    """Return a throttle signature with volatile runtime clocks minute-bucketed."""
+    items: list[tuple[str, Any]] = []
+    for raw_key, raw_value in status.items():
+        key = str(raw_key)
+        if key in _STATUS_CLOCK_DERIVED_KEYS:
+            # Derived from the two elapsed clocks; it will be refreshed whenever
+            # either clock crosses a bucket or another semantic field changes.
+            continue
+        value = raw_value
+        if key in _STATUS_CLOCK_KEYS:
+            try:
+                value = int(float(raw_value) // _STATUS_CLOCK_BUCKET_SEC)
+            except (TypeError, ValueError):
+                pass
+        items.append((key, value))
+    return tuple(sorted(items))
+
 
 def _manifest_path(session_dir: Path) -> Path:
     """Return the path to a session's ``manifest.json``.
@@ -821,8 +844,10 @@ class LangfuseEmitter:
         status timeline is queryable.
 
         Throttled to avoid flooding the trace: a snapshot is sent only when its
-        signature changed or after ``min_refresh_sec`` elapsed. Never flushes the
-        client; best-effort and a no-op unless live push is enabled.
+        signature changed or after ``min_refresh_sec`` elapsed. Runtime clocks
+        are minute-bucketed in that signature, so per-save second changes do not
+        defeat the throttle. Never flushes the client; best-effort and a no-op
+        unless live push is enabled.
 
         Args:
             status (dict[str, Any]): Flat scalar status summary (str/bool/int/
@@ -836,7 +861,7 @@ class LangfuseEmitter:
         try:
             import time
 
-            sig = tuple(sorted((str(k), status[k]) for k in status))
+            sig = _status_signature(status)
             now = time.monotonic()
             if (
                 self._last_status_sig is not None

--- a/src/hyperloom/orchestrator/trace/langfuse_emitter.py
+++ b/src/hyperloom/orchestrator/trace/langfuse_emitter.py
@@ -139,26 +139,49 @@ def _to_ns(dt: Any) -> int | None:
     return None
 
 
+# Optional kwargs dropped, in order, when the installed SDK rejects them. Each
+# rung is a superset of the previous one, so the richest call that the SDK
+# actually accepts wins instead of the whole observation being lost.
+_OBS_KWARG_LADDER: tuple[tuple[str, ...], ...] = (
+    (),
+    ("start_time",),
+    ("start_time", "level", "status_message"),
+)
+
+
 def _start_obs(parent: Any, **kwargs: Any) -> Any:
     """Create a child/root observation, tolerant of v2/v3 vs v4 signatures.
 
-    Tries the caller's kwargs first and, if the SDK rejects ``start_time`` with a
-    TypeError (v4 removed it), retries without it — keeping backdated timestamps
-    where supported and degrading to "start = now" only where required.
+    Tries the caller's kwargs first and, on a ``TypeError``, retries with
+    progressively fewer optional kwargs (:data:`_OBS_KWARG_LADDER`): ``v4``
+    removed ``start_time``, and older SDKs predate ``level`` /
+    ``status_message``. Degrading one rung at a time keeps backdated timestamps
+    and error levels wherever they are supported. Rungs that would repeat an
+    already-attempted signature are skipped.
 
     Args:
         parent: the parent observation (or client) to create the child on.
-        **kwargs: the keyword arguments forwarded to ``start_observation``;
-            ``start_time`` is dropped on a retry if the SDK rejects it.
+        **kwargs: the keyword arguments forwarded to ``start_observation``.
 
     Returns:
         The newly started observation.
+
+    Raises:
+        TypeError: If even the most reduced signature is rejected.
     """
-    try:
-        return parent.start_observation(**kwargs)
-    except TypeError:
-        kwargs.pop("start_time", None)
-        return parent.start_observation(**kwargs)
+    last: TypeError | None = None
+    attempted: set[frozenset[str]] = set()
+    for drop in _OBS_KWARG_LADDER:
+        attempt = {k: v for k, v in kwargs.items() if k not in drop}
+        signature = frozenset(attempt)
+        if signature in attempted:
+            continue
+        attempted.add(signature)
+        try:
+            return parent.start_observation(**attempt)
+        except TypeError as exc:
+            last = exc
+    raise last  # type: ignore[misc]  # the ladder always runs at least once
 
 
 def _end_time_wants_int(obs: Any) -> bool:
@@ -366,6 +389,7 @@ class LangfuseEmitter:
             "generations_paired": 0,  # of which had both token + text halves
             "generations_text_only": 0,
             "generations_token_only": 0,
+            "generations_failed": 0,  # of which recorded a failed LLM call (level=ERROR)
             "session_start_recorded": 0,  # 1 once the startup marker was sent
             "status_updates_sent": 0,  # live state.json status snapshots mirrored
             "scores_sent": 0,  # decision Scores created (span + trace)
@@ -566,10 +590,18 @@ class LangfuseEmitter:
     def _buffer(self, row: dict[str, Any], *, half: str) -> None:
         """Buffer one half of a generation and emit once both halves arrive.
 
+        A failed call is emitted immediately instead of being buffered: it has
+        no response, so its conversation half never arrives and waiting would
+        hold the failure until session end — or worse, let ``pair_key`` (which
+        does not consider status) marry it to a neighbouring successful call.
+
         Args:
             row: The token (``llm``) or conversation (``conv``) row.
             half: Which half this row represents (``"llm"`` or ``"conv"``).
         """
+        if half == "llm" and lfmap.generation_level(row) == lfmap.LEVEL_ERROR:
+            self._emit_generation(token_row=row, conv_row=None)
+            return
         key = lfmap.pair_key(row)
         emit_parts: dict[str, dict[str, Any]] | None = None
         with self._lock:
@@ -650,6 +682,7 @@ class LangfuseEmitter:
         end = lfmap.parse_ts(base.get("ts"))
         start = lfmap.generation_start(end, (token_row or {}).get("latency_ms"))
         has_text = conv_row is not None
+        level = lfmap.generation_level(base)
         try:
             parent = self._ensure_agent_span(phase, agent, start)
             gen = _start_obs(
@@ -662,9 +695,13 @@ class LangfuseEmitter:
                 output=(conv_row or {}).get("response"),
                 metadata=lfmap.generation_metadata(base, phase=phase, has_text=has_text),
                 usage_details=lfmap.usage_details(token_row or {}),
+                level=level,
+                status_message=lfmap.generation_status_message(base),
             )
             _end_obs(gen, end)
             self._counts["generations_sent"] += 1
+            if level == lfmap.LEVEL_ERROR:
+                self._counts["generations_failed"] += 1
             if token_row is not None and conv_row is not None:
                 self._counts["generations_paired"] += 1
             elif conv_row is not None:

--- a/src/hyperloom/orchestrator/trace/langfuse_mapping.py
+++ b/src/hyperloom/orchestrator/trace/langfuse_mapping.py
@@ -25,8 +25,6 @@ from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from .llm_trace import LLM_STATUS_OK
-
 UNPHASED = "(unphased)"
 UNKNOWN_AGENT = "(unknown)"
 
@@ -34,6 +32,11 @@ UNKNOWN_AGENT = "(unknown)"
 # error rate is queryable; everything else stays DEFAULT.
 LEVEL_DEFAULT = "DEFAULT"
 LEVEL_ERROR = "ERROR"
+
+# ``llm_trace.LLM_STATUS_OK``, re-declared rather than imported: this module is
+# a pure projection layer that ``llm_trace`` reaches back into via the emitter,
+# so importing it here would close an import cycle.
+_STATUS_OK = "ok"
 
 # Env-var name fragments whose value is redacted before the environment
 # snapshot is attached to session_start. Matched case-insensitively as a substring.
@@ -279,8 +282,8 @@ def generation_level(row: dict[str, Any]) -> str:
     Returns:
         ``ERROR`` for a failed call, else ``DEFAULT``.
     """
-    status = str(row.get("status") or LLM_STATUS_OK).strip().lower()
-    return LEVEL_DEFAULT if status == LLM_STATUS_OK else LEVEL_ERROR
+    status = str(row.get("status") or _STATUS_OK).strip().lower()
+    return LEVEL_DEFAULT if status == _STATUS_OK else LEVEL_ERROR
 
 
 def generation_status_message(row: dict[str, Any]) -> str | None:
@@ -326,7 +329,7 @@ def generation_metadata(
         "has_text": has_text,
         "latency_ms": row.get("latency_ms"),
         "reviewed_msg_ids": row.get("reviewed_msg_ids"),
-        "status": row.get("status") or LLM_STATUS_OK,
+        "status": row.get("status") or _STATUS_OK,
         "error_type": row.get("error_type"),
     }
 

--- a/src/hyperloom/orchestrator/trace/langfuse_mapping.py
+++ b/src/hyperloom/orchestrator/trace/langfuse_mapping.py
@@ -25,8 +25,15 @@ from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from .llm_trace import LLM_STATUS_OK
+
 UNPHASED = "(unphased)"
 UNKNOWN_AGENT = "(unknown)"
+
+# Langfuse observation levels we emit. A failed LLM call must be ERROR so the
+# error rate is queryable; everything else stays DEFAULT.
+LEVEL_DEFAULT = "DEFAULT"
+LEVEL_ERROR = "ERROR"
 
 # Env-var name fragments whose value is redacted before the environment
 # snapshot is attached to session_start. Matched case-insensitively as a substring.
@@ -260,6 +267,38 @@ def generation_name(row: dict[str, Any]) -> str:
     return str(row.get("component") or row.get("role") or "llm_call")
 
 
+def generation_level(row: dict[str, Any]) -> str:
+    """Map a row's terminal status onto a Langfuse observation level.
+
+    Rows written before ``status`` existed carry no such key and are treated as
+    successes, so a backfill of an old session does not turn every call red.
+
+    Args:
+        row: A token trace row dict.
+
+    Returns:
+        ``ERROR`` for a failed call, else ``DEFAULT``.
+    """
+    status = str(row.get("status") or LLM_STATUS_OK).strip().lower()
+    return LEVEL_DEFAULT if status == LLM_STATUS_OK else LEVEL_ERROR
+
+
+def generation_status_message(row: dict[str, Any]) -> str | None:
+    """The human-readable failure reason for a row, or ``None`` on success.
+
+    Args:
+        row: A token trace row dict.
+
+    Returns:
+        ``"<error_type>: <error_message>"`` (either part may be missing), or
+        ``None`` when the row is a success or carries no error detail.
+    """
+    if generation_level(row) == LEVEL_DEFAULT:
+        return None
+    parts = [str(row.get(k) or "").strip() for k in ("error_type", "error_message")]
+    return ": ".join(p for p in parts if p) or None
+
+
 def generation_metadata(
     row: dict[str, Any],
     *,
@@ -287,6 +326,8 @@ def generation_metadata(
         "has_text": has_text,
         "latency_ms": row.get("latency_ms"),
         "reviewed_msg_ids": row.get("reviewed_msg_ids"),
+        "status": row.get("status") or LLM_STATUS_OK,
+        "error_type": row.get("error_type"),
     }
 
 

--- a/src/hyperloom/orchestrator/trace/llm_trace.py
+++ b/src/hyperloom/orchestrator/trace/llm_trace.py
@@ -17,6 +17,13 @@ Design contract:
   ``BackendTurnResult.metadata``. Backends without a prompt-cache split
   (OpenAI / GEAK) report ``None`` for the two ``cache_*`` counters so the
   collector can tell "no cache concept" from "zero cache hits".
+* **Success and failure**: a row carries a terminal ``status``. Only
+  ``status="ok"`` rows have token accounting; ``status="error"`` rows record a
+  call that never produced a usable response (built via
+  :meth:`LLMCallRecord.for_failure`). Without them a failed call is simply
+  absent from the ledger, which reads as "never happened" rather than "failed"
+  — the reason Langfuse showed a 0% error rate while calls were demonstrably
+  failing. Spend rollups must therefore filter on ``status``.
 
 The record is a dataclass so call sites get constructor-time field checking
 and a single :meth:`to_row` serialization path; the closed-schema check in
@@ -61,6 +68,17 @@ VALID_COMPONENTS: frozenset[str] = frozenset(
 )
 
 
+# Closed vocabulary for a row's terminal status, so a typo'd status cannot make
+# a failed call silently rejoin the success rollups.
+LLM_STATUS_OK = "ok"
+LLM_STATUS_ERROR = "error"
+VALID_STATUSES: frozenset[str] = frozenset({LLM_STATUS_OK, LLM_STATUS_ERROR})
+
+# A gateway error body can embed an entire upstream payload (litellm wraps the
+# provider response verbatim), so cap what reaches the ledger.
+_ERROR_MESSAGE_MAX = 500
+
+
 # Canonical field contract for one ``llm_calls.jsonl`` row; the closed-schema
 # check compares serialized keys against this set exactly.
 _ROW_FIELDS: frozenset[str] = frozenset(
@@ -81,6 +99,9 @@ _ROW_FIELDS: frozenset[str] = frozenset(
         "cache_read_input_tokens",
         "latency_ms",
         "reviewed_msg_ids",
+        "status",
+        "error_type",
+        "error_message",
     }
 )
 
@@ -120,6 +141,11 @@ class LLMCallRecord:
     * ``cache_creation_input_tokens`` / ``cache_read_input_tokens`` —
       ``None`` for backends with no prompt-cache split.
 
+    Terminal status:
+
+    * ``status`` — ``ok`` or ``error`` (:data:`VALID_STATUSES`).
+    * ``error_type`` / ``error_message`` — set on ``error`` rows only.
+
     ``ts`` is filled by :meth:`to_row` at serialization time so a record
     built ahead of the actual write still timestamps the write.
     """
@@ -144,6 +170,11 @@ class LLMCallRecord:
     # Proposal ``msg_id``s this call reviewed (critic only), so the call can be
     # attributed to the decision it served. ``None`` for non-critic producers.
     reviewed_msg_ids: list[str] | None = None
+    # An ``error`` row records a call that never produced a usable response, so
+    # its token counters stay ``None``; spend rollups must exclude it.
+    status: str = LLM_STATUS_OK
+    error_type: str | None = None
+    error_message: str | None = None
 
     def to_row(self) -> dict[str, Any]:
         """Serialize to the on-disk row dict, stamping ``ts`` (UTC µs).
@@ -172,6 +203,9 @@ class LLMCallRecord:
             "cache_read_input_tokens": _coerce_optional_int(self.cache_read_input_tokens),
             "latency_ms": _coerce_optional_int(self.latency_ms),
             "reviewed_msg_ids": _coerce_optional_str_list(self.reviewed_msg_ids),
+            "status": str(self.status),
+            "error_type": _coerce_optional_str(self.error_type),
+            "error_message": _coerce_optional_str(self.error_message),
         }
 
     @classmethod
@@ -230,6 +264,61 @@ class LLMCallRecord:
             latency_ms=latency_ms if latency_ms is not None else md.get("latency_ms"),
         )
 
+    @classmethod
+    def for_failure(
+        cls,
+        *,
+        session_id: str,
+        component: str,
+        error: BaseException | str,
+        model: str | None = None,
+        role: str | None = None,
+        task_id: str | None = None,
+        dyn_id: str | None = None,
+        tick: int | None = None,
+        phase: str | None = None,
+        turn: int | None = None,
+        latency_ms: int | None = None,
+    ) -> "LLMCallRecord":
+        """Build an ``error`` record for a call that produced no usable response.
+
+        A failed call has no ``BackendTurnResult``, so :meth:`from_metadata`
+        cannot describe it and the token counters stay ``None``. The join keys
+        are still known at the call site, which is what lets the failure land on
+        the same trace / phase / agent as the successful calls around it.
+
+        Args:
+            session_id: Cross-process aggregation primary key.
+            component: Producer label; must be in :data:`VALID_COMPONENTS`.
+            error: The raised exception, or a pre-formatted message.
+            model: Backend model id, when the call site knows it.
+            role: Reactor role name, when known.
+            task_id: Decision-association task id, when known.
+            dyn_id: Dynamic-action id, when known.
+            tick: Timeline tick, when known.
+            phase: Phase name, when known.
+            turn: Multi-turn sub-agent sequence index, when known.
+            latency_ms: Time spent before failing, when measured.
+
+        Returns:
+            A populated :class:`LLMCallRecord` with ``status="error"``.
+        """
+        return cls(
+            session_id=session_id,
+            component=component,
+            role=role,
+            task_id=task_id,
+            dyn_id=dyn_id,
+            tick=tick,
+            phase=phase,
+            turn=turn,
+            model=model,
+            latency_ms=latency_ms,
+            status=LLM_STATUS_ERROR,
+            error_type=type(error).__name__ if isinstance(error, BaseException) else None,
+            error_message=str(error)[:_ERROR_MESSAGE_MAX],
+        )
+
 
 def _coerce_optional_str_list(value: Any) -> list[str] | None:
     """Coerce an iterable of ids to a list of non-empty strings, or ``None``.
@@ -286,6 +375,9 @@ def append_llm_call(
         error_cls=LLMTraceRowError,
         label="llm_calls",
     )
+    status = row.get("status")
+    if status not in VALID_STATUSES:
+        raise LLMTraceRowError(f"llm_calls row 'status'={status!r} is not one of {sorted(VALID_STATUSES)!r}")
     dest = llm_calls_path(session_dir)
     try:
         append_jsonl(dest, row, make_parents=True, sort_keys=True)
@@ -315,8 +407,11 @@ assert _DATACLASS_FIELDS | {"ts"} == _ROW_FIELDS, (
 
 
 __all__ = [
+    "LLM_STATUS_ERROR",
+    "LLM_STATUS_OK",
     "LLMCallRecord",
     "LLMTraceRowError",
     "VALID_COMPONENTS",
+    "VALID_STATUSES",
     "append_llm_call",
 ]


### PR DESCRIPTION
## Summary

Two independent pieces of work, both closing gaps in what Langfuse can see.

### 1. Explore spend telemetry

- persist completed EXPLORE wall-clock segments across macro cycles and include the live segment while EXPLORE is active
- publish KB hit status, Explore elapsed seconds, total session elapsed seconds, and Explore ratio through the existing Langfuse `session_status` mirror
- keep pre-telemetry resumes explicitly unknown and minute-bucket volatile clocks so frequent state saves do not flood Langfuse

### 2. Failed LLM calls are now reported

A failed call never reached the ledger at all. The row is built from `BackendTurnResult.metadata`, which only exists once a turn has succeeded, so a turn whose model call never returned left no trace anywhere. Langfuse consequently showed **zero errors across 30,803 generations in 24h** while calls were demonstrably failing (`litellm.BadRequestError: AnthropicException` in the task logs), which made the LLM error rate unobservable — an absent row reads as "never happened", not "failed".

**The ledger.** `llm_calls.jsonl` gains a terminal `status` plus `error_type` / `error_message`, guarded by a closed vocabulary the way `component` already is. `LLMCallRecord.for_failure()` covers the no-result path; token counters stay `None` because nothing was measured, and the message is capped since litellm wraps the upstream payload verbatim. The emitter maps `status` onto the Langfuse observation `level` / `status_message`.

**What counts as a failure.** `BackendError` is far too broad to drive an error rate — it also covers a missing `--review` path, an unreadable `emit.json`, an unsupported runtime phase, an absent SDK, none of which touched a provider. A new `LLMCallFailed` marker is raised only around actual provider calls (Codex chat + responses, the Claude stream, both critic transports) and only that is recorded. It subclasses `BackendError`, so retry and error-streak accounting are untouched by the marking.

**Who writes the row.** Wiring only the reactor would have missed most of it, because the other producers never let a failure reach the Coordinator: the critic self-writes its rows, the specialist turn loop catches and breaks, and the scorer folds per-model exceptions into an `errors` map via `gather(return_exceptions=True)`. Each now writes at its own call site, where the model, task and phase are still known — after the `gather` fold, "which model failed" is all that survives. And exactly one writer per failure: a backend exposing `set_trace_context` already owns its trace rows, so the Coordinator's failure path honours that hook instead of adding a second, poorer row for the same failure.

Three consequences that were not obvious and are worth a reviewer's attention:

- **failures skip the pair buffer.** They have no conversation half, so waiting for one would hold the failure until session end — or let the status-blind `pair_key` marry it to a neighbouring successful call.
- **the spend rollup filters them out.** `_fold_call_into_bucket` increments `calls`, so counting failures would inflate call counts and skew per-decision attribution. `calls` and token totals are unchanged by this PR; failure visibility is Langfuse's job, not the rollup's.
- **`_start_obs` now degrades one kwarg rung at a time.** An SDK predating `level` / `status_message` must lose those two fields rather than the whole observation.

**One behaviour change beyond telemetry.** A Claude provider failure now raises `LLMCallFailed` instead of propagating the raw SDK exception, so it lands on the backend-error streak rather than `crash_count`. That is the more accurate bucket for an upstream fault and it matches what Codex already did, but it is a real change in failure handling, not just tracing. Cancellation stays a bare `BaseException` and is re-raised untouched; `NoIntentEmitted` is raised outside that block, so a call that succeeded with unusable output remains distinct from one that failed.

**Deliberately not covered: the kernel path.** It is a post-hoc scrape of an out-of-process child that prints `FORGE_LLM_USAGE` only on success, so a missing marker cannot be told apart from a failed call, and the attempt dict carries only business outcomes (`improved`, `best_ms`). Synthesizing an LLM error from those is the same conflation this change removes. Closing it needs the child (GEAK / KernelForge `forge_submit`) to emit a failure marker of its own; the reasoning is commented at the call site.

Backward compatible: rows written before `status` existed carry no such key and are read as successes, so backfilling an old session does not turn it red.

### Drive-by

`explore_elapsed_accum_s` was added to `policy.CORE_STATE_FIELDS` by (1) but not to the robustness role's vendored copy, leaving both lock-step contract tests (`test_role_contract` and `test_agent_roles_and_policy`) red on this branch since `a026ff06f`. Synced, mirroring the upstream entry's position in the phase-state-machine group.

## Test plan

- [x] `test_llm_trace_unit` + `test_langfuse_emitter` + `test_claude_backend` + `test_codex_backend` + `test_trace_utils` + `test_trace_edge_coverage` + `test_role_contract` — 184 passed, 1 skipped (no `claude_agent_sdk` locally)
- [x] `test_proposal_scorer` — 19 passed (5 deselected; they import the Coordinator, see below)
- [x] New coverage: failure row shape / message truncation / default status / closed-vocabulary rejection; `LLMCallFailed` still catchable as `BackendError`; Codex chat + responses raising the marker; Claude marking a non-timeout stream error and *not* marking cancellation; scorer writing an error row through the `gather` fold; immediate emit at `level=ERROR`; legacy rows staying `DEFAULT`; both `_start_obs` degradation rungs
- [x] Regression for the double-write: a self-tracing backend's provider failure yields **exactly one** row, and it is the backend's richer one (real review model)
- [x] End-to-end by hand: write one success + one failure row, confirm the level mapping, confirm the spend rollup keeps only the success
- [x] `ruff` / `pylint` / `bandit` / CodeQL clean
- [x] Code CI green — 24/24 (all 8 test shards, both coverage jobs, CodeQL, lint, docs, packaging)

Not runnable locally: anything importing the Coordinator, because `recipe_kb/local_store.py` imports `fcntl` (Linux-only). That covers the three Coordinator tests added here — marker discrimination, per-turn row count, and the exactly-one-row regression — plus `test_critic_agent_backend`. All are covered by the CI shards.

## Follow-up

Production Langfuse traffic is still dominated by long-running sessions launched from older checkouts, so the new `status` field is not yet visible there. Worth re-checking once tasks start from this code — the query is `level=ERROR` on `/api/public/observations`, which should stop returning an unbroken run of `DEFAULT`.

## Downstream

Cortex already consumes the Explore telemetry fields in its runtime-status pipeline; older sessions continue to render unknown values. The `llm_calls.jsonl` schema change is additive, and the breakdown collectors treat a missing `status` as success.
