### PR TITLE
fix(profile): keep the torch-profiler bounds a replacing candidate wiped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   suppresses a pointless re-run. The verdict is matched tolerantly and only honoured
   when the manifest reports no KEEP, so it can never discard a validated fusion.
 
+- **Roofline runs no longer launch an unbounded torch profiler**: the profile
+  path injects `--profiler-config.delay_iterations/max_iterations` into
+  `EXTRA_VLLM_ARGS`, but the per-task merge that follows applies the candidate's
+  `extra_server_args` and `extra_envs` afterwards. A candidate carrying
+  `args_mode="replace"` (which `writeback` sets automatically as soon as a KEEP
+  needs `remove_args`) overwrote the whole flag string and took the bounds with
+  it, along with the `--profiler-config.ignore_frontend True` the profile YAML
+  supplies. vLLM reads a missing `max_iterations` as "profile until
+  `stop_profile`", so the worker accumulated every profiler event in host
+  anonymous memory — measured at 60 MiB/s with the production option set — until
+  the cgroup OOM-killer took the engine or worker process out mid-roofline, at
+  107–137 GiB RSS. Because `args_mode` is sticky on `current_best`, one such KEEP
+  turned *every* later roofline in that session into an OOM candidate.
+
+  `materialize_config_with_envs` now re-asserts the bounds after the
+  `extra_server_args`/`extra_envs` merges and warns when it had to restore them,
+  and it states `ignore_frontend` alongside the bounds (the AsyncLLM-side
+  profiler tracks no iterations and would otherwise capture the entire
+  `start_profile`..`stop_profile` range). Candidate flags still win for
+  everything else, and the append path is unchanged apart from no longer relying
+  on the YAML to carry `ignore_frontend`.
+
 ### Removed
 
 - **Kernel-agent LLM role retired** (breaking): the `kernel_agent` role has been

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,27 +36,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   suppresses a pointless re-run. The verdict is matched tolerantly and only honoured
   when the manifest reports no KEEP, so it can never discard a validated fusion.
 
-- **Roofline runs no longer launch an unbounded torch profiler**: the profile
-  path injects `--profiler-config.delay_iterations/max_iterations` into
-  `EXTRA_VLLM_ARGS`, but the per-task merge that follows applies the candidate's
-  `extra_server_args` and `extra_envs` afterwards. A candidate carrying
-  `args_mode="replace"` (which `writeback` sets automatically as soon as a KEEP
-  needs `remove_args`) overwrote the whole flag string and took the bounds with
-  it, along with the `--profiler-config.ignore_frontend True` the profile YAML
-  supplies. vLLM reads a missing `max_iterations` as "profile until
-  `stop_profile`", so the worker accumulated every profiler event in host
-  anonymous memory — measured at 60 MiB/s with the production option set — until
-  the cgroup OOM-killer took the engine or worker process out mid-roofline, at
-  107–137 GiB RSS. Because `args_mode` is sticky on `current_best`, one such KEEP
-  turned *every* later roofline in that session into an OOM candidate.
+- **vLLM roofline runs no longer launch an unbounded torch profiler**: the
+  profile path injects `--profiler-config.delay_iterations/max_iterations` into
+  `EXTRA_VLLM_ARGS`, but three later steps could each drop them — a candidate
+  carrying `args_mode="replace"` (which `writeback` sets automatically as soon as
+  a KEEP needs `remove_args`) overwrote the whole flag string, `extra_envs` could
+  override it outright, and `remove_args` strips flags by name — taking the
+  `--profiler-config.ignore_frontend True` from the profile YAML with them. vLLM
+  reads a missing `max_iterations` as "profile until `stop_profile`", so the
+  worker accumulated every profiler event in host anonymous memory — measured at
+  60 MiB/s with the production option set — until the cgroup OOM-killer took the
+  engine or worker process out mid-roofline, at 107–137 GiB RSS. Because
+  `args_mode` is sticky on `current_best`, one such KEEP turned *every* later
+  roofline in that session into an OOM candidate.
 
-  `materialize_config_with_envs` now re-asserts the bounds after the
-  `extra_server_args`/`extra_envs` merges and warns when it had to restore them,
-  and it states `ignore_frontend` alongside the bounds (the AsyncLLM-side
-  profiler tracks no iterations and would otherwise capture the entire
-  `start_profile`..`stop_profile` range). Candidate flags still win for
-  everything else, and the append path is unchanged apart from no longer relying
-  on the YAML to carry `ignore_frontend`.
+  `materialize_config_with_envs` now re-asserts the profiler flags as the LAST
+  write to `EXTRA_VLLM_ARGS` — after the `extra_server_args`/`extra_envs` merges
+  and after `remove_args`/`unset_envs` — restoring only the flags that went
+  missing, warning about exactly which ones, and re-running the shell-safety
+  guard on the result. `max_iterations` (not `delay_iterations`) is what decides
+  whether the capture is bounded, so that is what is checked. `ignore_frontend`
+  is stated alongside the bounds, since the AsyncLLM-side profiler tracks no
+  iterations and would otherwise capture the entire
+  `start_profile`..`stop_profile` range. Candidate flags still win for everything
+  else, and the append path is unchanged apart from no longer relying on the YAML
+  to carry `ignore_frontend`.
+
+  Scope: **vLLM only**. SGLang bounds its capture through `start_step`/`num_steps`
+  inside `PROFILE_EXTRA_BODY`, which is written before the same `extra_envs`
+  merge and is therefore droppable the same way, but it is not re-asserted here —
+  whether a non-positive `num_steps` means "unbounded" or "no capture" needs a
+  SGLang-side answer this layer does not have, and every OOM observed so far was
+  vLLM. The exposure is called out in a comment at that write site.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,13 +54,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   write to `EXTRA_VLLM_ARGS` — after the `extra_server_args`/`extra_envs` merges
   and after `remove_args`/`unset_envs` — restoring only the flags that went
   missing, warning about exactly which ones, and re-running the shell-safety
