### PR TITLE
fix(kernel): support runtime-JIT deployment for installed AITER sources

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_apply_and_bench.py
+++ b/src/hyperloom/agents/kernel/tests/test_apply_and_bench.py
@@ -215,3 +215,78 @@ def test_gpu_vram_used_none_without_gpu_scope(monkeypatch):
     assert _ab._gpu_vram_used_mb("") is None
     assert _ab._gpu_vram_used_mb(None) is None
     assert _ab._gpu_vram_used_mb("  ,  ") is None
+
+
+def test_apply_and_bench_accepts_and_reports_deferred_rebuild(
+    tmp_path,
+    monkeypatch,
+):
+    patch_file = tmp_path / "kernel.py"
+    target = tmp_path / "target.py"
+    patch_file.write_text("VALUE = 2\n", encoding="utf-8")
+    target.write_text("VALUE = 1\n", encoding="utf-8")
+    manifest = tmp_path / "manifest.json"
+    measurements = iter(
+        (
+            {
+                "status": "ok",
+                "median": 100.0,
+                "tput_spread": {"p25": 99.0, "p75": 101.0},
+                "tpot_spread_ms": {"median": 1.0},
+                "p99_tpot_spread_ms": {"median": 2.0},
+                "vram_used_mb": 1000,
+                "reps": [100.0],
+            },
+            {
+                "status": "ok",
+                "median": 110.0,
+                "tput_spread": {"p25": 109.0, "p75": 111.0},
+                "tpot_spread_ms": {"median": 0.9},
+                "p99_tpot_spread_ms": {"median": 1.8},
+                "vram_used_mb": 1000,
+                "reps": [110.0],
+            },
+        )
+    )
+    monkeypatch.setattr(ab, "_find_benchmark_serving", lambda: tmp_path)
+    monkeypatch.setattr(
+        ab,
+        "_serve_and_bench",
+        lambda *args, **kwargs: next(measurements),
+    )
+    monkeypatch.setattr(
+        ab,
+        "apply_kernel_patch",
+        lambda **kwargs: {
+            "status": "ok",
+            "manifest_path": str(manifest),
+            "rebuild": {
+                "status": "deferred",
+                "mode": "runtime_jit",
+            },
+        },
+    )
+    monkeypatch.setattr(
+        ab,
+        "revert_kernel_patch",
+        lambda manifest_path: {"status": "ok"},
+    )
+    monkeypatch.setattr(
+        ab,
+        "_engagement_proof",
+        lambda *args, **kwargs: {"engaged": True},
+    )
+
+    result = ab.apply_and_bench(
+        patch_path=str(patch_file),
+        target_file=str(target),
+        backup_root=str(tmp_path / "backups"),
+        model="model",
+        out_dir=str(tmp_path / "out"),
+    )
+
+    assert result["status"] == "ok"
+    assert result["applied"][0]["rebuild"] == {
+        "status": "deferred",
+        "mode": "runtime_jit",
+    }

--- a/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
+++ b/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
@@ -58,7 +58,11 @@ def test_detect_strategy_isolated_aiter_csrc_compiled_no_rebuild_command(akp, tm
     venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
     monkeypatch.setenv("VLLM_VENV_ROOT", str(venv_root))
     site = aiter_pkg.parent
-    akp._CACHED_KN_TARGET_ROOTS = (str(site) + "/",)
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(site) + "/",),
+    )
 
     target = site / "aiter_meta" / "csrc" / "kernels" / "foo.cu"
     strat = akp._detect_strategy(target, allow_unknown_target=False)
@@ -67,13 +71,17 @@ def test_detect_strategy_isolated_aiter_csrc_compiled_no_rebuild_command(akp, tm
     assert strat["root"] == str(site)
     assert strat["rebuild_mode"] == "runtime_jit"
     assert strat["rebuild_command"] == []
-    assert strat["artifact_roots"] == [aiter_pkg, site / "aiter_meta"]
+    assert strat["artifact_roots"] == []
 
 
 def test_detect_strategy_isolated_aiter_python_target_never_rebuilds(akp, tmp_path, monkeypatch):
     venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
     monkeypatch.setenv("VLLM_VENV_ROOT", str(venv_root))
-    akp._CACHED_KNOWN_TARGET_ROOTS = (str(aiter_pkg) + "/",)
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(aiter_pkg) + "/",),
+    )
 
     target = aiter_pkg / "ops" / "triton" / "k.py"
     strat = akp._detect_strategy(target, allow_unknown_target=False)
@@ -84,9 +92,40 @@ def test_detect_strategy_isolated_aiter_python_target_never_rebuilds(akp, tmp_pa
     assert strat["artifact_roots"] == []
 
 
+def test_installed_aiter_strategy_preserves_symlinked_site_packages(
+    akp,
+    tmp_path,
+    monkeypatch,
+):
+    real_site = tmp_path / "real" / "site-packages"
+    (real_site / "aiter").mkdir(parents=True)
+    (real_site / "aiter_meta" / "csrc" / "kernels").mkdir(parents=True)
+    linked_site = tmp_path / "venv" / "lib" / "python3.12" / "site-packages"
+    linked_site.parent.mkdir(parents=True)
+    linked_site.symlink_to(real_site, target_is_directory=True)
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(linked_site) + "/",),
+    )
+    target = linked_site / "aiter_meta" / "csrc" / "kernels" / "foo.cu"
+
+    strategy = akp._detect_strategy(target, allow_unknown_target=False)
+
+    assert strategy["root"] == str(linked_site.absolute())
+    assert strategy["rebuild_mode"] == "runtime_jit"
+    assert strategy["jit_build_dir"] == str(
+        linked_site.absolute() / "aiter" / "jit" / "build"
+    )
+
+
 def test_detect_strategy_sgl_workspace_aiter_unchanged(akp, monkeypatch):
     monkeypatch.setenv("VLLM_VENV_ROOT", "/opt/hyperloom/vllm-venv")
-    akp._CACHED_KNOWN_TARGET_ROOTS = ("/sgl-workspace/aiter/",)
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        ("/sgl-workspace/aiter/",),
+    )
 
     target = Path("/sgl-workspace/aiter/csrc/kernels/foo.cu")
     strat = akp._detect_strategy(target, allow_unknown_target=False)
@@ -95,6 +134,69 @@ def test_detect_strategy_sgl_workspace_aiter_unchanged(akp, monkeypatch):
     assert strat["root"] == "/sgl-workspace/aiter"
     assert strat["rebuild_mode"] == "command"
     assert strat["rebuild_command"] == ["/opt/venv/bin/python", "setup.py", "develop"]
+
+
+@pytest.mark.parametrize(
+    "relative",
+    (
+        "csrc/kernels/gen_instances.py",
+        "csrc/cpp_itfs/mha_fwd.py",
+    ),
+)
+def test_editable_aiter_csrc_python_keeps_source_only_strategy(
+    akp,
+    monkeypatch,
+    relative,
+):
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        ("/sgl-workspace/aiter/",),
+    )
+
+    strategy = akp._detect_strategy(
+        Path("/sgl-workspace/aiter") / relative,
+        allow_unknown_target=False,
+    )
+
+    assert strategy["compiled"] is False
+    assert strategy["root"] == "/sgl-workspace/aiter"
+    assert strategy["rebuild_mode"] == "none"
+    assert strategy["rebuild_command"] == []
+    assert strategy["artifact_roots"] == []
+
+
+def test_rebuild_strategy_uses_target_parent_for_legacy_strategy(
+    akp,
+    tmp_path,
+    monkeypatch,
+):
+    target_parent = tmp_path / "aiter_meta" / "csrc" / "kernels"
+    captured = {}
+
+    def _fake_rebuild(command, cwd, timeout_sec):
+        captured.update(
+            command=command,
+            cwd=cwd,
+            timeout_sec=timeout_sec,
+        )
+        return {"status": "ok"}
+
+    monkeypatch.setattr(akp, "_run_rebuild", _fake_rebuild)
+
+    result = akp._run_strategy_rebuild(
+        {"rebuild_command": []},
+        command_override=["python", "build.py"],
+        fallback_cwd=target_parent,
+        timeout_sec=123,
+    )
+
+    assert result["status"] == "ok"
+    assert captured == {
+        "command": ["python", "build.py"],
+        "cwd": target_parent,
+        "timeout_sec": 123,
+    }
 
 
 def test_apply_isolated_aiter_meta_csrc_defers_to_runtime_jit(
@@ -106,7 +208,11 @@ def test_apply_isolated_aiter_meta_csrc_defers_to_runtime_jit(
     monkeypatch.delenv("VLLM_VENV_ROOT", raising=False)
     monkeypatch.setattr(akp.importlib.util, "find_spec", lambda name: None)
     site = aiter_pkg.parent
-    akp._CACHED_KNOWN_TARGET_ROOTS = (str(site) + "/",)
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(site) + "/",),
+    )
     target = site / "aiter_meta" / "csrc" / "kernels" / "foo.cu"
     target.write_text(
         '#include <hip/hip_runtime.h>\nextern "C" void kernel() { int x = 1; }\n',
@@ -134,13 +240,14 @@ def test_apply_isolated_aiter_meta_csrc_defers_to_runtime_jit(
     assert result["rebuild"]["status"] == "deferred"
     assert result["rebuild"]["mode"] == "runtime_jit"
     assert result["jit_build_backup"]["status"] == "ok"
+    assert result["artifact_count"] == 0
     assert target.read_text(encoding="utf-8") == optimized
     manifest = json.loads(Path(result["manifest_path"]).read_text())
     assert manifest["status"] == "applied"
-    assert manifest["strategy"]["rebuild_mode"] == "runtime_jit"
-    assert manifest["strategy"]["jit_build_dir"] == str(
-        aiter_pkg / "jit" / "build"
-    )
+    assert manifest["strategy"]["rebuild_modes"] == ["runtime_jit"]
+    assert manifest["strategy"]["jit_build_dirs"] == [
+        str(aiter_pkg / "jit" / "build")
+    ]
 
     revert = akp.revert_kernel_patch(result["manifest_path"])
 
@@ -158,7 +265,11 @@ def test_apply_isolated_aiter_snapshot_invalidates_jit_for_python_codegen(
     monkeypatch.delenv("VLLM_VENV_ROOT", raising=False)
     monkeypatch.setattr(akp.importlib.util, "find_spec", lambda name: None)
     site = aiter_pkg.parent
-    akp._CACHED_KNOWN_TARGET_ROOTS = (str(site) + "/",)
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(site) + "/",),
+    )
     relative = Path("aiter_meta/csrc/kernels/gen_instances.py")
     target = site / relative
     target.write_text("TILE = 128\n", encoding="utf-8")
@@ -187,7 +298,6 @@ def test_apply_isolated_aiter_snapshot_invalidates_jit_for_python_codegen(
         target_file=target,
         backup_root=tmp_path / "backups",
         snapshot_dir=snapshot,
-        repo_root=site,
         kernel_id="k006",
     )
 
@@ -195,7 +305,11 @@ def test_apply_isolated_aiter_snapshot_invalidates_jit_for_python_codegen(
     assert result["rebuild"]["status"] == "deferred"
     assert result["rebuild"]["mode"] == "runtime_jit"
     assert result["jit_build_backup"]["status"] == "ok"
+    assert result["artifact_count"] == 0
     assert target.read_text(encoding="utf-8") == "TILE = 64\n"
+    snapshot_manifest = json.loads(Path(result["manifest_path"]).read_text())
+    assert snapshot_manifest["strategy"]["root"] == str(site)
+    assert snapshot_manifest["strategy"]["rebuild_modes"] == ["runtime_jit"]
 
 
 def test_runtime_jit_uses_target_root_not_importable_aiter(
@@ -224,7 +338,11 @@ def test_runtime_jit_uses_target_root_not_importable_aiter(
         ),
     )
     site = target_aiter.parent
-    akp._CACHED_KNOWN_TARGET_ROOTS = (str(site) + "/",)
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(site) + "/",),
+    )
     target = site / "aiter_meta" / "csrc" / "kernels" / "foo.cu"
     original = '#include <hip/hip_runtime.h>\nextern "C" void kernel() {}\n'
     optimized = (
@@ -261,7 +379,11 @@ def test_runtime_jit_rejects_unverified_cache_invalidation(
 ):
     _venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
     site = aiter_pkg.parent
-    akp._CACHED_KNOWN_TARGET_ROOTS = (str(site) + "/",)
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(site) + "/",),
+    )
     target = site / "aiter_meta" / "csrc" / "kernels" / "foo.cu"
     original = '#include <hip/hip_runtime.h>\nextern "C" void kernel() {}\n'
     target.write_text(original, encoding="utf-8")

--- a/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
+++ b/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
@@ -33,6 +34,7 @@ def _make_isolated_aiter(tmp_path: Path) -> tuple[Path, Path]:
     (aiter_pkg / "jit" / "build").mkdir(parents=True)
     (aiter_pkg / "csrc" / "kernels").mkdir(parents=True)
     (aiter_pkg / "ops" / "triton").mkdir(parents=True)
+    (site / "aiter_meta" / "csrc" / "kernels").mkdir(parents=True)
     return venv_root, aiter_pkg
 
 
@@ -55,15 +57,17 @@ def test_jit_build_dir_none_without_isolated_venv(akp, monkeypatch):
 def test_detect_strategy_isolated_aiter_csrc_compiled_no_rebuild_command(akp, tmp_path, monkeypatch):
     venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
     monkeypatch.setenv("VLLM_VENV_ROOT", str(venv_root))
-    akp._CACHED_KNOWN_TARGET_ROOTS = (str(aiter_pkg) + "/",)
+    site = aiter_pkg.parent
+    akp._CACHED_KN_TARGET_ROOTS = (str(site) + "/",)
 
-    target = aiter_pkg / "csrc" / "kernels" / "foo.cu"
+    target = site / "aiter_meta" / "csrc" / "kernels" / "foo.cu"
     strat = akp._detect_strategy(target, allow_unknown_target=False)
 
     assert strat["compiled"] is True
-    assert strat["root"] == str(aiter_pkg)
+    assert strat["root"] == str(site)
+    assert strat["rebuild_mode"] == "runtime_jit"
     assert strat["rebuild_command"] == []
-    assert strat["artifact_roots"] == [aiter_pkg]
+    assert strat["artifact_roots"] == [aiter_pkg, site / "aiter_meta"]
 
 
 def test_detect_strategy_isolated_aiter_python_target_never_rebuilds(akp, tmp_path, monkeypatch):
@@ -75,6 +79,7 @@ def test_detect_strategy_isolated_aiter_python_target_never_rebuilds(akp, tmp_pa
     strat = akp._detect_strategy(target, allow_unknown_target=False)
 
     assert strat["compiled"] is False
+    assert strat["rebuild_mode"] == "none"
     assert strat["rebuild_command"] == []
     assert strat["artifact_roots"] == []
 
@@ -88,4 +93,97 @@ def test_detect_strategy_sgl_workspace_aiter_unchanged(akp, monkeypatch):
 
     assert strat["compiled"] is True
     assert strat["root"] == "/sgl-workspace/aiter"
+    assert strat["rebuild_mode"] == "command"
     assert strat["rebuild_command"] == ["/opt/venv/bin/python", "setup.py", "develop"]
+
+
+def test_apply_isolated_aiter_meta_csrc_defers_to_runtime_jit(
+    akp,
+    tmp_path,
+    monkeypatch,
+):
+    venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
+    monkeypatch.setenv("VLLM_VENV_ROOT", str(venv_root))
+    monkeypatch.setattr(akp.importlib.util, "find_spec", lambda name: None)
+    site = aiter_pkg.parent
+    akp._CACHED_KNOWN_TARGET_ROOTS = (str(site) + "/",)
+    target = site / "aiter_meta" / "csrc" / "kernels" / "foo.cu"
+    target.write_text(
+        '#include <hip/hip_runtime.h>\nextern "C" void kernel() { int x = 1; }\n',
+        encoding="utf-8",
+    )
+    patch = tmp_path / "v1_forge.cu"
+    optimized = (
+        '#include <hip/hip_runtime.h>\n'
+        'extern "C" void kernel() { int x = 2; }\n'
+    )
+    patch.write_text(optimized, encoding="utf-8")
+    (aiter_pkg / "jit" / "build" / "stale.so").write_text(
+        "stale",
+        encoding="utf-8",
+    )
+
+    result = akp.apply_kernel_patch(
+        patch_path=patch,
+        target_file=target,
+        backup_root=tmp_path / "backups",
+        kernel_id="k003",
+    )
+
+    assert result["status"] == "ok", result
+    assert result["rebuild"]["status"] == "deferred"
+    assert result["rebuild"]["mode"] == "runtime_jit"
+    assert result["jit_build_backup"]["status"] == "ok"
+    assert target.read_text(encoding="utf-8") == optimized
+    manifest = json.loads(Path(result["manifest_path"]).read_text())
+    assert manifest["status"] == "applied"
+    assert manifest["strategy"]["rebuild_mode"] == "runtime_jit"
+
+
+def test_apply_isolated_aiter_snapshot_invalidates_jit_for_python_codegen(
+    akp,
+    tmp_path,
+    monkeypatch,
+):
+    venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
+    monkeypatch.setenv("VLLM_VENV_ROOT", str(venv_root))
+    monkeypatch.setattr(akp.importlib.util, "find_spec", lambda name: None)
+    site = aiter_pkg.parent
+    akp._CACHED_KNOWN_TARGET_ROOTS = (str(site) + "/",)
+    relative = Path("aiter_meta/csrc/kernels/gen_instances.py")
+    target = site / relative
+    target.write_text("TILE = 128\n", encoding="utf-8")
+    patch = tmp_path / "forge.patch"
+    patch.write_text(
+        "diff --git a/aiter_meta/csrc/kernels/gen_instances.py "
+        "b/aiter_meta/csrc/kernels/gen_instances.py\n"
+        "--- a/aiter_meta/csrc/kernels/gen_instances.py\n"
+        "+++ b/aiter_meta/csrc/kernels/gen_instances.py\n"
+        "@@ -1 +1 @@\n"
+        "-TILE = 128\n"
+        "+TILE = 64\n",
+        encoding="utf-8",
+    )
+    snapshot = tmp_path / "snapshot"
+    snapshot_target = snapshot / relative
+    snapshot_target.parent.mkdir(parents=True)
+    snapshot_target.write_text("TILE = 64\n", encoding="utf-8")
+    (aiter_pkg / "jit" / "build" / "stale.so").write_text(
+        "stale",
+        encoding="utf-8",
+    )
+
+    result = akp.apply_kernel_patch(
+        patch_path=patch,
+        target_file=target,
+        backup_root=tmp_path / "backups",
+        snapshot_dir=snapshot,
+        repo_root=site,
+        kernel_id="k006",
+    )
+
+    assert result["status"] == "ok", result
+    assert result["rebuild"]["status"] == "deferred"
+    assert result["rebuild"]["mode"] == "runtime_jit"
+    assert result["jit_build_backup"]["status"] == "ok"
+    assert target.read_text(encoding="utf-8") == "TILE = 64\n"

--- a/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
+++ b/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
@@ -503,10 +503,12 @@ def test_revert_exposes_runtime_jit_restore_failure(
     assert target.read_text(encoding="utf-8") == original
 
 
+@pytest.mark.parametrize("multinode", (False, True))
 def test_installed_snapshot_can_span_aiter_and_vllm(
     akp,
     tmp_path,
     monkeypatch,
+    multinode,
 ):
     _venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
     monkeypatch.delenv("VLLM_VENV_ROOT", raising=False)
@@ -554,6 +556,40 @@ def test_installed_snapshot_can_span_aiter_and_vllm(
         "stale",
         encoding="utf-8",
     )
+    if multinode:
+        monkeypatch.setattr(akp, "_is_multi_node", lambda: True)
+
+        def _fake_dispatch(**kwargs):
+            return {
+                "status": "ok",
+                "per_node": [
+                    {
+                        "host": "pod-a",
+                        "target_path": str(kwargs["target_file"]),
+                        "backup_path": (
+                            "/var/kernel_patch_backups/"
+                            f"{Path(kwargs['target_file']).name}.bak"
+                        ),
+                        "jit_backup": (
+                            {
+                                "status": "clean",
+                                "src": kwargs["jit_build_dir"],
+                            }
+                            if kwargs["jit_build_dir"]
+                            else {
+                                "status": "skipped",
+                                "reason": "not requested",
+                            }
+                        ),
+                    }
+                ],
+            }
+
+        monkeypatch.setattr(
+            akp,
+            "_dispatch_multinode_apply",
+            _fake_dispatch,
+        )
 
     result = akp.apply_kernel_patch(
         patch_path=patch,
@@ -572,6 +608,14 @@ def test_installed_snapshot_can_span_aiter_and_vllm(
         str(site / "aiter_meta"),
         str(site / "vllm"),
     ]
+    if multinode:
+        records = result["multinode"]["records_by_host"]["pod-a"]
+        assert len(records) == 2
+        assert len({record["backup_path"] for record in records}) == 2
+        assert sum(
+            (record.get("jit_backup") or {}).get("status") == "clean"
+            for record in records
+        ) == 1
 
 
 @pytest.mark.parametrize("explicit_repo_root", (False, True))
@@ -781,3 +825,65 @@ def test_runtime_jit_rejects_unverified_cache_invalidation(
     assert result["status"] == "failed"
     assert result["error_class"] == "aiter_jit_invalidation_failed"
     assert target.read_text(encoding="utf-8") == original
+
+
+def test_multinode_runtime_jit_is_invalidated_on_every_pod(
+    akp,
+    tmp_path,
+    monkeypatch,
+):
+    _venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
+    site = aiter_pkg.parent
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(site) + "/",),
+    )
+    monkeypatch.setattr(akp, "_is_multi_node", lambda: True)
+    target = site / "aiter_meta" / "csrc" / "kernels" / "foo.cu"
+    target.write_text(
+        '#include <hip/hip_runtime.h>\nextern "C" void kernel() {}\n',
+        encoding="utf-8",
+    )
+    patch = tmp_path / "v1_forge.cu"
+    patch.write_text(
+        '#include <hip/hip_runtime.h>\n'
+        'extern "C" void kernel() { int x = 2; }\n',
+        encoding="utf-8",
+    )
+    local_stale = aiter_pkg / "jit" / "build" / "local.so"
+    local_stale.write_text("local", encoding="utf-8")
+    captured = {}
+
+    def _fake_dispatch(**kwargs):
+        captured.update(kwargs)
+        return {
+            "status": "ok",
+            "per_node": [
+                {
+                    "host": host,
+                    "target_path": str(target),
+                    "backup_path": f"/var/kernel_patch_backups/{host}.bak",
+                    "jit_backup": {
+                        "status": "clean",
+                        "src": kwargs["jit_build_dir"],
+                    },
+                }
+                for host in ("pod-a", "pod-b")
+            ],
+        }
+
+    monkeypatch.setattr(akp, "_dispatch_multinode_apply", _fake_dispatch)
+
+    result = akp.apply_kernel_patch(
+        patch_path=patch,
+        target_file=target,
+        backup_root=tmp_path / "backups",
+        kernel_id="k-multinode",
+    )
+
+    assert result["status"] == "ok", result
+    assert captured["jit_build_dir"] == str(aiter_pkg / "jit" / "build")
+    assert result["jit_build_backup"]["status"] == "remote"
+    assert set(result["multinode"]["records_by_host"]) == {"pod-a", "pod-b"}
+    assert local_stale.is_file()

--- a/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
+++ b/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
@@ -549,6 +549,66 @@ def test_finalize_keeps_patch_and_deletes_local_backups(
     assert not jit_backup.exists()
 
 
+def test_finalize_rejects_reverted_manifest(
+    akp,
+    tmp_path,
+    monkeypatch,
+):
+    _venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
+    site = aiter_pkg.parent
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(site) + "/",),
+    )
+    target = site / "aiter_meta" / "csrc" / "kernels" / "foo.cu"
+    target.write_text(
+        '#include <hip/hip_runtime.h>\nextern "C" void kernel() {}\n',
+        encoding="utf-8",
+    )
+    patch = tmp_path / "v1_forge.cu"
+    patch.write_text(
+        '#include <hip/hip_runtime.h>\n'
+        'extern "C" void kernel() { int x = 2; }\n',
+        encoding="utf-8",
+    )
+    applied = akp.apply_kernel_patch(
+        patch_path=patch,
+        target_file=target,
+        backup_root=tmp_path / "backups",
+        kernel_id="k-reverted",
+    )
+    assert akp.revert_kernel_patch(applied["manifest_path"])["status"] == "ok"
+
+    finalized = akp.finalize_kernel_patch(applied["manifest_path"])
+
+    assert finalized["status"] == "failed"
+    assert "reverted" in finalized["error"]
+
+
+def test_finalize_never_deletes_manifest_directory(akp, tmp_path):
+    backup_root = tmp_path / "backup"
+    backup_root.mkdir()
+    manifest = backup_root / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "status": "applied",
+                "source_backup": {
+                    "backup_path": str(backup_root),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = akp.finalize_kernel_patch(manifest)
+
+    assert result["status"] == "partial"
+    assert manifest.is_file()
+    assert result["issues"][0]["error"] == "backup path equals manifest directory"
+
+
 @pytest.mark.parametrize("multinode", (False, True))
 def test_installed_snapshot_can_span_aiter_and_vllm(
     akp,

--- a/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
+++ b/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
@@ -34,6 +34,8 @@ def _make_isolated_aiter(tmp_path: Path) -> tuple[Path, Path]:
     (aiter_pkg / "jit" / "build").mkdir(parents=True)
     (aiter_pkg / "csrc" / "kernels").mkdir(parents=True)
     (aiter_pkg / "ops" / "triton").mkdir(parents=True)
+    (aiter_pkg / "__init__.py").write_text("", encoding="utf-8")
+    (aiter_pkg / "jit" / "__init__.py").write_text("", encoding="utf-8")
     (site / "aiter_meta" / "csrc" / "kernels").mkdir(parents=True)
     return venv_root, aiter_pkg
 
@@ -199,6 +201,133 @@ def test_rebuild_strategy_uses_target_parent_for_legacy_strategy(
     }
 
 
+def test_unknown_snapshot_layout_keeps_fail_fast_root(
+    akp,
+    tmp_path,
+    monkeypatch,
+):
+    framework_root = tmp_path / "app" / "ATOM" / "atom"
+    target = framework_root / "kernels" / "foo.cu"
+    target.parent.mkdir(parents=True)
+    original = 'extern "C" void kernel() {}\n'
+    optimized = 'extern "C" void kernel() { int x = 2; }\n'
+    target.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(framework_root) + "/",),
+    )
+    strategy = akp._detect_strategy(
+        target,
+        allow_unknown_target=False,
+    )
+    assert strategy["root"] == ""
+    assert strategy["deploy_roots"] == []
+    patch = tmp_path / "forge.patch"
+    patch.write_text(
+        "diff --git a/kernels/foo.cu b/kernels/foo.cu\n"
+        "--- a/kernels/foo.cu\n"
+        "+++ b/kernels/foo.cu\n"
+        "@@ -1 +1 @@\n"
+        '-extern "C" void kernel() {}\n'
+        '+extern "C" void kernel() { int x = 2; }\n',
+        encoding="utf-8",
+    )
+    snapshot_target = tmp_path / "snapshot" / "kernels" / "foo.cu"
+    snapshot_target.parent.mkdir(parents=True)
+    snapshot_target.write_text(optimized, encoding="utf-8")
+
+    result = akp.apply_kernel_patch(
+        patch_path=patch,
+        target_file=target,
+        backup_root=tmp_path / "backups",
+        snapshot_dir=tmp_path / "snapshot",
+        kernel_id="k-unknown-layout",
+    )
+
+    assert result["status"] == "failed"
+    assert "snapshot mode requires a known repo root" in result["error"]
+    assert target.read_text(encoding="utf-8") == original
+    assert not (target.parent / "kernels" / "foo.cu").exists()
+
+
+def test_apply_snapshot_keeps_legacy_optional_deploy_roots(
+    akp,
+    tmp_path,
+):
+    repo_root = tmp_path / "repo"
+    target = repo_root / "kernel.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("VALUE = 1\n", encoding="utf-8")
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    (snapshot / "kernel.py").write_text("VALUE = 2\n", encoding="utf-8")
+
+    result = akp.apply_snapshot(
+        descriptors=[
+            {
+                "op": "write",
+                "path": "kernel.py",
+                "mode": "",
+                "binary": False,
+                "is_new": False,
+            }
+        ],
+        snapshot_dir=snapshot,
+        repo_root=repo_root,
+        backup_dir=tmp_path / "backups",
+    )
+
+    assert result["status"] == "ok"
+    assert target.read_text(encoding="utf-8") == "VALUE = 2\n"
+
+
+@pytest.mark.parametrize(
+    "relative",
+    (
+        "aiter/jit/hostcall.cpp",
+        "aiter_meta/3rdparty/composable_kernel/include/tile.hpp",
+    ),
+)
+def test_runtime_jit_invalidates_for_compiled_sources_outside_csrc(
+    akp,
+    tmp_path,
+    monkeypatch,
+    relative,
+):
+    _venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
+    site = aiter_pkg.parent
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(site) + "/",),
+    )
+    target = site / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    original = "inline int kernel_entry() { return 1; }\n"
+    optimized = "inline int kernel_entry() { return 2; }\n"
+    target.write_text(original, encoding="utf-8")
+    patch = tmp_path / f"v1_forge{target.suffix}"
+    patch.write_text(optimized, encoding="utf-8")
+    (aiter_pkg / "jit" / "build" / "stale.so").write_text(
+        "stale",
+        encoding="utf-8",
+    )
+
+    result = akp.apply_kernel_patch(
+        patch_path=patch,
+        target_file=target,
+        backup_root=tmp_path / "backups",
+        kernel_id="k-outside-csrc",
+    )
+
+    assert result["status"] == "ok", result
+    assert result["rebuild"]["status"] == "deferred"
+    assert result["jit_build_backup"]["status"] == "ok"
+    assert not (aiter_pkg / "jit" / "build").exists()
+    assert target.read_text(encoding="utf-8") == optimized
+
+
 def test_apply_isolated_aiter_meta_csrc_defers_to_runtime_jit(
     akp,
     tmp_path,
@@ -249,9 +378,15 @@ def test_apply_isolated_aiter_meta_csrc_defers_to_runtime_jit(
         str(aiter_pkg / "jit" / "build")
     ]
 
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        ("/unrelated/static/root/",),
+    )
     revert = akp.revert_kernel_patch(result["manifest_path"])
 
     assert revert["status"] == "ok"