-  guard on the result. `max_iterations` (not `delay_iterations`) is what decides
-  whether the capture is bounded, so that is what is checked. `ignore_frontend`
-  is stated alongside the bounds, since the AsyncLLM-side profiler tracks no
-  iterations and would otherwise capture the entire
-  `start_profile`..`stop_profile` range. Candidate flags still win for everything
-  else, and the append path is unchanged apart from no longer relying on the YAML
-  to carry `ignore_frontend`.
+  guard on the result. `ignore_frontend` is stated alongside the bounds, since the
+  AsyncLLM-side profiler tracks no iterations and would otherwise capture the
+  entire `start_profile`..`stop_profile` range. Candidate flags still win for
+  everything else, and the append path is unchanged apart from no longer relying
+  on the YAML to carry `ignore_frontend`.
+
+  The re-assertion checks flag VALUES, not just flag names, for the two flags that
+  decide whether the capture is bounded at all: `max_iterations` has to parse as a
+  positive integer within the computed serialization-safe cap (vLLM reads 0 as "no
+  limit"), and `ignore_frontend` has to be true. A name-only check accepted
+  `--profiler-config.max_iterations 0` and then logged that it had bounded the
+  profiler — worse than not guarding, since the warning sends the next
+  investigation the wrong way. The injected flags also keep overriding whatever the
+  YAML pins, via the repeated-flag last-wins vLLM's argparse already applies: a
+  hand-written `max_iterations 100000` is unbounded in practice and must not
+  displace the computed budget (`HYPERLOOM_PROFILE_MAX_ITERS` is the override
+  channel for that), and a stale `capture_torch_profiler_dir` must not send this
+  run's traces to a previous session's directory.
 
   Scope: **vLLM only**. SGLang bounds its capture through `start_step`/`num_steps`
   inside `PROFILE_EXTRA_BODY`, which is written before the same `extra_envs`

--- a/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -514,7 +514,7 @@ def test_materialize_profile_bounds_survive_a_replacing_candidate(
     # The candidate's own flags must still take effect, JSON value unmangled.
     assert "--no-enable-prefix-caching" in extra, extra
     assert '--compilation-config {"cudagraph_capture_sizes":[17,34,1088]}' in extra, extra
-    assert "lost the torch-profiler bounds" in caplog.text
+    assert "lost torch-profiler flags" in caplog.text
 
 
 def test_materialize_profile_bounds_survive_an_extra_envs_override(
@@ -575,6 +575,88 @@ def test_materialize_profile_adds_ignore_frontend_when_yaml_omits_it(
     out = _materialize_config_with_envs(src, tmp_path)
     extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
     assert "--profiler-config.ignore_frontend True" in extra, extra
+
+
+def test_materialize_profile_bounds_outlive_remove_args(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    """``remove_args`` runs after the merges, so the re-assertion has to be the last write.
+
+    The two arrive together in practice: ``args_mode="replace"`` exists precisely
+    because the KEEP carried ``remove_args`` (profile.py copies both off
+    ``base_*``), so a restore that lands before ``remove_server_args`` can be
+    undone by it -- while still logging that it restored the bounds.
+    """
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=True, sglang=False)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    caplog.set_level("WARNING")
+    out = _materialize_config_with_envs(
+        src,
+        tmp_path,
+        extra_server_args="--no-enable-prefix-caching",
+        args_mode="replace",
+        remove_args=["--profiler-config.max_iterations"],
+    )
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert "--profiler-config.max_iterations 128" in extra, extra
+    assert "lost torch-profiler flags" in caplog.text
+
+
+def test_materialize_profile_restores_max_iterations_even_when_delay_survives(
+    tmp_path,
+    monkeypatch,
+):
+    """``delay_iterations`` is a bad sentinel: it is ``max_iterations`` that bounds the capture.
+
+    A candidate that happens to carry a delay flag used to satisfy the guard and
+    leave the run with no cap at all -- exactly the unbounded profiler this is
+    meant to prevent.
+    """
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=True, sglang=False)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(
+        src,
+        tmp_path,
+        extra_server_args="--profiler-config.delay_iterations 0",
+        args_mode="replace",
+    )
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert "--profiler-config.max_iterations 128" in extra, extra
+    assert "--profiler-config.ignore_frontend True" in extra, extra
+    assert "--profiler-config.capture_torch_profiler_dir " in extra, extra
+    # The candidate's own delay value is left alone; only the missing flags return.
+    assert extra.count("--profiler-config.delay_iterations") == 1, extra
+
+
+def test_materialize_profile_restore_does_not_duplicate_surviving_flags(
+    tmp_path,
+    monkeypatch,
+):
+    """The restore re-states only what is missing; vLLM warns on duplicate keys."""
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=True, sglang=False)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(
+        src,
+        tmp_path,
+        extra_envs={
+            "EXTRA_VLLM_ARGS": "--profiler-config.ignore_frontend True --quantization fp8",
+        },
+    )
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert extra.count("--profiler-config.ignore_frontend True") == 1, extra
+    assert "--profiler-config.max_iterations 128" in extra, extra
+    assert "--quantization fp8" in extra, extra
 
 
 def test_materialize_profile_window_sglang_skill_formula(

--- a/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -577,6 +577,168 @@ def test_materialize_profile_adds_ignore_frontend_when_yaml_omits_it(
     assert "--profiler-config.ignore_frontend True" in extra, extra
 
 
+def test_materialize_profile_cap_wins_over_a_max_iterations_pinned_in_the_yaml(
+    tmp_path,
+    monkeypatch,
+):
+    """The computed cap has to override a YAML-pinned value, not defer to it.
+
+    The cap is a serialization-safe budget (``HYPERLOOM_PROFILE_MAX_STEPS_CAP`` /
+    steady-floor); a hand-written ``max_iterations 100000`` is unbounded in practice.
+    Injecting unconditionally and letting the repeated flag win last is what enforces
+    that -- skipping injection because the name is already present hands the run the
+    YAML value and silently discards the budget. ``HYPERLOOM_PROFILE_MAX_ITERS`` is
+    the operator override channel, not the YAML.
+    """
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=False, sglang=False)
+    src = _profile_yaml(
+        tmp_path,
+        "vllm",
+        {
+            "CONC": 32,
+            "ISL": 256,
+            "OSL": 1024,
+            "EXTRA_VLLM_ARGS": "--profiler-config.max_iterations 100000",
+        },
+    )
+    out = _materialize_config_with_envs(src, tmp_path)
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert "--profiler-config.max_iterations 128" in extra, extra
+    # Last occurrence wins in vLLM's argparse, so the injected cap must come after.
+    assert extra.rindex("max_iterations 128") > extra.rindex("max_iterations 100000"), extra
+
+
+def test_materialize_profile_capture_dir_wins_over_a_stale_yaml_path(
+    tmp_path,
+    monkeypatch,
+):
+    """A stale capture dir left in the YAML would send this run's traces to the
+    previous session's directory, so this run's dir has to be injected after it."""
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=True, sglang=False)
+    src = _profile_yaml(
+        tmp_path,
+        "vllm",
+        {
+            "CONC": 32,
+            "ISL": 256,
+            "OSL": 1024,
+            "EXTRA_VLLM_ARGS": "--profiler-config.capture_torch_profiler_dir /stale/run",
+        },
+    )
+    out = _materialize_config_with_envs(src, tmp_path)
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert "capture_traces" in extra, extra
+    assert extra.rindex("capture_traces") > extra.rindex("/stale/run"), extra
+
+
+def test_materialize_profile_restore_rejects_a_zero_max_iterations(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    """``max_iterations 0`` is vLLM's own spelling of "no limit".
+
+    Matching the flag by name alone accepted it, so the guard logged that it had made
+    the profiler bounded while the run stayed unbounded -- worse than not guarding,
+    because the warning sends the next investigation the wrong way.
+    """
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=True, sglang=False)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    caplog.set_level("WARNING")
+    out = _materialize_config_with_envs(
+        src,
+        tmp_path,
+        extra_server_args="--profiler-config.max_iterations 0",
+        args_mode="replace",
+    )
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert "--profiler-config.max_iterations 128" in extra, extra
+    assert extra.rindex("max_iterations 128") > extra.rindex("max_iterations 0"), extra
+    assert "lost torch-profiler flags" in caplog.text
+
+
+def test_materialize_profile_restore_rejects_a_max_iterations_above_the_cap(
+    tmp_path,
+    monkeypatch,
+):
+    """Above the serialization-safe cap is unbounded in every way that matters."""
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=True, sglang=False)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(
+        src,
+        tmp_path,
+        extra_server_args="--profiler-config.max_iterations 100000",
+        args_mode="replace",
+    )
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert extra.rindex("max_iterations 128") > extra.rindex("max_iterations 100000"), extra
+
+
+def test_materialize_profile_restore_rejects_ignore_frontend_false(
+    tmp_path,
+    monkeypatch,
+):
+    """A frontend profiler left on tracks no iterations and captures the whole range;
+    that is how an API-server process became an OOM victim."""
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=True, sglang=False)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(
+        src,
+        tmp_path,
+        extra_server_args="--profiler-config.ignore_frontend False",
+        args_mode="replace",
+    )
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert "--profiler-config.ignore_frontend True" in extra, extra
+    assert extra.rindex("ignore_frontend True") > extra.rindex("ignore_frontend False"), extra
+
+
+def test_materialize_profile_restore_accepts_a_bound_that_already_holds(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    """A candidate carrying a valid in-cap bound is left alone and logs nothing."""
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=True, sglang=False)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    caplog.set_level("WARNING")
+    out = _materialize_config_with_envs(
+        src,
+        tmp_path,
+        extra_envs={
+            "EXTRA_VLLM_ARGS": (
+                "--profiler-config.delay_iterations 6080 "
+                "--profiler-config.max_iterations 64 "
+                "--profiler-config.ignore_frontend True "
+                "--profiler-config.capture_torch_profiler_dir /x "
+                "--profiler-config.detailed_trace_annotation True"
+            ),
+        },
+    )
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert extra.count("--profiler-config.max_iterations") == 1, extra
+    assert "--profiler-config.max_iterations 64" in extra, extra
+    assert "lost torch-profiler flags" not in caplog.text
+
+
 def test_materialize_profile_bounds_outlive_remove_args(
     tmp_path,
     monkeypatch,

--- a/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -467,6 +467,111 @@ def test_materialize_profile_window_vllm_skill_formula_explicit_R(
     assert envs["RANDOM_RANGE_RATIO"] == 0.5
 
 
+def test_materialize_profile_bounds_survive_a_replacing_candidate(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    """A candidate with args_mode="replace" must not strip the profiler bounds.
+
+    Once ``current_best`` carries ``args_mode="replace"``, the candidate's flag
+    string overwrote EXTRA_VLLM_ARGS wholesale and took the injected
+    ``max_iterations`` with it. vLLM reads a missing ``max_iterations`` as
+    "profile until stop_profile", which grew host RAM at ~60 MiB/s until the
+    cgroup OOM-killer took the engine process out mid-roofline.
+    """
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=True, sglang=False)
+    src = _profile_yaml(
+        tmp_path,
+        "vllm",
+        {
+            "CONC": 32,
+            "ISL": 256,
+            "OSL": 1024,
+            "EXTRA_VLLM_ARGS": "--profiler-config.ignore_frontend True",
+        },
+    )
+    caplog.set_level("WARNING")
+    out = _materialize_config_with_envs(
+        src,
+        tmp_path,
+        extra_server_args="--no-enable-prefix-caching",
+        args_mode="replace",
+    )
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert "--profiler-config.delay_iterations 6080" in extra, extra
+    assert "--profiler-config.max_iterations 128" in extra, extra
+    # The frontend profiler tracks no iterations, so it has to come back too.
+    assert "--profiler-config.ignore_frontend True" in extra, extra
+    assert "--profiler-config.capture_torch_profiler_dir " in extra, extra
+    # The candidate's own flag must still take effect.
+    assert "--no-enable-prefix-caching" in extra, extra
+    assert "lost the torch-profiler bounds" in caplog.text
+
+
+def test_materialize_profile_bounds_survive_an_extra_envs_override(
+    tmp_path,
+    monkeypatch,
+):
+    """``extra_envs`` is applied last and unconditionally, so an EXTRA_VLLM_ARGS entry there is the other way the bounds can vanish."""
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=True, sglang=False)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(
+        src,
+        tmp_path,
+        extra_envs={"EXTRA_VLLM_ARGS": "--quantization fp8"},
+    )
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert "--profiler-config.delay_iterations 6080" in extra, extra
+    assert "--profiler-config.max_iterations 128" in extra, extra
+    assert "--quantization fp8" in extra, extra
+
+
+def test_materialize_profile_states_ignore_frontend_exactly_once(
+    tmp_path,
+    monkeypatch,
+):
+    """The bounds imply ignore_frontend, but the YAML usually already sets it and vLLM warns on duplicate keys."""
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=False, sglang=False)
+    src = _profile_yaml(
+        tmp_path,
+        "vllm",
+        {
+            "CONC": 32,
+            "ISL": 256,
+            "OSL": 1024,
+            "EXTRA_VLLM_ARGS": "--profiler-config.ignore_frontend True",
+        },
+    )
+    out = _materialize_config_with_envs(src, tmp_path)
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert extra.count("--profiler-config.ignore_frontend True") == 1, extra
+
+
+def test_materialize_profile_adds_ignore_frontend_when_yaml_omits_it(
+    tmp_path,
+    monkeypatch,
+):
+    """Bounding only the worker profiler leaves AsyncLLM capturing the whole range, so the flag is injected alongside the bounds."""
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=False, sglang=False)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(src, tmp_path)
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert "--profiler-config.ignore_frontend True" in extra, extra
+
+
 def test_materialize_profile_window_sglang_skill_formula(
     tmp_path,
     monkeypatch,

--- a/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -495,10 +495,14 @@ def test_materialize_profile_bounds_survive_a_replacing_candidate(
         },
     )
     caplog.set_level("WARNING")