+    assert revert["jit_build_restore"]["status"] == "ok"
     assert target.read_text(encoding="utf-8").endswith("int x = 1; }\n")
     assert (aiter_pkg / "jit" / "build" / "stale.so").is_file()
 
@@ -314,6 +449,58 @@ def test_apply_isolated_aiter_snapshot_invalidates_jit_for_python_codegen(
         str(site / "aiter_meta"),
     ]
     assert snapshot_manifest["strategy"]["rebuild_modes"] == ["runtime_jit"]
+
+
+def test_revert_exposes_runtime_jit_restore_failure(
+    akp,
+    tmp_path,
+    monkeypatch,
+):
+    _venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
+    site = aiter_pkg.parent
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(site) + "/",),
+    )
+    target = site / "aiter_meta" / "csrc" / "kernels" / "foo.cu"
+    original = '#include <hip/hip_runtime.h>\nextern "C" void kernel() {}\n'
+    target.write_text(original, encoding="utf-8")
+    patch = tmp_path / "v1_forge.cu"
+    patch.write_text(
+        '#include <hip/hip_runtime.h>\n'
+        'extern "C" void kernel() { int x = 2; }\n',
+        encoding="utf-8",
+    )
+    (aiter_pkg / "jit" / "build" / "stale.so").write_text(
+        "stale",
+        encoding="utf-8",
+    )
+    applied = akp.apply_kernel_patch(
+        patch_path=patch,
+        target_file=target,
+        backup_root=tmp_path / "backups",
+        kernel_id="k003",
+    )
+    assert applied["status"] == "ok", applied
+    monkeypatch.setattr(
+        akp,
+        "_restore_aiter_jit_build",
+        lambda *args, **kwargs: {
+            "status": "failed",
+            "error": "simulated restore failure",
+        },
+    )
+
+    reverted = akp.revert_kernel_patch(applied["manifest_path"])
+
+    assert reverted["status"] == "partial"
+    assert reverted["jit_build_restore"] == {
+        "status": "failed",
+        "error": "simulated restore failure",
+    }
+    assert reverted["revert_issues"][0]["kind"] == "jit_build_restore"
+    assert target.read_text(encoding="utf-8") == original
 
 
 def test_installed_snapshot_can_span_aiter_and_vllm(

--- a/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
+++ b/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
@@ -136,6 +136,7 @@ def test_detect_strategy_sgl_workspace_aiter_unchanged(akp, monkeypatch):
     assert strat["root"] == "/sgl-workspace/aiter"
     assert strat["rebuild_mode"] == "command"
     assert strat["rebuild_command"] == ["/opt/venv/bin/python", "setup.py", "develop"]
+    assert strat["jit_build_dir"] == "/sgl-workspace/aiter/aiter/jit/build"
 
 
 @pytest.mark.parametrize(
@@ -501,6 +502,51 @@ def test_revert_exposes_runtime_jit_restore_failure(
     }
     assert reverted["revert_issues"][0]["kind"] == "jit_build_restore"
     assert target.read_text(encoding="utf-8") == original
+
+
+def test_finalize_keeps_patch_and_deletes_local_backups(
+    akp,
+    tmp_path,
+    monkeypatch,
+):
+    _venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
+    site = aiter_pkg.parent
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(site) + "/",),
+    )
+    target = site / "aiter_meta" / "csrc" / "kernels" / "foo.cu"
+    target.write_text(
+        '#include <hip/hip_runtime.h>\nextern "C" void kernel() {}\n',
+        encoding="utf-8",
+    )
+    patch = tmp_path / "v1_forge.cu"
+    optimized = (
+        '#include <hip/hip_runtime.h>\n'
+        'extern "C" void kernel() { int x = 2; }\n'
+    )
+    patch.write_text(optimized, encoding="utf-8")
+    (aiter_pkg / "jit" / "build" / "baseline.so").write_text(
+        "baseline",
+        encoding="utf-8",
+    )
+    applied = akp.apply_kernel_patch(
+        patch_path=patch,
+        target_file=target,
+        backup_root=tmp_path / "backups",
+        kernel_id="k-finalize",
+    )
+    manifest = json.loads(Path(applied["manifest_path"]).read_text())
+    source_backup = Path(manifest["source_backup"]["backup_path"])
+    jit_backup = Path(manifest["jit_build_backup"]["backup_path"])
+
+    finalized = akp.finalize_kernel_patch(applied["manifest_path"])
+
+    assert finalized["status"] == "ok"
+    assert target.read_text(encoding="utf-8") == optimized
+    assert not source_backup.exists()
+    assert not jit_backup.exists()
 
 
 @pytest.mark.parametrize("multinode", (False, True))

--- a/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
+++ b/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
@@ -102,8 +102,8 @@ def test_apply_isolated_aiter_meta_csrc_defers_to_runtime_jit(
     tmp_path,
     monkeypatch,
 ):
-    venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
-    monkeypatch.setenv("VLLM_VENV_ROOT", str(venv_root))
+    _venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
+    monkeypatch.delenv("VLLM_VENV_ROOT", raising=False)
     monkeypatch.setattr(akp.importlib.util, "find_spec", lambda name: None)
     site = aiter_pkg.parent
     akp._CACHED_KNOWN_TARGET_ROOTS = (str(site) + "/",)
@@ -138,6 +138,15 @@ def test_apply_isolated_aiter_meta_csrc_defers_to_runtime_jit(
     manifest = json.loads(Path(result["manifest_path"]).read_text())
     assert manifest["status"] == "applied"
     assert manifest["strategy"]["rebuild_mode"] == "runtime_jit"
+    assert manifest["strategy"]["jit_build_dir"] == str(
+        aiter_pkg / "jit" / "build"
+    )
+
+    revert = akp.revert_kernel_patch(result["manifest_path"])
+
+    assert revert["status"] == "ok"
+    assert target.read_text(encoding="utf-8").endswith("int x = 1; }\n")
+    assert (aiter_pkg / "jit" / "build" / "stale.so").is_file()
 
 
 def test_apply_isolated_aiter_snapshot_invalidates_jit_for_python_codegen(
@@ -145,8 +154,8 @@ def test_apply_isolated_aiter_snapshot_invalidates_jit_for_python_codegen(
     tmp_path,
     monkeypatch,
 ):
-    venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
-    monkeypatch.setenv("VLLM_VENV_ROOT", str(venv_root))
+    _venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
+    monkeypatch.delenv("VLLM_VENV_ROOT", raising=False)
     monkeypatch.setattr(akp.importlib.util, "find_spec", lambda name: None)
     site = aiter_pkg.parent
     akp._CACHED_KNOWN_TARGET_ROOTS = (str(site) + "/",)
@@ -187,3 +196,97 @@ def test_apply_isolated_aiter_snapshot_invalidates_jit_for_python_codegen(
     assert result["rebuild"]["mode"] == "runtime_jit"
     assert result["jit_build_backup"]["status"] == "ok"
     assert target.read_text(encoding="utf-8") == "TILE = 64\n"
+
+
+def test_runtime_jit_uses_target_root_not_importable_aiter(
+    akp,
+    tmp_path,
+    monkeypatch,
+):
+    _venv_root, target_aiter = _make_isolated_aiter(tmp_path / "target")
+    import_aiter = (
+        tmp_path
+        / "imported"
+        / "lib"
+        / "python3.12"
+        / "site-packages"
+        / "aiter"
+    )
+    imported_build = import_aiter / "jit" / "build"
+    imported_build.mkdir(parents=True)
+    (imported_build / "unrelated.so").write_text("unrelated", encoding="utf-8")
+    monkeypatch.delenv("VLLM_VENV_ROOT", raising=False)
+    monkeypatch.setattr(
+        akp.importlib.util,
+        "find_spec",
+        lambda name: types.SimpleNamespace(
+            submodule_search_locations=[str(import_aiter)]
+        ),
+    )
+    site = target_aiter.parent
+    akp._CACHED_KNOWN_TARGET_ROOTS = (str(site) + "/",)
+    target = site / "aiter_meta" / "csrc" / "kernels" / "foo.cu"
+    original = '#include <hip/hip_runtime.h>\nextern "C" void kernel() {}\n'
+    optimized = (
+        '#include <hip/hip_runtime.h>\n'
+        'extern "C" void kernel() { int x = 2; }\n'
+    )
+    target.write_text(original, encoding="utf-8")
+    patch = tmp_path / "v1_forge.cu"
+    patch.write_text(optimized, encoding="utf-8")
+    (target_aiter / "jit" / "build" / "target.so").write_text(
+        "target",
+        encoding="utf-8",
+    )
+
+    result = akp.apply_kernel_patch(
+        patch_path=patch,
+        target_file=target,
+        backup_root=tmp_path / "backups",
+        kernel_id="k003",
+    )
+
+    assert result["status"] == "ok", result
+    assert result["jit_build_backup"]["src"] == str(
+        target_aiter / "jit" / "build"
+    )
+    assert not (target_aiter / "jit" / "build").exists()
+    assert (imported_build / "unrelated.so").is_file()
+
+
+def test_runtime_jit_rejects_unverified_cache_invalidation(
+    akp,
+    tmp_path,
+    monkeypatch,
+):
+    _venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
+    site = aiter_pkg.parent
+    akp._CACHED_KNOWN_TARGET_ROOTS = (str(site) + "/",)
+    target = site / "aiter_meta" / "csrc" / "kernels" / "foo.cu"
+    original = '#include <hip/hip_runtime.h>\nextern "C" void kernel() {}\n'
+    target.write_text(original, encoding="utf-8")
+    patch = tmp_path / "v1_forge.cu"
+    patch.write_text(
+        '#include <hip/hip_runtime.h>\n'
+        'extern "C" void kernel() { int x = 2; }\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        akp,
+        "_invalidate_aiter_jit_build",
+        lambda *args, **kwargs: {
+            "status": "skipped",
+            "reason": "aiter package not importable",
+        },
+    )
+
+    result = akp.apply_kernel_patch(
+        patch_path=patch,
+        target_file=target,
+        backup_root=tmp_path / "backups",
+        kernel_id="k003",
+    )
+
+    assert result["status"] == "failed"
+    assert result["error_class"] == "aiter_jit_invalidation_failed"
+    assert target.read_text(encoding="utf-8") == original

--- a/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
+++ b/src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py
@@ -309,7 +309,189 @@ def test_apply_isolated_aiter_snapshot_invalidates_jit_for_python_codegen(
     assert target.read_text(encoding="utf-8") == "TILE = 64\n"
     snapshot_manifest = json.loads(Path(result["manifest_path"]).read_text())
     assert snapshot_manifest["strategy"]["root"] == str(site)
+    assert snapshot_manifest["strategy"]["deploy_roots"] == [
+        str(site / "aiter"),
+        str(site / "aiter_meta"),
+    ]
     assert snapshot_manifest["strategy"]["rebuild_modes"] == ["runtime_jit"]
+
+
+def test_installed_snapshot_can_span_aiter_and_vllm(
+    akp,
+    tmp_path,
+    monkeypatch,
+):
+    _venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
+    monkeypatch.delenv("VLLM_VENV_ROOT", raising=False)
+    monkeypatch.setattr(akp.importlib.util, "find_spec", lambda name: None)
+    site = aiter_pkg.parent
+    vllm = site / "vllm"
+    vllm.mkdir()
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(site) + "/",),
+    )
+    aiter_relative = Path("aiter_meta/csrc/kernels/gen_instances.py")
+    vllm_relative = Path("vllm/_aiter_ops.py")
+    aiter_target = site / aiter_relative
+    vllm_target = site / vllm_relative
+    aiter_target.write_text("TILE = 128\n", encoding="utf-8")
+    vllm_target.write_text("ENABLED = False\n", encoding="utf-8")
+    patch = tmp_path / "forge.patch"
+    patch.write_text(
+        "diff --git a/aiter_meta/csrc/kernels/gen_instances.py "
+        "b/aiter_meta/csrc/kernels/gen_instances.py\n"
+        "--- a/aiter_meta/csrc/kernels/gen_instances.py\n"
+        "+++ b/aiter_meta/csrc/kernels/gen_instances.py\n"
+        "@@ -1 +1 @@\n"
+        "-TILE = 128\n"
+        "+TILE = 64\n"
+        "diff --git a/vllm/_aiter_ops.py b/vllm/_aiter_ops.py\n"
+        "--- a/vllm/_aiter_ops.py\n"
+        "+++ b/vllm/_aiter_ops.py\n"
+        "@@ -1 +1 @@\n"
+        "-ENABLED = False\n"
+        "+ENABLED = True\n",
+        encoding="utf-8",
+    )
+    snapshot = tmp_path / "snapshot"
+    for relative, content in (
+        (aiter_relative, "TILE = 64\n"),
+        (vllm_relative, "ENABLED = True\n"),
+    ):
+        destination = snapshot / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(content, encoding="utf-8")
+    (aiter_pkg / "jit" / "build" / "stale.so").write_text(
+        "stale",
+        encoding="utf-8",
+    )
+
+    result = akp.apply_kernel_patch(
+        patch_path=patch,
+        target_file=aiter_target,
+        backup_root=tmp_path / "backups",
+        snapshot_dir=snapshot,
+        kernel_id="k-cross-framework",
+    )
+
+    assert result["status"] == "ok", result
+    assert aiter_target.read_text(encoding="utf-8") == "TILE = 64\n"
+    assert vllm_target.read_text(encoding="utf-8") == "ENABLED = True\n"
+    manifest = json.loads(Path(result["manifest_path"]).read_text())
+    assert manifest["strategy"]["deploy_roots"] == [
+        str(site / "aiter"),
+        str(site / "aiter_meta"),
+        str(site / "vllm"),
+    ]
+
+
+@pytest.mark.parametrize("explicit_repo_root", (False, True))
+def test_installed_snapshot_rejects_other_site_packages(
+    akp,
+    tmp_path,
+    monkeypatch,
+    explicit_repo_root,
+):
+    _venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
+    site = aiter_pkg.parent
+    torch = site / "torch"
+    torch.mkdir()
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(site) + "/",),
+    )
+    aiter_relative = Path("aiter_meta/csrc/kernels/gen_instances.py")
+    torch_relative = Path("torch/runtime.py")
+    aiter_target = site / aiter_relative
+    torch_target = site / torch_relative
+    aiter_target.write_text("TILE = 128\n", encoding="utf-8")
+    torch_target.write_text("VALUE = 1\n", encoding="utf-8")
+    patch = tmp_path / "forge.patch"
+    patch.write_text(
+        "diff --git a/aiter_meta/csrc/kernels/gen_instances.py "
+        "b/aiter_meta/csrc/kernels/gen_instances.py\n"
+        "--- a/aiter_meta/csrc/kernels/gen_instances.py\n"
+        "+++ b/aiter_meta/csrc/kernels/gen_instances.py\n"
+        "@@ -1 +1 @@\n"
+        "-TILE = 128\n"
+        "+TILE = 64\n"
+        "diff --git a/torch/runtime.py b/torch/runtime.py\n"
+        "--- a/torch/runtime.py\n"
+        "+++ b/torch/runtime.py\n"
+        "@@ -1 +1 @@\n"
+        "-VALUE = 1\n"
+        "+VALUE = 2\n",
+        encoding="utf-8",
+    )
+    snapshot = tmp_path / "snapshot"
+    for relative, content in (
+        (aiter_relative, "TILE = 64\n"),
+        (torch_relative, "VALUE = 2\n"),
+    ):
+        destination = snapshot / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(content, encoding="utf-8")
+
+    result = akp.apply_kernel_patch(
+        patch_path=patch,
+        target_file=aiter_target,
+        backup_root=tmp_path / "backups",
+        snapshot_dir=snapshot,
+        repo_root=site if explicit_repo_root else None,
+        kernel_id="k-forbidden-package",
+    )
+
+    assert result["status"] == "failed"
+    assert "outside authorized deploy roots" in result["error"]
+    assert aiter_target.read_text(encoding="utf-8") == "TILE = 128\n"
+    assert torch_target.read_text(encoding="utf-8") == "VALUE = 1\n"
+
+
+def test_installed_snapshot_rejects_symlink_to_other_package(
+    akp,
+    tmp_path,
+    monkeypatch,
+):
+    _venv_root, aiter_pkg = _make_isolated_aiter(tmp_path)
+    site = aiter_pkg.parent
+    (site / "torch").mkdir()
+    monkeypatch.setattr(
+        akp,
+        "_CACHED_KNOWN_TARGET_ROOTS",
+        (str(site) + "/",),
+    )
+    target = site / "aiter_meta" / "csrc" / "kernels" / "gen_instances.py"
+    target.write_text("TILE = 128\n", encoding="utf-8")
+    relative = Path("aiter_meta/csrc/kernels/runtime.py")
+    patch = tmp_path / "forge.patch"
+    patch.write_text(
+        "diff --git a/aiter_meta/csrc/kernels/runtime.py "
+        "b/aiter_meta/csrc/kernels/runtime.py\n"
+        "new file mode 120000\n"
+        "--- /dev/null\n"
+        "+++ b/aiter_meta/csrc/kernels/runtime.py\n"
+        "@@ -0,0 +1 @@\n"
+        "+../../../torch/runtime.py\n",
+        encoding="utf-8",
+    )
+    snapshot_link = tmp_path / "snapshot" / relative
+    snapshot_link.parent.mkdir(parents=True)
+    snapshot_link.symlink_to("../../../torch/runtime.py")
+
+    result = akp.apply_kernel_patch(
+        patch_path=patch,
+        target_file=target,
+        backup_root=tmp_path / "backups",
+        snapshot_dir=tmp_path / "snapshot",
+        kernel_id="k-forbidden-symlink",
+    )
+
+    assert result["status"] == "failed"
+    assert "symlink target is outside authorized deploy roots" in result["error"]
+    assert not (site / relative).exists()
 
 
 def test_runtime_jit_uses_target_root_not_importable_aiter(

--- a/src/hyperloom/agents/kernel/tools/apply_and_bench.py
+++ b/src/hyperloom/agents/kernel/tools/apply_and_bench.py
@@ -801,7 +801,13 @@ def apply_and_bench(
         )
         _log(out, f"deploy {Path(target).name} <- {Path(src_path).name} status={res.get('status')}")
         applied.append(
-            {"target": target, "source": src_path, "status": res.get("status"), "manifest": res.get("manifest_path")}
+            {
+                "target": target,
+                "source": src_path,
+                "status": res.get("status"),
+                "manifest": res.get("manifest_path"),
+                "rebuild": res.get("rebuild"),
+            }
         )
         if res.get("status") == "ok" and res.get("manifest_path"):
             manifests.append(res["manifest_path"])

--- a/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
+++ b/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
@@ -54,6 +54,15 @@ _FALLBACK_KNOWN_TARGET_ROOTS: tuple[str, ...] = (
 
 _CACHED_KNOWN_TARGET_ROOTS: tuple[str, ...] | None = None
 
+_ALLOWED_KERNEL_DEPLOY_PACKAGES = frozenset(
+    {"aiter", "aiter_meta", "sglang", "vllm"}
+)
+_EDITABLE_KERNEL_DEPLOY_ROOTS = (
+    Path("/sgl-workspace/aiter"),
+    Path("/sgl-workspace/sglang"),
+    Path("/sgl-workspace/vllm"),
+)
+
 
 _UNSAFE_COMMAND_TOKENS = {";", "&&", "||", "|", ">", ">>", "<", "<<", "`"}
 _UNSAFE_COMMAND_CHARS_RE = re.compile(r"[;&|`$<>\r\n]")
@@ -542,15 +551,24 @@ def parse_patch_manifest(patch_text: str) -> list[dict[str, Any]]:
     return descriptors
 
 
-def _contained_dest(repo_root: Path, rel_path: str) -> Path:
-    """Resolve ``rel_path`` under ``repo_root``, rejecting any escape.
+def _contained_dest(
+    repo_root: Path,
+    rel_path: str,
+    *,
+    deploy_roots: Iterable[Path] | None = None,
+) -> Path:
+    """Resolve ``rel_path`` under its coordinate and authorized deploy roots.
 
     Rejects absolute paths and any ``..`` traversal, and confirms the resolved
-    destination stays inside ``repo_root``.
+    destination stays inside ``repo_root``. When ``deploy_roots`` is provided,
+    it must also stay inside an explicitly authorized framework root.
 
     Args:
         repo_root (Path): The framework repo root that destinations must stay in.
         rel_path (str): Repo-relative target path from the patch manifest.
+        deploy_roots (Iterable[Path] | None): Authorized framework roots.
+            ``None`` preserves coordinate-only validation for legacy callers;
+            an empty iterable rejects every destination.
 
     Returns:
         Path: The validated absolute destination path.
@@ -569,6 +587,12 @@ def _contained_dest(repo_root: Path, rel_path: str) -> Path:
         dest.relative_to(root)
     except ValueError as exc:
         raise ValueError(f"patch path escapes repo root {root}: {rel_path}") from exc
+    if deploy_roots is not None:
+        allowed = [Path(path).resolve() for path in deploy_roots]
+        if not any(_within_root(dest, allowed_root) for allowed_root in allowed):
+            raise ValueError(
+                f"patch path is outside authorized deploy roots: {rel_path}"
+            )
     return dest
 
 
@@ -603,6 +627,7 @@ def apply_snapshot(
     descriptors: list[dict[str, Any]],
     snapshot_dir: str | Path,
     repo_root: str | Path,
+    deploy_roots: Iterable[str | Path],
     backup_dir: str | Path,
 ) -> dict[str, Any]:
     """Apply a content-addressed snapshot atomically (all-or-nothing).
@@ -621,6 +646,8 @@ def apply_snapshot(
         snapshot_dir (str | Path): Directory holding byte-exact final contents
             for every ``write`` path (mirrored at the same relative path).
         repo_root (str | Path): Framework repo root the targets live under.
+        deploy_roots (Iterable[str | Path]): Authorized framework roots under
+            which every write/delete destination must remain.
         backup_dir (str | Path): Where per-path backups + the revert manifest
             are written.
 
@@ -630,6 +657,7 @@ def apply_snapshot(
             an ``error`` and the offending path.
     """
     root = Path(repo_root)
+    allowed_roots = [Path(path) for path in deploy_roots]
     snap = Path(snapshot_dir)
     backups: list[dict[str, Any]] = []
 
@@ -637,7 +665,11 @@ def apply_snapshot(
     staged: list[tuple[dict[str, Any], Path, Path | None]] = []
     try:
         for desc in descriptors:
-            dest = _contained_dest(root, desc["path"])
+            dest = _contained_dest(
+                root,
+                desc["path"],
+                deploy_roots=allowed_roots,
+            )
             src: Path | None = None
             if desc["op"] == "write":
                 src = snap / desc["path"]
@@ -647,6 +679,25 @@ def apply_snapshot(
                         "error": f"snapshot missing content for {desc['path']}",
                         "path": desc["path"],
                     }
+                if src.is_symlink():
+                    link_target = os.readlink(src)
+                    resolved_link = (
+                        Path(link_target)
+                        if os.path.isabs(link_target)
+                        else dest.parent / link_target
+                    ).resolve()
+                    if not any(
+                        _within_root(resolved_link, allowed_root)
+                        for allowed_root in allowed_roots
+                    ):
+                        return {
+                            "status": "failed",
+                            "error": (
+                                "snapshot symlink target is outside authorized "
+                                f"deploy roots: {desc['path']} -> {link_target}"
+                            ),
+                            "path": desc["path"],
+                        }
             staged.append((desc, dest, src))
     except ValueError as exc:
         return {"status": "failed", "error": str(exc), "path": "<pre-flight>"}
@@ -685,7 +736,11 @@ def apply_snapshot(
                 dest.unlink(missing_ok=True)
             else:
                 # Re-validate containment right before the write (close TOCTOU window).
-                _contained_dest(root, desc["path"])
+                _contained_dest(
+                    root,
+                    desc["path"],
+                    deploy_roots=allowed_roots,
+                )
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 if dest.is_symlink():
                     dest.unlink()
@@ -787,6 +842,37 @@ def _isolated_aiter_pkg_root() -> Path | None:
     return None
 
 
+def _installed_kernel_package(
+    target_file: Path,
+) -> tuple[Path, str] | None:
+    """Return ``(site-packages root, package name)`` for an allowed framework."""
+    # Preserve the lexical install path: venv/site-packages is commonly a
+    # symlink, and resolving it here would make strategy classification disagree
+    # with the path matching performed by _detect_strategy.
+    target = target_file.absolute()
+    for parent in target.parents:
+        if (
+            parent.name in _ALLOWED_KERNEL_DEPLOY_PACKAGES
+            and parent.parent.name in {"site-packages", "dist-packages"}
+        ):
+            return parent.parent, parent.name
+    return None
+
+
+def _installed_kernel_deploy_roots(coordinate_root: Path) -> list[Path]:
+    """Return existing, explicitly allowed framework packages under a wheel root."""
+    return [
+        coordinate_root / package
+        for package in sorted(_ALLOWED_KERNEL_DEPLOY_PACKAGES)
+        if (coordinate_root / package).is_dir()
+    ]
+
+
+def _editable_kernel_deploy_roots() -> list[Path]:
+    """Return existing editable framework roots supported by kernel integration."""
+    return [root for root in _EDITABLE_KERNEL_DEPLOY_ROOTS if root.is_dir()]
+
+
 def _installed_aiter_runtime_root(target_file: Path) -> Path | None:
     """Return the package root shared by installed ``aiter`` and ``aiter_meta``.
 
@@ -794,17 +880,10 @@ def _installed_aiter_runtime_root(target_file: Path) -> Path | None:
     into the sibling ``aiter_meta`` package. Both are runtime-JIT inputs and must
     share one deployment/rebuild strategy.
     """
-    # Preserve the lexical install path: venv/site-packages is commonly a
-    # symlink, and resolving it here would make strategy classification disagree
-    # with the path matching performed by _detect_strategy.
-    target = target_file.absolute()
-    for parent in target.parents:
-        if (
-            parent.name in {"aiter", "aiter_meta"}
-            and parent.parent.name in {"site-packages", "dist-packages"}
-        ):
-            return parent.parent
-    return None
+    installed = _installed_kernel_package(target_file)
+    if installed is None or installed[1] not in {"aiter", "aiter_meta"}:
+        return None
+    return installed[0]
 
 
 def _target_is_in_aiter_csrc(target_file: Path) -> bool:
@@ -1328,39 +1407,50 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
     rebuild_mode = _REBUILD_MODE_NONE
     rebuild_command: list[str] = []
     artifact_roots: list[Path] = []
+    deploy_roots: list[Path] = []
     jit_build_dir = ""
+    installed_kernel = _installed_kernel_package(target_file)
     installed_aiter_root = _installed_aiter_runtime_root(target_file)
 
     if "/sgl-workspace/aiter/" in lower:
         root = Path("/sgl-workspace/aiter")
+        deploy_roots = _editable_kernel_deploy_roots()
         rebuild_mode = _REBUILD_MODE_COMMAND
         rebuild_command = ["/opt/venv/bin/python", "setup.py", "develop"]
         artifact_roots = [root]
     elif "/sgl-workspace/sglang/sgl-kernel/" in lower:
         root = Path("/sgl-workspace/sglang/sgl-kernel")
+        deploy_roots = _editable_kernel_deploy_roots()
         rebuild_mode = _REBUILD_MODE_COMMAND
         rebuild_command = ["/opt/venv/bin/python", "-m", "pip", "install", "-e", "."]
         artifact_roots = [root]
     elif "/sgl-workspace/sglang/" in lower:
         root = Path("/sgl-workspace/sglang")
+        deploy_roots = _editable_kernel_deploy_roots()
         rebuild_mode = _REBUILD_MODE_COMMAND
         rebuild_command = ["/opt/venv/bin/python", "-m", "pip", "install", "-e", "python"]
         artifact_roots = [root]
     elif "/sgl-workspace/vllm/" in lower:
         root = Path("/sgl-workspace/vllm")
+        deploy_roots = _editable_kernel_deploy_roots()
         rebuild_mode = _REBUILD_MODE_COMMAND
         rebuild_command = ["/opt/venv/bin/python", "-m", "pip", "install", "-e", "."]
         artifact_roots = [root]
     elif installed_aiter_root:
         root = installed_aiter_root
+        deploy_roots = _installed_kernel_deploy_roots(installed_aiter_root)
         rebuild_mode = _REBUILD_MODE_RUNTIME_JIT
         jit_build_dir = str(installed_aiter_root / "aiter" / "jit" / "build")
         # Runtime-JIT artifacts live under jit/build and are moved aside as one
         # tree below. Recursively copying wheel .so/.co files here is redundant
         # and can consume gigabytes per integration attempt.
         artifact_roots = []
+    elif installed_kernel:
+        root = installed_kernel[0]
+        deploy_roots = _installed_kernel_deploy_roots(installed_kernel[0])
     elif allow_unknown_target:
         root = target_file.parent
+        deploy_roots = [root]
 
     if (
         suffix in PYTHON_SOURCE_SUFFIXES
@@ -1376,6 +1466,8 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
         jit_build_dir = ""
     if root is None:
         root = target_file.parent
+    if not deploy_roots:
+        deploy_roots = [root]
 
     return {
         "compiled": compiled,
@@ -1383,6 +1475,7 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
         "rebuild_mode": rebuild_mode,
         "rebuild_command": rebuild_command,
         "artifact_roots": artifact_roots,
+        "deploy_roots": deploy_roots,
         "jit_build_dir": jit_build_dir,
     }
 
@@ -1839,6 +1932,9 @@ def apply_kernel_patch(
         "strategy": {
             "compiled": strategy["compiled"],
             "root": strategy["root"],
+            "deploy_roots": [
+                str(path) for path in strategy.get("deploy_roots") or []
+            ],
             "rebuild_modes": [strategy["rebuild_mode"]],
             "jit_build_dirs": (
                 [strategy["jit_build_dir"]]
@@ -2096,6 +2192,18 @@ def _apply_kernel_patch_snapshot(
             ),
         }
     repo_root = Path(resolved_root)
+    deploy_roots = [
+        Path(path)
+        for path in primary_strategy.get("deploy_roots") or []
+    ]
+    if not deploy_roots:
+        return {
+            "status": "failed",
+            "error": (
+                "snapshot mode requires at least one authorized framework "
+                f"deploy root for target: {target}"
+            ),
+        }
     backup_dir = Path(backup_root) / f"{_safe_name(kernel_id or target.stem)}_{_path_hash(target)}"
     backup_dir.mkdir(parents=True, exist_ok=True)
     manifest_path = backup_dir / "manifest.json"
@@ -2104,7 +2212,11 @@ def _apply_kernel_patch_snapshot(
     write_paths: list[Path] = []
     for desc in descriptors:
         try:
-            dest = _contained_dest(repo_root, desc["path"])
+            dest = _contained_dest(
+                repo_root,
+                desc["path"],
+                deploy_roots=deploy_roots,
+            )
         except ValueError as exc:
             return {"status": "failed", "error": str(exc), "path": desc["path"]}
         if desc["op"] == "write":
@@ -2142,6 +2254,7 @@ def _apply_kernel_patch_snapshot(
         "strategy": {
             "compiled": compiled,
             "root": str(repo_root),
+            "deploy_roots": [str(path) for path in deploy_roots],
             "rebuild_modes": sorted(
                 {strat["rebuild_mode"] for strat in rebuild_strategies}
             ),
@@ -2167,6 +2280,7 @@ def _apply_kernel_patch_snapshot(
         descriptors=descriptors,
         snapshot_dir=snapshot_dir,
         repo_root=repo_root,
+        deploy_roots=deploy_roots,
         backup_dir=backup_dir,
     )
     if applied["status"] != "ok":
@@ -2189,7 +2303,11 @@ def _apply_kernel_patch_snapshot(
     # gone. Any mismatch -> full restore.
     snap = Path(snapshot_dir)
     for desc in descriptors:
-        dest = _contained_dest(repo_root, desc["path"])
+        dest = _contained_dest(
+            repo_root,
+            desc["path"],
+            deploy_roots=deploy_roots,
+        )
         if desc["op"] == "delete":
             if dest.exists():
                 revert_kernel_patch(manifest_path)

--- a/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
+++ b/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
@@ -154,6 +154,7 @@ def _dispatch_multinode_apply(
     patch_path: Path,
     kernel_id: str,
     backup_dir_on_pod: str,
+    jit_build_dir: str = "",
     timeout_sec: int = 180,
 ) -> dict[str, Any]:
     """Fan a patch out to every pod (head + workers).
@@ -185,6 +186,8 @@ def _dispatch_multinode_apply(
         backup_dir_on_pod,
         "--kernel-id",
         kernel_id or "",
+        "--jit-build-dir",
+        str(jit_build_dir or ""),
     ]
     proc = subprocess.run(
         cmd,
@@ -215,8 +218,9 @@ def _dispatch_multinode_apply(
 
 def _dispatch_multinode_revert(
     *,
-    target_path: str,
-    backup_map: dict[str, str],
+    target_path: str = "",
+    backup_map: dict[str, str] | None = None,
+    records_by_host: dict[str, list[dict[str, Any]]] | None = None,
     timeout_sec: int = 120,
 ) -> dict[str, Any]:
     """Restore the original file on every pod that received the apply.
@@ -238,8 +242,10 @@ def _dispatch_multinode_revert(
         "revert-patch",
         "--target-path",
         str(target_path),
+        "--records-json",
+        json.dumps(records_by_host or {}, sort_keys=True),
         "--backup-map-json",
-        json.dumps(backup_map, sort_keys=True),
+        json.dumps(backup_map or {}, sort_keys=True),
     ]
     proc = subprocess.run(
         cmd,
@@ -1779,17 +1785,26 @@ def revert_kernel_patch(manifest_path: str | Path) -> dict[str, Any]:
     # Multi-node: fan-out a revert to every pod that received the apply (best-effort).
     multinode_info = manifest.get("multinode") or {}
     mn_revert: dict[str, Any] = {}
-    if multinode_info and multinode_info.get("host_backup_map"):
+    if multinode_info and (
+        multinode_info.get("records_by_host")
+        or multinode_info.get("host_backup_map")
+    ):
         target_path = multinode_info.get("target_path") or (source_backup.get("path") if source_backup else "")
         backup_map = multinode_info.get("host_backup_map") or {}
-        if target_path and backup_map:
+        records_by_host = multinode_info.get("records_by_host") or {}
+        if records_by_host or (target_path and backup_map):
             try:
                 mn_revert = _dispatch_multinode_revert(
                     target_path=target_path,
                     backup_map=backup_map,
+                    records_by_host=records_by_host,
                 )
             except Exception as exc:  # noqa: BLE001
                 mn_revert = {"status": "failed", "error": str(exc)}
+        if mn_revert and mn_revert.get("status") != "ok":
+            revert_issues.append(
+                {"kind": "multinode_revert", **mn_revert}
+            )
 
     reverted_at = utc_now()
     partial = bool(skipped_untrusted_backups or revert_issues)
@@ -2001,6 +2016,15 @@ def apply_kernel_patch(
         if target.suffix.lower() in PYTHON_SOURCE_SUFFIXES
         else {"status": "skipped", "reason": "not a python source target"}
     )
+    strategy_jit_dir = str(strategy.get("jit_build_dir") or "").strip()
+    remote_jit_dir = (
+        strategy_jit_dir
+        if (
+            strategy.get("rebuild_mode") == _REBUILD_MODE_RUNTIME_JIT
+            and not skip_rebuild
+        )
+        else ""
+    )
 
     # Multi-node: fan-out the patch to every RayJob pod, else hard-revert the sandbox copy.
     multinode_info: dict[str, Any] = {}
@@ -2015,6 +2039,7 @@ def apply_kernel_patch(
                 patch_path=patch,
                 kernel_id=kernel_id,
                 backup_dir_on_pod=pod_backup_dir,
+                jit_build_dir=remote_jit_dir,
             )
         except Exception as exc:  # noqa: BLE001
             # Pod fan-out failed: revert sandbox copy.
@@ -2031,16 +2056,19 @@ def apply_kernel_patch(
             }
         # Persist per-host backups {hostname: backup_path} so revert can find them.
         backup_map: dict[str, str] = {}
+        records_by_host: dict[str, list[dict[str, Any]]] = {}
         for entry in mn_apply.get("per_node", []) or []:
             host = (entry.get("host") or "").strip()
             bp = (entry.get("backup_path") or "").strip()
             if host and bp:
                 backup_map[host] = bp
+                records_by_host.setdefault(host, []).append(dict(entry))
         multinode_info = {
             "status": "ok",
             "target_path": str(target),
             "backup_dir_on_pod": pod_backup_dir,
             "host_backup_map": backup_map,
+            "records_by_host": records_by_host,
             "per_node": mn_apply.get("per_node", []),
         }
         # Persist multinode info now so a later rebuild failure reverts pod-side patches too.
@@ -2064,12 +2092,35 @@ def apply_kernel_patch(
     }
     if strategy["compiled"] and not skip_rebuild:
         # Move aiter jit/build/ aside so post-rebuild import re-JITs cleanly.
-        strategy_jit_dir = str(strategy.get("jit_build_dir") or "").strip()
-        jit_build_backup = _invalidate_aiter_jit_build(
-            target,
-            backup_dir,
-            jit_build_dir=Path(strategy_jit_dir) if strategy_jit_dir else None,
-        )
+        if _is_multi_node() and remote_jit_dir:
+            remote_records = list(multinode_info.get("per_node") or [])
+            invalid = [
+                record
+                for record in remote_records
+                if (record.get("jit_backup") or {}).get("status")
+                not in {"ok", "clean"}
+            ]
+            if not remote_records or invalid:
+                revert = revert_kernel_patch(manifest_path)
+                return {
+                    "status": "failed",
+                    "error_class": "aiter_jit_invalidation_failed",
+                    "error": "one or more pods did not invalidate AITER JIT",
+                    "manifest_path": str(manifest_path),
+                    "revert": revert,
+                }
+            jit_build_backup = {
+                "status": "remote",
+                "per_node": [
+                    record.get("jit_backup") for record in remote_records
+                ],
+            }
+        else:
+            jit_build_backup = _invalidate_aiter_jit_build(
+                target,
+                backup_dir,
+                jit_build_dir=Path(strategy_jit_dir) if strategy_jit_dir else None,
+            )
         if jit_build_backup.get("status") in {"ok", "clean"}:
             # Persist the backup record before rebuild so a failure can still restore.
             manifest["jit_build_backup"] = jit_build_backup
@@ -2077,9 +2128,10 @@ def apply_kernel_patch(
                 json.dumps(manifest, indent=2, sort_keys=True) + "\n",
                 encoding="utf-8",
             )
-        invalidation_error = _runtime_jit_invalidation_error(
-            strategy,
-            jit_build_backup,
+        invalidation_error = (
+            ""
+            if jit_build_backup.get("status") == "remote"
+            else _runtime_jit_invalidation_error(strategy, jit_build_backup)
         )
         if jit_build_backup.get("status") == "failed" or invalidation_error:
             # Refuse to benchmark against an unknown/stale binary.
@@ -2102,19 +2154,16 @@ def apply_kernel_patch(
         # dir name, so pristine + patched collide; move the cache aside for a clean re-baseline.
         cpp_itfs_cache_backup = _invalidate_aiter_cpp_itfs_cache(target, backup_dir)
         if cpp_itfs_cache_backup.get("status") == "failed":
-            # Refuse to re-baseline against a stale runtime cache: restore and bail.
-            try:
-                shutil.copy2(source_backup["backup_path"], target)
-            except OSError:
-                pass
-            if jit_build_backup.get("status") == "ok":
-                _restore_aiter_jit_build(jit_build_backup)
+            # Refuse to re-baseline against a stale runtime cache. The manifest
+            # owns both local and per-pod source/JIT backups.
+            revert = revert_kernel_patch(manifest_path)
             return {
                 "status": "failed",
                 "error_class": "aiter_cpp_itfs_invalidation_failed",
                 "error": (f"aiter cpp_itfs runtime cache invalidation failed: {cpp_itfs_cache_backup.get('error')}"),
                 "manifest_path": str(manifest_path),
                 "cpp_itfs_cache_backup": cpp_itfs_cache_backup,
+                "revert": revert,
             }
         if cpp_itfs_cache_backup.get("status") == "ok":
             # Persist before rebuild so a failure can restore the moved-aside cache.
@@ -2144,7 +2193,7 @@ def apply_kernel_patch(
     manifest["applied_at"] = utc_now()
     manifest["rebuild"] = rebuild
     manifest["cache_clear"] = cache_clear
-    if jit_build_backup.get("status") in {"ok", "clean", "skipped"}:
+    if jit_build_backup.get("status") in {"ok", "clean", "remote", "skipped"}:
         # Surface skipped reason too for manifest auditing.
         manifest["jit_build_backup"] = jit_build_backup
     if cpp_itfs_cache_backup.get("status") in {"ok", "skipped"}:
@@ -2383,36 +2432,69 @@ def _apply_kernel_patch_snapshot(
 
     # Multi-node fan-out: push every write path to every pod.
     multinode_info: dict[str, Any] = {}
+    runtime_jit_strategy = (
+        runtime_jit_strategies[0] if runtime_jit_strategies else {}
+    )
+    strategy_jit_dir = str(
+        runtime_jit_strategy.get("jit_build_dir") or ""
+    ).strip()
     if _is_multi_node():
         pod_backup_dir = os.environ.get("HYPERLOOM_MN_KERNEL_BACKUP_DIR", _MN_POD_BACKUP_DIR_DEFAULT)
         per_node_all: list[dict[str, Any]] = []
         backup_map: dict[str, str] = {}
+        records_by_host: dict[str, list[dict[str, Any]]] = {}
         try:
-            for p in write_paths:
+            for index, p in enumerate(write_paths):
                 mn_apply = _dispatch_multinode_apply(
                     target_file=p,
                     patch_path=snap / Path(p).relative_to(repo_root),
                     kernel_id=kernel_id,
                     backup_dir_on_pod=pod_backup_dir,
+                    jit_build_dir=(
+                        strategy_jit_dir
+                        if index == 0 and strategy_jit_dir and not skip_rebuild
+                        else ""
+                    ),
                 )
-                per_node_all.extend(mn_apply.get("per_node", []) or [])
+                new_records = list(mn_apply.get("per_node", []) or [])
+                per_node_all.extend(new_records)
+                for entry in new_records:
+                    host = (entry.get("host") or "").strip()
+                    bp = (entry.get("backup_path") or "").strip()
+                    if host and bp:
+                        backup_map[host] = bp
+                        records_by_host.setdefault(host, []).append(
+                            dict(entry)
+                        )
+                multinode_info = {
+                    "status": "partial",
+                    "target_path": str(target),
+                    "backup_dir_on_pod": pod_backup_dir,
+                    "host_backup_map": backup_map,
+                    "records_by_host": records_by_host,
+                    "per_node": per_node_all,
+                }
+                # Persist after every file so a later dispatch failure can
+                # revert all already-patched files on every pod.
+                manifest["multinode"] = multinode_info
+                manifest_path.write_text(
+                    json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
         except Exception as exc:  # noqa: BLE001
-            revert_kernel_patch(manifest_path)
+            revert = revert_kernel_patch(manifest_path)
             return {
                 "status": "failed",
                 "error": f"multi-node apply fan-out failed; repo restored: {exc}",
                 "manifest_path": str(manifest_path),
+                "revert": revert,
             }
-        for entry in per_node_all:
-            host = (entry.get("host") or "").strip()
-            bp = (entry.get("backup_path") or "").strip()
-            if host and bp:
-                backup_map[host] = bp
         multinode_info = {
             "status": "ok",
             "target_path": str(target),
             "backup_dir_on_pod": pod_backup_dir,
             "host_backup_map": backup_map,
+            "records_by_host": records_by_host,
             "per_node": per_node_all,
         }
         manifest["multinode"] = multinode_info
@@ -2432,23 +2514,50 @@ def _apply_kernel_patch_snapshot(
             ),
             target,
         )
-        runtime_jit_strategy = (
-            runtime_jit_strategies[0] if runtime_jit_strategies else {}
-        )
-        strategy_jit_dir = str(
-            runtime_jit_strategy.get("jit_build_dir") or ""
-        ).strip()
-        jit_build_backup = _invalidate_aiter_jit_build(
-            aiter_jit_target,
-            backup_dir,
-            jit_build_dir=Path(strategy_jit_dir) if strategy_jit_dir else None,
-        )
+        if _is_multi_node() and strategy_jit_dir:
+            records_by_host = dict(
+                multinode_info.get("records_by_host") or {}
+            )
+            host_jit = {
+                host: [
+                    record.get("jit_backup")
+                    for record in records
+                    if (record.get("jit_backup") or {}).get("status")
+                    in {"ok", "clean"}
+                ]
+                for host, records in records_by_host.items()
+            }
+            if not host_jit or any(
+                len(records) != 1 for records in host_jit.values()
+            ):
+                revert = revert_kernel_patch(manifest_path)
+                return {
+                    "status": "failed",
+                    "error_class": "aiter_jit_invalidation_failed",
+                    "error": "each pod must invalidate AITER JIT exactly once",
+                    "manifest_path": str(manifest_path),
+                    "revert": revert,
+                }
+            jit_build_backup = {
+                "status": "remote",
+                "per_host": host_jit,
+            }
+        else:
+            jit_build_backup = _invalidate_aiter_jit_build(
+                aiter_jit_target,
+                backup_dir,
+                jit_build_dir=Path(strategy_jit_dir) if strategy_jit_dir else None,
+            )
         if jit_build_backup.get("status") in {"ok", "clean"}:
             manifest["jit_build_backup"] = jit_build_backup
             manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        invalidation_error = _runtime_jit_invalidation_error(
-            runtime_jit_strategy,
-            jit_build_backup,
+        invalidation_error = (
+            ""
+            if jit_build_backup.get("status") == "remote"
+            else _runtime_jit_invalidation_error(
+                runtime_jit_strategy,
+                jit_build_backup,
+            )
         )
         if jit_build_backup.get("status") == "failed" or invalidation_error:
             revert = revert_kernel_patch(manifest_path)
@@ -2516,7 +2625,7 @@ def _apply_kernel_patch_snapshot(
     manifest["applied_at"] = utc_now()
     manifest["rebuild"] = rebuild
     manifest["cache_clear"] = cache_clear
-    if jit_build_backup.get("status") in {"ok", "clean", "skipped"}:
+    if jit_build_backup.get("status") in {"ok", "clean", "remote", "skipped"}:
         manifest["jit_build_backup"] = jit_build_backup
     if cpp_itfs_cache_backup.get("status") in {"ok", "skipped"}:
         manifest["cpp_itfs_cache_backup"] = cpp_itfs_cache_backup

--- a/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
+++ b/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
@@ -767,6 +767,9 @@ def _clear_python_kernel_caches(target: Path) -> dict[str, Any]:
 # split wheel (``/aiter_meta/csrc/``); both feed the same importable ``aiter``
 # JIT build, so the rebuild gates must recognise both layouts.
 _AITER_CSRC_MARKERS = ("/aiter/csrc/", "/aiter_meta/csrc/")
+_REBUILD_MODE_COMMAND = "command"
+_REBUILD_MODE_NONE = "none"
+_REBUILD_MODE_RUNTIME_JIT = "runtime_jit"
 
 
 def _isolated_aiter_pkg_root() -> Path | None:
@@ -777,9 +780,27 @@ def _isolated_aiter_pkg_root() -> Path | None:
     lib = Path(vllm_venv) / "lib"
     if not lib.is_dir():
         return None
-    for match in sorted(lib.glob("python*/site-packages/aiter")):
-        if match.is_dir():
-            return match
+    for package_dir in ("site-packages", "dist-packages"):
+        for match in sorted(lib.glob(f"python*/{package_dir}/aiter")):
+            if match.is_dir():
+                return match
+    return None
+
+
+def _installed_aiter_runtime_root(target_file: Path) -> Path | None:
+    """Return the package root shared by installed ``aiter`` and ``aiter_meta``.
+
+    AITER wheels split runtime Python/JIT code into ``aiter`` and device sources
+    into the sibling ``aiter_meta`` package. Both are runtime-JIT inputs and must
+    share one deployment/rebuild strategy.
+    """
+    target = target_file.resolve()
+    for parent in target.parents:
+        if (
+            parent.name in {"aiter", "aiter_meta"}
+            and parent.parent.name in {"site-packages", "dist-packages"}
+        ):
+            return parent.parent
     return None
 
 
@@ -1233,7 +1254,8 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
 
     Matches the target against the known framework roots (aiter / sglang /
     vllm) to pick the rebuild command and artifact roots, and decides whether
-    the target is a compiled source. Python targets never rebuild.
+    the target feeds a compiled runtime. Python codegen under AITER ``csrc``
+    requires the same rebuild/JIT invalidation as a native source.
 
     Args:
         target_file (Path): The file being patched.
@@ -1243,8 +1265,8 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
 
     Returns:
         dict[str, Any]: A strategy dict with ``compiled`` (bool), ``root``
-            (str), ``rebuild_command`` (list[str]) and ``artifact_roots``
-            (list[Path]).
+            (str), ``rebuild_mode`` (str), ``rebuild_command`` (list[str]) and
+            ``artifact_roots`` (list[Path]).
 
     Raises:
         ValueError: When the target is outside the known roots and
@@ -1259,40 +1281,59 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
     suffix = target_file.suffix.lower()
     compiled = suffix in COMPILED_SOURCE_SUFFIXES
     root = None
+    rebuild_mode = _REBUILD_MODE_NONE
     rebuild_command: list[str] = []
     artifact_roots: list[Path] = []
+    installed_aiter_root = _installed_aiter_runtime_root(target_file)
 
     if "/sgl-workspace/aiter/" in lower:
         root = Path("/sgl-workspace/aiter")
+        rebuild_mode = _REBUILD_MODE_COMMAND
         rebuild_command = ["/opt/venv/bin/python", "setup.py", "develop"]
         artifact_roots = [root]
     elif "/sgl-workspace/sglang/sgl-kernel/" in lower:
         root = Path("/sgl-workspace/sglang/sgl-kernel")
+        rebuild_mode = _REBUILD_MODE_COMMAND
         rebuild_command = ["/opt/venv/bin/python", "-m", "pip", "install", "-e", "."]
         artifact_roots = [root]
     elif "/sgl-workspace/sglang/" in lower:
         root = Path("/sgl-workspace/sglang")
+        rebuild_mode = _REBUILD_MODE_COMMAND
         rebuild_command = ["/opt/venv/bin/python", "-m", "pip", "install", "-e", "python"]
         artifact_roots = [root]
     elif "/sgl-workspace/vllm/" in lower:
         root = Path("/sgl-workspace/vllm")
+        rebuild_mode = _REBUILD_MODE_COMMAND
         rebuild_command = ["/opt/venv/bin/python", "-m", "pip", "install", "-e", "."]
         artifact_roots = [root]
-    elif isolated_aiter_root := _isolated_aiter_pkg_root():
-        if _within_root(target_file, isolated_aiter_root):
-            root = isolated_aiter_root
-            artifact_roots = [root]
+    elif installed_aiter_root:
+        root = installed_aiter_root
+        rebuild_mode = _REBUILD_MODE_RUNTIME_JIT
+        artifact_roots = [
+            package
+            for package in (
+                installed_aiter_root / "aiter",
+                installed_aiter_root / "aiter_meta",
+            )
+            if package.is_dir()
+        ]
     elif allow_unknown_target:
         root = target_file.parent
 
-    if suffix in PYTHON_SOURCE_SUFFIXES:
+    if suffix in PYTHON_SOURCE_SUFFIXES and _target_is_in_aiter_csrc(target_file):
+        compiled = True
+    elif suffix in PYTHON_SOURCE_SUFFIXES:
         compiled = False
+        rebuild_mode = _REBUILD_MODE_NONE
         rebuild_command = []
         artifact_roots = []
+    elif compiled and root is None:
+        root = target_file.parent
 
     return {
         "compiled": compiled,
         "root": str(root) if root else "",
+        "rebuild_mode": rebuild_mode,
         "rebuild_command": rebuild_command,
         "artifact_roots": artifact_roots,
     }
@@ -1370,6 +1411,35 @@ def _run_rebuild(command: list[str], cwd: Path, timeout_sec: int) -> dict[str, A
         "command": command,
         "cwd": str(cwd),
     }
+
+
+def _run_strategy_rebuild(
+    strategy: dict[str, Any],
+    *,
+    command_override: list[str],
+    timeout_sec: int,
+) -> dict[str, Any]:
+    """Run an eager rebuild or record a runtime-JIT handoff."""
+    command = command_override or list(strategy["rebuild_command"])
+    cwd = Path(strategy["root"])
+    if command:
+        return _run_rebuild(command, cwd, timeout_sec)
+    if strategy.get("rebuild_mode") == _REBUILD_MODE_RUNTIME_JIT:
+        return {
+            "status": "deferred",
+            "mode": _REBUILD_MODE_RUNTIME_JIT,
+            "reason": (
+                "installed AITER sources compile on runtime import after JIT "
+                "cache invalidation"
+            ),
+            "cwd": str(cwd),
+        }
+    return _run_rebuild([], cwd, timeout_sec)
+
+
+def _rebuild_completed(result: dict[str, Any]) -> bool:
+    """Return whether apply may proceed after this rebuild result."""
+    return result.get("status") in {"ok", "deferred"}
 
 
 def _revert_backup_trusted(backup_path: str, backup_root: Path) -> bool:
@@ -1684,6 +1754,7 @@ def apply_kernel_patch(
         "strategy": {
             "compiled": strategy["compiled"],
             "root": strategy["root"],
+            "rebuild_mode": strategy["rebuild_mode"],
         },
         "created_at": utc_now(),
     }
@@ -1751,11 +1822,7 @@ def apply_kernel_patch(
             encoding="utf-8",
         )
 
-    command: list[str] = []
-    if rebuild_command:
-        command = list(coerced_rebuild_command)
-    elif not skip_rebuild:
-        command = list(strategy["rebuild_command"])
+    command_override = list(coerced_rebuild_command) if rebuild_command else []
 
     rebuild = {"status": "skipped", "reason": "source-only patch or skip_rebuild=true"}
     jit_build_backup: dict[str, Any] = {
@@ -1817,9 +1884,12 @@ def apply_kernel_patch(
                 encoding="utf-8",
             )
 
-        cwd = Path(strategy["root"] or target.parent)
-        rebuild = _run_rebuild(command, cwd, rebuild_timeout_sec)
-        if rebuild["status"] != "ok":
+        rebuild = _run_strategy_rebuild(
+            strategy,
+            command_override=command_override,
+            timeout_sec=rebuild_timeout_sec,
+        )
+        if not _rebuild_completed(rebuild):
             revert = revert_kernel_patch(manifest_path)
             return {
                 "status": "failed",
@@ -1956,7 +2026,13 @@ def _apply_kernel_patch_snapshot(
         "mode": "snapshot",
         "descriptors": descriptors,
         "artifacts": artifacts,
-        "strategy": {"compiled": compiled, "root": str(repo_root)},
+        "strategy": {
+            "compiled": compiled,
+            "root": str(repo_root),
+            "rebuild_modes": sorted(
+                {strat["rebuild_mode"] for strat in rebuild_strategies}
+            ),
+        },
         "created_at": utc_now(),
     }
     if producer_manifest:
@@ -2062,9 +2138,7 @@ def _apply_kernel_patch_snapshot(
         manifest["multinode"] = multinode_info
         manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
-    command: list[str] = []
-    if rebuild_command:
-        command = list(coerced_rebuild_command)
+    command_override = list(coerced_rebuild_command) if rebuild_command else []
 
     rebuild: dict[str, Any] = {"status": "skipped", "reason": "source-only patch or skip_rebuild=true"}
     jit_build_backup: dict[str, Any] = {"status": "skipped", "reason": "rebuild not run"}
@@ -2123,11 +2197,13 @@ def _apply_kernel_patch_snapshot(
         # Rebuild each distinct compiled root. Any failure -> full restore.
         rebuild_records: list[dict[str, Any]] = []
         for strat in rebuild_strategies:
-            cmd = command or list(strat["rebuild_command"])
-            cwd = Path(strat["root"] or target.parent)
-            rec = _run_rebuild(cmd, cwd, rebuild_timeout_sec)
+            rec = _run_strategy_rebuild(
+                strat,
+                command_override=command_override,
+                timeout_sec=rebuild_timeout_sec,
+            )
             rebuild_records.append(rec)
-            if rec["status"] != "ok":
+            if not _rebuild_completed(rec):
                 revert = revert_kernel_patch(manifest_path)
                 return {
                     "status": "failed",

--- a/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
+++ b/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
@@ -1886,6 +1886,19 @@ def finalize_kernel_patch(manifest_path: str | Path) -> dict[str, Any]:
     """Delete backups after an integrated patch becomes the new baseline."""
     manifest_file = Path(manifest_path)
     manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+    manifest_status = str(manifest.get("status") or "")
+    if manifest_status == "finalized":
+        return {
+            "status": "ok",
+            "manifest_path": str(manifest_file),
+            "reason": "already finalized",
+        }
+    if manifest_status not in {"applied", "finalized_partial"}:
+        return {
+            "status": "failed",
+            "manifest_path": str(manifest_file),
+            "error": f"cannot finalize manifest in state {manifest_status!r}",
+        }
     backup_root = manifest_file.resolve().parent
     deleted: list[str] = []
     issues: list[dict[str, Any]] = []
@@ -1912,6 +1925,15 @@ def finalize_kernel_patch(manifest_path: str | Path) -> dict[str, Any]:
 
     for raw in sorted(path for path in candidates if path):
         path = Path(raw)
+        if path.resolve() == backup_root:
+            issues.append(
+                {
+                    "kind": "untrusted_backup",
+                    "path": str(path),
+                    "error": "backup path equals manifest directory",
+                }
+            )
+            continue
         if not _within_root(path, backup_root):
             issues.append(
                 {"kind": "untrusted_backup", "path": str(path)}

--- a/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
+++ b/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
@@ -273,6 +273,42 @@ def _dispatch_multinode_revert(
     }
 
 
+def _dispatch_multinode_finalize(
+    records_by_host: dict[str, list[dict[str, Any]]],
+    timeout_sec: int = 120,
+) -> dict[str, Any]:
+    """Delete accepted transaction backups on every inference pod."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "hyperloom.inference_optimizer.multi_node",
+        "finalize-patch",
+        "--records-json",
+        json.dumps(records_by_host, sort_keys=True),
+        "--timeout-sec",
+        str(timeout_sec),
+    ]
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout_sec,
+    )
+    out = (proc.stdout or "").strip()
+    try:
+        parsed = json.loads(out) if out.startswith("{") else {}
+    except json.JSONDecodeError:
+        parsed = {}
+    if proc.returncode != 0 or parsed.get("status") != "ok":
+        return {
+            "status": "partial",
+            "returncode": proc.returncode,
+            "result": parsed,
+            "stderr_tail": (proc.stderr or "")[-2000:],
+        }
+    return parsed
+
+
 def _safe_name(value: str) -> str:
     """Sanitize a filename component to a safe, short identifier.
 
@@ -914,6 +950,15 @@ def _target_is_in_aiter_csrc(target_file: Path) -> bool:
     return any(marker in norm for marker in _AITER_CSRC_MARKERS)
 
 
+def _target_uses_aiter_jit(target_file: Path) -> bool:
+    """Return whether a source belongs to an installed/editable AITER runtime."""
+    normalized = str(target_file).replace(os.sep, "/")
+    return (
+        _installed_aiter_runtime_root(target_file) is not None
+        or "/sgl-workspace/aiter/" in normalized
+    )
+
+
 def _aiter_jit_build_dir() -> Path | None:
     """Locate the importable aiter package's ``jit/build`` directory.
 
@@ -1448,6 +1493,7 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
         root = Path("/sgl-workspace/aiter")
         deploy_roots = _editable_kernel_deploy_roots()
         rebuild_mode = _REBUILD_MODE_COMMAND
+        jit_build_dir = "/sgl-workspace/aiter/aiter/jit/build"
         rebuild_command = ["/opt/venv/bin/python", "setup.py", "develop"]
         artifact_roots = [root]
     elif "/sgl-workspace/sglang/sgl-kernel/" in lower:
@@ -1836,6 +1882,76 @@ def revert_kernel_patch(manifest_path: str | Path) -> dict[str, Any]:
     return result
 
 
+def finalize_kernel_patch(manifest_path: str | Path) -> dict[str, Any]:
+    """Delete backups after an integrated patch becomes the new baseline."""
+    manifest_file = Path(manifest_path)
+    manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+    backup_root = manifest_file.resolve().parent
+    deleted: list[str] = []
+    issues: list[dict[str, Any]] = []
+    multinode = manifest.get("multinode") or {}
+    records_by_host = dict(multinode.get("records_by_host") or {})
+    remote_result: dict[str, Any] = {}
+    if records_by_host:
+        remote_result = _dispatch_multinode_finalize(records_by_host)
+        if remote_result.get("status") != "ok":
+            issues.append(
+                {"kind": "multinode_finalize", **remote_result}
+            )
+
+    candidates: set[str] = set()
+    for entry in manifest.get("artifacts") or []:
+        candidates.add(str(entry.get("backup_path") or ""))
+    for entry in manifest.get("source_backups") or []:
+        candidates.add(str(entry.get("backup_path") or ""))
+    source_backup = manifest.get("source_backup") or {}
+    candidates.add(str(source_backup.get("backup_path") or ""))
+    for key in ("jit_build_backup", "cpp_itfs_cache_backup"):
+        record = manifest.get(key) or {}
+        candidates.add(str(record.get("backup_path") or ""))
+
+    for raw in sorted(path for path in candidates if path):
+        path = Path(raw)
+        if not _within_root(path, backup_root):
+            issues.append(
+                {"kind": "untrusted_backup", "path": str(path)}
+            )
+            continue
+        try:
+            if path.is_dir():
+                shutil.rmtree(path)
+            elif path.exists():
+                path.unlink()
+            deleted.append(str(path))
+        except OSError as exc:
+            issues.append(
+                {
+                    "kind": "delete_failed",
+                    "path": str(path),
+                    "error": str(exc),
+                }
+            )
+
+    manifest["status"] = "finalized_partial" if issues else "finalized"
+    manifest["finalized_at"] = utc_now()
+    manifest["finalize_deleted"] = deleted
+    if remote_result:
+        manifest["multinode_finalize"] = remote_result
+    if issues:
+        manifest["finalize_issues"] = issues
+    manifest_file.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "status": "partial" if issues else "ok",
+        "manifest_path": str(manifest_file),
+        "deleted": deleted,
+        "issues": issues,
+        "multinode_finalize": remote_result,
+    }
+
+
 def _multi_root_strategies(
     live_paths: Iterable[Path],
     *,
@@ -2020,7 +2136,8 @@ def apply_kernel_patch(
     remote_jit_dir = (
         strategy_jit_dir
         if (
-            strategy.get("rebuild_mode") == _REBUILD_MODE_RUNTIME_JIT
+            strategy["compiled"]
+            and strategy_jit_dir
             and not skip_rebuild
         )
         else ""
@@ -2060,9 +2177,10 @@ def apply_kernel_patch(
         for entry in mn_apply.get("per_node", []) or []:
             host = (entry.get("host") or "").strip()
             bp = (entry.get("backup_path") or "").strip()
-            if host and bp:
-                backup_map[host] = bp
+            if host:
                 records_by_host.setdefault(host, []).append(dict(entry))
+                if bp:
+                    backup_map[host] = bp
         multinode_info = {
             "status": "ok",
             "target_path": str(target),
@@ -2315,15 +2433,15 @@ def _apply_kernel_patch_snapshot(
 
     rebuild_strategies = _multi_root_strategies(write_paths, allow_unknown_target=allow_unknown_target)
     compiled = bool(rebuild_strategies)
-    runtime_jit_strategies = [
+    jit_strategies = [
         strategy
         for strategy in rebuild_strategies
-        if strategy.get("rebuild_mode") == _REBUILD_MODE_RUNTIME_JIT
+        if strategy.get("jit_build_dir")
     ]
-    if len(runtime_jit_strategies) > 1:
+    if len(jit_strategies) > 1:
         return {
             "status": "failed",
-            "error": "snapshot spans multiple installed AITER runtime-JIT roots",
+            "error": "snapshot spans multiple AITER JIT roots",
         }
 
     artifacts: list[dict[str, str]] = []
@@ -2352,7 +2470,7 @@ def _apply_kernel_patch_snapshot(
             "jit_build_dirs": sorted(
                 {
                     str(strat["jit_build_dir"])
-                    for strat in runtime_jit_strategies
+                    for strat in jit_strategies
                     if strat.get("jit_build_dir")
                 }
             ),
@@ -2432,19 +2550,23 @@ def _apply_kernel_patch_snapshot(
 
     # Multi-node fan-out: push every write path to every pod.
     multinode_info: dict[str, Any] = {}
-    runtime_jit_strategy = (
-        runtime_jit_strategies[0] if runtime_jit_strategies else {}
+    jit_strategy = (
+        jit_strategies[0] if jit_strategies else {}
     )
     strategy_jit_dir = str(
-        runtime_jit_strategy.get("jit_build_dir") or ""
+        jit_strategy.get("jit_build_dir") or ""
     ).strip()
+    jit_dispatch_target = next(
+        (path for path in write_paths if _target_uses_aiter_jit(path)),
+        None,
+    )
     if _is_multi_node():
         pod_backup_dir = os.environ.get("HYPERLOOM_MN_KERNEL_BACKUP_DIR", _MN_POD_BACKUP_DIR_DEFAULT)
         per_node_all: list[dict[str, Any]] = []
         backup_map: dict[str, str] = {}
         records_by_host: dict[str, list[dict[str, Any]]] = {}
         try:
-            for index, p in enumerate(write_paths):
+            for p in write_paths:
                 mn_apply = _dispatch_multinode_apply(
                     target_file=p,
                     patch_path=snap / Path(p).relative_to(repo_root),
@@ -2452,7 +2574,11 @@ def _apply_kernel_patch_snapshot(
                     backup_dir_on_pod=pod_backup_dir,
                     jit_build_dir=(
                         strategy_jit_dir
-                        if index == 0 and strategy_jit_dir and not skip_rebuild
+                        if (
+                            p == jit_dispatch_target
+                            and strategy_jit_dir
+                            and not skip_rebuild
+                        )
                         else ""
                     ),
                 )
@@ -2461,11 +2587,12 @@ def _apply_kernel_patch_snapshot(
                 for entry in new_records:
                     host = (entry.get("host") or "").strip()
                     bp = (entry.get("backup_path") or "").strip()
-                    if host and bp:
-                        backup_map[host] = bp
+                    if host:
                         records_by_host.setdefault(host, []).append(
                             dict(entry)
                         )
+                        if bp:
+                            backup_map[host] = bp
                 multinode_info = {
                     "status": "partial",
                     "target_path": str(target),
@@ -2506,14 +2633,7 @@ def _apply_kernel_patch_snapshot(
     jit_build_backup: dict[str, Any] = {"status": "skipped", "reason": "rebuild not run"}
     cpp_itfs_cache_backup: dict[str, Any] = {"status": "skipped", "reason": "rebuild not run", "is_cpp_itfs": False}
     if compiled and not skip_rebuild:
-        aiter_jit_target = next(
-            (
-                path
-                for path in write_paths
-                if _target_is_in_aiter_csrc(path)
-            ),
-            target,
-        )
+        aiter_jit_target = jit_dispatch_target or target
         if _is_multi_node() and strategy_jit_dir:
             records_by_host = dict(
                 multinode_info.get("records_by_host") or {}
@@ -2555,7 +2675,7 @@ def _apply_kernel_patch_snapshot(
             ""
             if jit_build_backup.get("status") == "remote"
             else _runtime_jit_invalidation_error(
-                runtime_jit_strategy,
+                jit_strategy,
                 jit_build_backup,
             )
         )

--- a/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
+++ b/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
@@ -794,7 +794,10 @@ def _installed_aiter_runtime_root(target_file: Path) -> Path | None:
     into the sibling ``aiter_meta`` package. Both are runtime-JIT inputs and must
     share one deployment/rebuild strategy.
     """
-    target = target_file.resolve()
+    # Preserve the lexical install path: venv/site-packages is commonly a
+    # symlink, and resolving it here would make strategy classification disagree
+    # with the path matching performed by _detect_strategy.
+    target = target_file.absolute()
     for parent in target.parents:
         if (
             parent.name in {"aiter", "aiter_meta"}
@@ -852,8 +855,9 @@ def _invalidate_aiter_jit_build(
             Falls back to runtime discovery for non-runtime-JIT strategies.
 
     Returns:
-        A status dict with ``status`` of ``ok``, ``skipped``, or ``failed``
-        and supporting fields.
+        A status dict with ``status`` of ``ok`` (cache moved), ``clean``
+        (authoritative cache absent/empty), ``skipped``, or ``failed`` and
+        supporting fields.
     """
     if not _target_is_in_aiter_csrc(target_file):
         return {"status": "skipped", "reason": "target not under aiter/csrc/"}
@@ -1351,18 +1355,18 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
         root = installed_aiter_root
         rebuild_mode = _REBUILD_MODE_RUNTIME_JIT
         jit_build_dir = str(installed_aiter_root / "aiter" / "jit" / "build")
-        artifact_roots = [
-            package
-            for package in (
-                installed_aiter_root / "aiter",
-                installed_aiter_root / "aiter_meta",
-            )
-            if package.is_dir()
-        ]
+        # Runtime-JIT artifacts live under jit/build and are moved aside as one
+        # tree below. Recursively copying wheel .so/.co files here is redundant
+        # and can consume gigabytes per integration attempt.
+        artifact_roots = []
     elif allow_unknown_target:
         root = target_file.parent
 
-    if suffix in PYTHON_SOURCE_SUFFIXES and _target_is_in_aiter_csrc(target_file):
+    if (
+        suffix in PYTHON_SOURCE_SUFFIXES
+        and installed_aiter_root is not None
+        and _target_is_in_aiter_csrc(target_file)
+    ):
         compiled = True
     elif suffix in PYTHON_SOURCE_SUFFIXES:
         compiled = False
@@ -1370,7 +1374,7 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
         rebuild_command = []
         artifact_roots = []
         jit_build_dir = ""
-    elif compiled and root is None:
+    if root is None:
         root = target_file.parent
 
     return {
@@ -1461,11 +1465,13 @@ def _run_strategy_rebuild(
     strategy: dict[str, Any],
     *,
     command_override: list[str],
+    fallback_cwd: Path,
     timeout_sec: int,
 ) -> dict[str, Any]:
     """Run an eager rebuild or record a runtime-JIT handoff."""
-    command = command_override or list(strategy["rebuild_command"])
-    cwd = Path(strategy["root"])
+    command = command_override or list(strategy.get("rebuild_command") or [])
+    strategy_root = str(strategy.get("root") or "").strip()
+    cwd = Path(strategy_root) if strategy_root else fallback_cwd
     if command:
         return _run_rebuild(command, cwd, timeout_sec)
     if strategy.get("rebuild_mode") == _REBUILD_MODE_RUNTIME_JIT:
@@ -1505,7 +1511,7 @@ def _runtime_jit_invalidation_error(
     return ""
 
 
-def _rebuild_completed(result: dict[str, Any]) -> bool:
+def _rebuild_ok_to_proceed(result: dict[str, Any]) -> bool:
     """Return whether apply may proceed after this rebuild result."""
     return result.get("status") in {"ok", "deferred"}
 
@@ -1833,8 +1839,12 @@ def apply_kernel_patch(
         "strategy": {
             "compiled": strategy["compiled"],
             "root": strategy["root"],
-            "rebuild_mode": strategy["rebuild_mode"],
-            "jit_build_dir": strategy["jit_build_dir"],
+            "rebuild_modes": [strategy["rebuild_mode"]],
+            "jit_build_dirs": (
+                [strategy["jit_build_dir"]]
+                if strategy.get("jit_build_dir")
+                else []
+            ),
         },
         "created_at": utc_now(),
     }
@@ -1979,9 +1989,10 @@ def apply_kernel_patch(
         rebuild = _run_strategy_rebuild(
             strategy,
             command_override=command_override,
+            fallback_cwd=target.parent,
             timeout_sec=rebuild_timeout_sec,
         )
-        if not _rebuild_completed(rebuild):
+        if not _rebuild_ok_to_proceed(rebuild):
             revert = revert_kernel_patch(manifest_path)
             return {
                 "status": "failed",
@@ -2326,10 +2337,11 @@ def _apply_kernel_patch_snapshot(
             rec = _run_strategy_rebuild(
                 strat,
                 command_override=command_override,
+                fallback_cwd=target.parent,
                 timeout_sec=rebuild_timeout_sec,
             )
             rebuild_records.append(rec)
-            if not _rebuild_completed(rec):
+            if not _rebuild_ok_to_proceed(rec):
                 revert = revert_kernel_patch(manifest_path)
                 return {
                     "status": "failed",

--- a/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
+++ b/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
@@ -984,7 +984,7 @@ def _invalidate_aiter_jit_build(
             "src": str(jit_build),
         }
     backup_dir.mkdir(parents=True, exist_ok=True)
-    backup_path = backup_dir / "jit_build"
+    backup_path = backup_dir / f"jit_build_{time.time_ns()}"
     if backup_path.exists():
         return {
             "status": "failed",

--- a/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
+++ b/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
@@ -841,14 +841,15 @@ def _invalidate_aiter_jit_build(
     target_file: Path,
     backup_dir: Path,
     *,
-    jit_build_dir_override: Path | None = None,
+    jit_build_dir: Path | None = None,
 ) -> dict[str, Any]:
     """Move aiter ``jit/build/`` aside so a post-rebuild import re-JITs.
 
     Args:
         target_file: The file being patched (gates the operation).
         backup_dir: Directory to move the ``jit/build`` tree into.
-        jit_build_dir_override: Test-only override for the jit/build location.
+        jit_build_dir: Authoritative JIT build path from the apply strategy.
+            Falls back to runtime discovery for non-runtime-JIT strategies.
 
     Returns:
         A status dict with ``status`` of ``ok``, ``skipped``, or ``failed``
@@ -856,11 +857,15 @@ def _invalidate_aiter_jit_build(
     """
     if not _target_is_in_aiter_csrc(target_file):
         return {"status": "skipped", "reason": "target not under aiter/csrc/"}
-    jit_build = jit_build_dir_override or _aiter_jit_build_dir()
+    jit_build = jit_build_dir or _aiter_jit_build_dir()
     if jit_build is None:
         return {"status": "skipped", "reason": "aiter package not importable"}
     if not jit_build.exists():
-        return {"status": "skipped", "reason": "aiter jit/build/ does not exist"}
+        return {
+            "status": "clean",
+            "reason": "aiter jit/build/ does not exist",
+            "src": str(jit_build),
+        }
     try:
         is_empty = not any(jit_build.iterdir())
     except OSError as exc:
@@ -870,7 +875,11 @@ def _invalidate_aiter_jit_build(
             "src": str(jit_build),
         }
     if is_empty:
-        return {"status": "skipped", "reason": "aiter jit/build/ is empty"}
+        return {
+            "status": "clean",
+            "reason": "aiter jit/build/ is empty",
+            "src": str(jit_build),
+        }
     backup_dir.mkdir(parents=True, exist_ok=True)
     backup_path = backup_dir / "jit_build"
     if backup_path.exists():
@@ -896,7 +905,27 @@ def _invalidate_aiter_jit_build(
     }
 
 
-def _restore_aiter_jit_build(jit_build_backup: dict[str, Any]) -> dict[str, Any]:
+def _trusted_installed_aiter_jit_build_dir(path: Path) -> bool:
+    """Validate a strategy-persisted installed AITER JIT destination."""
+    resolved = path.resolve()
+    runtime_root = _installed_aiter_runtime_root(resolved)
+    if (
+        runtime_root is None
+        or resolved != (runtime_root / "aiter" / "jit" / "build").resolve()
+    ):
+        return False
+    return any(
+        Path(raw.rstrip("/")).is_absolute()
+        and _within_root(resolved, Path(raw.rstrip("/")))
+        for raw in known_target_roots()
+    )
+
+
+def _restore_aiter_jit_build(
+    jit_build_backup: dict[str, Any],
+    *,
+    expected_jit_build_dir: str | Path | None = None,
+) -> dict[str, Any]:
     """Restore an aiter ``jit/build`` backup, reversing the invalidation.
 
     Any regenerated ``jit/build`` directory is removed first.
@@ -904,24 +933,34 @@ def _restore_aiter_jit_build(jit_build_backup: dict[str, Any]) -> dict[str, Any]
     Args:
         jit_build_backup: The backup record returned by
             :func:`_invalidate_aiter_jit_build`.
+        expected_jit_build_dir: Apply-time strategy path. Runtime-JIT restores
+            use this instead of rediscovering aiter from the current process.
 
     Returns:
         A status dict with ``status`` of ``ok``, ``skipped``, or ``failed``.
     """
     if not isinstance(jit_build_backup, dict) or jit_build_backup.get("status") != "ok":
         return {"status": "skipped", "reason": "no backup recorded"}
-    src = Path(jit_build_backup.get("src", ""))
-    backup_path = Path(jit_build_backup.get("backup_path", ""))
-    if not src or not backup_path:
+    src_raw = str(jit_build_backup.get("src") or "").strip()
+    backup_raw = str(jit_build_backup.get("backup_path") or "").strip()
+    if not src_raw or not backup_raw:
         return {"status": "skipped", "reason": "incomplete backup record"}
+    src = Path(src_raw)
+    backup_path = Path(backup_raw)
     # The manifest is untrusted at revert time; ``src`` is an ``rmtree`` target.
-    # Only the importable aiter jit/build dir is a legitimate destination.
-    expected = _aiter_jit_build_dir()
-    if expected is None or not _within_root(src, expected):
+    # Only the strategy-pinned or importable aiter jit/build dir is legitimate.
+    expected_raw = str(expected_jit_build_dir or "").strip()
+    expected = Path(expected_raw) if expected_raw else _aiter_jit_build_dir()
+    if expected_raw and not _trusted_installed_aiter_jit_build_dir(expected):
+        return {
+            "status": "skipped",
+            "reason": f"untrusted strategy jit/build dir: {expected}",
+        }
+    if expected is None or src.resolve() != expected.resolve():
         log.warning(
             "revert: skipping jit/build restore; recorded src %s does not match the "
-            "importable aiter jit/build dir %s (aiter reinstalled/relocated, cross-process "
-            "resume, or a forged manifest). jit/build left invalidated; next import re-JITs.",
+            "strategy/import aiter jit/build dir %s (aiter reinstalled/relocated "
+            "or a forged manifest). jit/build left invalidated; next import re-JITs.",
             src,
             expected,
         )
@@ -1266,7 +1305,8 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
     Returns:
         dict[str, Any]: A strategy dict with ``compiled`` (bool), ``root``
             (str), ``rebuild_mode`` (str), ``rebuild_command`` (list[str]) and
-            ``artifact_roots`` (list[Path]).
+            ``artifact_roots`` (list[Path]). Runtime-JIT strategies also carry
+            the authoritative ``jit_build_dir``.
 
     Raises:
         ValueError: When the target is outside the known roots and
@@ -1284,6 +1324,7 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
     rebuild_mode = _REBUILD_MODE_NONE
     rebuild_command: list[str] = []
     artifact_roots: list[Path] = []
+    jit_build_dir = ""
     installed_aiter_root = _installed_aiter_runtime_root(target_file)
 
     if "/sgl-workspace/aiter/" in lower:
@@ -1309,6 +1350,7 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
     elif installed_aiter_root:
         root = installed_aiter_root
         rebuild_mode = _REBUILD_MODE_RUNTIME_JIT
+        jit_build_dir = str(installed_aiter_root / "aiter" / "jit" / "build")
         artifact_roots = [
             package
             for package in (
@@ -1327,6 +1369,7 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
         rebuild_mode = _REBUILD_MODE_NONE
         rebuild_command = []
         artifact_roots = []
+        jit_build_dir = ""
     elif compiled and root is None:
         root = target_file.parent
 
@@ -1336,6 +1379,7 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
         "rebuild_mode": rebuild_mode,
         "rebuild_command": rebuild_command,
         "artifact_roots": artifact_roots,
+        "jit_build_dir": jit_build_dir,
     }
 
 
@@ -1435,6 +1479,30 @@ def _run_strategy_rebuild(
             "cwd": str(cwd),
         }
     return _run_rebuild([], cwd, timeout_sec)
+
+
+def _runtime_jit_invalidation_error(
+    strategy: dict[str, Any],
+    result: dict[str, Any],
+) -> str:
+    """Return why a runtime-JIT strategy cannot safely defer compilation."""
+    if strategy.get("rebuild_mode") != _REBUILD_MODE_RUNTIME_JIT:
+        return ""
+    expected_raw = str(strategy.get("jit_build_dir") or "").strip()
+    actual_raw = str(result.get("src") or "").strip()
+    if not expected_raw:
+        return "runtime-JIT strategy has no authoritative jit_build_dir"
+    if not actual_raw or Path(actual_raw).resolve() != Path(expected_raw).resolve():
+        return (
+            "JIT invalidation did not inspect the strategy-pinned build dir "
+            f"{expected_raw}"
+        )
+    if result.get("status") not in {"ok", "clean"}:
+        return (
+            "strategy-pinned JIT build dir was not invalidated or proven clean: "
+            f"{result.get('reason') or result.get('error') or result.get('status')}"
+        )
+    return ""
 
 
 def _rebuild_completed(result: dict[str, Any]) -> bool:
@@ -1550,7 +1618,18 @@ def revert_kernel_patch(manifest_path: str | Path) -> dict[str, Any]:
     # Restore aiter jit/build/ (before multi-node fan-out) if apply moved it aside.
     jit_build_backup = manifest.get("jit_build_backup") or {}
     if jit_build_backup.get("status") == "ok":
-        jit_build_restore = _restore_aiter_jit_build(jit_build_backup)
+        strategy = manifest.get("strategy") or {}
+        expected_jit_build_dir = str(
+            strategy.get("jit_build_dir") or ""
+        ).strip()
+        if not expected_jit_build_dir:
+            snapshot_jit_dirs = list(strategy.get("jit_build_dirs") or [])
+            if len(snapshot_jit_dirs) == 1:
+                expected_jit_build_dir = str(snapshot_jit_dirs[0])
+        jit_build_restore = _restore_aiter_jit_build(
+            jit_build_backup,
+            expected_jit_build_dir=expected_jit_build_dir or None,
+        )
         manifest["jit_build_restore"] = jit_build_restore
         if jit_build_restore.get("status") == "ok" and jit_build_restore.get("restored_to"):
             restored.append(str(jit_build_restore["restored_to"]))
@@ -1755,6 +1834,7 @@ def apply_kernel_patch(
             "compiled": strategy["compiled"],
             "root": strategy["root"],
             "rebuild_mode": strategy["rebuild_mode"],
+            "jit_build_dir": strategy["jit_build_dir"],
         },
         "created_at": utc_now(),
     }
@@ -1836,27 +1916,39 @@ def apply_kernel_patch(
     }
     if strategy["compiled"] and not skip_rebuild:
         # Move aiter jit/build/ aside so post-rebuild import re-JITs cleanly.
-        jit_build_backup = _invalidate_aiter_jit_build(target, backup_dir)
-        if jit_build_backup.get("status") == "failed":
-            # Refuse to rebuild against an inconsistent jit cache: restore and bail.
-            try:
-                shutil.copy2(source_backup["backup_path"], target)
-            except OSError:
-                pass
-            return {
-                "status": "failed",
-                "error_class": "aiter_jit_invalidation_failed",
-                "error": (f"aiter jit/build/ invalidation failed: {jit_build_backup.get('error')}"),
-                "manifest_path": str(manifest_path),
-                "jit_build_backup": jit_build_backup,
-            }
-        if jit_build_backup.get("status") == "ok":
+        strategy_jit_dir = str(strategy.get("jit_build_dir") or "").strip()
+        jit_build_backup = _invalidate_aiter_jit_build(
+            target,
+            backup_dir,
+            jit_build_dir=Path(strategy_jit_dir) if strategy_jit_dir else None,
+        )
+        if jit_build_backup.get("status") in {"ok", "clean"}:
             # Persist the backup record before rebuild so a failure can still restore.
             manifest["jit_build_backup"] = jit_build_backup
             manifest_path.write_text(
                 json.dumps(manifest, indent=2, sort_keys=True) + "\n",
                 encoding="utf-8",
             )
+        invalidation_error = _runtime_jit_invalidation_error(
+            strategy,
+            jit_build_backup,
+        )
+        if jit_build_backup.get("status") == "failed" or invalidation_error:
+            # Refuse to benchmark against an unknown/stale binary.
+            revert = revert_kernel_patch(manifest_path)
+            detail = (
+                invalidation_error
+                or str(jit_build_backup.get("error") or "")
+                or str(jit_build_backup.get("reason") or "")
+            )
+            return {
+                "status": "failed",
+                "error_class": "aiter_jit_invalidation_failed",
+                "error": f"aiter jit/build/ invalidation failed: {detail}",
+                "manifest_path": str(manifest_path),
+                "jit_build_backup": jit_build_backup,
+                "revert": revert,
+            }
 
         # aiter cpp_itfs kernels runtime-compile into $HOME/.aiter/build/ with a param-hashed
         # dir name, so pristine + patched collide; move the cache aside for a clean re-baseline.
@@ -1903,7 +1995,7 @@ def apply_kernel_patch(
     manifest["applied_at"] = utc_now()
     manifest["rebuild"] = rebuild
     manifest["cache_clear"] = cache_clear
-    if jit_build_backup.get("status") in {"ok", "skipped"}:
+    if jit_build_backup.get("status") in {"ok", "clean", "skipped"}:
         # Surface skipped reason too for manifest auditing.
         manifest["jit_build_backup"] = jit_build_backup
     if cpp_itfs_cache_backup.get("status") in {"ok", "skipped"}:
@@ -2009,6 +2101,16 @@ def _apply_kernel_patch_snapshot(
 
     rebuild_strategies = _multi_root_strategies(write_paths, allow_unknown_target=allow_unknown_target)
     compiled = bool(rebuild_strategies)
+    runtime_jit_strategies = [
+        strategy
+        for strategy in rebuild_strategies
+        if strategy.get("rebuild_mode") == _REBUILD_MODE_RUNTIME_JIT
+    ]
+    if len(runtime_jit_strategies) > 1:
+        return {
+            "status": "failed",
+            "error": "snapshot spans multiple installed AITER runtime-JIT roots",
+        }
 
     artifacts: list[dict[str, str]] = []
     if compiled:
@@ -2031,6 +2133,13 @@ def _apply_kernel_patch_snapshot(
             "root": str(repo_root),
             "rebuild_modes": sorted(
                 {strat["rebuild_mode"] for strat in rebuild_strategies}
+            ),
+            "jit_build_dirs": sorted(
+                {
+                    str(strat["jit_build_dir"])
+                    for strat in runtime_jit_strategies
+                    if strat.get("jit_build_dir")
+                }
             ),
         },
         "created_at": utc_now(),
@@ -2152,22 +2261,39 @@ def _apply_kernel_patch_snapshot(
             ),
             target,
         )
+        runtime_jit_strategy = (
+            runtime_jit_strategies[0] if runtime_jit_strategies else {}
+        )
+        strategy_jit_dir = str(
+            runtime_jit_strategy.get("jit_build_dir") or ""
+        ).strip()
         jit_build_backup = _invalidate_aiter_jit_build(
             aiter_jit_target,
             backup_dir,
+            jit_build_dir=Path(strategy_jit_dir) if strategy_jit_dir else None,
         )
-        if jit_build_backup.get("status") == "failed":
-            revert_kernel_patch(manifest_path)
+        if jit_build_backup.get("status") in {"ok", "clean"}:
+            manifest["jit_build_backup"] = jit_build_backup
+            manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        invalidation_error = _runtime_jit_invalidation_error(
+            runtime_jit_strategy,
+            jit_build_backup,
+        )
+        if jit_build_backup.get("status") == "failed" or invalidation_error:
+            revert = revert_kernel_patch(manifest_path)
+            detail = (
+                invalidation_error
+                or str(jit_build_backup.get("error") or "")
+                or str(jit_build_backup.get("reason") or "")
+            )
             return {
                 "status": "failed",
                 "error_class": "aiter_jit_invalidation_failed",
-                "error": f"aiter jit/build/ invalidation failed: {jit_build_backup.get('error')}",
+                "error": f"aiter jit/build/ invalidation failed: {detail}",
                 "manifest_path": str(manifest_path),
                 "jit_build_backup": jit_build_backup,
+                "revert": revert,
             }
-        if jit_build_backup.get("status") == "ok":
-            manifest["jit_build_backup"] = jit_build_backup
-            manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
         cpp_itfs_target = next(
             (
@@ -2218,7 +2344,7 @@ def _apply_kernel_patch_snapshot(
     manifest["applied_at"] = utc_now()
     manifest["rebuild"] = rebuild
     manifest["cache_clear"] = cache_clear
-    if jit_build_backup.get("status") in {"ok", "skipped"}:
+    if jit_build_backup.get("status") in {"ok", "clean", "skipped"}:
         manifest["jit_build_backup"] = jit_build_backup
     if cpp_itfs_cache_backup.get("status") in {"ok", "skipped"}:
         manifest["cpp_itfs_cache_backup"] = cpp_itfs_cache_backup

--- a/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
+++ b/src/hyperloom/agents/kernel/tools/apply_kernel_patch.py
@@ -590,8 +590,10 @@ def _contained_dest(
     if deploy_roots is not None:
         allowed = [Path(path).resolve() for path in deploy_roots]
         if not any(_within_root(dest, allowed_root) for allowed_root in allowed):
+            roots_text = ", ".join(str(path) for path in allowed) or "<none>"
             raise ValueError(
-                f"patch path is outside authorized deploy roots: {rel_path}"
+                "patch path is outside authorized deploy roots: "
+                f"{rel_path}; authorized roots: {roots_text}"
             )
     return dest
 
@@ -627,8 +629,8 @@ def apply_snapshot(
     descriptors: list[dict[str, Any]],
     snapshot_dir: str | Path,
     repo_root: str | Path,
-    deploy_roots: Iterable[str | Path],
     backup_dir: str | Path,
+    deploy_roots: Iterable[str | Path] | None = None,
 ) -> dict[str, Any]:
     """Apply a content-addressed snapshot atomically (all-or-nothing).
 
@@ -646,10 +648,11 @@ def apply_snapshot(
         snapshot_dir (str | Path): Directory holding byte-exact final contents
             for every ``write`` path (mirrored at the same relative path).
         repo_root (str | Path): Framework repo root the targets live under.
-        deploy_roots (Iterable[str | Path]): Authorized framework roots under
-            which every write/delete destination must remain.
         backup_dir (str | Path): Where per-path backups + the revert manifest
             are written.
+        deploy_roots (Iterable[str | Path] | None): Authorized framework roots
+            under which every write/delete destination must remain. ``None``
+            preserves the legacy coordinate-root-only contract.
 
     Returns:
         dict[str, Any]: ``status="ok"`` with ``source_backups`` (the revert
@@ -657,7 +660,12 @@ def apply_snapshot(
             an ``error`` and the offending path.
     """
     root = Path(repo_root)
-    allowed_roots = [Path(path) for path in deploy_roots]
+    allowed_roots = (
+        None
+        if deploy_roots is None
+        else [Path(path) for path in deploy_roots]
+    )
+    symlink_roots = [root] if allowed_roots is None else allowed_roots
     snap = Path(snapshot_dir)
     backups: list[dict[str, Any]] = []
 
@@ -688,7 +696,7 @@ def apply_snapshot(
                     ).resolve()
                     if not any(
                         _within_root(resolved_link, allowed_root)
-                        for allowed_root in allowed_roots
+                        for allowed_root in symlink_roots
                     ):
                         return {
                             "status": "failed",
@@ -938,8 +946,14 @@ def _invalidate_aiter_jit_build(
         (authoritative cache absent/empty), ``skipped``, or ``failed`` and
         supporting fields.
     """
-    if not _target_is_in_aiter_csrc(target_file):
-        return {"status": "skipped", "reason": "target not under aiter/csrc/"}
+    if jit_build_dir is None and not _target_is_in_aiter_csrc(target_file):
+        return {
+            "status": "skipped",
+            "reason": (
+                "target is outside aiter csrc and no runtime-JIT build dir "
+                "was supplied"
+            ),
+        }
     jit_build = jit_build_dir or _aiter_jit_build_dir()
     if jit_build is None:
         return {"status": "skipped", "reason": "aiter package not importable"}
@@ -997,10 +1011,9 @@ def _trusted_installed_aiter_jit_build_dir(path: Path) -> bool:
         or resolved != (runtime_root / "aiter" / "jit" / "build").resolve()
     ):
         return False
-    return any(
-        Path(raw.rstrip("/")).is_absolute()
-        and _within_root(resolved, Path(raw.rstrip("/")))
-        for raw in known_target_roots()
+    return (
+        (runtime_root / "aiter" / "__init__.py").is_file()
+        and (runtime_root / "aiter" / "jit" / "__init__.py").is_file()
     )
 
 
@@ -1008,6 +1021,7 @@ def _restore_aiter_jit_build(
     jit_build_backup: dict[str, Any],
     *,
     expected_jit_build_dir: str | Path | None = None,
+    backup_root: str | Path | None = None,
 ) -> dict[str, Any]:
     """Restore an aiter ``jit/build`` backup, reversing the invalidation.
 
@@ -1018,6 +1032,8 @@ def _restore_aiter_jit_build(
             :func:`_invalidate_aiter_jit_build`.
         expected_jit_build_dir: Apply-time strategy path. Runtime-JIT restores
             use this instead of rediscovering aiter from the current process.
+        backup_root: Apply manifest's backup directory. The recorded backup
+            must remain contained under this root.
 
     Returns:
         A status dict with ``status`` of ``ok``, ``skipped``, or ``failed``.
@@ -1030,14 +1046,22 @@ def _restore_aiter_jit_build(
         return {"status": "skipped", "reason": "incomplete backup record"}
     src = Path(src_raw)
     backup_path = Path(backup_raw)
+    if backup_root is not None and not _within_root(
+        backup_path,
+        Path(backup_root),
+    ):
+        return {
+            "status": "failed",
+            "error": f"untrusted jit/build backup path: {backup_path}",
+        }
     # The manifest is untrusted at revert time; ``src`` is an ``rmtree`` target.
     # Only the strategy-pinned or importable aiter jit/build dir is legitimate.
     expected_raw = str(expected_jit_build_dir or "").strip()
     expected = Path(expected_raw) if expected_raw else _aiter_jit_build_dir()
     if expected_raw and not _trusted_installed_aiter_jit_build_dir(expected):
         return {
-            "status": "skipped",
-            "reason": f"untrusted strategy jit/build dir: {expected}",
+            "status": "failed",
+            "error": f"untrusted strategy jit/build dir: {expected}",
         }
     if expected is None or src.resolve() != expected.resolve():
         log.warning(
@@ -1048,13 +1072,13 @@ def _restore_aiter_jit_build(
             expected,
         )
         return {
-            "status": "skipped",
-            "reason": f"jit/build src {src} is not the importable aiter jit/build dir",
+            "status": "failed",
+            "error": f"jit/build src {src} does not match expected dir {expected}",
         }
     if not backup_path.exists():
         return {
-            "status": "skipped",
-            "reason": f"backup path missing: {backup_path}",
+            "status": "failed",
+            "error": f"backup path missing: {backup_path}",
         }
     if src.exists():
         try:
@@ -1398,7 +1422,9 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
     target = str(target_file)
     lower = target.lower()
     roots = known_target_roots()
-    if not allow_unknown_target and not any(root in lower for root in roots):
+    if not allow_unknown_target and not any(
+        str(root).lower() in lower for root in roots
+    ):
         raise ValueError(f"target_file is outside known reusable source roots: {target_file}")
 
     suffix = target_file.suffix.lower()
@@ -1464,9 +1490,7 @@ def _detect_strategy(target_file: Path, *, allow_unknown_target: bool) -> dict[s
         rebuild_command = []
         artifact_roots = []
         jit_build_dir = ""
-    if root is None:
-        root = target_file.parent
-    if not deploy_roots:
+    if not deploy_roots and root is not None:
         deploy_roots = [root]
 
     return {
@@ -1645,6 +1669,7 @@ def revert_kernel_patch(manifest_path: str | Path) -> dict[str, Any]:
     backup_root = manifest_file.resolve().parent
     restored: list[str] = []
     skipped_untrusted_backups: list[dict[str, str]] = []
+    revert_issues: list[dict[str, Any]] = []
     for item in manifest.get("artifacts", []):
         src = Path(item["backup_path"])
         dst = Path(item["path"])
@@ -1716,8 +1741,10 @@ def revert_kernel_patch(manifest_path: str | Path) -> dict[str, Any]:
 
     # Restore aiter jit/build/ (before multi-node fan-out) if apply moved it aside.
     jit_build_backup = manifest.get("jit_build_backup") or {}
+    jit_build_restore: dict[str, Any] = {}
     if jit_build_backup.get("status") == "ok":
         strategy = manifest.get("strategy") or {}
+        # Singular key is retained for manifests created by earlier releases.
         expected_jit_build_dir = str(
             strategy.get("jit_build_dir") or ""
         ).strip()
@@ -1728,10 +1755,18 @@ def revert_kernel_patch(manifest_path: str | Path) -> dict[str, Any]:
         jit_build_restore = _restore_aiter_jit_build(
             jit_build_backup,
             expected_jit_build_dir=expected_jit_build_dir or None,
+            backup_root=backup_root,
         )
         manifest["jit_build_restore"] = jit_build_restore
         if jit_build_restore.get("status") == "ok" and jit_build_restore.get("restored_to"):
             restored.append(str(jit_build_restore["restored_to"]))
+        elif jit_build_restore.get("status") != "ok":
+            revert_issues.append(
+                {
+                    "kind": "jit_build_restore",
+                    **jit_build_restore,
+                }
+            )
 
     # Restore the aiter cpp_itfs runtime cache moved aside during apply.
     cpp_itfs_cache_backup = manifest.get("cpp_itfs_cache_backup") or {}
@@ -1757,22 +1792,29 @@ def revert_kernel_patch(manifest_path: str | Path) -> dict[str, Any]:
                 mn_revert = {"status": "failed", "error": str(exc)}
 
     reverted_at = utc_now()
-    manifest["status"] = "reverted_partial" if skipped_untrusted_backups else "reverted"
+    partial = bool(skipped_untrusted_backups or revert_issues)
+    manifest["status"] = "reverted_partial" if partial else "reverted"
     manifest["reverted_at"] = reverted_at
     manifest["restored_paths"] = restored
     if skipped_untrusted_backups:
         manifest["skipped_untrusted_backups"] = skipped_untrusted_backups
+    if revert_issues:
+        manifest["revert_issues"] = revert_issues
     if mn_revert:
         manifest["multinode_revert"] = mn_revert
     manifest_file.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     result: dict[str, Any] = {
-        "status": "partial" if skipped_untrusted_backups else "ok",
+        "status": "partial" if partial else "ok",
         "manifest_path": str(manifest_file),
         "restored_paths": restored,
         "reverted_at": reverted_at,
     }
+    if jit_build_restore:
+        result["jit_build_restore"] = jit_build_restore
     if skipped_untrusted_backups:
         result["skipped_untrusted_backups"] = skipped_untrusted_backups
+    if revert_issues:
+        result["revert_issues"] = revert_issues
     # Only attach multinode_revert when fan-out actually ran.
     if mn_revert:
         result["multinode_revert"] = mn_revert

--- a/src/hyperloom/inference_optimizer/multi_node/cli.py
+++ b/src/hyperloom/inference_optimizer/multi_node/cli.py
@@ -1190,6 +1190,27 @@ def _build_multinode_revert_patch_entrypoint(
     )
 
 
+def _build_multinode_finalize_patch_entrypoint(
+    records_json: str,
+    timeout_sec: int,
+) -> str:
+    """Compose the head-pod entrypoint that finalizes accepted backups."""
+    pps = _read_pod_script("patch_path_safety.py")
+    py = _read_pod_script("kernel_patch_multinode.py")
+    return (
+        f"{_MN_ENTRYPOINT_PREAMBLE}"
+        f'cat > "$WORK_DIR/patch_path_safety.py" '
+        f"<<'__MN_PPATH_EOF__'\n"
+        f"{pps}__MN_PPATH_EOF__\n"
+        f'cat > "$WORK_DIR/kernel_patch_multinode.py" '
+        f"<<'__MN_KPATCH_PY_EOF__'\n"
+        f"{py}__MN_KPATCH_PY_EOF__\n"
+        f'python3 "$WORK_DIR/kernel_patch_multinode.py" finalize '
+        f"--records-json {shlex.quote(str(records_json))} "
+        f"--timeout-sec {int(timeout_sec)}"
+    )
+
+
 def _build_multinode_apply_tracelens_patch_entrypoint(
     tracelens_root: str,
     sglang_version_pin: str,
@@ -1411,6 +1432,7 @@ from .commands.infera import (
     _infera_kill_inference as _infera_kill_inference,
     _infera_apply_tracelens_patch as _infera_apply_tracelens_patch,
     _infera_apply_patch as _infera_apply_patch,
+    _infera_finalize_patch as _infera_finalize_patch,
     _infera_revert_patch as _infera_revert_patch,
     _infera_kernel_bench as _infera_kernel_bench,
     cmd_install_geak as cmd_install_geak,
@@ -1543,6 +1565,36 @@ def cmd_revert_patch(args: argparse.Namespace) -> int:
         err("revert-patch: could not parse per-pod JSON from dashboard logs")
         if args.print_logs:
             print(logs)
+        return EXIT_TRANSIENT
+    print(json.dumps(parsed, indent=2, sort_keys=True))
+    return rc
+
+
+def cmd_finalize_patch(args: argparse.Namespace) -> int:
+    """Delete backups after a patch becomes the accepted baseline."""
+    if _load_state().get("backend") == "infera":
+        return _infera_finalize_patch(args)
+    state = _load_state()
+    if not (state.get("head_pod_ip") or "").strip():
+        return EXIT_CONFIG_ERROR
+    try:
+        records = json.loads(args.records_json or "{}")
+    except json.JSONDecodeError:
+        return EXIT_CONFIG_ERROR
+    if not records:
+        return EXIT_CONFIG_ERROR
+    entrypoint = _build_multinode_finalize_patch_entrypoint(
+        args.records_json,
+        args.timeout_sec,
+    )
+    rc, parsed, _logs = _submit_and_collect_pod_json(
+        state,
+        entrypoint,
+        label="finalize-patch",
+        poll_interval=args.poll_interval,
+        poll_timeout=_poll_timeout_from_args(args),
+    )
+    if parsed is None:
         return EXIT_TRANSIENT
     print(json.dumps(parsed, indent=2, sort_keys=True))
     return rc
@@ -2343,6 +2395,15 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--print-logs", action="store_true")
     _add_common_poll_flags(sp)
     sp.set_defaults(func=cmd_revert_patch)
+
+    sp = sub.add_parser(
+        "finalize-patch",
+        help="delete backups for a patch accepted as the new baseline",
+    )
+    sp.add_argument("--records-json", required=True)
+    sp.add_argument("--timeout-sec", type=int, default=60)
+    _add_common_poll_flags(sp)
+    sp.set_defaults(func=cmd_finalize_patch)
 
     # apply-tracelens-patch (multi-node only)
     sp = sub.add_parser(

--- a/src/hyperloom/inference_optimizer/multi_node/cli.py
+++ b/src/hyperloom/inference_optimizer/multi_node/cli.py
@@ -1121,6 +1121,7 @@ def _build_multinode_apply_patch_entrypoint(
     backup_dir: str,
     kernel_id: str,
     timeout_sec: int,
+    jit_build_dir: str = "",
 ) -> str:
     """Compose the head-pod entrypoint that fans out a kernel patch to every pod via heredoc-embedded kernel_patch_multinode.py.
 
@@ -1149,6 +1150,7 @@ def _build_multinode_apply_patch_entrypoint(
         f"--patch-b64 {shlex.quote(str(patch_b64))} "
         f"--backup-dir {shlex.quote(str(backup_dir))} "
         f"--kernel-id {shlex.quote(str(kernel_id))} "
+        f"--jit-build-dir {shlex.quote(str(jit_build_dir))} "
         f"--timeout-sec {int(timeout_sec)}"
     )
 
@@ -1157,6 +1159,7 @@ def _build_multinode_revert_patch_entrypoint(
     target_path: str,
     backup_map_json: str,
     timeout_sec: int,
+    records_json: str = "",
 ) -> str:
     """Compose the head-pod entrypoint that fans out a revert via heredoc-embedded kernel_patch_multinode.py (``backup_map_json`` from the matching apply).
 
@@ -1181,6 +1184,7 @@ def _build_multinode_revert_patch_entrypoint(
         f"{py}__MN_KPATCH_PY_EOF__\n"
         f'python3 "$WORK_DIR/kernel_patch_multinode.py" revert '
         f"--target-path {shlex.quote(str(target_path))} "
+        f"--records-json {shlex.quote(str(records_json))} "
         f"--backup-map-json {shlex.quote(str(backup_map_json))} "
         f"--timeout-sec {int(timeout_sec)}"
     )
@@ -1468,6 +1472,7 @@ def cmd_apply_patch(args: argparse.Namespace) -> int:
         args.backup_dir,
         args.kernel_id,
         args.timeout_sec,
+        str(args.jit_build_dir or ""),
     )
     rc, parsed, logs = _submit_and_collect_pod_json(
         state,
@@ -1509,20 +1514,23 @@ def cmd_revert_patch(args: argparse.Namespace) -> int:
         return EXIT_CONFIG_ERROR
 
     try:
+        decoded_records = json.loads(args.records_json or "{}")
         decoded_map = json.loads(args.backup_map_json or "{}")
     except json.JSONDecodeError as exc:
-        err(f"--backup-map-json is not valid JSON: {exc}")
+        err(f"revert records JSON is invalid: {exc}")
         return EXIT_CONFIG_ERROR
-    if not decoded_map:
-        err("--backup-map-json must be a non-empty {host: backup_path} object")
+    if not decoded_records and not decoded_map:
+        err("revert requires non-empty --records-json or --backup-map-json")
         return EXIT_CONFIG_ERROR
 
-    info(f"revert-patch: target={args.target_path} backup_hosts={list(decoded_map.keys())}")
+    hosts = list((decoded_records or decoded_map).keys())
+    info(f"revert-patch: target={args.target_path} backup_hosts={hosts}")
 
     entrypoint = _build_multinode_revert_patch_entrypoint(
         args.target_path,
         args.backup_map_json,
         args.timeout_sec,
+        args.records_json,
     )
     rc, parsed, logs = _submit_and_collect_pod_json(
         state,
@@ -2313,6 +2321,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="directory on each pod where the pre-patch original is saved (e.g. /var/kernel_patch_backups)",
     )
     sp.add_argument("--kernel-id", default="", help="optional id used to construct backup filename")
+    sp.add_argument("--jit-build-dir", default="")
     sp.add_argument("--timeout-sec", type=int, default=120, help="per-actor timeout (default 120s)")
     sp.add_argument("--print-logs", action="store_true", help="dump full dashboard job_logs on parse failure")
     _add_common_poll_flags(sp)
@@ -2323,10 +2332,11 @@ def build_parser() -> argparse.ArgumentParser:
         "revert-patch",
         help="fan-out a kernel patch revert; multi-node only",
     )
-    sp.add_argument("--target-path", required=True)
+    sp.add_argument("--target-path", default="")
+    sp.add_argument("--records-json", default="")
     sp.add_argument(
         "--backup-map-json",
-        required=True,
+        default="",
         help="JSON object {hostname: backup_path} from the matching apply-patch result",
     )
     sp.add_argument("--timeout-sec", type=int, default=60)

--- a/src/hyperloom/inference_optimizer/multi_node/commands/infera.py
+++ b/src/hyperloom/inference_optimizer/multi_node/commands/infera.py
@@ -842,7 +842,8 @@ def _infera_apply_patch(args: argparse.Namespace) -> int:
         f"apply --target-path {shlex.quote(str(args.target_path))} "
         f"--patch-b64 {shlex.quote(str(patch_b64))} "
         f"--backup-dir {shlex.quote(str(args.backup_dir))} "
-        f"--kernel-id {shlex.quote(str(args.kernel_id))}"
+        f"--kernel-id {shlex.quote(str(args.kernel_id))} "
+        f"--jit-build-dir {shlex.quote(str(args.jit_build_dir or ''))}"
     )
     per_node: list[dict] = []
     failures: list[dict] = []
@@ -864,6 +865,22 @@ def _infera_apply_patch(args: argparse.Namespace) -> int:
                     **tx,
                 }
             )
+    rollback: list[dict] = []
+    if failures:
+        for record in per_node:
+            ip = str(record.get("host") or "")
+            target = _infera_target_for_host(state, ip)
+            op_args = (
+                "revert --records-json "
+                f"{shlex.quote(json.dumps([record], sort_keys=True))}"
+            )
+            parsed, tx = _infera_ssh_node_op(
+                state,
+                target,
+                op_args,
+                timeout=args.timeout_sec,
+            )
+            rollback.append({"host": ip, **(parsed or tx)})
     payload = {
         "command": "apply",
         "target_path": args.target_path,
@@ -871,6 +888,7 @@ def _infera_apply_patch(args: argparse.Namespace) -> int:
         "backup_dir": args.backup_dir,
         "per_node": per_node,
         "failures": failures,
+        "rollback": rollback,
         "status": "ok" if not failures else "partial",
     }
     print(json.dumps(payload, indent=2, sort_keys=True))
@@ -889,21 +907,33 @@ def _infera_revert_patch(args: argparse.Namespace) -> int:
     """
     state = _infera_require_state()
     try:
+        records_by_host = json.loads(args.records_json or "{}")
         backup_map = json.loads(args.backup_map_json or "{}")
     except json.JSONDecodeError as exc:
         err(f"--backup-map-json not valid JSON: {exc}")
         return EXIT_CONFIG_ERROR
-    if not backup_map:
-        err("--backup-map-json must be a non-empty {host: backup_path} object")
+    if not records_by_host and not backup_map:
+        err("revert requires non-empty records or backup map")
         return EXIT_CONFIG_ERROR
+    if not records_by_host:
+        records_by_host = {
+            host: [
+                {
+                    "target_path": args.target_path,
+                    "backup_path": backup_path,
+                }
+            ]
+            for host, backup_path in backup_map.items()
+        }
     per_node: list[dict] = []
     failures: list[dict] = []
-    for ip, backup_path in backup_map.items():
+    for ip, records in records_by_host.items():
         target = _infera_target_for_host(state, str(ip))
         port = int(target.get("sshPort") or _mn_cli._infera_default_ssh_port(state))
         info(f"revert-patch (infera): ssh -> {ip}:{port}")
         op_args = (
-            f"revert --target-path {shlex.quote(str(args.target_path))} --backup-path {shlex.quote(str(backup_path))}"
+            "revert --records-json "
+            f"{shlex.quote(json.dumps(records, sort_keys=True))}"
         )
         parsed, tx = _infera_ssh_node_op(state, target, op_args, timeout=args.timeout_sec)
         if parsed and str(parsed.get("status")) in ("restored", "noop_missing_backup"):

--- a/src/hyperloom/inference_optimizer/multi_node/commands/infera.py
+++ b/src/hyperloom/inference_optimizer/multi_node/commands/infera.py
@@ -843,7 +843,8 @@ def _infera_apply_patch(args: argparse.Namespace) -> int:
         f"--patch-b64 {shlex.quote(str(patch_b64))} "
         f"--backup-dir {shlex.quote(str(args.backup_dir))} "
         f"--kernel-id {shlex.quote(str(args.kernel_id))} "
-        f"--jit-build-dir {shlex.quote(str(args.jit_build_dir or ''))}"
+        f"--jit-build-dir "
+        f"{shlex.quote(str(getattr(args, 'jit_build_dir', '') or ''))}"
     )
     per_node: list[dict] = []
     failures: list[dict] = []
@@ -907,7 +908,9 @@ def _infera_revert_patch(args: argparse.Namespace) -> int:
     """
     state = _infera_require_state()
     try:
-        records_by_host = json.loads(args.records_json or "{}")
+        records_by_host = json.loads(
+            getattr(args, "records_json", "") or "{}"
+        )
         backup_map = json.loads(args.backup_map_json or "{}")
     except json.JSONDecodeError as exc:
         err(f"--backup-map-json not valid JSON: {exc}")

--- a/src/hyperloom/inference_optimizer/multi_node/commands/infera.py
+++ b/src/hyperloom/inference_optimizer/multi_node/commands/infera.py
@@ -954,6 +954,54 @@ def _infera_revert_patch(args: argparse.Namespace) -> int:
     return 0 if not failures else 1
 
 
+def _infera_finalize_patch(args: argparse.Namespace) -> int:
+    """Delete accepted patch backups on each Infera pod."""
+    state = _infera_require_state()
+    try:
+        records_by_host = json.loads(args.records_json or "{}")
+    except json.JSONDecodeError as exc:
+        err(f"--records-json not valid JSON: {exc}")
+        return EXIT_CONFIG_ERROR
+    per_node, failures = [], []
+    for ip, records in records_by_host.items():
+        target = _infera_target_for_host(state, str(ip))
+        op_args = (
+            "finalize --records-json "
+            f"{shlex.quote(json.dumps(records, sort_keys=True))}"
+        )
+        parsed, tx = _infera_ssh_node_op(
+            state,
+            target,
+            op_args,
+            timeout=args.timeout_sec,
+        )
+        if parsed and str(parsed.get("status")) == "finalized":
+            per_node.append({"host": ip, **parsed})
+        else:
+            failures.append(
+                {
+                    "host": ip,
+                    "error": (parsed or {}).get("error")
+                    or tx.get("stderr")
+                    or "unknown",
+                    **tx,
+                }
+            )
+    print(
+        json.dumps(
+            {
+                "command": "finalize",
+                "per_node": per_node,
+                "failures": failures,
+                "status": "ok" if not failures else "partial",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0 if not failures else 1
+
+
 def _infera_kernel_bench(args: argparse.Namespace) -> int:
     """Infera kernel-bench: run the micro-benchmark on ONE GPU pod over SSH.
 

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/kernel_node_ops.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/kernel_node_ops.py
@@ -42,6 +42,8 @@ from patch_path_safety import (  # noqa: E402
     assert_backup_dir_allowed,
     assert_revert_paths_allowed,
     assert_target_path_allowed,
+    invalidate_aiter_jit_build,
+    restore_aiter_jit_build,
 )
 
 _MAX_ARTIFACT_BYTES = 1 * 1024 * 1024
@@ -110,15 +112,21 @@ def _do_apply(a: argparse.Namespace) -> int:
         data = base64.b64decode(a.patch_b64.encode("ascii"))
     except Exception as exc:  # noqa: BLE001
         return _emit({"status": "failed", "host": host, "error": f"patch_b64 not valid base64: {exc!r}"})
-    atomic_write_bytes(target, data)
+    jit_backup = invalidate_aiter_jit_build(
+        Path(a.jit_build_dir) if a.jit_build_dir else None,
+        bdir,
+        f"{_safe_name(a.kernel_id or target.stem)}_{host}_{int(time.time())}",
+    )
     compile_result: dict[str, Any] = {"status": "skipped", "reason": "non-py target"}
-    if target.suffix.lower() == ".py":
-        try:
+    try:
+        atomic_write_bytes(target, data)
+        if target.suffix.lower() == ".py":
             py_compile.compile(str(target), doraise=True)
             compile_result = {"status": "ok"}
-        except py_compile.PyCompileError as exc:
-            shutil.copy2(backup_path, target)
-            return _emit({"status": "failed", "host": host, "error": f"py_compile failed (auto-reverted): {exc.msg}"})
+    except Exception as exc:  # noqa: BLE001
+        shutil.copy2(backup_path, target)
+        restore_aiter_jit_build(jit_backup)
+        return _emit({"status": "failed", "host": host, "error": str(exc)})
     return _emit(
         {
             "status": "ok",
@@ -127,6 +135,7 @@ def _do_apply(a: argparse.Namespace) -> int:
             "backup_path": str(backup_path),
             "wrote_bytes": len(data),
             "compile": compile_result,
+            "jit_backup": jit_backup,
         }
     )
 
@@ -145,19 +154,47 @@ def _do_revert(a: argparse.Namespace) -> int:
         int: the process exit code from emitting the result.
     """
     host = socket.gethostname()
-    target = Path(a.target_path)
-    backup = Path(a.backup_path)
-    if not backup.is_file():
-        return _emit(
-            {"status": "noop_missing_backup", "host": host, "target_path": str(target), "backup_path": str(backup)}
-        )
+    records = json.loads(a.records_json or "[]")
+    if not records and a.target_path and a.backup_path:
+        records = [
+            {
+                "target_path": a.target_path,
+                "backup_path": a.backup_path,
+            }
+        ]
+    if not records:
+        return _emit({"status": "failed", "host": host, "error": "empty revert records"})
+    restored: list[str] = []
+    jit_records: list[dict] = []
     try:
-        assert_revert_paths_allowed(target, backup)
-    except ValueError as exc:
+        for record in reversed(records):
+            target = Path(str(record.get("target_path") or ""))
+            backup = Path(str(record.get("backup_path") or ""))
+            if not backup.is_file():
+                raise FileNotFoundError(f"backup missing: {backup}")
+            assert_revert_paths_allowed(target, backup)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(backup, target)
+            restored.append(str(target))
+            jit_record = record.get("jit_backup")
+            if isinstance(jit_record, dict) and jit_record.get("status") in {"ok", "clean"}:
+                jit_records.append(jit_record)
+        jit_restore = {"status": "skipped", "reason": "no JIT backup"}
+        if jit_records:
+            first = jit_records[0]
+            if any(record != first for record in jit_records[1:]):
+                raise ValueError("conflicting JIT backup records")
+            jit_restore = restore_aiter_jit_build(first)
+    except Exception as exc:  # noqa: BLE001
         return _emit({"status": "failed", "host": host, "error": str(exc)})
-    target.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(backup, target)
-    return _emit({"status": "restored", "host": host, "target_path": str(target), "backup_path": str(backup)})
+    return _emit(
+        {
+            "status": "restored",
+            "host": host,
+            "restored_targets": restored,
+            "jit_restore": jit_restore,
+        }
+    )
 
 
 def _do_bench(a: argparse.Namespace) -> int:
@@ -267,10 +304,12 @@ def main() -> int:
     ap.add_argument("--patch-b64", required=True)
     ap.add_argument("--backup-dir", required=True)
     ap.add_argument("--kernel-id", default="")
+    ap.add_argument("--jit-build-dir", default="")
 
     rp = sub.add_parser("revert")
-    rp.add_argument("--target-path", required=True)
-    rp.add_argument("--backup-path", required=True)
+    rp.add_argument("--target-path", default="")
+    rp.add_argument("--backup-path", default="")
+    rp.add_argument("--records-json", default="")
 
     bp = sub.add_parser("bench")
     bp.add_argument("--workspace", required=True)

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/kernel_node_ops.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/kernel_node_ops.py
@@ -112,8 +112,9 @@ def _do_apply(a: argparse.Namespace) -> int:
         data = base64.b64decode(a.patch_b64.encode("ascii"))
     except Exception as exc:  # noqa: BLE001
         return _emit({"status": "failed", "host": host, "error": f"patch_b64 not valid base64: {exc!r}"})
+    jit_build_dir = str(getattr(a, "jit_build_dir", "") or "")
     jit_backup = invalidate_aiter_jit_build(
-        Path(a.jit_build_dir) if a.jit_build_dir else None,
+        Path(jit_build_dir) if jit_build_dir else None,
         bdir,
         f"{_safe_name(a.kernel_id or target.stem)}_{host}_{int(time.time())}",
     )
@@ -123,6 +124,19 @@ def _do_apply(a: argparse.Namespace) -> int:
         if target.suffix.lower() == ".py":
             py_compile.compile(str(target), doraise=True)
             compile_result = {"status": "ok"}
+    except py_compile.PyCompileError as exc:
+        shutil.copy2(backup_path, target)
+        restore_aiter_jit_build(jit_backup)
+        return _emit(
+            {
+                "status": "failed",
+                "host": host,
+                "error": (
+                    "py_compile failed (auto-reverted): "
+                    f"{exc.msg}"
+                ),
+            }
+        )
     except Exception as exc:  # noqa: BLE001
         shutil.copy2(backup_path, target)
         restore_aiter_jit_build(jit_backup)
@@ -154,7 +168,21 @@ def _do_revert(a: argparse.Namespace) -> int:
         int: the process exit code from emitting the result.
     """
     host = socket.gethostname()
-    records = json.loads(a.records_json or "[]")
+    records_json = getattr(a, "records_json", "") or ""
+    records = json.loads(records_json or "[]")
+    if (
+        not records_json
+        and getattr(a, "backup_path", "")
+        and not Path(a.backup_path).is_file()
+    ):
+        return _emit(
+            {
+                "status": "noop_missing_backup",
+                "host": host,
+                "target_path": str(getattr(a, "target_path", "")),
+                "backup_path": str(a.backup_path),
+            }
+        )
     if not records and a.target_path and a.backup_path:
         records = [
             {

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/kernel_node_ops.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/kernel_node_ops.py
@@ -42,6 +42,7 @@ from patch_path_safety import (  # noqa: E402
     assert_backup_dir_allowed,
     assert_revert_paths_allowed,
     assert_target_path_allowed,
+    finalize_patch_records,
     invalidate_aiter_jit_build,
     restore_aiter_jit_build,
 )
@@ -169,7 +170,17 @@ def _do_revert(a: argparse.Namespace) -> int:
     """
     host = socket.gethostname()
     records_json = getattr(a, "records_json", "") or ""
-    records = json.loads(records_json or "[]")
+    try:
+        records = json.loads(records_json or "[]")
+    except json.JSONDecodeError as exc:
+        return _emit(
+            {
+                "status": "failed",
+                "host": host,
+                "error": f"records_json is invalid: {exc}",
+                "restored_targets": [],
+            }
+        )
     if (
         not records_json
         and getattr(a, "backup_path", "")
@@ -214,7 +225,14 @@ def _do_revert(a: argparse.Namespace) -> int:
                 raise ValueError("conflicting JIT backup records")
             jit_restore = restore_aiter_jit_build(first)
     except Exception as exc:  # noqa: BLE001
-        return _emit({"status": "failed", "host": host, "error": str(exc)})
+        return _emit(
+            {
+                "status": "failed",
+                "host": host,
+                "error": str(exc),
+                "restored_targets": restored,
+            }
+        )
     return _emit(
         {
             "status": "restored",
@@ -223,6 +241,17 @@ def _do_revert(a: argparse.Namespace) -> int:
             "jit_restore": jit_restore,
         }
     )
+
+
+def _do_finalize(a: argparse.Namespace) -> int:
+    """Delete backups for a transaction that has been accepted."""
+    host = socket.gethostname()
+    try:
+        records = json.loads(getattr(a, "records_json", "") or "[]")
+        result = finalize_patch_records(records)
+    except (json.JSONDecodeError, OSError, ValueError) as exc:
+        return _emit({"status": "failed", "host": host, "error": str(exc)})
+    return _emit({"host": host, **result})
 
 
 def _do_bench(a: argparse.Namespace) -> int:
@@ -339,6 +368,9 @@ def main() -> int:
     rp.add_argument("--backup-path", default="")
     rp.add_argument("--records-json", default="")
 
+    fp = sub.add_parser("finalize")
+    fp.add_argument("--records-json", required=True)
+
     bp = sub.add_parser("bench")
     bp.add_argument("--workspace", required=True)
     bp.add_argument("--bench-command", required=True)
@@ -351,6 +383,8 @@ def main() -> int:
         return _do_apply(a)
     if a.command == "revert":
         return _do_revert(a)
+    if a.command == "finalize":
+        return _do_finalize(a)
     if a.command == "bench":
         return _do_bench(a)
     p.print_help(sys.stderr)

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/kernel_patch_multinode.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/kernel_patch_multinode.py
@@ -36,6 +36,7 @@ from patch_path_safety import (  # noqa: E402
     assert_backup_dir_allowed,
     assert_revert_paths_allowed,
     assert_target_path_allowed,
+    finalize_patch_records,
     invalidate_aiter_jit_build,
     restore_aiter_jit_build,
 )
@@ -175,6 +176,11 @@ def _revert_remote(records: list[dict]) -> dict:
     }
 
 
+def _finalize_remote(records: list[dict]) -> dict:
+    """Delete backups for an accepted transaction on one pod."""
+    return {"host": socket.gethostname(), **finalize_patch_records(records)}
+
+
 def _alive_nodes(min_gpu: int = 0) -> list[dict]:
     """Return the list of currently-alive Ray nodes.
 
@@ -308,9 +314,27 @@ def _do_revert(args: argparse.Namespace) -> int:
         ``1`` (including when ``backup_map_json`` is empty).
     """
     ray.init(ignore_reinit_error=True, log_to_driver=True)
-    records_by_host: dict[str, list[dict]] = json.loads(args.records_json or "{}")
-    if not records_by_host and args.backup_map_json:
-        backup_map: dict[str, str] = json.loads(args.backup_map_json)
+    try:
+        records_by_host: dict[str, list[dict]] = json.loads(
+            args.records_json or "{}"
+        )
+        backup_map: dict[str, str] = json.loads(
+            args.backup_map_json or "{}"
+        )
+    except json.JSONDecodeError as exc:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "command": "revert",
+                    "status": "failed",
+                    "error": f"revert records JSON is invalid: {exc}",
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        return 1
+    if not records_by_host and backup_map:
         records_by_host = {
             host: [
                 {
@@ -386,6 +410,63 @@ def _do_revert(args: argparse.Namespace) -> int:
     return 0 if not failures else 1
 
 
+def _do_finalize(args: argparse.Namespace) -> int:
+    """Finalize accepted patch transactions on every recorded host."""
+    try:
+        records_by_host: dict[str, list[dict]] = json.loads(
+            args.records_json or "{}"
+        )
+    except json.JSONDecodeError as exc:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "command": "finalize",
+                    "status": "failed",
+                    "error": f"records JSON is invalid: {exc}",
+                }
+            )
+            + "\n"
+        )
+        return 1
+    ray.init(ignore_reinit_error=True, log_to_driver=True)
+    by_host = {
+        str(node.get("NodeManagerHostname") or ""): node["NodeID"]
+        for node in _alive_nodes()
+        if node.get("NodeManagerHostname")
+    }
+    FinalizeActor = ray.remote(num_cpus=0, num_gpus=0)(_finalize_remote)
+    refs = []
+    failures = []
+    for host, records in records_by_host.items():
+        node_id = by_host.get(host)
+        if not node_id:
+            failures.append({"host": host, "error": "host is not alive"})
+            continue
+        ref = FinalizeActor.options(
+            scheduling_strategy=NodeAffinitySchedulingStrategy(
+                node_id=node_id,
+                soft=False,
+            )
+        ).remote(records)
+        refs.append((host, ref))
+    per_node = []
+    for host, ref in refs:
+        try:
+            per_node.append(
+                {"host": host, **ray.get(ref, timeout=args.timeout_sec)}
+            )
+        except Exception as exc:  # noqa: BLE001
+            failures.append({"host": host, "error": str(exc)})
+    payload = {
+        "command": "finalize",
+        "per_node": per_node,
+        "failures": failures,
+        "status": "ok" if not failures else "partial",
+    }
+    sys.stdout.write(json.dumps(payload, indent=2) + "\n")
+    return 0 if not failures else 1
+
+
 def main() -> int:
     """Parse CLI arguments and dispatch the ``apply`` or ``revert`` command.
 
@@ -422,11 +503,17 @@ def main() -> int:
     rp.add_argument("--backup-map-json", default="", help="legacy hostname -> backup path map")
     rp.add_argument("--timeout-sec", type=int, default=60)
 
+    fp = sub.add_parser("finalize", help="delete backups for accepted patches")
+    fp.add_argument("--records-json", required=True)
+    fp.add_argument("--timeout-sec", type=int, default=60)
+
     args = p.parse_args()
     if args.command == "apply":
         return _do_apply(args)
     if args.command == "revert":
         return _do_revert(args)
+    if args.command == "finalize":
+        return _do_finalize(args)
     p.print_help(sys.stderr)
     return 2
 

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/kernel_patch_multinode.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/kernel_patch_multinode.py
@@ -36,6 +36,8 @@ from patch_path_safety import (  # noqa: E402
     assert_backup_dir_allowed,
     assert_revert_paths_allowed,
     assert_target_path_allowed,
+    invalidate_aiter_jit_build,
+    restore_aiter_jit_build,
 )
 
 
@@ -69,6 +71,7 @@ def _apply_remote(
     patch_b64: str,
     backup_dir: str,
     kernel_id: str,
+    jit_build_dir: str = "",
 ) -> dict:
     """Apply a single patch on this pod; raises on any error (surfaced via ``ray.get``).
 
@@ -106,16 +109,22 @@ def _apply_remote(
     except Exception as exc:
         raise ValueError(f"patch_b64 not valid base64: {exc!r}") from exc
 
-    atomic_write_bytes(target, data)
+    jit_backup = invalidate_aiter_jit_build(
+        Path(jit_build_dir) if jit_build_dir else None,
+        bdir,
+        f"{_safe_name(kernel_id or target.stem)}_{host}_{int(time.time())}",
+    )
 
     compile_result: dict[str, Any] = {"status": "skipped", "reason": "non-py target"}
-    if target.suffix.lower() == ".py":
-        try:
+    try:
+        atomic_write_bytes(target, data)
+        if target.suffix.lower() == ".py":
             py_compile.compile(str(target), doraise=True)
             compile_result = {"status": "ok"}
-        except py_compile.PyCompileError as exc:
-            shutil.copy2(backup_path, target)
-            raise ValueError(f"py_compile failed on {target} (auto-reverted): {exc.msg}") from exc
+    except Exception:
+        shutil.copy2(backup_path, target)
+        restore_aiter_jit_build(jit_backup)
+        raise
 
     return {
         "host": host,
@@ -123,42 +132,46 @@ def _apply_remote(
         "backup_path": str(backup_path),
         "wrote_bytes": len(data),
         "compile": compile_result,
+        "jit_backup": jit_backup,
     }
 
 
-def _revert_remote(
-    target_path: str,
-    backup_path: str,
-) -> dict:
-    """Restore ``target_path`` from ``backup_path`` on this pod; noop when the backup is missing.
+def _revert_remote(records: list[dict]) -> dict:
+    """Restore every source and JIT backup recorded for one pod.
 
     Args:
-        target_path: Absolute path of the file to restore on the pod.
-        backup_path: Path of the saved pre-patch backup.
+        records: Apply records for all files patched on this pod.
 
     Returns:
         dict: Per-host result with ``status`` of ``restored`` or
         ``noop_missing_backup``.
     """
     host = socket.gethostname()
-    target = Path(target_path)
-    backup = Path(backup_path)
-    if not backup.is_file():
-        _log(f"revert noop on {host}: backup missing at {backup}")
-        return {
-            "host": host,
-            "target_path": str(target),
-            "backup_path": str(backup),
-            "status": "noop_missing_backup",
-        }
-    assert_revert_paths_allowed(target, backup)
-    target.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(backup, target)
+    restored: list[str] = []
+    jit_records: list[dict] = []
+    for record in reversed(records):
+        target = Path(str(record.get("target_path") or ""))
+        backup = Path(str(record.get("backup_path") or ""))
+        if not backup.is_file():
+            raise FileNotFoundError(f"backup missing on {host}: {backup}")
+        assert_revert_paths_allowed(target, backup)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(backup, target)
+        restored.append(str(target))
+        jit_record = record.get("jit_backup")
+        if isinstance(jit_record, dict) and jit_record.get("status") in {"ok", "clean"}:
+            jit_records.append(jit_record)
+    jit_restore = {"status": "skipped", "reason": "no JIT backup"}
+    if jit_records:
+        first = jit_records[0]
+        if any(record != first for record in jit_records[1:]):
+            raise ValueError("conflicting JIT backup records for one pod")
+        jit_restore = restore_aiter_jit_build(first)
     return {
         "host": host,
-        "target_path": str(target),
-        "backup_path": str(backup),
         "status": "restored",
+        "restored_targets": restored,
+        "jit_restore": jit_restore,
     }
 
 
@@ -223,19 +236,51 @@ def _do_apply(args: argparse.Namespace) -> int:
             args.patch_b64,
             args.backup_dir,
             args.kernel_id,
+            args.jit_build_dir,
         )
-        refs.append((node_id[:16], ref))
+        refs.append((node_id, ref))
 
     per_node: list[dict] = []
     failures: list[dict] = []
-    for short_id, ref in refs:
+    successful_nodes: list[tuple[str, dict]] = []
+    for node_id, ref in refs:
+        short_id = node_id[:16]
         try:
             res = ray.get(ref, timeout=args.timeout_sec)
             per_node.append({"node_id": short_id, **res})
+            successful_nodes.append((node_id, res))
         except Exception as exc:  # noqa: BLE001
             _log(f"node {short_id}: apply FAILED: {type(exc).__name__}: {exc}")
             failures.append({"node_id": short_id, "error": str(exc), "error_class": type(exc).__name__})
 
+    rollback: list[dict] = []
+    if failures and successful_nodes:
+        RevertActor = ray.remote(num_cpus=0, num_gpus=0)(_revert_remote)
+        rollback_refs = [
+            (
+                node_id,
+                RevertActor.options(
+                    scheduling_strategy=NodeAffinitySchedulingStrategy(
+                        node_id=node_id,
+                        soft=False,
+                    )
+                ).remote([record]),
+            )
+            for node_id, record in successful_nodes
+        ]
+        for node_id, ref in rollback_refs:
+            try:
+                rollback.append(
+                    {"node_id": node_id[:16], **ray.get(ref, timeout=args.timeout_sec)}
+                )
+            except Exception as exc:  # noqa: BLE001
+                rollback.append(
+                    {
+                        "node_id": node_id[:16],
+                        "status": "failed",
+                        "error": str(exc),
+                    }
+                )
     payload = {
         "command": "apply",
         "target_path": args.target_path,
@@ -243,6 +288,7 @@ def _do_apply(args: argparse.Namespace) -> int:
         "backup_dir": args.backup_dir,
         "per_node": per_node,
         "failures": failures,
+        "rollback": rollback,
         "status": "ok" if not failures else "partial",
     }
     sys.stdout.write(json.dumps(payload, indent=2) + "\n")
@@ -262,14 +308,25 @@ def _do_revert(args: argparse.Namespace) -> int:
         ``1`` (including when ``backup_map_json`` is empty).
     """
     ray.init(ignore_reinit_error=True, log_to_driver=True)
-    backup_map: dict[str, str] = json.loads(args.backup_map_json or "{}")
-    if not backup_map:
+    records_by_host: dict[str, list[dict]] = json.loads(args.records_json or "{}")
+    if not records_by_host and args.backup_map_json:
+        backup_map: dict[str, str] = json.loads(args.backup_map_json)
+        records_by_host = {
+            host: [
+                {
+                    "target_path": args.target_path,
+                    "backup_path": backup_path,
+                }
+            ]
+            for host, backup_path in backup_map.items()
+        }
+    if not records_by_host:
         sys.stdout.write(
             json.dumps(
                 {
                     "command": "revert",
                     "status": "failed",
-                    "error": "empty backup_map_json (expected {hostname: backup_path})",
+                    "error": "empty records_json",
                 },
                 indent=2,
             )
@@ -283,25 +340,32 @@ def _do_revert(args: argparse.Namespace) -> int:
         host = (n.get("NodeManagerHostname") or "").strip()
         if host:
             by_host[host] = n["NodeID"]
-    _log(f"revert: alive nodes={len(nodes)} target={args.target_path} backups={len(backup_map)}")
+    _log(f"revert: alive nodes={len(nodes)} hosts={len(records_by_host)}")
 
     RevertActor = ray.remote(num_cpus=0, num_gpus=0)(_revert_remote)
     refs = []
-    for host, backup_path in backup_map.items():
+    failures: list[dict] = []
+    for host, records in records_by_host.items():
         node_id = by_host.get(host)
         if not node_id:
             _log(f"WARN host {host} not currently alive; revert skipped for this host")
+            failures.append(
+                {
+                    "host": host,
+                    "error": "host is not currently alive",
+                    "error_class": "HostUnavailable",
+                }
+            )
             continue
         ref = RevertActor.options(
             scheduling_strategy=NodeAffinitySchedulingStrategy(
                 node_id=node_id,
                 soft=False,
             ),
-        ).remote(args.target_path, backup_path)
+        ).remote(records)
         refs.append((host, ref))
 
     per_node: list[dict] = []
-    failures: list[dict] = []
     for host, ref in refs:
         try:
             res = ray.get(ref, timeout=args.timeout_sec)
@@ -349,11 +413,13 @@ def main() -> int:
     ap.add_argument("--patch-b64", required=True, help="base64-encoded new file contents")
     ap.add_argument("--backup-dir", required=True, help="directory on each pod where the pre-patch original is saved")
     ap.add_argument("--kernel-id", default="", help="optional id used to construct backup filename")
+    ap.add_argument("--jit-build-dir", default="")
     ap.add_argument("--timeout-sec", type=int, default=120, help="per-actor timeout (default 120s)")
 
     rp = sub.add_parser("revert", help="restore target_path from per-pod backup")
-    rp.add_argument("--target-path", required=True)
-    rp.add_argument("--backup-map-json", required=True, help="JSON object mapping pod hostname -> backup file path")
+    rp.add_argument("--target-path", default="")
+    rp.add_argument("--records-json", default="")
+    rp.add_argument("--backup-map-json", default="", help="legacy hostname -> backup path map")
     rp.add_argument("--timeout-sec", type=int, default=60)
 
     args = p.parse_args()

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/patch_path_safety.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/patch_path_safety.py
@@ -9,6 +9,7 @@ hosts the atomic write both apply paths use to land a patched file.
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -176,6 +177,64 @@ def assert_revert_paths_allowed(target: Path, backup: Path) -> None:
     """
     assert_target_path_allowed(target, must_exist=False)
     assert_backup_path_allowed(backup)
+
+
+def assert_aiter_jit_build_allowed(jit_build: Path) -> None:
+    """Validate an AITER ``jit/build`` path before recursive mutation."""
+    resolved = jit_build.resolve()
+    if (
+        resolved.name != "build"
+        or resolved.parent.name != "jit"
+        or resolved.parent.parent.name != "aiter"
+        or not (resolved.parent / "__init__.py").is_file()
+        or not (resolved.parent.parent / "__init__.py").is_file()
+    ):
+        raise ValueError(f"invalid AITER jit/build path: {jit_build}")
+
+
+def invalidate_aiter_jit_build(
+    jit_build: Path | None,
+    backup_dir: Path,
+    backup_name: str,
+) -> dict:
+    """Move one pod's stale AITER JIT cache aside before patched serving."""
+    if jit_build is None:
+        return {"status": "skipped", "reason": "no jit_build_dir supplied"}
+    assert_aiter_jit_build_allowed(jit_build)
+    assert_backup_dir_allowed(backup_dir)
+    resolved = jit_build.resolve()
+    if not resolved.exists() or not any(resolved.iterdir()):
+        return {"status": "clean", "src": str(resolved)}
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    backup = backup_dir / f"{backup_name}_jit_build"
+    assert_backup_path_allowed(backup)
+    if backup.exists():
+        raise ValueError(f"JIT backup already exists: {backup}")
+    shutil.move(str(resolved), str(backup))
+    return {
+        "status": "ok",
+        "src": str(resolved),
+        "backup_path": str(backup),
+    }
+
+
+def restore_aiter_jit_build(record: dict) -> dict:
+    """Remove candidate JIT output and restore a pod's baseline cache."""
+    if not isinstance(record, dict) or record.get("status") not in {"ok", "clean"}:
+        return {"status": "skipped", "reason": "no JIT invalidation record"}
+    src = Path(str(record.get("src") or ""))
+    assert_aiter_jit_build_allowed(src)
+    if src.exists():
+        shutil.rmtree(src)
+    if record.get("status") == "clean":
+        return {"status": "restored_clean", "restored_to": str(src)}
+    backup = Path(str(record.get("backup_path") or ""))
+    assert_backup_path_allowed(backup)
+    if not backup.exists():
+        raise FileNotFoundError(f"JIT backup does not exist: {backup}")
+    src.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(backup), str(src))
+    return {"status": "restored", "restored_to": str(src)}
 
 
 def atomic_write_bytes(target: Path, data: bytes) -> None:

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/patch_path_safety.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/patch_path_safety.py
@@ -21,25 +21,28 @@ _DEFAULT_PATCH_TARGET_ROOTS: tuple[str, ...] = (
     "/sgl-workspace/aiter/",
     "/sgl-workspace/sglang/",
     "/sgl-workspace/vllm/",
-    "/app/ATOM/atom/",
-    "/app/xDiT/",
     "/opt/venv/lib/python3.10/site-packages/aiter/",
+    "/opt/venv/lib/python3.10/site-packages/aiter_meta/",
     "/opt/venv/lib/python3.10/site-packages/sglang/",
     "/opt/venv/lib/python3.10/site-packages/vllm/",
-    "/opt/venv/lib/python3.10/site-packages/atom/",
     "/opt/venv/lib/python3.12/site-packages/aiter/",
+    "/opt/venv/lib/python3.12/site-packages/aiter_meta/",
     "/opt/venv/lib/python3.12/site-packages/sglang/",
     "/opt/venv/lib/python3.12/site-packages/vllm/",
-    "/opt/venv/lib/python3.12/site-packages/atom/",
     "/usr/local/lib/python3.12/dist-packages/aiter/",
+    "/usr/local/lib/python3.12/dist-packages/aiter_meta/",
     "/usr/local/lib/python3.12/dist-packages/sglang/",
     "/usr/local/lib/python3.12/dist-packages/vllm/",
-    "/usr/local/lib/python3.12/dist-packages/atom/",
     "/usr/local/lib/python3.10/dist-packages/aiter/",
+    "/usr/local/lib/python3.10/dist-packages/aiter_meta/",
     "/usr/local/lib/python3.10/dist-packages/sglang/",
     "/usr/local/lib/python3.10/dist-packages/vllm/",
-    "/usr/local/lib/python3.10/dist-packages/atom/",
-    "/aiter_meta/csrc/",
+)
+_ALLOWED_PATCH_PACKAGES = frozenset(
+    {"aiter", "aiter_meta", "sglang", "vllm"}
+)
+_ALLOWED_EDITABLE_ROOTS = frozenset(
+    {"/sgl-workspace/aiter", "/sgl-workspace/sglang", "/sgl-workspace/vllm"}
 )
 
 
@@ -86,8 +89,20 @@ def resolve_patch_target_roots() -> tuple[str, ...]:
         tuple[str, ...]: Normalized framework root prefixes.
     """
     env = os.environ.get("INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS", "").strip()
-    env_roots = tuple(_normalize_root(p) for p in env.split(":") if p.strip()) if env else ()
-    return _merge_roots(_DEFAULT_PATCH_TARGET_ROOTS, env_roots)
+    env_roots: list[str] = []
+    for raw in env.split(":") if env else ():
+        candidate = Path(raw.strip())
+        if not candidate.is_absolute():
+            continue
+        resolved = candidate.resolve()
+        is_package = (
+            resolved.name in _ALLOWED_PATCH_PACKAGES
+            and resolved.parent.name in {"site-packages", "dist-packages"}
+        )
+        is_editable = str(resolved) in _ALLOWED_EDITABLE_ROOTS
+        if is_package or is_editable:
+            env_roots.append(_normalize_root(str(resolved)))
+    return _merge_roots(_DEFAULT_PATCH_TARGET_ROOTS, tuple(env_roots))
 
 
 def resolve_kernel_backup_root() -> Path:
@@ -182,6 +197,7 @@ def assert_revert_paths_allowed(target: Path, backup: Path) -> None:
 def assert_aiter_jit_build_allowed(jit_build: Path) -> None:
     """Validate an AITER ``jit/build`` path before recursive mutation."""
     resolved = jit_build.resolve()
+    assert_target_path_allowed(resolved, must_exist=False)
     if (
         resolved.name != "build"
         or resolved.parent.name != "jit"

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/patch_path_safety.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/patch_path_safety.py
@@ -1,15 +1,16 @@
 """Path constraints for kernel patch apply/revert on inference pods (stdlib only).
 
 Shared by ``kernel_node_ops.py`` (Infera SSH) and ``kernel_patch_multinode.py``
-(RayJob). Keeps patch targets under framework install roots and backups under
-``$HYPERLOOM_MN_KERNEL_BACKUP_DIR`` (default ``/var/kernel_patch_backups``), and
-hosts the atomic write both apply paths use to land a patched file.
+(RayJob). Restricts patch targets to vLLM/SGLang/AITER install roots, keeps
+backups under ``$HYPERLOOM_MN_KERNEL_BACKUP_DIR`` (default
+``/var/kernel_patch_backups``), and hosts the atomic write both apply paths use.
 """
 
 from __future__ import annotations
 
 import os
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 
@@ -93,6 +94,10 @@ def resolve_patch_target_roots() -> tuple[str, ...]:
     for raw in env.split(":") if env else ():
         candidate = Path(raw.strip())
         if not candidate.is_absolute():
+            sys.stderr.write(
+                "WARN ignoring unsafe framework source root for pod patching: "
+                f"{raw!r}\n"
+            )
             continue
         resolved = candidate.resolve()
         is_package = (
@@ -102,6 +107,11 @@ def resolve_patch_target_roots() -> tuple[str, ...]:
         is_editable = str(resolved) in _ALLOWED_EDITABLE_ROOTS
         if is_package or is_editable:
             env_roots.append(_normalize_root(str(resolved)))
+        else:
+            sys.stderr.write(
+                "WARN ignoring unsafe framework source root for pod patching: "
+                f"{raw!r}\n"
+            )
     return _merge_roots(_DEFAULT_PATCH_TARGET_ROOTS, tuple(env_roots))
 
 

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/patch_path_safety.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/patch_path_safety.py
@@ -240,17 +240,45 @@ def restore_aiter_jit_build(record: dict) -> dict:
         return {"status": "skipped", "reason": "no JIT invalidation record"}
     src = Path(str(record.get("src") or ""))
     assert_aiter_jit_build_allowed(src)
-    if src.exists():
-        shutil.rmtree(src)
     if record.get("status") == "clean":
+        if src.exists():
+            shutil.rmtree(src)
         return {"status": "restored_clean", "restored_to": str(src)}
     backup = Path(str(record.get("backup_path") or ""))
     assert_backup_path_allowed(backup)
     if not backup.exists():
         raise FileNotFoundError(f"JIT backup does not exist: {backup}")
+    if src.exists():
+        shutil.rmtree(src)
     src.parent.mkdir(parents=True, exist_ok=True)
     shutil.move(str(backup), str(src))
     return {"status": "restored", "restored_to": str(src)}
+
+
+def finalize_patch_records(records: list[dict]) -> dict:
+    """Delete source/JIT backups after a patch becomes the accepted baseline."""
+    deleted: list[str] = []
+    jit_backups: set[str] = set()
+    for record in records:
+        backup_raw = str(record.get("backup_path") or "").strip()
+        if backup_raw:
+            backup = Path(backup_raw)
+            assert_backup_path_allowed(backup)
+            if backup.is_file():
+                backup.unlink()
+                deleted.append(str(backup))
+        jit_record = record.get("jit_backup")
+        if isinstance(jit_record, dict):
+            jit_backup = str(jit_record.get("backup_path") or "").strip()
+            if jit_backup:
+                jit_backups.add(jit_backup)
+    for backup_raw in sorted(jit_backups):
+        backup = Path(backup_raw)
+        assert_backup_path_allowed(backup)
+        if backup.is_dir():
+            shutil.rmtree(backup)
+            deleted.append(str(backup))
+    return {"status": "finalized", "deleted": deleted}
 
 
 def atomic_write_bytes(target: Path, data: bytes) -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_common_utils.py
+++ b/src/hyperloom/inference_optimizer/tests/test_common_utils.py
@@ -619,6 +619,7 @@ def test_infera_node_ops_apply_revert_and_bench(tmp_path: Path, monkeypatch: pyt
         [
             ({"status": "ok", "backup_path": "/b0"}, {"rc": 0, "stderr": ""}),
             ({"status": "failed", "error": "nope"}, {"rc": 1, "stderr": "bad"}),
+            ({"status": "restored"}, {"rc": 0, "stderr": ""}),
         ]
     )
     monkeypatch.setattr(inf, "_infera_ssh_node_op", lambda *a, **kw: next(responses))

--- a/src/hyperloom/inference_optimizer/tests/test_coverage_gap_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coverage_gap_units.py
@@ -536,6 +536,7 @@ def test_infera_node_ops_apply_revert_and_bench(tmp_path: Path, monkeypatch: pyt
         [
             ({"status": "ok", "backup_path": "/b0"}, {"rc": 0, "stderr": ""}),
             ({"status": "failed", "error": "nope"}, {"rc": 1, "stderr": "bad"}),
+            ({"status": "restored"}, {"rc": 0, "stderr": ""}),
         ]
     )
     monkeypatch.setattr(inf, "_infera_ssh_node_op", lambda *a, **kw: next(responses))

--- a/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
@@ -608,7 +608,37 @@ def test_invalidate_aiter_jit_build_runs_for_aiter_meta_target(apply_tool, tmp_p
 
     assert res["status"] == "ok", res
     assert not jit_build.exists()  # moved aside so the next import re-JITs
-    assert (backup_dir / "jit_build" / "module_aiter_core.so").is_file()
+    backups = list(backup_dir.glob("jit_build_*/module_aiter_core.so"))
+    assert len(backups) == 1
+
+
+def test_invalidate_aiter_jit_build_ignores_orphaned_prior_backup(
+    apply_tool,
+    tmp_path,
+) -> None:
+    jit_build = tmp_path / "aiter" / "jit" / "build"
+    jit_build.mkdir(parents=True)
+    (jit_build / "first.so").write_bytes(b"first")
+    backup_dir = tmp_path / "backup"
+
+    first = apply_tool._invalidate_aiter_jit_build(
+        _AITER_META_CU,
+        backup_dir,
+        jit_build_dir=jit_build,
+    )
+    jit_build.mkdir(parents=True)
+    (jit_build / "second.so").write_bytes(b"second")
+    second = apply_tool._invalidate_aiter_jit_build(
+        _AITER_META_CU,
+        backup_dir,
+        jit_build_dir=jit_build,
+    )
+
+    assert first["status"] == "ok"
+    assert second["status"] == "ok"
+    assert first["backup_path"] != second["backup_path"]
+    assert Path(first["backup_path"]).is_dir()
+    assert Path(second["backup_path"]).is_dir()
 
 
 _APPLY_BENCH_PATH = (

--- a/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
@@ -129,6 +129,7 @@ class TestGlobInstallPackageRoots:
     def test_finds_dist_packages_under_usr_local(self, tmp_path, monkeypatch):
         base = tmp_path / "usr_local_lib" / "python3.12" / "dist-packages"
         (base / "vllm").mkdir(parents=True)
+        (base / "aiter_meta").mkdir()
         monkeypatch.setattr(
             fp,
             "_INSTALL_GLOB_PARENTS",
@@ -136,6 +137,7 @@ class TestGlobInstallPackageRoots:
         )
         roots = fp._glob_install_package_roots()
         assert any("dist-packages/vllm/" in r for r in roots)
+        assert any("dist-packages/aiter_meta/" in r for r in roots)
 
 
 class TestResolvePatchTargetRoots:
@@ -173,24 +175,24 @@ class TestProbeFrameworkSourceRootsForEnv:
     ):
         venv = tmp_path / "venv"
         site = venv / "lib" / "python3.12" / "site-packages"
-        for name in ("vllm", "sglang", "aiter"):
+        for name in ("vllm", "sglang", "aiter", "aiter_meta"):
             (site / name).mkdir(parents=True)
         monkeypatch.setattr(fp, "_DEFAULT_SOURCE_ROOTS", ())
         monkeypatch.setattr(fp, "_find_spec_origin", lambda name: None)
         monkeypatch.setattr(fp, "_glob_install_package_roots", lambda: ())
         monkeypatch.setenv("VIRTUAL_ENV", str(venv))
         result = fp.probe_framework_source_roots_for_env()
-        for name in ("vllm", "sglang", "aiter"):
+        for name in ("vllm", "sglang", "aiter", "aiter_meta"):
             assert f"{name}/" in result
 
     def test_isolated_vllm_venv_root_fallback(self, tmp_path, monkeypatch):
         # Isolated vLLM: main VIRTUAL_ENV has no vllm; VLLM_VENV_ROOT points at
-        # the isolated venv holding vllm + aiter, which must still be discovered.
+        # the isolated venv holding vllm + split AITER, which must be discovered.
         main_venv = tmp_path / "opt-venv"
         (main_venv / "lib" / "python3.12" / "site-packages").mkdir(parents=True)
         iso_venv = tmp_path / "vllm-venv"
         iso_site = iso_venv / "lib" / "python3.12" / "site-packages"
-        for name in ("vllm", "aiter"):
+        for name in ("vllm", "aiter", "aiter_meta"):
             (iso_site / name).mkdir(parents=True)
         monkeypatch.setattr(fp, "_find_spec_origin", lambda name: None)
         monkeypatch.setattr(fp, "_glob_install_package_roots", lambda: ())
@@ -199,6 +201,7 @@ class TestProbeFrameworkSourceRootsForEnv:
         result = fp._discover_installed_framework_roots()
         assert any(r.endswith("/vllm/") for r in result)
         assert any(r.endswith("/aiter/") for r in result)
+        assert any(r.endswith("/aiter_meta/") for r in result)
 
     def test_dedupes_origins_against_defaults(self, tmp_path, monkeypatch):
         shared = tmp_path / "shared"

--- a/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
@@ -603,7 +603,7 @@ def test_invalidate_aiter_jit_build_runs_for_aiter_meta_target(apply_tool, tmp_p
     res = apply_tool._invalidate_aiter_jit_build(
         _AITER_META_CU,
         backup_dir,
-        jit_build_dir_override=jit_build,
+        jit_build_dir=jit_build,
     )
 
     assert res["status"] == "ok", res

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_integrate_and_report.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_integrate_and_report.py
@@ -873,6 +873,65 @@ async def test_integrate_handler_resolves_patch_and_target_from_state(
 
 
 @pytest.mark.asyncio
+async def test_integrate_handler_accepts_runtime_jit_deferred_apply(
+    session_dir,
+    tmp_path,
+):
+    base_yaml = tmp_path / "base.yaml"
+    _write_baseline_yaml(base_yaml)
+    target, patch_file = _write_patch_pair(tmp_path)
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text("{}\n", encoding="utf-8")
+
+    def _fake_run(cmd, *args, **kwargs):
+        out_idx = cmd.index("--output-dir")
+        slot = Path(cmd[out_idx + 1])
+        _fake_workspace(slot, tput=900.0)
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout="ok",
+            stderr="",
+        )
+
+    apply_result = {
+        "status": "ok",
+        "manifest_path": str(manifest),
+        "target_file": str(target),
+        "rebuild": {
+            "status": "deferred",
+            "mode": "runtime_jit",
+        },
+    }
+    payload = {
+        "base_tput": 800.0,
+        "config_path": str(base_yaml),
+        "kernel_id": "k006",
+        "patch_path": str(patch_file),
+        "target_file": str(target),
+    }
+    with (
+        patch.object(
+            krh,
+            "_maybe_apply_kernel_patch",
+            return_value=apply_result,
+        ),
+        patch(
+            "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
+            side_effect=_fake_run,
+        ),
+    ):
+        result = await krh.integrate_handler(payload, session_dir=session_dir)
+
+    assert result["status"] == "ok"
+    assert result["decision"] == "KEEP"
+    assert result["apply_result"]["rebuild"] == {
+        "status": "deferred",
+        "mode": "runtime_jit",
+    }
+
+
+@pytest.mark.asyncio
 async def test_integrate_handler_fails_when_patch_inputs_missing(
     session_dir,
     tmp_path,

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_integrate_and_report.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_integrate_and_report.py
@@ -869,6 +869,7 @@ async def test_integrate_handler_resolves_patch_and_target_from_state(
     assert res["patch_path"] == str(patch_file)
     assert res["target_file"] == str(target)
     assert res["apply_result"]["status"] == "ok"
+    assert res["finalize_result"]["status"] == "ok"
     assert target.read_text(encoding="utf-8") == "def kernel():\n    return 'optimized'\n"
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_node_ops.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_node_ops.py
@@ -28,8 +28,8 @@ def _repo_root() -> Path:
 
 @pytest.fixture
 def patch_env(tmp_path, monkeypatch):
-    fw = tmp_path / "fw"
-    fw.mkdir()
+    fw = tmp_path / "lib" / "python3.12" / "site-packages" / "vllm"
+    fw.mkdir(parents=True)
     bak = tmp_path / "bak"
     bak.mkdir()
     monkeypatch.setenv("INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS", f"{fw}/")

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_node_ops.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_node_ops.py
@@ -179,6 +179,52 @@ def test_revert_missing_backup_is_noop(tmp_path, capsys):
     assert payload["status"] == "noop_missing_backup"
 
 
+def test_revert_invalid_records_json_is_structured(tmp_path, capsys):
+    k = _load("kno_revert_invalid_json")
+    rc = k._do_revert(argparse.Namespace(records_json="{"))
+    payload = _last_json(capsys)
+
+    assert rc == 1
+    assert payload["status"] == "failed"
+    assert payload["restored_targets"] == []
+
+
+def test_revert_failure_reports_already_restored_targets(
+    patch_env,
+    capsys,
+):
+    fw, bak = patch_env
+    k = _load("kno_revert_partial")
+    restored_target = fw / "restored.py"
+    restored_target.write_text("candidate\n", encoding="utf-8")
+    valid_backup = bak / "restored.bak"
+    valid_backup.write_text("baseline\n", encoding="utf-8")
+    missing_target = fw / "missing.py"
+    missing_target.write_text("candidate\n", encoding="utf-8")
+    rc = k._do_revert(
+        argparse.Namespace(
+            records_json=json.dumps(
+                [
+                    {
+                        "target_path": str(missing_target),
+                        "backup_path": str(bak / "missing.bak"),
+                    },
+                    {
+                        "target_path": str(restored_target),
+                        "backup_path": str(valid_backup),
+                    },
+                ]
+            )
+        )
+    )
+    payload = _last_json(capsys)
+
+    assert rc == 1
+    assert payload["status"] == "failed"
+    assert payload["restored_targets"] == [str(restored_target)]
+    assert restored_target.read_text(encoding="utf-8") == "baseline\n"
+
+
 def test_revert_restores_from_backup(patch_env, capsys):
     fw, bak = patch_env
     k = _load("kno_revert_ok")

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_patch_jit_transaction.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_patch_jit_transaction.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import shutil
 import sys
 from pathlib import Path
 
@@ -100,3 +101,72 @@ def test_pod_jit_transaction_clears_candidate_when_baseline_was_clean(
 
     assert restored["status"] == "restored_clean"
     assert not build.exists()
+
+
+def test_missing_baseline_backup_preserves_candidate_cache(
+    tmp_path,
+    monkeypatch,
+):
+    safety = _load_module()
+    aiter, build = _make_aiter_jit(tmp_path)
+    (build / "baseline.so").write_text("baseline", encoding="utf-8")
+    backup_root = tmp_path / "backups"
+    monkeypatch.setenv("HYPERLOOM_MN_KERNEL_BACKUP_DIR", str(backup_root))
+    monkeypatch.setenv(
+        "INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS",
+        str(aiter),
+    )
+    record = safety.invalidate_aiter_jit_build(
+        build,
+        backup_root,
+        "kernel_host",
+    )
+    shutil.rmtree(record["backup_path"])
+    build.mkdir(parents=True)
+    candidate = build / "candidate.so"
+    candidate.write_text("candidate", encoding="utf-8")
+
+    try:
+        safety.restore_aiter_jit_build(record)
+    except FileNotFoundError:
+        pass
+    else:
+        raise AssertionError("missing baseline backup must fail restore")
+
+    assert candidate.is_file()
+
+
+def test_finalize_deletes_source_and_jit_backups(
+    tmp_path,
+    monkeypatch,
+):
+    safety = _load_module()
+    aiter, build = _make_aiter_jit(tmp_path)
+    (build / "baseline.so").write_text("baseline", encoding="utf-8")
+    backup_root = tmp_path / "backups"
+    backup_root.mkdir()
+    monkeypatch.setenv("HYPERLOOM_MN_KERNEL_BACKUP_DIR", str(backup_root))
+    monkeypatch.setenv(
+        "INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS",
+        str(aiter),
+    )
+    jit_record = safety.invalidate_aiter_jit_build(
+        build,
+        backup_root,
+        "kernel_host",
+    )
+    source_backup = backup_root / "source.bak"
+    source_backup.write_text("source", encoding="utf-8")
+
+    result = safety.finalize_patch_records(
+        [
+            {
+                "backup_path": str(source_backup),
+                "jit_backup": jit_record,
+            }
+        ]
+    )
+
+    assert result["status"] == "finalized"
+    assert not source_backup.exists()
+    assert not Path(jit_record["backup_path"]).exists()

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_patch_jit_transaction.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_patch_jit_transaction.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "multi_node"
+    / "scripts"
+    / "patch_path_safety.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "_patch_path_safety_transaction_test",
+        _SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_aiter_jit(tmp_path: Path) -> tuple[Path, Path]:
+    aiter = tmp_path / "site-packages" / "aiter"
+    jit = aiter / "jit"
+    build = jit / "build"
+    build.mkdir(parents=True)
+    (aiter / "__init__.py").write_text("", encoding="utf-8")
+    (jit / "__init__.py").write_text("", encoding="utf-8")
+    return aiter, build
+
+
+def test_pod_jit_transaction_restores_baseline_cache(
+    tmp_path,
+    monkeypatch,
+):
+    safety = _load_module()
+    _aiter, build = _make_aiter_jit(tmp_path)
+    (build / "baseline.so").write_text("baseline", encoding="utf-8")
+    backup_root = tmp_path / "backups"
+    monkeypatch.setenv(
+        "HYPERLOOM_MN_KERNEL_BACKUP_DIR",
+        str(backup_root),
+    )
+
+    record = safety.invalidate_aiter_jit_build(
+        build,
+        backup_root,
+        "kernel_host",
+    )
+
+    assert record["status"] == "ok"
+    assert not build.exists()
+    build.mkdir(parents=True)
+    (build / "candidate.so").write_text("candidate", encoding="utf-8")
+
+    restored = safety.restore_aiter_jit_build(record)
+
+    assert restored["status"] == "restored"
+    assert (build / "baseline.so").is_file()
+    assert not (build / "candidate.so").exists()
+
+
+def test_pod_jit_transaction_clears_candidate_when_baseline_was_clean(
+    tmp_path,
+    monkeypatch,
+):
+    safety = _load_module()
+    _aiter, build = _make_aiter_jit(tmp_path)
+    backup_root = tmp_path / "backups"
+    monkeypatch.setenv(
+        "HYPERLOOM_MN_KERNEL_BACKUP_DIR",
+        str(backup_root),
+    )
+
+    record = safety.invalidate_aiter_jit_build(
+        build,
+        backup_root,
+        "kernel_host",
+    )
+
+    assert record["status"] == "clean"
+    build.mkdir(parents=True, exist_ok=True)
+    (build / "candidate.so").write_text("candidate", encoding="utf-8")
+
+    restored = safety.restore_aiter_jit_build(record)
+
+    assert restored["status"] == "restored_clean"
+    assert not build.exists()

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_patch_jit_transaction.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_patch_jit_transaction.py
@@ -47,6 +47,10 @@ def test_pod_jit_transaction_restores_baseline_cache(
         "HYPERLOOM_MN_KERNEL_BACKUP_DIR",
         str(backup_root),
     )
+    monkeypatch.setenv(
+        "INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS",
+        str(_aiter),
+    )
 
     record = safety.invalidate_aiter_jit_build(
         build,
@@ -76,6 +80,10 @@ def test_pod_jit_transaction_clears_candidate_when_baseline_was_clean(
     monkeypatch.setenv(
         "HYPERLOOM_MN_KERNEL_BACKUP_DIR",
         str(backup_root),
+    )
+    monkeypatch.setenv(
+        "INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS",
+        str(_aiter),
     )
 
     record = safety.invalidate_aiter_jit_build(

--- a/src/hyperloom/inference_optimizer/tests/test_patch_path_safety.py
+++ b/src/hyperloom/inference_optimizer/tests/test_patch_path_safety.py
@@ -42,6 +42,7 @@ def patch_env(tmp_path, monkeypatch):
 def test_discovery_env_cannot_expand_patch_roots(
     monkeypatch,
     unsafe_root,
+    capsys,
 ):
     pps = _load_patch_path_safety(f"pps_unsafe_{unsafe_root!r}")
     monkeypatch.setenv(
@@ -52,6 +53,7 @@ def test_discovery_env_cannot_expand_patch_roots(
     roots = pps.resolve_patch_target_roots()
 
     assert unsafe_root not in roots
+    assert "ignoring unsafe framework source root" in capsys.readouterr().err
 
 
 def test_custom_installed_framework_root_is_allowed(tmp_path, monkeypatch):

--- a/src/hyperloom/inference_optimizer/tests/test_patch_path_safety.py
+++ b/src/hyperloom/inference_optimizer/tests/test_patch_path_safety.py
@@ -29,13 +29,59 @@ def _load_patch_path_safety(unique_name: str):
 
 @pytest.fixture
 def patch_env(tmp_path, monkeypatch):
-    fw = tmp_path / "fw"
-    fw.mkdir()
+    fw = tmp_path / "lib" / "python3.12" / "site-packages" / "vllm"
+    fw.mkdir(parents=True)
     bak = tmp_path / "bak"
     bak.mkdir()
     monkeypatch.setenv("INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS", f"{fw}/")
     monkeypatch.setenv("HYPERLOOM_MN_KERNEL_BACKUP_DIR", str(bak))
     return fw, bak
+
+
+@pytest.mark.parametrize("unsafe_root", ("/", "relative/path", "/tmp"))
+def test_discovery_env_cannot_expand_patch_roots(
+    monkeypatch,
+    unsafe_root,
+):
+    pps = _load_patch_path_safety(f"pps_unsafe_{unsafe_root!r}")
+    monkeypatch.setenv(
+        "INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS",
+        unsafe_root,
+    )
+
+    roots = pps.resolve_patch_target_roots()
+
+    assert unsafe_root not in roots
+
+
+def test_custom_installed_framework_root_is_allowed(tmp_path, monkeypatch):
+    pps = _load_patch_path_safety("pps_custom_package")
+    root = tmp_path / "venv" / "lib" / "python3.12" / "site-packages" / "aiter"
+    root.mkdir(parents=True)
+    monkeypatch.setenv(
+        "INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS",
+        str(root),
+    )
+
+    assert f"{root}/" in pps.resolve_patch_target_roots()
+
+
+def test_fake_aiter_shape_outside_framework_root_is_rejected(
+    tmp_path,
+    monkeypatch,
+):
+    pps = _load_patch_path_safety("pps_fake_aiter")
+    fake = tmp_path / "random" / "aiter"
+    (fake / "jit" / "build").mkdir(parents=True)
+    (fake / "__init__.py").write_text("", encoding="utf-8")
+    (fake / "jit" / "__init__.py").write_text("", encoding="utf-8")
+    monkeypatch.delenv(
+        "INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS",
+        raising=False,
+    )
+
+    with pytest.raises(ValueError, match="framework patch roots"):
+        pps.assert_aiter_jit_build_allowed(fake / "jit" / "build")
 
 
 def test_assert_revert_paths_allowed_happy_path(patch_env):

--- a/src/hyperloom/orchestrator/framework/paths.py
+++ b/src/hyperloom/orchestrator/framework/paths.py
@@ -149,11 +149,13 @@ def _glob_install_package_roots() -> tuple[str, ...]:
     """
     patterns = (
         "python*/dist-packages/aiter",
+        "python*/dist-packages/aiter_meta",
         "python*/dist-packages/sglang",
         "python*/dist-packages/vllm",
         "python*/dist-packages/atom",
         "python*/dist-packages/xfuser",
         "python*/site-packages/aiter",
+        "python*/site-packages/aiter_meta",
         "python*/site-packages/sglang",
         "python*/site-packages/vllm",
         "python*/site-packages/atom",
@@ -216,6 +218,7 @@ def _discover_installed_framework_roots() -> tuple[str, ...]:
                 "python*/site-packages/vllm",
                 "python*/site-packages/sglang",
                 "python*/site-packages/aiter",
+                "python*/site-packages/aiter_meta",
                 "python*/site-packages/atom",
                 "python*/site-packages/xfuser",
             ):
@@ -233,6 +236,7 @@ def _discover_installed_framework_roots() -> tuple[str, ...]:
                 for pattern in (
                     "python*/site-packages/vllm",
                     "python*/site-packages/aiter",
+                    "python*/site-packages/aiter_meta",
                 ):
                     for match in sorted(site.glob(pattern)):
                         if match.is_dir():

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -1169,6 +1169,20 @@ def _maybe_revert_kernel_patch(apply_result: HandlerResult) -> HandlerResult:
     return tool.revert_kernel_patch(apply_result["manifest_path"])
 
 
+def _maybe_finalize_kernel_patch(
+    apply_result: HandlerResult,
+) -> HandlerResult:
+    """Delete backups once a KEEP becomes the accepted baseline."""
+    if (
+        apply_result.get("status") != "ok"
+        or not apply_result.get("manifest_path")
+    ):
+        return {"status": "skipped", "reason": "no applied patch manifest"}
+    return _load_apply_tool().finalize_kernel_patch(
+        apply_result["manifest_path"]
+    )
+
+
 def _find_selected_kernel_source(state: Any, kernel_id: str) -> str:
     """Look up a kernel's source file from the last trace-analyze result.
 
@@ -6410,6 +6424,11 @@ async def integrate_handler(
             paired_pristine_revert if paired_pristine_revert is not None else _maybe_revert_kernel_patch(apply_result)
         )
     )
+    finalize_result = (
+        _maybe_finalize_kernel_patch(apply_result)
+        if decision == "KEEP"
+        else {"status": "skipped", "reason": "non-KEEP decision"}
+    )
 
     result: dict[str, Any] = {
         "status": "ok",
@@ -6426,6 +6445,7 @@ async def integrate_handler(
         "extra_envs": dict(payload.get("extra_envs") or {}),
         "apply_result": apply_result,
         "revert_result": revert_result,
+        "finalize_result": finalize_result,
         "rebuild_check": rebuild_check,
         "task_group_key": str(payload.get("task_group_key") or ""),
         "identity_route": str(payload.get("identity_route") or ""),


### PR DESCRIPTION
## Summary

Installed AITER kernel artifacts could pass Forge micro-validation but never reach E2E. HyperLoom classified `aiter` / `aiter_meta` native sources as compiled, found no eager rebuild command for wheel layouts, interpreted the skipped rebuild as a failure, and immediately restored the original source. In the Mixtral session that motivated this change, k003 and k006 both produced correct, faster micro artifacts and then failed integration with `apply_failed: no rebuild command`.

This PR makes installed AITER deployment explicitly runtime-JIT: apply the complete source snapshot, invalidate the exact cache used by that runtime, start a fresh serving process, and let E2E remain the final KEEP/REVERT gate.

### 1. Target-pinned runtime-JIT deployment

- Recognizes split wheel layouts where Python/JIT code lives under `aiter` and device/codegen sources live under sibling `aiter_meta`.
- Pins `jit/build` to the selected target's install root instead of rediscovering AITER through the orchestrator process's import path or `VLLM_VENV_ROOT`.
- Supports native sources and Python codegen under installed AITER, including compiled headers and JIT sources outside `csrc`.
- Keeps editable `/sgl-workspace/aiter` Python-source behavior unchanged; full `setup.py develop` is not triggered for ordinary codegen edits.
- Records deferred runtime-JIT state in the apply manifest and propagates it through `apply_and_bench` and E2E integration.

### 2. Complete, bounded snapshot deployment

Forge patches can legitimately span AITER plus their vLLM/SGLang wrappers. `site-packages` remains the coordinate system for those relative paths, but it is no longer the write authorization boundary.

- Snapshot writes are limited to resolved `aiter`, `aiter_meta`, `vllm`, and `sglang` package roots.
- Explicit `repo_root=site-packages` cannot authorize writes to unrelated packages such as `torch` or `pip`.
- Write, delete, rename, post-verify, symlink, and multi-node fan-out paths use the same deploy-root containment checks.
- Unknown layouts retain fail-fast behavior and require an explicit valid mapping; they no longer fall back to `target.parent` and create nested paths.
- Discovery-only source-root configuration cannot expand pod write/delete permissions to `/` or arbitrary shallow paths.

### 3. Transactional source and JIT state

Single-node and multi-node integration now treat source files and AITER caches as one transaction.

- Uses unique JIT backup paths so an orphan from a crashed attempt cannot permanently block later optimization.
- Invalidates and backs up `aiter/jit/build` independently on every RayJob/Infera inference pod.
- Preserves every per-host, per-file backup for multi-file snapshots instead of overwriting earlier records with the final file.
- Rolls back successful pods when another pod fails apply.
- Restores source and baseline JIT state together; a missing baseline backup is detected before candidate cache deletion.
- Surfaces partial restore details, including already-restored targets and JIT restore failures, as structured results.
- Final KEEP promotes the applied state to the new baseline and finalizes that transaction, deleting its local and pod-side source/JIT backups. REVERT continues to restore them.

### 4. Safety and compatibility

- Destructive JIT paths require both framework-root containment and the exact `aiter/jit/build` package shape.
- Backup paths remain confined to the configured kernel backup root.
- `apply_snapshot` keeps its legacy optional `deploy_roots=None` calling contract; HyperLoom's integration path always supplies bounded roots.
- New pod CLI fields (`--jit-build-dir`, `--records-json`) have backward-compatible defaults for direct callers and older test fixtures.
- Existing manifest key readers retain compatibility with manifests created before this change.

## Effect on the motivating failure

The old behavior stopped after copying the candidate source:

```text
compiled=true + rebuild_command=[]
→ rebuild.status=skipped
→ apply_failed
→ source and JIT state restored
→ no E2E measurement
```

The new behavior is:

```text
validated Forge snapshot
→ bounded source apply
→ target-pinned JIT invalidation on every serving pod
→ deferred runtime JIT on fresh server startup
→ E2E KEEP / REVERT
```

This PR does not claim an E2E gain for k003 or k006; it restores the missing deployment/measurement path so E2E can make that decision.

## Test plan

- Installed `aiter_meta` native source apply without importable AITER or `VLLM_VENV_ROOT`.
- Import-path/target-path mismatch: only the target runtime cache is invalidated.
- Python codegen, non-`csrc` C++ sources, and CK headers trigger the correct runtime-JIT behavior.
- Editable AITER Python sources remain source-only.
- Cross-package AITER + vLLM snapshot succeeds; unrelated package and escaping symlink writes fail before mutation.
- Cross-process JIT restore, missing backup behavior, unique orphan-safe backups, and final KEEP cleanup.
- RayJob/Infera per-pod JIT invalidation, partial apply rollback, multi-file backup retention, structured invalid JSON, and partial restore reporting.
- Legacy direct `Namespace` callers and optional `apply_snapshot` arguments remain compatible.

Commands run on the final branch:

```text
pytest src/hyperloom/inference_optimizer/tests/test_kernel_patch_jit_transaction.py \
       src/hyperloom/inference_optimizer/tests/test_kernel_node_ops.py \
       src/hyperloom/inference_optimizer/tests/test_multi_node_scripts.py \
       src/hyperloom/agents/kernel/tests/test_apply_kernel_patch_isolated_aiter.py \
       src/hyperloom/inference_optimizer/tests/test_kernel_integrate_and_report.py
# 160 passed

pytest src/hyperloom/inference_optimizer/tests/test_common_utils.py \
       src/hyperloom/inference_optimizer/tests/test_coverage_gap_units.py \
       src/hyperloom/inference_optimizer/tests/test_external_multi_node.py \
       src/hyperloom/inference_optimizer/tests/test_integrate_payload_defaults.py \
       src/hyperloom/agents/kernel/tests/test_kernel_optimization_verification.py
# 274 passed
```

Python compilation, IDE lint diagnostics, and `git diff --check` also pass.

## Linked issues

N/A

## Breaking changes

No. New manifest fields and pod CLI arguments are additive, legacy readers/callers remain supported, and the public `apply_snapshot` fallback remains available.