+    # Verbatim from the gemma-4-26B-A4B roofline that was OOM-killed, JSON flag
+    # included -- the restore has to survive a string the arg merger refuses to
+    # tokenize.
+    candidate = '--no-enable-prefix-caching --compilation-config {"cudagraph_capture_sizes":[17,34,1088]}'
     out = _materialize_config_with_envs(
         src,
         tmp_path,
-        extra_server_args="--no-enable-prefix-caching",
+        extra_server_args=candidate,
         args_mode="replace",
     )
     extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
@@ -507,8 +511,9 @@ def test_materialize_profile_bounds_survive_a_replacing_candidate(
     # The frontend profiler tracks no iterations, so it has to come back too.
     assert "--profiler-config.ignore_frontend True" in extra, extra
     assert "--profiler-config.capture_torch_profiler_dir " in extra, extra
-    # The candidate's own flag must still take effect.
+    # The candidate's own flags must still take effect, JSON value unmangled.
     assert "--no-enable-prefix-caching" in extra, extra
+    assert '--compilation-config {"cudagraph_capture_sizes":[17,34,1088]}' in extra, extra
     assert "lost the torch-profiler bounds" in caplog.text
 
 

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -671,9 +671,11 @@ def materialize_config_with_envs(
 
     _is_scriptable_profile = _fw_reg.is_scriptable(bench.get("framework"))
     profile_num_prompts: int | None = None
-    # Remembered so the per-task ``extra_server_args``/``extra_envs`` merges below
-    # cannot leave the profiler unbounded; see the re-assertion after those merges.
-    pending_vllm_profiler_args: str = ""
+    # ``(sentinel, flag)`` pairs remembered so the re-assertion at the very end of
+    # this function can restore exactly the profiler flags that some later step
+    # dropped, without re-stating the ones that survived. See that block for why a
+    # dropped ``max_iterations`` is an OOM and not a cosmetic problem.
+    pending_vllm_profiler_flags: list[tuple[str, str]] = []
     if is_profile and not _is_scriptable_profile:
         try:
             r_val = float(envs.get("RANDOM_RANGE_RATIO", 1.0))
@@ -807,26 +809,29 @@ def materialize_config_with_envs(
             profile_num_prompts = None
         elif "vllm" in fw:
             existing_vllm_args = str(envs.get("EXTRA_VLLM_ARGS", ""))
-            profiler_args_parts = [
-                f"--profiler-config.delay_iterations {delay_iters}",
-                f"--profiler-config.max_iterations {max_iters}",
+            profiler_flags = [
+                ("delay_iterations", f"--profiler-config.delay_iterations {delay_iters}"),
+                ("max_iterations", f"--profiler-config.max_iterations {max_iters}"),
             ]
             if tracelens_patch_ok:
                 # TraceLens-patched vLLM exposes capture_torch_profiler_dir +
                 # detailed_trace_annotation; unpatched vLLM rejects them.
                 capture_dir = output_dir / "capture_traces"
-                profiler_args_parts.append(f"--profiler-config.capture_torch_profiler_dir {capture_dir}")
-                profiler_args_parts.append("--profiler-config.detailed_trace_annotation True")
+                profiler_flags.append(
+                    (
+                        "capture_torch_profiler_dir",
+                        f"--profiler-config.capture_torch_profiler_dir {capture_dir}",
+                    )
+                )
+                profiler_flags.append(("detailed_trace_annotation", "--profiler-config.detailed_trace_annotation True"))
             # vLLM's AsyncLLM-side profiler tracks no iterations and captures the
             # whole start_profile..stop_profile range, so it has to stay off
             # wherever we bound the worker-side one. The YAML normally carries the
-            # flag; the restore path below has to re-state it because a replacing
-            # candidate wipes the YAML value too.
-            _ignore_frontend = "--profiler-config.ignore_frontend True"
-            pending_vllm_profiler_args = " ".join([*profiler_args_parts, _ignore_frontend])
-            if "ignore_frontend" not in existing_vllm_args:
-                profiler_args_parts.append(_ignore_frontend)
-            profiler_args = " ".join(profiler_args_parts)
+            # flag, but a replacing candidate wipes the YAML value too, so it
+            # belongs in the set the re-assertion can restore.
+            profiler_flags.append(("ignore_frontend", "--profiler-config.ignore_frontend True"))
+            pending_vllm_profiler_flags = profiler_flags
+            profiler_args = " ".join(flag for sentinel, flag in profiler_flags if sentinel not in existing_vllm_args)
             if "delay_iterations" not in existing_vllm_args:
                 envs["EXTRA_VLLM_ARGS"] = f"{existing_vllm_args} {profiler_args}".strip()
         else:
@@ -874,6 +879,14 @@ def materialize_config_with_envs(
                         )
             extra_body["shape_discovery"] = _shape_disc
             extra_body.setdefault("roofline_annotations", True)
+            # NOTE: this write happens before the per-task ``extra_envs`` merge, so
+            # an ``extra_envs`` entry for PROFILE_EXTRA_BODY can still drop
+            # start_step/num_steps the way ``args_mode="replace"`` used to drop
+            # vLLM's --profiler-config bounds. The vLLM side is re-asserted at the
+            # end of this function; SGLang is NOT, because deciding whether a
+            # non-positive num_steps means "unbounded" or "no capture" needs a
+            # SGLang-side answer this layer does not have. Every OOM observed so
+            # far was vLLM.
             envs["PROFILE_EXTRA_BODY"] = _json.dumps(extra_body)
             if tracelens_patch_ok and _shape_disc:
                 # TraceLens-patched SGLang exposes
@@ -952,29 +965,6 @@ def materialize_config_with_envs(
     for key, value in safe_extra_envs.items():
         envs[str(key)] = str(value)
     framework_env = server_args_env_name(bench.get("framework"))
-    if pending_vllm_profiler_args and framework_env == "EXTRA_VLLM_ARGS":
-        # A candidate carrying ``args_mode="replace"`` (or an ``extra_envs``
-        # override of EXTRA_VLLM_ARGS) overwrites the whole flag string, taking
-        # the profiler bounds injected above with it. vLLM reads a missing
-        # max_iterations as "profile forever" and accumulates every event in host
-        # RAM at ~60 MiB/s until the cgroup OOM-killer takes the engine out, so
-        # restore the bounds rather than launching an unbounded profiler.
-        from ._grid_runner import merge_server_args
-
-        _profile_args = str(envs.get(framework_env, "")).strip()
-        if "delay_iterations" not in _profile_args:
-            log.warning(
-                "profile server args lost the torch-profiler bounds during the "
-                "per-task merge (replace_args=%s); restoring %r to keep the "
-                "profiler from running unbounded.",
-                bool(replace_args),
-                pending_vllm_profiler_args,
-            )
-            envs[framework_env] = (
-                merge_server_args(_profile_args, pending_vllm_profiler_args)
-                if _profile_args
-                else pending_vllm_profiler_args
-            )
     # Final dedup after reference/server_args merges: collapse repeated
     # vLLM/atom single-value flags to last-wins so recipe/variant values
     # override earlier ones (no-op for sglang).
@@ -1238,6 +1228,33 @@ def materialize_config_with_envs(
     for key in unset_list:
         if isinstance(extra_envs, dict) and key in extra_envs:
             envs[str(key)] = str(extra_envs[key])
+    if pending_vllm_profiler_flags and framework_env == "EXTRA_VLLM_ARGS":
+        # The profile path's iteration bounds have to be the LAST word on this env,
+        # because three separate steps above can drop them: a candidate carrying
+        # ``args_mode="replace"`` (which writeback sets as soon as a KEEP needs
+        # ``remove_args``) overwrites the whole flag string, ``extra_envs`` can
+        # override it outright, and ``remove_args`` itself strips flags by name.
+        # vLLM reads a missing ``max_iterations`` as "profile until stop_profile",
+        # and the worker then accumulates every profiler event in host RAM at
+        # ~60 MiB/s until the cgroup OOM-killer takes it out mid-roofline. No
+        # exploration result is worth that, so the bounds win over all three.
+        from ._grid_runner import merge_server_args
+
+        profile_args = str(envs.get(framework_env, "")).strip()
+        restored = [flag for sentinel, flag in pending_vllm_profiler_flags if sentinel not in profile_args]
+        if restored:
+            log.warning(
+                "profile server args lost torch-profiler flags %r (replace_args=%s); "
+                "restoring them so the profiler cannot run unbounded.",
+                restored,
+                bool(replace_args),
+            )
+            merged = " ".join(restored)
+            if profile_args:
+                merged = merge_server_args(profile_args, merged)
+            # _finalize_framework_server_args already ran, so re-apply the sink-side
+            # guard it ends with rather than shipping an unvalidated string.
+            envs[framework_env] = validate_server_args_shell_safe(merged)
     filtered_envs = filter_benchmark_env_mapping(envs)
     dropped_credentials = sorted(set(envs) - set(filtered_envs))
     if dropped_credentials:

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -671,6 +671,9 @@ def materialize_config_with_envs(
 
     _is_scriptable_profile = _fw_reg.is_scriptable(bench.get("framework"))
     profile_num_prompts: int | None = None
+    # Remembered so the per-task ``extra_server_args``/``extra_envs`` merges below
+    # cannot leave the profiler unbounded; see the re-assertion after those merges.
+    pending_vllm_profiler_args: str = ""
     if is_profile and not _is_scriptable_profile:
         try:
             r_val = float(envs.get("RANDOM_RANGE_RATIO", 1.0))
@@ -814,6 +817,15 @@ def materialize_config_with_envs(
                 capture_dir = output_dir / "capture_traces"
                 profiler_args_parts.append(f"--profiler-config.capture_torch_profiler_dir {capture_dir}")
                 profiler_args_parts.append("--profiler-config.detailed_trace_annotation True")
+            # vLLM's AsyncLLM-side profiler tracks no iterations and captures the
+            # whole start_profile..stop_profile range, so it has to stay off
+            # wherever we bound the worker-side one. The YAML normally carries the
+            # flag; the restore path below has to re-state it because a replacing
+            # candidate wipes the YAML value too.
+            _ignore_frontend = "--profiler-config.ignore_frontend True"
+            pending_vllm_profiler_args = " ".join([*profiler_args_parts, _ignore_frontend])
+            if "ignore_frontend" not in existing_vllm_args:
+                profiler_args_parts.append(_ignore_frontend)
             profiler_args = " ".join(profiler_args_parts)
             if "delay_iterations" not in existing_vllm_args:
                 envs["EXTRA_VLLM_ARGS"] = f"{existing_vllm_args} {profiler_args}".strip()
@@ -940,6 +952,29 @@ def materialize_config_with_envs(
     for key, value in safe_extra_envs.items():
         envs[str(key)] = str(value)
     framework_env = server_args_env_name(bench.get("framework"))
+    if pending_vllm_profiler_args and framework_env == "EXTRA_VLLM_ARGS":
+        # A candidate carrying ``args_mode="replace"`` (or an ``extra_envs``
+        # override of EXTRA_VLLM_ARGS) overwrites the whole flag string, taking
+        # the profiler bounds injected above with it. vLLM reads a missing
+        # max_iterations as "profile forever" and accumulates every event in host
+        # RAM at ~60 MiB/s until the cgroup OOM-killer takes the engine out, so
+        # restore the bounds rather than launching an unbounded profiler.
+        from ._grid_runner import merge_server_args
+
+        _profile_args = str(envs.get(framework_env, "")).strip()
+        if "delay_iterations" not in _profile_args:
+            log.warning(
+                "profile server args lost the torch-profiler bounds during the "
+                "per-task merge (replace_args=%s); restoring %r to keep the "
+                "profiler from running unbounded.",
+                bool(replace_args),
+                pending_vllm_profiler_args,
+            )
+            envs[framework_env] = (
+                merge_server_args(_profile_args, pending_vllm_profiler_args)
+                if _profile_args
+                else pending_vllm_profiler_args
+            )
     # Final dedup after reference/server_args merges: collapse repeated
     # vLLM/atom single-value flags to last-wins so recipe/variant values
     # override earlier ones (no-op for sglang).

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -365,6 +365,52 @@ def default_baseline_config() -> Path:
     return asset_root() / rel
 
 
+_PROFILER_FLAG_RE = re.compile(r"--profiler-config\.(\w+)[=\s]+(\S+)")
+_TRUTHY_FLAG_VALUES = frozenset({"1", "on", "true", "yes"})
+
+
+def _profiler_flag_value(server_args: str, name: str) -> str | None:
+    """The value vLLM would resolve for ``--profiler-config.<name>``, or None.
+
+    Returns the LAST occurrence, because repeated flags are how this layer overrides
+    earlier ones and vLLM's argparse resolves them last-wins. Accepts both
+    ``--flag value`` and ``--flag=value``. Regex rather than tokenization: this runs
+    after JSON-valued flags have been compacted, and one unbalanced quote must not
+    take the whole guard down with it.
+    """
+    value: str | None = None
+    for match in _PROFILER_FLAG_RE.finditer(server_args or ""):
+        if match.group(1) == name:
+            value = match.group(2)
+    return value
+
+
+def _profiler_bound_holds(name: str, value: str | None, *, cap: int) -> bool:
+    """Whether the value already present keeps this flag's guarantee.
+
+    Name-only matching is not enough for the two flags that decide whether the
+    capture is bounded at all: vLLM reads ``max_iterations`` of 0 (or absent) as "no
+    limit", and a frontend profiler left on tracks no iterations and captures the
+    entire ``start_profile``..``stop_profile`` range. A guard that accepted those
+    would report success while the run stayed unbounded, which is worse than not
+    guarding -- the warning would send the next investigation the wrong way.
+
+    Every other flag only decides what the trace contains or where it lands, so its
+    presence is the whole contract.
+    """
+    if value is None:
+        return False
+    if name == "max_iterations":
+        try:
+            iterations = int(value)
+        except ValueError:
+            return False
+        return 0 < iterations <= cap
+    if name == "ignore_frontend":
+        return value.strip().lower() in _TRUTHY_FLAG_VALUES
+    return True
+
+
 def _finalize_framework_server_args(
     envs: dict[str, Any],
     bench: dict[str, Any],
@@ -676,6 +722,10 @@ def materialize_config_with_envs(
     # dropped, without re-stating the ones that survived. See that block for why a
     # dropped ``max_iterations`` is an OOM and not a cosmetic problem.
     pending_vllm_profiler_flags: list[tuple[str, str]] = []
+    # The serialization-safe capture cap computed below, so the re-assertion can reject
+    # a max_iterations that is above it (or non-positive, which vLLM reads as no limit)
+    # instead of accepting the flag on its name alone.
+    pending_vllm_profiler_cap: int = 0
     if is_profile and not _is_scriptable_profile:
         try:
             r_val = float(envs.get("RANDOM_RANGE_RATIO", 1.0))
@@ -831,7 +881,20 @@ def materialize_config_with_envs(
             # belongs in the set the re-assertion can restore.
             profiler_flags.append(("ignore_frontend", "--profiler-config.ignore_frontend True"))
             pending_vllm_profiler_flags = profiler_flags
-            profiler_args = " ".join(flag for sentinel, flag in profiler_flags if sentinel not in existing_vllm_args)
+            pending_vllm_profiler_cap = max_iters
+            # Injected unconditionally so the computed cap WINS over anything the YAML
+            # pins, via the repeated-flag last-wins that vLLM's argparse and this
+            # layer both rely on. Filtering out a flag the YAML already carries would
+            # hand the run e.g. a hand-written ``max_iterations 100000`` -- unbounded
+            # in practice -- and quietly discard the serialization-safe budget
+            # computed above; HYPERLOOM_PROFILE_MAX_ITERS is the override channel for
+            # that, not the YAML. ``ignore_frontend`` is the exception: the shipped
+            # profile YAML already sets it, and vLLM warns on duplicate keys.
+            profiler_args = " ".join(
+                flag
+                for sentinel, flag in profiler_flags
+                if sentinel != "ignore_frontend" or "ignore_frontend" not in existing_vllm_args
+            )
             if "delay_iterations" not in existing_vllm_args:
                 envs["EXTRA_VLLM_ARGS"] = f"{existing_vllm_args} {profiler_args}".strip()
         else:
@@ -1241,7 +1304,15 @@ def materialize_config_with_envs(
         from ._grid_runner import merge_server_args
 
         profile_args = str(envs.get(framework_env, "")).strip()
-        restored = [flag for sentinel, flag in pending_vllm_profiler_flags if sentinel not in profile_args]
+        restored = [
+            flag
+            for name, flag in pending_vllm_profiler_flags
+            if not _profiler_bound_holds(
+                name,
+                _profiler_flag_value(profile_args, name),
+                cap=pending_vllm_profiler_cap,
+            )
+        ]
         if restored:
             log.warning(
                 "profile server args lost torch-profiler flags %r (replace_args=%s); "


### PR DESCRIPTION
## Problem

Several CI tasks were killed by the cgroup OOM-killer over the last few days. The kernel `dmesg` records name the victims precisely: `VLLM::Worker_TP` at 130.2 and 136.8 GiB anon-rss, `VLLM::EngineCore` at 107.2 and 107.3 GiB, with page cache at 4.9 MiB at the moment of death — 99.7% anonymous memory. The faulting instruction is inside glibc `_int_malloc` writing a chunk header, with `RDX` decoding to 4064 B / 20448 B chunks on a heap already ~100 GiB deep. So this was millions of small allocations piling up, not one oversized buffer.

Every victim was in the **roofline** phase.

## Root cause

`materialize_config_with_envs` injects the torch-profiler capture window into `EXTRA_VLLM_ARGS`:

```python
profiler_args_parts = [
    f"--profiler-config.delay_iterations {delay_iters}",
    f"--profiler-config.max_iterations {max_iters}",
]
...
if "delay_iterations" not in existing_vllm_args:
    envs["EXTRA_VLLM_ARGS"] = f"{existing_vllm_args} {profiler_args}".strip()
```

The per-task merge runs ~100 lines **later**, and its own comment says it must not drop the profile path's flags — but the `replace_args` branch does exactly that:

```python
if server_args:
    # Merge into (not overwrite) the framework env so the profile path's
    # graph-capture flags aren't dropped.
    ...
    if replace_args:
        envs[framework_env] = server_args
```

`writeback` marks `current_best["args_mode"] = "replace"` automatically as soon as a KEEP carries `remove_args` or `unset_envs`. From that point on the candidate's flag string replaces `EXTRA_VLLM_ARGS` wholesale, taking the bounds *and* the `--profiler-config.ignore_frontend True` that `profile_vllm.yaml` supplies. `extra_envs` (applied last and unconditionally) is a second way in.

In vLLM, `max_iterations = 0` means no limit, and `warmup_iterations = 0` means no `torch.profiler.schedule` at all, so nothing ever calls `on_trace_ready`:

```
ProfilerConfig(profiler='torch', torch_profiler_with_stack=True,
  torch_profiler_record_shapes=True, torch_profiler_with_memory=True,
  ignore_frontend=False, delay_iterations=0, max_iterations=0, ...)
```

That is the config vLLM logged in the gemma run that was killed. The profiler recorded from `/start_profile` at 06:28:58 until the kernel killed the worker at 06:57:53 — 29 minutes.

## Evidence

Ablation on one MI355X, Llama-3.1-8B-Instruct, identical serve flags and identical load generator:

| Configuration | Anon growth | Peak | Extrapolated to 107 GiB |
|---|---|---|---|
| Profiler off, 900 s, 91,701 requests served | **0.19 MiB/s** | 6.12 GiB | never |
| Profiler on, all options off | 20.3 MiB/s | 22.05 GiB | ~85 min |
| `+ with_memory + record_shapes + with_flops` | 47.8 MiB/s | 18.15 GiB | 32 min |
| **+ `with_stack` (the production set)** | **60.1 MiB/s** | 21.63 GiB | **24 min** |

24 minutes predicted against 29 minutes observed. The growth is perfectly linear with no plateau, and `smaps` puts 9.2 of 15 GiB in a single `[heap]` region — matching the malloc stack trace from the kernel log. glibc arenas hold only 448 MiB, so this is the main `brk` heap, not arena fragmentation.

Ruled out as causes (each ablated separately, all peaked at 5.7–6.1 GiB with no growth): `--quantization fp8`, ngram speculative decoding, prefix caching, `ROCM_AITER_UNIFIED_ATTN`, `--kv-cache-dtype fp8_e4m3`, `--max-num-seqs 1024`.

The production sessions corroborate the mechanism directly — both flip from bounded to unbounded at the point their `current_best` became replacing, and never recover:

| Session | Roofline runs with bounds | Roofline runs without |
|---|---|---|
| Llama-3.1-8B | 08-04 20:33 → 08-05 02:10 | 08-05 05:51 onward (OOM at 10:01) |
| gemma-4-26B-A4B | 08-04 09:02 → 08-05 01:36 | 08-05 05:29 onward (OOM at 06:57) |

A DeepSeek-V4-Flash session whose `current_best` was a single additive flag (`--kv-cache-dtype fp8_ds_mla`, so `args_mode="append"`) kept `delay_iterations 6080 / max_iterations 128`, logged `Max profiling iterations reached. Stopping profiler...` 5 seconds after starting, and survived.

## Fix

Re-assert the profiler bounds after the `extra_server_args` / `extra_envs` merges, warn when they had to be restored, and state `ignore_frontend` alongside them — the AsyncLLM-side profiler tracks no iterations, so bounding only the worker leaves the frontend capturing the whole range (which is how the API-server process became the victim in one of the kills).

Candidate flags still win for everything else. The append path is unchanged except that it no longer depends on the YAML to carry `ignore_frontend`.

## Test plan

- [x] `test_materialize_profile_bounds_survive_a_replacing_candidate` — reproduces the OOM configuration (`args_mode="replace"`) and asserts the bounds, `ignore_frontend`, the TraceLens capture flags and the candidate's own flag all survive, plus the restore warning.
- [x] `test_materialize_profile_bounds_survive_an_extra_envs_override` — covers the second path in.
- [x] `test_materialize_profile_states_ignore_frontend_exactly_once` — vLLM warns on duplicate keys, so the flag must not be doubled when the YAML already sets it.
- [x] `test_materialize_profile_adds_ignore_frontend_when_yaml_omits_it`
- [x] Existing suites green: 262 passed across `test_profile_and_kernel_handlers.py`, `test_workload_envs.py`, `test_workload_envs_branches_unit.py`, `test_cli_workload_envs.py`. The one failure, `test_profile_yaml_has_torch_profiler_enabled`, is a pre-existing Windows-only `cp1252` decode of `profile_sglang.yaml`; no YAML is touched by this change.
- [x] `ruff check` and `ruff format --check` clean.

## Follow-ups (not in this PR)

- The profile path enables `with_stack`, `record_shapes` and `with_memory`, which together triple the per-event cost (20 → 60 MiB/s). Bounded capture makes that survivable, but trimming what TraceLens does not consume would give margin back.
- Independent of memory: with `--quantization fp8`, AITER logs `Warning: Latency not found for MI_M=16, MI_N=16, MI_K=128...` — 3.2 million lines / 450 MB of `server.log` in 16 minutes (zero lines without fp8).
- The cgroups have `memory.high` unset, so there is no soft-throttle stage before the OOM killer.
