### PR TITLE
fix(kernel): stop sentinel strings from short-circuiting source resolution

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_llm_source_fallback.py
+++ b/src/hyperloom/agents/kernel/tests/test_llm_source_fallback.py
@@ -1,0 +1,190 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""The LLM tier of source resolution: selection only, and off by default.
+
+This pipeline was broken by an LLM writing a placeholder into a field that was
+consumed as a path, so the tier that reintroduces an LLM has to be provably
+unable to repeat that: it may only echo back one of the paths it was given, the
+answer is checked against the filesystem, and it stays off unless enabled.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+import _llm_source_fallback as lsf  # noqa: E402
+
+
+@pytest.fixture()
+def enabled(monkeypatch):
+    monkeypatch.setenv("HYPERLOOM_KERNEL_SOURCE_LLM_FALLBACK", "1")
+
+
+@pytest.fixture()
+def files(tmp_path):
+    real = tmp_path / "kernel.py"
+    real.write_text("@triton.jit\ndef my_kernel():\n    pass\n", encoding="utf-8")
+    test_file = tmp_path / "test_kernel.py"
+    test_file.write_text("def test_my_kernel():\n    pass\n", encoding="utf-8")
+    return str(real), str(test_file)
+
+
+def _replies(payload) -> callable:
+    text = payload if isinstance(payload, str) else json.dumps(payload)
+    return lambda _prompt, _model, _timeout: text
+
+
+# --- Off by default -----------------------------------------------------------
+
+
+def test_disabled_by_default(monkeypatch, files):
+    monkeypatch.delenv("HYPERLOOM_KERNEL_SOURCE_LLM_FALLBACK", raising=False)
+    assert lsf.llm_fallback_enabled() is False
+    picked, _conf, reason = lsf.select_source_via_llm(
+        "my_kernel", [files[0]], complete=_replies({"source_file": files[0], "confidence": 1.0})
+    )
+    assert picked == ""
+    assert reason == "disabled"
+
+
+@pytest.mark.parametrize("value", ["1", "true", "YES", "on"])
+def test_enabled_by_truthy_flag(monkeypatch, value):
+    monkeypatch.setenv("HYPERLOOM_KERNEL_SOURCE_LLM_FALLBACK", value)
+    assert lsf.llm_fallback_enabled() is True
+
+
+# --- Selection, never generation ----------------------------------------------
+
+
+def test_accepts_a_candidate_from_the_shortlist(enabled, files):
+    real, test_file = files
+    picked, confidence, _reason = lsf.select_source_via_llm(
+        "my_kernel",
+        [test_file, real],
+        complete=_replies({"source_file": real, "confidence": 0.9, "reason": "defines the kernel"}),
+    )
+    assert picked == real
+    assert confidence == 0.9
+
+
+def test_rejects_a_path_outside_the_shortlist(enabled, files, tmp_path):
+    """An invented path is the failure mode this tier must not have."""
+    invented = str(tmp_path / "hallucinated.py")
+    picked, _conf, reason = lsf.select_source_via_llm(
+        "my_kernel", [files[0]], complete=_replies({"source_file": invented, "confidence": 1.0})
+    )
+    assert picked == ""
+    assert "not one of the candidates" in reason
+
+
+def test_rejects_a_shortlisted_path_that_vanished(enabled, tmp_path):
+    missing = str(tmp_path / "gone.py")
+    picked, _conf, reason = lsf.select_source_via_llm(
+        "my_kernel", [missing], complete=_replies({"source_file": missing, "confidence": 1.0})
+    )
+    assert picked == ""
+    assert "does not exist" in reason
+
+
+def test_rejects_a_path_outside_the_framework_roots(enabled, files):
+    picked, _conf, reason = lsf.select_source_via_llm(
+        "my_kernel",
+        [files[0]],
+        framework_roots=("/sgl-workspace/sglang",),
+        complete=_replies({"source_file": files[0], "confidence": 1.0}),
+    )
+    assert picked == ""
+    assert "outside every framework root" in reason
+
+
+def test_no_candidates_short_circuits_without_calling_the_model(enabled):
+    def _boom(*_args):  # pragma: no cover - must not run
+        raise AssertionError("model called with an empty shortlist")
+
+    picked, _conf, reason = lsf.select_source_via_llm("my_kernel", [], complete=_boom)
+    assert picked == ""
+    assert "no candidates" in reason
+
+
+# --- Confidence and malformed replies -----------------------------------------
+
+
+def test_low_confidence_is_discarded(enabled, files):
+    picked, confidence, reason = lsf.select_source_via_llm(
+        "my_kernel", [files[0]], complete=_replies({"source_file": files[0], "confidence": 0.4})
+    )
+    assert picked == ""
+    assert confidence == 0.4
+    assert "below" in reason
+
+
+def test_empty_answer_means_none_of_the_candidates(enabled, files):
+    picked, _conf, reason = lsf.select_source_via_llm(
+        "my_kernel", [files[0]], complete=_replies({"source_file": "", "confidence": 0.0})
+    )
+    assert picked == ""
+    assert "no candidate" in reason
+
+
+def test_prose_wrapped_json_is_still_parsed(enabled, files):
+    real = files[0]
+    reply = f'Sure!\n```json\n{{"source_file": "{real}", "confidence": 0.95}}\n```\n'
+    picked, _conf, _reason = lsf.select_source_via_llm("my_kernel", [real], complete=_replies(reply))
+    assert picked == real
+
+
+def test_non_json_reply_is_rejected(enabled, files):
+    picked, _conf, reason = lsf.select_source_via_llm(
+        "my_kernel", [files[0]], complete=_replies("I could not determine the file.")
+    )
+    assert picked == ""
+    assert "no JSON object" in reason
+
+
+def test_model_error_is_swallowed(enabled, files):
+    def _raise(*_args):
+        raise RuntimeError("gateway 401")
+
+    picked, _conf, reason = lsf.select_source_via_llm("my_kernel", [files[0]], complete=_raise)
+    assert picked == ""
+    assert "llm call failed" in reason
+
+
+# --- Wiring into finalization --------------------------------------------------
+
+
+def test_finalizer_skips_the_tier_when_disabled(monkeypatch):
+    import tracelens_analysis as tl
+
+    monkeypatch.delenv("HYPERLOOM_KERNEL_SOURCE_LLM_FALLBACK", raising=False)
+    item = {"name": "some_kernel", "gpu_pct": 40.0, "source_file": ""}
+    tl._apply_llm_source_fallback(item)
+    assert item["source_file"] == ""
+
+
+def test_finalizer_skips_cold_kernels(monkeypatch):
+    """Below the GPU-share floor the round-trip is not worth its cost."""
+    import tracelens_analysis as tl
+
+    monkeypatch.setenv("HYPERLOOM_KERNEL_SOURCE_LLM_FALLBACK", "1")
+    called = []
+    monkeypatch.setattr(tl, "collect_source_candidates_via_grep", lambda *_a, **_k: called.append(1) or [])
+    tl._apply_llm_source_fallback({"name": "k", "gpu_pct": 0.5, "source_file": ""})
+    assert not called
+
+
+def test_runtime_api_names_yield_no_shortlist():
+    import tracelens_analysis as tl
+
+    assert tl.collect_source_candidates_via_grep("hipGraphLaunch") == []

--- a/src/hyperloom/agents/kernel/tests/test_source_resolution_guards.py
+++ b/src/hyperloom/agents/kernel/tests/test_source_resolution_guards.py
@@ -1,0 +1,242 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Guards that keep an unresolved-launcher sentinel from becoming a source_file.
+
+TraceLens writes ``launcher_path = "Not found"`` for every Synthetic Op (a
+device kernel with no cpu_op parent, e.g. a hand-written Triton kernel launched
+straight from Python). That string used to survive parsing as a truthy
+``source_file``, which skipped the grep fallback and made classify_patchability
+reject the hottest kernels with "source not under a reusable framework root:
+Not found". These tests pin the three guards that close that path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+import tracelens_analysis as tl  # noqa: E402
+import tracelens_skill_runner as tsr  # noqa: E402
+
+
+_HEADERS = [
+    "operation",
+    "args",
+    "kernel path",
+    "time (ms)",
+    "%e2e",
+    "count",
+    "flops/byte",
+    "efficiency",
+    "bound",
+]
+
+
+def _row(kernel_path: str) -> dict | None:
+    """Build one candidate from a data-table row carrying ``kernel_path``."""
+    cells = [
+        "hipModuleLaunchKernel->_mxfp8_grouped_gemm_kernel (Synthetic Op)",
+        "",
+        kernel_path,
+        "15.671",
+        "7.04",
+        "114",
+        "—",
+        "—",
+        "—",
+    ]
+    return tsr._row_to_candidate(
+        _HEADERS,
+        cells,
+        category="other",
+        rank=1,
+        title="MXFP8 grouped GEMM",
+        library="",
+        impact={},
+    )
+
+
+# --- Guard 1: launcher placeholder normalisation ---------------------------
+
+
+def test_not_found_sentinel_normalized_to_empty():
+    cand = _row("Not found")
+    assert cand is not None
+    assert cand["source_file"] == ""
+    assert cand["tracelens_launcher_path"] == ""
+
+
+def test_not_found_sentinel_variants_normalized():
+    for raw in ("Not found", "NOT FOUND", "not found", "not_found", "notfound", "  Not Found  "):
+        cand = _row(raw)
+        assert cand is not None, raw
+        assert cand["source_file"] == "", raw
+
+
+def test_legacy_dash_placeholders_still_normalized():
+    for raw in ("-", "—", "–", "n/a", "unknown"):
+        cand = _row(raw)
+        assert cand is not None, raw
+        assert cand["source_file"] == "", raw
+
+
+def test_real_launcher_path_survives():
+    real = "/sgl-workspace/sglang/python/sglang/kernels/ops/moe/mxfp8_moe_amd_gfx95.py(124): _grouped_gemm_mxfp8"
+    cand = _row(real)
+    assert cand is not None
+    assert cand["tracelens_launcher_path"] == real
+    assert cand["source_file"] != ""
+
+
+def test_not_found_is_in_shared_placeholder_set():
+    assert "not found" in tsr._LAUNCHER_PATH_PLACEHOLDERS
+
+
+# --- Guard 2: bare runtime-API names are not kernels ------------------------
+
+
+def test_bare_runtime_api_names_detected():
+    for name in (
+        "hipGraphLaunch",
+        "hipModuleLaunchKernel",
+        "hipLaunchKernel",
+        "cudaLaunchKernel",
+        "cudaGraphLaunch",
+    ):
+        assert tl.is_runtime_api_name(name), name
+
+
+def test_runtime_api_wrapping_a_kernel_is_not_blocked():
+    """The wrapper prefix is stripped, so the real kernel must still resolve."""
+    for name in (
+        "hipModuleLaunchKernel->_mxfp8_grouped_gemm_kernel (Synthetic Op)",
+        "hipGraphLaunch->_mxfp8_linear_kernel (Synthetic Op)",
+    ):
+        assert not tl.is_runtime_api_name(name), name
+
+
+def test_grep_refuses_bare_runtime_api():
+    for name in ("hipGraphLaunch", "hipModuleLaunchKernel", "hipLaunchKernel"):
+        assert tl.locate_source_via_grep(name) == "", name
+
+
+# --- Guard 3: a source_file must be path-shaped -----------------------------
+
+
+def test_non_path_source_file_is_zeroed():
+    """Any value lacking a source extension is rejected, not just 'Not found'.
+
+    Covers the vendor labels TraceLens also emits in this field.
+    """
+    for sentinel in ("Not found", "N/A", "unknown", "TBD", "<unresolved>", "AITER (vendor)", "Triton (vendor)"):
+        item = {"name": "k", "source_file": sentinel, "kernel_repo": "", "source_type": "python"}
+        tl._stamp_candidate_metadata(item, None)
+        assert item["source_file"] == "", sentinel
+        assert item["source_file_rejected"] == sentinel
+        assert item["source_resolution_method"] == "rejected_non_path_sentinel"
+
+
+def test_path_shaped_but_absent_file_is_kept_and_flagged(tmp_path):
+    """Keyed on shape, not presence: the analysis host need not own the
+    serving container's filesystem."""
+    missing = str(tmp_path / "does_not_exist.py")
+    item = {"name": "k", "source_file": missing, "kernel_repo": "", "source_type": "python"}
+    tl._stamp_candidate_metadata(item, None)
+    assert item["source_file"] == missing
+    assert item["source_file_missing_on_disk"] is True
+    assert "source_file_rejected" not in item
+
+
+def test_package_relative_path_survives():
+    """TraceLens emits package-relative launchers such as sgl_kernel/moe.py."""
+    item = {"name": "k", "source_file": "sgl_kernel/moe.py", "kernel_repo": "", "source_type": "python"}
+    tl._stamp_candidate_metadata(item, None)
+    assert item["source_file"] == "sgl_kernel/moe.py"
+    assert "source_file_rejected" not in item
+
+
+def test_existing_source_file_is_preserved_without_flags(tmp_path):
+    real = tmp_path / "kernel.py"
+    real.write_text("import triton\n", encoding="utf-8")
+    item = {"name": "k", "source_file": str(real), "kernel_repo": "", "source_type": "python"}
+    tl._stamp_candidate_metadata(item, None)
+    assert item["source_file"] == str(real)
+    assert "source_file_rejected" not in item
+    assert "source_file_missing_on_disk" not in item
+
+
+def test_empty_source_file_does_not_get_a_rejected_marker():
+    item = {"name": "k", "source_file": "", "kernel_repo": "", "source_type": "unknown"}
+    tl._stamp_candidate_metadata(item, None)
+    assert item["source_file"] == ""
+    assert "source_file_rejected" not in item
+
+
+# --- Guard 4: trace-relative launcher paths are absolutized -----------------
+#
+# torch profiler records a frame path relative to the sys.path entry the module
+# came from ("aiter/dist/x.py"). Patchability keys on an absolute framework
+# root, so a relative path would be rejected for the wrong reason.
+
+
+def test_relative_path_resolves_via_the_installed_package(monkeypatch):
+    """The real case: the pinned checkout roots do not exist on this host.
+
+    torch profiler records "vllm/models/x.py" relative to the sys.path entry the
+    module came from. A pinned list cannot cover that -- the same package sits
+    under /sgl-workspace in the serving image and under dist-packages on a wheel
+    install -- so resolution has to locate the package at runtime.
+    """
+    # Pinned roots deliberately absent, exactly as on a wheel-install host.
+    monkeypatch.setattr(tl, "_PACKAGE_INNER_ROOTS", ("/nonexistent/aiter/aiter",))
+    tl._package_parent_dir.cache_clear()
+
+    spec = importlib.util.find_spec("json")
+    assert spec and spec.origin
+    stdlib_dir = Path(spec.origin).parent
+
+    got = tl.absolutize_launcher_path("json/decoder.py")
+    assert got == str(stdlib_dir / "decoder.py")
+    assert os.path.isfile(got)
+
+
+def test_pinned_checkout_root_still_works_as_fallback(tmp_path, monkeypatch):
+    """An editable checkout that this interpreter cannot import must still resolve."""
+    pkg = tmp_path / "aiter" / "aiter" / "dist"
+    pkg.mkdir(parents=True)
+    (pkg / "custom_all_reduce.py").write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.setattr(tl, "_PACKAGE_INNER_ROOTS", (str(tmp_path / "aiter" / "aiter"),))
+    tl._package_parent_dir.cache_clear()
+
+    got = tl.absolutize_launcher_path("aiter/dist/custom_all_reduce.py")
+    assert got == str(pkg / "custom_all_reduce.py")
+
+
+def test_non_identifier_head_is_not_probed_as_a_package(monkeypatch):
+    monkeypatch.setattr(tl, "_PACKAGE_INNER_ROOTS", ())
+    tl._package_parent_dir.cache_clear()
+    assert tl.absolutize_launcher_path("not-an-identifier/mod.py") == "not-an-identifier/mod.py"
+
+
+def test_absolute_launcher_path_is_returned_unchanged():
+    assert tl.absolutize_launcher_path("/sgl-workspace/x.py") == "/sgl-workspace/x.py"
+
+
+def test_unresolvable_relative_path_is_left_alone(monkeypatch, tmp_path):
+    """Never fabricate: an unjoinable path stays as-is rather than becoming
+    a plausible-looking path that does not exist."""
+    monkeypatch.setattr(tl, "_PACKAGE_INNER_ROOTS", (str(tmp_path / "nope" / "nope"),))
+    assert tl.absolutize_launcher_path("pkg/mod.py") == "pkg/mod.py"
+
+
+def test_empty_path_is_safe():
+    assert tl.absolutize_launcher_path("") == ""

--- a/src/hyperloom/agents/kernel/tests/test_trace_launcher_resolver.py
+++ b/src/hyperloom/agents/kernel/tests/test_trace_launcher_resolver.py
@@ -1,0 +1,390 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Tests for recovering a kernel's Python launcher frame from a Kineto trace.
+
+The resolver exists because TraceLens reports ``launcher_path = "Not found"``
+for hand-written Triton kernels (no ``cpu_op`` parent), even though the trace
+still carries the full ``python_function`` chain down to the launch.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+from _trace_launcher_resolver import (  # noqa: E402
+    LauncherFrame,
+    resolve_launchers_from_trace,
+)
+
+
+_USER_FRAME = "/repo/pkg/kernels/moe.py(124): _grouped_gemm"
+_TID = 7
+
+
+def _kernel(name: str, corr: int) -> dict:
+    return {"cat": "kernel", "name": name, "ts": 200.0, "dur": 10.0, "args": {"correlation": corr}}
+
+
+def _runtime(corr: int, api: str = "hipModuleLaunchKernel", ts: float = 150.0) -> dict:
+    return {
+        "cat": "cuda_runtime",
+        "name": api,
+        "tid": _TID,
+        "ts": ts,
+        "dur": 5.0,
+        "args": {"correlation": corr},
+    }
+
+
+def _frame(name: str, ts: float = 100.0, dur: float = 200.0, tid: int = _TID) -> dict:
+    return {"cat": "python_function", "name": name, "tid": tid, "ts": ts, "dur": dur}
+
+
+def _write(path: Path, events: list[dict], *, gzipped: bool = False) -> Path:
+    blob = json.dumps({"traceEvents": events})
+    if gzipped:
+        with gzip.open(path, "wt", encoding="utf-8") as fh:
+            fh.write(blob)
+    else:
+        path.write_text(blob, encoding="utf-8")
+    return path
+
+
+def _stack(*frames: str, base_ts: float = 100.0) -> list[dict]:
+    """Nested frames, outermost first, all covering the launch at ts=150."""
+    out = []
+    for depth, name in enumerate(frames):
+        out.append(_frame(name, ts=base_ts + depth, dur=200.0 - 2 * depth))
+    return out
+
+
+def test_resolves_user_frame_behind_triton_plumbing(tmp_path):
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack(
+                "/repo/serve/runner.py(10): forward",
+                _USER_FRAME,
+                "/venv/triton/runtime/jit.py(708): run",
+                "/venv/triton/backends/amd/driver.py(831): __call__",
+                "<built-in function launch>",
+            ),
+            _runtime(1),
+            _kernel("_grouped_gemm_kernel", 1),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"_grouped_gemm_kernel"})
+    assert set(got) == {"_grouped_gemm_kernel"}
+    frame = got["_grouped_gemm_kernel"]
+    assert frame.source_file == "/repo/pkg/kernels/moe.py"
+    assert frame.line == 124
+    assert frame.function == "_grouped_gemm"
+    assert frame.launch_api == "hipModuleLaunchKernel"
+    assert frame.frame == _USER_FRAME
+
+
+def test_reads_gzipped_trace(tmp_path):
+    trace = _write(
+        tmp_path / "t.json.gz",
+        [*_stack(_USER_FRAME), _runtime(1), _kernel("_grouped_gemm_kernel", 1)],
+        gzipped=True,
+    )
+    got = resolve_launchers_from_trace([trace], {"_grouped_gemm_kernel"})
+    assert got["_grouped_gemm_kernel"].line == 124
+
+
+def test_pure_graph_replay_kernel_is_omitted(tmp_path):
+    """A replay stack ends at torch/cuda/graphs.py, so nothing is guessed."""
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack(
+                "/repo/serve/runner.py(10): forward",
+                "/venv/torch/cuda/graphs.py(139): replay",
+            ),
+            _runtime(1, api="hipGraphLaunch"),
+            _kernel("_grouped_gemm_kernel", 1),
+        ],
+    )
+    assert resolve_launchers_from_trace([trace], {"_grouped_gemm_kernel"}) == {}
+
+
+def test_eager_probe_preferred_over_graph_replay(tmp_path):
+    """With both launch paths present, the eager one supplies the answer."""
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            # Graph replay on one thread.
+            _frame("/venv/torch/cuda/graphs.py(139): replay", ts=100.0, dur=100.0, tid=9),
+            {
+                "cat": "cuda_runtime",
+                "name": "hipGraphLaunch",
+                "tid": 9,
+                "ts": 150.0,
+                "dur": 5.0,
+                "args": {"correlation": 1},
+            },
+            _kernel("_grouped_gemm_kernel", 1),
+            # Eager launch on another thread.
+            *_stack(_USER_FRAME),
+            _runtime(2),
+            _kernel("_grouped_gemm_kernel", 2),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"_grouped_gemm_kernel"})
+    assert got["_grouped_gemm_kernel"].source_file == "/repo/pkg/kernels/moe.py"
+    assert got["_grouped_gemm_kernel"].launch_api == "hipModuleLaunchKernel"
+
+
+def test_non_python_frames_are_ignored(tmp_path):
+    """nn.Module markers carry no path(line) and must not be mistaken for source."""
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack(
+                _USER_FRAME,
+                "nn.Module: FusedMoE_0",
+                "/venv/torch/nn/modules/module.py(1779): _call_impl",
+            ),
+            _runtime(1),
+            _kernel("_grouped_gemm_kernel", 1),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"_grouped_gemm_kernel"})
+    assert got["_grouped_gemm_kernel"].source_file == "/repo/pkg/kernels/moe.py"
+
+
+def test_kernel_without_matching_runtime_is_omitted(tmp_path):
+    trace = _write(tmp_path / "t.json", [*_stack(_USER_FRAME), _kernel("_grouped_gemm_kernel", 99)])
+    assert resolve_launchers_from_trace([trace], {"_grouped_gemm_kernel"}) == {}
+
+
+def test_truncated_mangled_symbol_still_matches(tmp_path):
+    """TraceLens elides a long mangled symbol; the trace keeps the full name.
+
+    Real case: the Kernel Name cell reads
+    ``_ZN5aiter33reduce_scatter_cross_device_storeIDF16bLi8EEEvPNS_8RankDataENS_1...``
+    while the trace event is the untruncated symbol.
+    """
+    full = "_ZN5aiter33reduce_scatter_cross_device_storeIDF16bLi8EEEvPNS_8RankDataENS_11RankSignalsEiiii"
+    truncated = "_ZN5aiter33reduce_scatter_cross_device_storeIDF16bLi8EEEvPNS_8RankDataENS_1..."
+    trace = _write(
+        tmp_path / "t.json",
+        [*_stack(_USER_FRAME), _runtime(1), _kernel(full, 1)],
+    )
+    got = resolve_launchers_from_trace([trace], {truncated})
+    assert set(got) == {truncated}
+    assert got[truncated].line == 124
+
+
+# --- JIT toolchain plumbing (real stacks from a Kimi-K3 / vLLM run) ----------
+
+
+def test_flydsl_jit_plumbing_is_skipped_for_the_real_kernel(tmp_path):
+    """Verbatim eager stack of aiter's FlyDSL MoE GEMM.
+
+    Every FlyDSL-compiled kernel bottoms out in the same
+    ``flydsl/compiler/jit_executor.py: __call__``; resolving there aims a backend
+    at the compiler and collapses distinct kernels onto one source.
+    """
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack(
+                "aiter/fused_moe.py(538): fused_moe_",
+                "aiter/fused_moe.py(2478): fused_moe_2stages",
+                "aiter/fused_moe.py(1169): _flydsl_stage1_wrapper",
+                "aiter/ops/flydsl/moe_kernels.py(1261): flydsl_moe_stage1",
+                "aiter/ops/flydsl/moe_kernels.py(859): _run_compiled",
+                "flydsl/compiler/jit_function.py(1635): __call__",
+                "flydsl/compiler/jit_executor.py(210): __call__",
+                "<flydsl-dispatch>(34): dispatch",
+            ),
+            _runtime(1),
+            _kernel("moe_gemm1_0", 1),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"moe_gemm1_0"})
+    frame = got["moe_gemm1_0"]
+    assert frame.source_file == "aiter/ops/flydsl/moe_kernels.py"
+    assert frame.line == 859
+    assert "jit_executor" not in frame.source_file
+    assert "jit_function" not in frame.source_file
+
+
+def test_two_flydsl_kernels_do_not_collapse_onto_the_compiler(tmp_path):
+    """The concrete damage: both MoE GEMMs used to resolve to jit_executor.py."""
+    def _flydsl_stack(kernel_line: int, base_ts: float) -> list[dict]:
+        return _stack(
+            f"aiter/ops/flydsl/moe_kernels.py({kernel_line}): flydsl_moe",
+            "flydsl/compiler/jit_executor.py(210): __call__",
+            base_ts=base_ts,
+        )
+
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_flydsl_stack(1261, 100.0),
+            _runtime(1, ts=150.0),
+            _kernel("moe_gemm1_0", 1),
+            *_flydsl_stack(1480, 400.0),
+            _runtime(2, ts=450.0),
+            _kernel("moe_gemm2_0", 2),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"moe_gemm1_0", "moe_gemm2_0"})
+    assert got["moe_gemm1_0"].line == 1261
+    assert got["moe_gemm2_0"].line == 1480
+
+
+def test_flydsl_authored_kernel_stays_visible(tmp_path):
+    """Only flydsl/compiler/ is plumbing; a kernel written in FlyDSL is a target."""
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack(
+                "/repo/kernels/my_flydsl_kernel.py(42): my_kernel",
+                "flydsl/compiler/jit_executor.py(210): __call__",
+            ),
+            _runtime(1),
+            _kernel("my_flydsl_kernel_0", 1),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"my_flydsl_kernel_0"})
+    assert got["my_flydsl_kernel_0"].source_file == "/repo/kernels/my_flydsl_kernel.py"
+
+
+def test_aiter_jit_and_flydsl_are_treated_alike(tmp_path):
+    """Both JIT toolchains must yield the caller, not their dispatch wrapper."""
+    cases = {
+        "aiter_kernel_0": "aiter/jit/core.py(1504): wrapper",
+        "flydsl_kernel_0": "flydsl/compiler/jit_executor.py(210): __call__",
+    }
+    for index, (kernel, plumbing) in enumerate(cases.items(), start=1):
+        trace = _write(
+            tmp_path / f"t{index}.json",
+            [
+                *_stack("/repo/ops/real_kernel.py(77): launch_it", plumbing),
+                _runtime(index),
+                _kernel(kernel, index),
+            ],
+        )
+        got = resolve_launchers_from_trace([trace], {kernel})
+        assert got[kernel].source_file == "/repo/ops/real_kernel.py", kernel
+        assert got[kernel].line == 77, kernel
+
+
+def test_triton_stack_unaffected_by_the_flydsl_rule(tmp_path):
+    """Regression guard: the vLLM Triton path from the same run still resolves."""
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack(
+                "vllm/models/kimi_k3/amd/linear.py(571): forward",
+                "vllm/models/kimi_k3/amd/ops/attn_res.py(88): attn_res",
+                "triton/runtime/jit.py(720): run",
+                "triton/backends/amd/driver.py(343): __call__",
+                "<built-in function launch>",
+            ),
+            _runtime(1),
+            _kernel("_attn_res_kernel", 1),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"_attn_res_kernel"})
+    assert got["_attn_res_kernel"].source_file == "vllm/models/kimi_k3/amd/ops/attn_res.py"
+    assert got["_attn_res_kernel"].line == 88
+
+
+def test_ambiguous_elided_prefix_is_refused(tmp_path):
+    """Two distinct symbols behind one elided name cannot be told apart.
+
+    Attributing either launcher to the shared prefix would hand a backend the
+    wrong source file, so the resolver declines and leaves it to grep.
+    """
+    shared = "_ZN5aiter40some_quite_long_collective_symbol_nameI"
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack(_USER_FRAME),
+            _runtime(1),
+            _kernel(shared + "Lb0EEEvPf", 1),
+            _runtime(2, ts=160.0),
+            _kernel(shared + "Lb1EEEvPd", 2),
+        ],
+    )
+    assert resolve_launchers_from_trace([trace], {shared + "..."}) == {}
+
+
+def test_unambiguous_elided_prefix_still_resolves(tmp_path):
+    """One symbol behind the elision is fine -- that is the normal case."""
+    full = "_ZN5aiter40some_quite_long_collective_symbol_nameILb0EEEvPf"
+    trace = _write(
+        tmp_path / "t.json",
+        [*_stack(_USER_FRAME), _runtime(1), _kernel(full, 1)],
+    )
+    elided = "_ZN5aiter40some_quite_long_collective_symbol_nameI..."
+    assert set(resolve_launchers_from_trace([trace], {elided})) == {elided}
+
+
+def test_degenerate_elided_prefix_is_refused(tmp_path):
+    """``_ZN5...`` prefixes an entire namespace and must not bind a kernel."""
+    trace = _write(
+        tmp_path / "t.json",
+        [*_stack(_USER_FRAME), _runtime(1), _kernel("_ZN5aiter9unrelatedE", 1)],
+    )
+    assert resolve_launchers_from_trace([trace], {"_ZN5..."}) == {}
+
+
+def test_unwanted_kernels_are_not_resolved(tmp_path):
+    trace = _write(
+        tmp_path / "t.json",
+        [*_stack(_USER_FRAME), _runtime(1), _kernel("_some_other_kernel", 1)],
+    )
+    assert resolve_launchers_from_trace([trace], {"_grouped_gemm_kernel"}) == {}
+
+
+def test_empty_inputs_short_circuit(tmp_path):
+    trace = _write(tmp_path / "t.json", [_kernel("_k", 1)])
+    assert resolve_launchers_from_trace([], {"_k"}) == {}
+    assert resolve_launchers_from_trace([trace], set()) == {}
+    assert resolve_launchers_from_trace([trace], {"  "}) == {}
+
+
+def test_missing_or_corrupt_trace_fails_soft(tmp_path):
+    missing = tmp_path / "nope.json"
+    corrupt = tmp_path / "bad.json"
+    corrupt.write_text("this is not json", encoding="utf-8")
+    assert resolve_launchers_from_trace([missing], {"_k"}) == {}
+    assert resolve_launchers_from_trace([corrupt], {"_k"}) == {}
+
+
+def test_stops_after_all_kernels_resolved(tmp_path):
+    """The second file must not be opened once the first answered everything."""
+    first = _write(
+        tmp_path / "a.json",
+        [*_stack(_USER_FRAME), _runtime(1), _kernel("_grouped_gemm_kernel", 1)],
+    )
+    absent = tmp_path / "b-does-not-exist.json"
+    got = resolve_launchers_from_trace([first, absent], {"_grouped_gemm_kernel"})
+    assert set(got) == {"_grouped_gemm_kernel"}
+
+
+def test_launcher_frame_render():
+    frame = LauncherFrame(
+        source_file="/repo/a.py",
+        line=7,
+        function="fn",
+        sample_count=2,
+        launch_api="hipLaunchKernel",
+    )
+    assert frame.frame == "/repo/a.py(7): fn"

--- a/src/hyperloom/agents/kernel/tools/_llm_source_fallback.py
+++ b/src/hyperloom/agents/kernel/tools/_llm_source_fallback.py
@@ -1,0 +1,217 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Last-resort semantic pick of a kernel's source file, from a fixed shortlist.
+
+This is the final tier of source resolution, behind the curated dictionary, the
+trace-derived launcher, and the name grep. It exists for models or frameworks
+where all three come up empty -- not for any case seen so far.
+
+Two properties keep it from becoming another source of nondeterminism, which
+matters because an unresolved-launcher sentinel produced by an LLM is what broke
+this pipeline in the first place:
+
+* **Selection, never generation.** The model receives a shortlist gathered by a
+  relaxed grep and may only return one of those exact strings. A path it invents
+  is rejected outright.
+* **Off unless asked.** Gated behind ``HYPERLOOM_KERNEL_SOURCE_LLM_FALLBACK``, so
+  a normal run's resolution stays fully deterministic.
+
+Every accepted answer is stamped ``source_resolution_method="llm_fallback"`` so
+it can be audited apart from deterministic resolutions.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Callable
+
+# An answer below this confidence is discarded: a coin-flip pick would send a
+# backend at the wrong file and burn a whole optimization attempt.
+_MIN_CONFIDENCE = 0.7
+
+# Head of each shortlisted file shown to the model; enough to tell a kernel
+# definition from a test or a dispatch shim.
+_PREVIEW_LINES = 40
+_PREVIEW_CHARS = 2000
+
+_DEFAULT_TIMEOUT_SEC = 60.0
+
+_ENV_FLAG = "HYPERLOOM_KERNEL_SOURCE_LLM_FALLBACK"
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+_JSON_BLOCK_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+_SYSTEM_PROMPT = (
+    "You identify which source file implements a GPU kernel. "
+    "You are given the kernel symbol and a shortlist of candidate files. "
+    "Choose the file that DEFINES the kernel body. Reject files that merely "
+    "call it, test it, or dispatch to it, and reject a CPU implementation when "
+    "the kernel runs on GPU. "
+    'Answer with JSON only: {"source_file": "<one of the candidates, verbatim>", '
+    '"confidence": <0..1>, "reason": "<one sentence>"}. '
+    'If none of the candidates defines the kernel, return "source_file": "".'
+)
+
+
+def llm_fallback_enabled() -> bool:
+    """Whether the operator opted into the LLM tier."""
+    return str(os.environ.get(_ENV_FLAG, "")).strip().lower() in _TRUTHY
+
+
+def _preview(path: str) -> str:
+    """First lines of ``path``, for telling an implementation from a shim."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            head = "".join(next(fh, "") for _ in range(_PREVIEW_LINES))
+    except OSError:
+        return "<unreadable>"
+    return head[:_PREVIEW_CHARS]
+
+
+def _build_prompt(kernel_name: str, candidates: list[str]) -> str:
+    """Render the shortlist with a preview of each file."""
+    parts = [f"Kernel symbol: {kernel_name}", "", "Candidates:"]
+    for index, path in enumerate(candidates, 1):
+        parts.append(f"\n[{index}] {path}\n```\n{_preview(path)}\n```")
+    return "\n".join(parts)
+
+
+def _parse_answer(text: str) -> tuple[bool, str, float, str]:
+    """Extract ``(parsed, source_file, confidence, reason)`` from a model reply.
+
+    ``parsed`` separates "the reply was unreadable" from "the model answered that
+    no candidate fits". Collapsing the two would report a malformed reply as a
+    considered verdict and send triage the wrong way.
+    """
+    match = _JSON_BLOCK_RE.search(text or "")
+    if not match:
+        return False, "", 0.0, "no JSON object in reply"
+    try:
+        payload = json.loads(match.group(0))
+    except (TypeError, ValueError) as exc:
+        return False, "", 0.0, f"unparseable JSON: {exc}"
+    if not isinstance(payload, dict):
+        return False, "", 0.0, "JSON payload is not an object"
+    try:
+        confidence = float(payload.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        confidence = 0.0
+    return (
+        True,
+        str(payload.get("source_file") or "").strip(),
+        confidence,
+        str(payload.get("reason") or "").strip(),
+    )
+
+
+def _validate(
+    picked: str,
+    candidates: list[str],
+    framework_roots: tuple[str, ...],
+) -> tuple[bool, str]:
+    """Check the pick against the shortlist, the filesystem and the roots."""
+    if not picked:
+        return False, "model reported no candidate defines the kernel"
+    if picked not in candidates:
+        # The whole point of a shortlist is that the answer comes from it.
+        return False, f"path is not one of the candidates: {picked!r}"
+    if not os.path.isfile(picked):
+        return False, f"path does not exist: {picked!r}"
+    if framework_roots:
+        low = picked.lower()
+        if not any(root.lower() in low for root in framework_roots if root):
+            return False, f"path is outside every framework root: {picked!r}"
+    return True, ""
+
+
+def _complete(prompt: str, model: str, timeout_sec: float) -> str:
+    """One chat completion against the configured OpenAI-compatible endpoint."""
+    from openai import OpenAI  # noqa: PLC0415 - optional dependency
+
+    from hyperloom.common.llm_config import openai_client_kwargs  # noqa: PLC0415
+
+    client = OpenAI(**openai_client_kwargs())
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ],
+        temperature=0.0,
+        timeout=timeout_sec,
+    )
+    return str(response.choices[0].message.content or "")
+
+
+def select_source_via_llm(
+    kernel_name: str,
+    candidates: list[str],
+    *,
+    framework_roots: tuple[str, ...] = (),
+    model: str = "",
+    timeout_sec: float = _DEFAULT_TIMEOUT_SEC,
+    log: Callable[[str], None] | None = None,
+    complete: Callable[[str, str, float], str] | None = None,
+) -> tuple[str, float, str]:
+    """Pick the file that defines ``kernel_name`` from ``candidates``.
+
+    Args:
+        kernel_name: The kernel symbol being resolved.
+        candidates: Shortlist of on-disk paths from the relaxed grep. An empty
+            list short-circuits: with nothing to choose from there is nothing to
+            ask, and inventing a path is not allowed.
+        framework_roots: Accepted path roots; a pick outside them is rejected.
+        model: Chat model; defaults to ``$CLAUDE_MODEL``.
+        timeout_sec: Per-call ceiling. There is no retry -- a failure here is
+            advisory and the candidate simply stays unresolved.
+        log: Optional ``callable(str)`` for diagnostics.
+        complete: Injection point for the completion call (tests).
+
+    Returns:
+        ``(source_file, confidence, reason)``; ``source_file`` is ``""`` on any
+        failure, including a low-confidence answer.
+    """
+    def _say(message: str) -> None:
+        if callable(log):
+            log(f"llm_source_fallback: {message}")
+
+    if not llm_fallback_enabled():
+        return "", 0.0, "disabled"
+    if not kernel_name or not candidates:
+        return "", 0.0, "no candidates to choose from"
+
+    shortlist = [str(c) for c in candidates if str(c).strip()]
+    caller = complete or _complete
+    chosen_model = model or os.environ.get("CLAUDE_MODEL") or "claude-opus-4-6"
+    try:
+        reply = caller(_build_prompt(kernel_name, shortlist), chosen_model, timeout_sec)
+    except Exception as exc:  # noqa: BLE001 - advisory tier, never fatal
+        _say(f"call failed: {exc!r}")
+        return "", 0.0, f"llm call failed: {exc!r}"
+
+    parsed, picked, confidence, reason = _parse_answer(reply)
+    if not parsed:
+        _say(f"rejected: {reason}")
+        return "", 0.0, reason
+    ok, why = _validate(picked, shortlist, framework_roots)
+    if not ok:
+        _say(f"rejected: {why}")
+        return "", confidence, why
+    if confidence < _MIN_CONFIDENCE:
+        _say(f"rejected: confidence {confidence:.2f} < {_MIN_CONFIDENCE}")
+        return "", confidence, f"confidence {confidence:.2f} below {_MIN_CONFIDENCE}"
+
+    _say(f"accepted {picked} (confidence={confidence:.2f})")
+    return picked, confidence, reason
+
+
+__all__ = ["llm_fallback_enabled", "select_source_via_llm"]

--- a/src/hyperloom/agents/kernel/tools/_trace_launcher_resolver.py
+++ b/src/hyperloom/agents/kernel/tools/_trace_launcher_resolver.py
@@ -1,0 +1,375 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Resolve a device kernel to its Python launcher frame, straight from the trace.
+
+Motivation: TraceLens cannot attribute a hand-written Triton kernel. Such a
+kernel is launched through ``triton.jit`` and never passes the ATen dispatcher,
+so it has no ``cpu_op`` parent; TraceLens files it as a ``(Synthetic Op)`` with
+``launcher_path = "Not found"``. The information is nonetheless present in the
+trace: ``with_stack`` profiling records the full ``python_function`` chain down
+to the launch, ending at the user frame that called the kernel.
+
+This module recovers that frame deterministically, which is strictly better than
+the name-grep fallback it precedes: it yields a line number and function name,
+and it cannot produce grep's false positives (a test file or a CPU implementation
+that merely mentions the kernel name).
+
+Design constraints:
+
+* **Streaming, two passes.** ``python_function`` dominates a trace (order 10^6
+  events, ~95% of the file). Pass 1 reads only ``kernel`` and ``cuda_runtime``
+  (order 10^4) to pick probe timestamps; pass 2 walks the frames but retains
+  only those enclosing a probe, so peak memory stays flat.
+* **Eager probes preferred.** A CUDA-graph replay launch has no per-kernel
+  Python frame -- its stack ends at ``torch/cuda/graphs.py: replay`` -- so
+  probes are drawn from non-graph launch APIs first. The same kernel is the same
+  source on both paths, so one eager sample covers the graph launches too.
+* **Fail soft.** Any error yields an empty mapping; the caller falls back to the
+  existing grep resolution.
+"""
+
+from __future__ import annotations
+
+import bisect
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from _bypass_trace_reader import _open_trace_binary, stream_events
+
+# Kineto event categories consulted here.
+_CAT_KERNEL = "kernel"
+_CAT_RUNTIME = "cuda_runtime"
+_CAT_PYTHON = "python_function"
+
+# Launch APIs that replay a captured graph: the launching Python frame belongs
+# to the capture, not to this call, so these are poor probes.
+_GRAPH_LAUNCH_APIS = frozenset({"hipgraphlaunch", "cudagraphlaunch"})
+
+# A ``python_function`` name of the form "<path>(<line>): <func>".
+_FRAME_RE = re.compile(r"^(?P<path>.+?)\((?P<line>\d+)\):\s*(?P<func>.+)$")
+
+# Frames between the user's call site and the launch: launcher plumbing that is
+# never the kernel's source. Walking outward, these are skipped.
+#
+# Every JIT toolchain contributes one of these. A JIT-built op's innermost Python
+# frame is the compile-and-dispatch wrapper, not its kernel:
+#   * triton  -> ``triton/runtime/jit.py: run``
+#   * aiter   -> ``aiter/jit/core.py: wrapper``
+#   * FlyDSL  -> ``flydsl/compiler/jit_executor.py: __call__``
+# Those files are build machinery shared by every kernel the toolchain compiles,
+# so admitting one both aims a backend at unpatchable code and collapses distinct
+# kernels onto a single source (two MoE GEMMs both resolving to jit_executor.py).
+#
+# Scope matters: only ``flydsl/compiler/`` is plumbing. A kernel *written* in
+# FlyDSL is a legitimate target -- ``classify_patchability`` accepts
+# ``source_type="flydsl"`` -- so ``aiter/ops/flydsl/`` must stay visible.
+_SKIP_FRAME_RE = re.compile(
+    r"(?:"
+    r"triton/runtime/|triton/backends/|triton/compiler/"
+    r"|aiter/jit/"
+    r"|flydsl/compiler/"
+    r"|torch/nn/modules/module\.py"
+    r"|torch/utils/_contextlib\.py"
+    r"|torch/_dynamo/|torch/_inductor/"
+    r"|/_ops\.py"
+    r"|^<"
+    r")"
+)
+
+# Generic decorator frames. Path-based skipping cannot catch these: a guard or
+# retry decorator lives in an ordinary repo file, yet its body is plumbing. The
+# function name is the stable signal (TraceLens keeps an equivalent list for its
+# own entry-point search).
+_WRAPPER_FUNC_NAMES = frozenset(
+    {
+        "call",
+        "custom_wrapper",
+        "decorate",
+        "decorate_context",
+        "handle_torch_function",
+        "inner",
+        "outer_wrapper",
+        "wrapped",
+        "wrapper",
+        "wrapper_custom",
+        "_fn",
+        "_inner",
+        "_wrapped",
+        "_wrapper",
+    }
+)
+
+# Reaching this frame means the launch came from a graph replay: everything
+# further out belongs to the replay call site, not to the kernel.
+_GRAPH_REPLAY_MARKER = "torch/cuda/graphs.py"
+
+# Probe budget per kernel. Oversampled relative to ``max_samples_per_kernel``
+# because some probes land on frames that resolve to nothing.
+_PROBE_OVERSAMPLE = 4
+
+# Shortest elided symbol prefix allowed to match. Below this a prefix carries no
+# identity (``_ZN5...`` matches an entire namespace); real TraceLens elisions run
+# far longer, so this only rejects degenerate input.
+_MIN_ELIDED_PREFIX = 16
+
+
+@dataclass(frozen=True)
+class LauncherFrame:
+    """A resolved Python launcher for one device kernel."""
+
+    source_file: str
+    line: int
+    function: str
+    sample_count: int
+    launch_api: str
+
+    @property
+    def frame(self) -> str:
+        """The frame rendered in TraceLens' ``<path>(<line>): <func>`` form."""
+        return f"{self.source_file}({self.line}): {self.function}"
+
+
+def _is_elided(name: str) -> bool:
+    """Whether TraceLens shortened this symbol with a trailing ellipsis."""
+    return name.rstrip(" ").endswith("...")
+
+
+def _match_kernel(event_name: str, wanted: Iterable[str]) -> str | None:
+    """Return the wanted kernel name contained in ``event_name``, if any.
+
+    Substring rather than equality: a device kernel name may carry a template or
+    ``.kd`` suffix around the symbol TraceLens reports.
+
+    A long mangled symbol is additionally elided by TraceLens with a trailing
+    ellipsis while the trace keeps the full name, so an elided name falls back to
+    matching on its prefix. That fallback needs a floor: a stub like ``_ZN5...``
+    is a prefix of every symbol in the namespace and would bind an arbitrary
+    kernel. Sibling template instantiations can still both match a shared prefix,
+    which is harmless -- they are the same source file.
+    """
+    for name in wanted:
+        if not name:
+            continue
+        if name in event_name:
+            return name
+        probe = name.rstrip(". ")
+        if probe != name and len(probe) >= _MIN_ELIDED_PREFIX and probe in event_name:
+            return name
+    return None
+
+
+def _collect_probes(
+    trace_file: Path,
+    kernel_names: set[str],
+    probe_budget: int,
+) -> dict[str, list[tuple[int, float, str]]]:
+    """Pass 1: pick ``(tid, ts, launch_api)`` probes for each wanted kernel.
+
+    Reads only ``kernel`` and ``cuda_runtime`` events. Eager launches are
+    preferred over graph replays (see module docstring).
+    """
+    corr_to_kernel: dict[Any, str] = {}
+    runtimes: dict[Any, tuple[int, float, str]] = {}
+    # Distinct trace symbols each requested name matched, to detect an elided
+    # prefix that spans more than one kernel.
+    matched_symbols: dict[str, set[str]] = defaultdict(set)
+    with _open_trace_binary(trace_file) as fh:
+        for ev in stream_events(fh):
+            cat = ev.get("cat")
+            if cat == _CAT_KERNEL:
+                event_name = str(ev.get("name") or "")
+                matched = _match_kernel(event_name, kernel_names)
+                if matched is None:
+                    continue
+                matched_symbols[matched].add(event_name)
+                corr = (ev.get("args") or {}).get("correlation")
+                if corr is not None:
+                    corr_to_kernel[corr] = matched
+            elif cat == _CAT_RUNTIME:
+                corr = (ev.get("args") or {}).get("correlation")
+                if corr is None:
+                    continue
+                runtimes[corr] = (
+                    int(ev.get("tid") or 0),
+                    float(ev.get("ts") or 0.0),
+                    str(ev.get("name") or ""),
+                )
+
+    # An elided name that spans several distinct symbols cannot be attributed:
+    # the launcher of one would be reported as the launcher of another. Drop it
+    # rather than pick arbitrarily; the grep tier still gets its turn.
+    ambiguous = {
+        name
+        for name, symbols in matched_symbols.items()
+        if _is_elided(name) and len(symbols) > 1
+    }
+    if ambiguous:
+        corr_to_kernel = {c: k for c, k in corr_to_kernel.items() if k not in ambiguous}
+
+    eager: dict[str, list[tuple[int, float, str]]] = defaultdict(list)
+    graph: dict[str, list[tuple[int, float, str]]] = defaultdict(list)
+    for corr, kernel in corr_to_kernel.items():
+        rt = runtimes.get(corr)
+        if rt is None:
+            continue
+        bucket = graph if rt[2].strip().lower() in _GRAPH_LAUNCH_APIS else eager
+        if len(bucket[kernel]) < probe_budget:
+            bucket[kernel].append(rt)
+
+    # Eager first; top up with graph probes only when a kernel has no eager call.
+    probes: dict[str, list[tuple[int, float, str]]] = {}
+    for kernel in kernel_names:
+        picked = list(eager.get(kernel) or [])
+        if not picked:
+            picked = list(graph.get(kernel) or [])
+        if picked:
+            probes[kernel] = picked[:probe_budget]
+    return probes
+
+
+def _collect_enclosing_frames(
+    trace_file: Path,
+    probes: dict[str, list[tuple[int, float, str]]],
+) -> dict[tuple[int, float], list[tuple[float, str]]]:
+    """Pass 2: gather the ``python_function`` frames enclosing each probe.
+
+    Only frames whose ``[ts, ts+dur]`` span covers a probe are retained, keeping
+    memory proportional to the probe count rather than to the trace.
+    """
+    # Per-thread sorted probe timestamps, for a bisect membership test.
+    by_tid: dict[int, list[float]] = defaultdict(list)
+    for samples in probes.values():
+        for tid, ts, _api in samples:
+            by_tid[tid].append(ts)
+    for tid in by_tid:
+        by_tid[tid] = sorted(set(by_tid[tid]))
+
+    enclosing: dict[tuple[int, float], list[tuple[float, str]]] = defaultdict(list)
+    with _open_trace_binary(trace_file) as fh:
+        for ev in stream_events(fh):
+            if ev.get("cat") != _CAT_PYTHON:
+                continue
+            tid = int(ev.get("tid") or 0)
+            stamps = by_tid.get(tid)
+            if not stamps:
+                continue
+            start = float(ev.get("ts") or 0.0)
+            end = start + float(ev.get("dur") or 0.0)
+            lo = bisect.bisect_left(stamps, start)
+            hi = bisect.bisect_right(stamps, end)
+            if lo >= hi:
+                continue
+            name = str(ev.get("name") or "")
+            for ts in stamps[lo:hi]:
+                enclosing[(tid, ts)].append((start, name))
+    return enclosing
+
+
+def _innermost_user_frame(frames: list[tuple[float, str]]) -> tuple[str, int, str] | None:
+    """Pick the innermost user ``.py`` frame from one probe's enclosing frames.
+
+    Frames are ordered outermost-first by start time, so the walk runs in
+    reverse. Launcher plumbing is skipped; hitting the graph-replay marker means
+    this probe carries no per-kernel call site.
+    """
+    for _start, name in sorted(frames, key=lambda item: item[0], reverse=True):
+        if _GRAPH_REPLAY_MARKER in name:
+            return None
+        if _SKIP_FRAME_RE.search(name):
+            continue
+        match = _FRAME_RE.match(name)
+        if not match:
+            continue
+        path = match.group("path").strip()
+        if not path.endswith(".py"):
+            continue
+        func = match.group("func").strip()
+        if func in _WRAPPER_FUNC_NAMES:
+            continue
+        return path, int(match.group("line")), func
+    return None
+
+
+def resolve_launchers_from_trace(
+    trace_files: list[Path] | list[str],
+    kernel_names: set[str],
+    *,
+    max_samples_per_kernel: int = 3,
+    log: Any = None,
+) -> dict[str, LauncherFrame]:
+    """Resolve device kernel names to their Python launcher frames.
+
+    Args:
+        trace_files: Candidate trace files, most representative first. Files are
+            read in order and reading stops once every kernel is resolved, so a
+            single rank's trace normally suffices.
+        kernel_names: Device kernel symbols to resolve.
+        max_samples_per_kernel: Probes to agree on per kernel; the majority frame
+            wins.
+        log: Optional ``callable(str)`` for diagnostics.
+
+    Returns:
+        Kernel name -> resolved launcher. Kernels with no eager sample (pure
+        graph replay) or no usable frame are omitted, never guessed.
+    """
+    wanted = {str(k) for k in kernel_names if str(k).strip()}
+    if not wanted or not trace_files:
+        return {}
+
+    resolved: dict[str, LauncherFrame] = {}
+    probe_budget = max(1, int(max_samples_per_kernel)) * _PROBE_OVERSAMPLE
+
+    for raw_path in trace_files:
+        remaining = wanted - set(resolved)
+        if not remaining:
+            break
+        trace_file = Path(raw_path)
+        try:
+            probes = _collect_probes(trace_file, remaining, probe_budget)
+            if not probes:
+                continue
+            enclosing = _collect_enclosing_frames(trace_file, probes)
+        except (OSError, ValueError) as exc:  # fail soft; grep fallback still runs
+            if callable(log):
+                log(f"trace_launcher_resolver: {trace_file.name}: {exc!r}")
+            continue
+
+        for kernel, samples in probes.items():
+            votes: Counter[tuple[str, int, str]] = Counter()
+            api_votes: Counter[str] = Counter()
+            for tid, ts, api in samples:
+                if sum(votes.values()) >= max_samples_per_kernel:
+                    break
+                frames = enclosing.get((tid, ts))
+                if not frames:
+                    continue
+                found = _innermost_user_frame(frames)
+                if found is None:
+                    continue
+                votes[found] += 1
+                api_votes[api] += 1
+            if not votes:
+                continue
+            (path, line, func), count = votes.most_common(1)[0]
+            resolved[kernel] = LauncherFrame(
+                source_file=path,
+                line=line,
+                function=func,
+                sample_count=count,
+                launch_api=(api_votes.most_common(1)[0][0] if api_votes else ""),
+            )
+
+    if callable(log):
+        log(f"trace_launcher_resolver: resolved {len(resolved)}/{len(wanted)} kernel(s) from trace")
+    return resolved
+
+
+__all__ = ["LauncherFrame", "resolve_launchers_from_trace"]

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -14,6 +14,7 @@ import asyncio
 import csv
 import functools
 import gzip
+import importlib.util
 import json
 import os
 import re
@@ -46,6 +47,7 @@ except Exception:
 
 from tracelens_arch_benchmark import normalize_platform, populate_gpu_arch_json
 from tracelens_skill_runner import (
+    _LAUNCHER_PATH_PLACEHOLDERS,
     _parse_launcher_path,
     _resolve_launcher_to_abs_source,
     aggregate_by_source_function,
@@ -2108,6 +2110,38 @@ def _prefer_symbol_definition(keyword: str, hits: list[Path]) -> list[Path]:
     return _rank_paths(definers) if definers else _rank_paths(hits)
 
 
+# Bare HIP/CUDA launch APIs. TraceLens emits these as standalone rows when it
+# aggregates launches it could not attribute to a device kernel, but they are
+# runtime entry points, not kernels. Grepping them matches wherever the API name
+# merely appears -- e.g. aiter's hipify name-mapping table, which then gets
+# routed to a backend as if it were rewritable kernel source.
+_RUNTIME_API_NAMES: frozenset[str] = frozenset(
+    {
+        "cudagraphlaunch",
+        "cudalaunchcooperativekernel",
+        "cudalaunchkernel",
+        "cudamodulelaunchkernel",
+        "hipextlaunchkernel",
+        "hipgraphlaunch",
+        "hiplaunchcooperativekernel",
+        "hiplaunchkernel",
+        "hipmodulelaunchkernel",
+    }
+)
+
+
+def is_runtime_api_name(name: str) -> bool:
+    """Return whether ``name`` is a bare HIP/CUDA launch API rather than a kernel.
+
+    Args:
+        name (str): Kernel symbol/name, possibly profiler-wrapped.
+
+    Returns:
+        bool: ``True`` when the normalised name is a bare launch API.
+    """
+    return _normalize_profiler_op_name(name).strip().lower() in _RUNTIME_API_NAMES
+
+
 def locate_source_via_grep(name: str) -> str:
     """Locate a kernel source file by grepping known repos.
 
@@ -2119,6 +2153,10 @@ def locate_source_via_grep(name: str) -> str:
     Returns:
         str: The best-ranked matching source path, or ``""`` when none.
     """
+    # A bare launch API has no source of its own; grepping it only yields
+    # incidental mentions (see _RUNTIME_API_NAMES).
+    if is_runtime_api_name(name):
+        return ""
     tried: set[str] = set()
     # Primary pass: keyword extraction + ranking.
     for keyword in _candidate_keywords(name):
@@ -2144,6 +2182,50 @@ def locate_source_via_grep(name: str) -> str:
         if hits:
             return str(_prefer_symbol_definition(keyword, hits)[0])
     return ""
+
+
+def collect_source_candidates_via_grep(name: str, limit: int = 8) -> list[str]:
+    """Shortlist every plausible source for ``name``, ranked, without deciding.
+
+    Where :func:`locate_source_via_grep` commits to the top hit of the first
+    keyword that matches, this widens the net -- every keyword and every trailing
+    sub-window -- and returns the union. It feeds the LLM tier, which needs
+    several options to choose between; on its own it decides nothing.
+
+    Args:
+        name (str): Kernel symbol/name to locate.
+        limit (int): Maximum paths to return.
+
+    Returns:
+        list[str]: Ranked, deduplicated candidate paths (possibly empty).
+    """
+    if is_runtime_api_name(name):
+        return []
+    hits: list[Path] = []
+    seen_keywords: set[str] = set()
+    for keyword in [*_candidate_keywords(name), *_compound_subwindow_keywords(name)]:
+        if not keyword or keyword in seen_keywords:
+            continue
+        seen_keywords.add(keyword)
+        for root in KNOWN_SEARCH_ROOTS:
+            hits.extend(_grep_for_keyword(keyword, Path(root)))
+    if not hits:
+        return []
+    ordered: list[str] = []
+    seen_paths: set[str] = set()
+    # Definition sites first: a file that merely mentions the symbol is the
+    # exact confusion the LLM tier is meant to resolve, not inherit.
+    primary = _candidate_keywords(name)
+    ranked = _prefer_symbol_definition(primary[0], hits) if primary else _rank_paths(hits)
+    for path in ranked:
+        text = str(path)
+        if text in seen_paths:
+            continue
+        seen_paths.add(text)
+        ordered.append(text)
+        if len(ordered) >= max(1, limit):
+            break
+    return ordered
 
 
 def find_repo_root(source_file: str) -> str:
@@ -2775,7 +2857,7 @@ def analyze_trace_files(trace_files: list[Path], top_k: int) -> list[dict[str, A
 
     candidates = sorted(aggregates.values(), key=lambda x: x["duration_us"], reverse=True)
     top = candidates[:top_k]
-    return _finalize_candidates(top, total_dur=total_dur)
+    return _finalize_candidates(top, total_dur=total_dur, trace_files=trace_files)
 
 
 def load_op_category_map(
@@ -3610,8 +3692,47 @@ def recover_other_bucket_candidates(
     return out
 
 
+# A resolved source_file always carries a source extension, whether absolute
+# ("/sgl-workspace/.../fused_moe.py"), package-relative ("sgl_kernel/moe.py"), or
+# TraceLens' frame form ("path.py(124): fn"). Producer placeholders never do --
+# "Not found", "N/A", "AITER (vendor)", "unknown".
+_SOURCE_EXT_RE = re.compile(
+    r"\.(?:py|pyx|cu|cuh|hip|cpp|cxx|cc|hpp|hh|h|s|asm|jinja)\b",
+    re.IGNORECASE,
+)
+
+
+def looks_like_source_path(value: str) -> bool:
+    """Return whether ``value`` has the shape of a source-file path.
+
+    Args:
+        value (str): Candidate ``source_file`` value.
+
+    Returns:
+        bool: ``True`` when it carries a path separator and a source extension.
+    """
+    text = (value or "").strip()
+    return "/" in text and bool(_SOURCE_EXT_RE.search(text))
+
+
 def _stamp_candidate_metadata(item: dict[str, Any], op_cat_map: dict[str, str] | None) -> None:
     """Stamp routing, backend, and category metadata onto a finalized candidate."""
+    # Defensive gate against upstream sentinels. A real source_file always looks
+    # like a path (absolute, or package-relative such as "sgl_kernel/moe.py"); a
+    # bare word is a placeholder the producer used for "unresolved". Admitting
+    # one is how classify_patchability ends up reporting the nonsensical "source
+    # not under a reusable framework root: Not found". Keyed on shape rather than
+    # on-disk presence so an analysis host that lacks the serving container's
+    # filesystem still classifies normally.
+    source_file = str(item.get("source_file") or "").strip()
+    if source_file and not looks_like_source_path(source_file):
+        item["source_file_rejected"] = source_file
+        item["source_file"] = ""
+        item["source_resolution_method"] = "rejected_non_path_sentinel"
+    elif source_file and not os.path.isfile(source_file):
+        # Path-shaped but absent: keep it (the resolution may target the serving
+        # container) and leave a breadcrumb for triage.
+        item["source_file_missing_on_disk"] = True
     reusable, skip_reason = classify_patchability(item)
     item["reusable_native_kernel"] = reusable
     item["skip_reason"] = skip_reason
@@ -3630,12 +3751,150 @@ def _stamp_candidate_metadata(item: dict[str, Any], op_cat_map: dict[str, str] |
     item.setdefault("source_path", item.get("source_file", ""))
 
 
+#: A candidate below this GPU share is not worth an LLM round-trip.
+_LLM_FALLBACK_MIN_GPU_PCT = 5.0
+
+
+def _apply_llm_source_fallback(item: dict[str, Any]) -> None:
+    """Last-resort LLM pick for a candidate every deterministic tier missed.
+
+    No-op unless the operator enabled the tier and the candidate is hot enough to
+    justify the call. Mutates ``item`` in place only on an accepted answer.
+    """
+    try:
+        from _llm_source_fallback import llm_fallback_enabled, select_source_via_llm  # noqa: PLC0415
+
+        if not llm_fallback_enabled():
+            return
+        try:
+            gpu_pct = float(item.get("gpu_pct") or 0.0)
+        except (TypeError, ValueError):
+            gpu_pct = 0.0
+        if gpu_pct < _LLM_FALLBACK_MIN_GPU_PCT:
+            return
+        name = str(item.get("name") or "")
+        shortlist = collect_source_candidates_via_grep(name)
+        if not shortlist:
+            return
+        picked, confidence, reason = select_source_via_llm(
+            name,
+            shortlist,
+            framework_roots=tuple(KNOWN_SEARCH_ROOTS),
+        )
+        if picked:
+            item["source_file"] = picked
+            item["source_resolution_method"] = "llm_fallback"
+            item["source_resolution_confidence"] = confidence
+            item["source_resolution_reason"] = reason
+    except Exception:  # noqa: BLE001 - advisory tier, never breaks finalization
+        return
+
+
+@functools.lru_cache(maxsize=64)
+def _package_parent_dir(package: str) -> str:
+    """Directory holding ``package``'s own directory, resolved at runtime.
+
+    Uses ``find_spec`` so the package is located without importing it (the same
+    approach ``_bypass_source_resolver`` takes for aiter). Returns ``""`` when
+    the name is not a package on this interpreter's path.
+    """
+    if not package or not package.isidentifier():
+        return ""
+    try:
+        spec = importlib.util.find_spec(package)
+    except (AttributeError, ImportError, ValueError):
+        return ""
+    if spec is None:
+        return ""
+    for location in list(getattr(spec, "submodule_search_locations", None) or []):
+        parent = os.path.dirname(str(location).rstrip("/"))
+        if parent:
+            return parent
+    origin = str(getattr(spec, "origin", "") or "")
+    return os.path.dirname(os.path.dirname(origin)) if origin else ""
+
+
+def absolutize_launcher_path(path: str) -> str:
+    """Best-effort absolute path for a trace-relative launcher frame.
+
+    torch profiler records a frame path relative to the ``sys.path`` entry the
+    module was imported from (``aiter/dist/x.py``), whereas patchability keys on
+    an absolute framework root. The relative path already starts with the package
+    name, so it joins against each package's *parent*.
+
+    Args:
+        path (str): Launcher path from the trace, absolute or relative.
+
+    Returns:
+        str: The absolutized path when one exists on disk, else ``path``.
+    """
+    if not path or os.path.isabs(path):
+        return path
+    # The relative path starts with the package name ("vllm/models/..."), so
+    # locate that package where it actually lives. A pinned list cannot do this:
+    # the same package sits under /sgl-workspace in the serving image and under
+    # dist-packages on a wheel install, and the Python version moves too.
+    parent = _package_parent_dir(path.split("/", 1)[0])
+    if parent:
+        candidate = os.path.join(parent, path)
+        if os.path.isfile(candidate):
+            return candidate
+    # Fall back to the pinned checkout layouts (editable installs whose package
+    # dir is not importable from this process).
+    for inner_root in _PACKAGE_INNER_ROOTS:
+        candidate = os.path.join(os.path.dirname(inner_root), path)
+        if os.path.isfile(candidate):
+            return candidate
+    return path
+
+
+def _trace_launcher_key(item: dict[str, Any]) -> str:
+    """Device kernel symbol to look this candidate up by in the trace."""
+    name = str(item.get("device_kernel_name") or "").strip()
+    if not name:
+        name = _normalize_profiler_op_name(str(item.get("name") or ""))
+    return name.strip()
+
+
+def _resolve_trace_launchers(
+    candidates: list[dict[str, Any]],
+    trace_files: list[Path] | None,
+) -> dict[str, Any]:
+    """Batch-resolve launcher frames for candidates that still lack a source.
+
+    One trace scan for the whole candidate list; returns ``{}`` when there is
+    nothing to look up or the trace cannot be read, so the grep fallback stays
+    in charge.
+    """
+    if not trace_files:
+        return {}
+    wanted = {
+        key
+        for item in candidates
+        # Shape, not truthiness: an upstream placeholder ("AITER (vendor)",
+        # "Not found") is a non-empty string, and treating it as a resolved
+        # source would skip the very candidates this resolver exists for.
+        if not looks_like_source_path(str(item.get("source_file") or ""))
+        and (key := _trace_launcher_key(item))
+        and not is_runtime_api_name(key)
+    }
+    if not wanted:
+        return {}
+    try:
+        from _trace_launcher_resolver import resolve_launchers_from_trace  # noqa: PLC0415
+
+        return resolve_launchers_from_trace([Path(p) for p in trace_files], wanted)
+    except Exception:  # noqa: BLE001 - advisory resolution, never fatal
+        return {}
+
+
 def _finalize_candidates(
     top: list[dict[str, Any]],
     *,
     total_dur: float | None = None,
     perf_report_csv_dir: Path | str | None = None,
     framework: str | None = None,
+    trace_files: list[Path] | None = None,
 ) -> list[dict[str, Any]]:
     """Apply shared post-processing to parsed candidate rows.
 
@@ -3653,6 +3912,9 @@ def _finalize_candidates(
             dual-framework image routes to the correct container's source. Only
             ``vllm``/``sglang`` steer routing; other values fall back to on-disk
             presence then default ordering.
+        trace_files: Optional raw trace files. When given, a kernel TraceLens
+            could not attribute is resolved to its Python launcher frame
+            directly from the trace, ahead of the name-grep fallback.
 
     Returns:
         The finalized candidate list (the same ``top`` object).
@@ -3662,6 +3924,16 @@ def _finalize_candidates(
     # Dict-first: resolve each op to its editable .cu and expand composite
     # fan-out into one candidate per sub-kernel before finalizing.
     top = _expand_op_fanout(top, framework=framework, op_dominant_kernel=op_dom_map)
+    # Drop upstream placeholders up front. They are non-empty strings, so every
+    # later "did we already resolve this?" check would read them as a resolved
+    # source and skip the resolution tiers entirely.
+    for item in top:
+        if isinstance(item, dict):
+            raw_source = str(item.get("source_file") or "").strip()
+            if raw_source and not looks_like_source_path(raw_source):
+                item["source_file_rejected"] = raw_source
+                item["source_file"] = ""
+    trace_launchers = _resolve_trace_launchers(top, trace_files)
     sum_dur = total_dur if total_dur is not None else sum(it.get("duration_us", 0.0) for it in top)
     sum_dur = sum_dur or 1.0
     # Recover the fused-MoE expert kernel's operand shapes (its trace event carries
@@ -3755,8 +4027,20 @@ def _finalize_candidates(
         # unresolved dispatch. An in-dict non-rewritable verdict is authoritative,
         # so we keep its .py launcher as context and do NOT grep/promote.
         if res is None or res.status == "unresolved":
+            # Trace-derived launcher first: it carries a line number and cannot
+            # produce grep's false positives (a test file or CPU implementation
+            # that merely mentions the symbol).
+            if not item.get("source_file"):
+                frame = trace_launchers.get(_trace_launcher_key(item))
+                if frame is not None:
+                    item["source_file"] = absolutize_launcher_path(frame.source_file)
+                    item["source_line"] = frame.line
+                    item["source_function"] = frame.function
+                    item["source_resolution_method"] = "trace_python_stack"
             if not item.get("source_file"):
                 item["source_file"] = locate_source_via_grep(item["name"])
+            if not item.get("source_file"):
+                _apply_llm_source_fallback(item)
             # Promote a tiny pybind shim TU to the real device code.
             item["kernel_repo"] = find_repo_root(item.get("source_file", ""))
             item["source_file"] = upgrade_pybind_shim_source(
@@ -4349,8 +4633,8 @@ def deterministic_extract_hot_kernels(
             if not isinstance(eff_pct, (int, float)):
                 eff_pct = 0
 
-            launcher_path = full_op.get("launcher_path", "")
-            if launcher_path in ("\u2014", "-", ""):
+            launcher_path = str(full_op.get("launcher_path", "") or "")
+            if launcher_path.strip().lower() in _LAUNCHER_PATH_PLACEHOLDERS:
                 launcher_path = ""
             source_file = _resolve_source_file_from_kernel_path(launcher_path)
 
@@ -4402,8 +4686,8 @@ def deterministic_extract_hot_kernels(
         # ``launcher_path`` only points at the calling Python wrapper, so it must
         # not be used as the editable source.
         op_name = op.get("name", "") or op.get("operation", "")
-        launcher_path = op.get("launcher_path", "")
-        if launcher_path in ("\u2014", "-"):
+        launcher_path = str(op.get("launcher_path", "") or "")
+        if launcher_path.strip().lower() in _LAUNCHER_PATH_PLACEHOLDERS:
             launcher_path = ""
 
         # Resolve the symbol to its definition site (never falling back to the
@@ -5275,6 +5559,12 @@ def _enrich_kernel_contract(item: dict[str, Any], model_params: dict[str, Any] |
         ("reduce_scatter", "reducescatter"),
         ("all_to_all", "alltoall"),
         ("broadcast",),
+        # aiter's custom all-reduce kernels are named cross_device_reduce_*
+        # (1stage / 2stage / half_butterfly). They implement all-reduce
+        # semantics, so they must be matched before the bare "reduce" tag
+        # below, which maps to a rank-0-only dist.reduce reference and would
+        # make the parity gate meaningless on every other rank.
+        ("cross_device_reduce",),
         ("reduce",),
     )
     _OPMAP = {
@@ -6390,6 +6680,7 @@ def main() -> int:
                             total_dur=total_dur or None,
                             perf_report_csv_dir=(tracelens_dir / "perf_report_csvs"),
                             framework=args.framework or None,
+                            trace_files=trace_files,
                         )
                         append_log(
                             log_path,
@@ -6526,6 +6817,7 @@ def main() -> int:
                             total_dur=total_dur or None,
                             perf_report_csv_dir=(skill_result.output_dir / "perf_report_csvs"),
                             framework=args.framework or None,
+                            trace_files=trace_files,
                         )
                         append_log(
                             log_path,

--- a/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
@@ -1334,7 +1334,9 @@ def _row_to_candidate(
     args = record.get("args", "").replace("<br>", "\n").strip()
     shapes = [s.strip() for s in args.split("\n") if s.strip() and s.strip() not in {"-", "—"}]
     kernel_path = record.get("kernel path", "").strip()
-    if kernel_path in {"-", "—"}:
+    # Share the launcher placeholder vocabulary so a sentinel such as TraceLens'
+    # "Not found" cannot survive as a fake source_file (see the constant).
+    if kernel_path.lower() in _LAUNCHER_PATH_PLACEHOLDERS:
         kernel_path = ""
     # Device kernel symbol(s) used to disambiguate dispatch ops; keep the full
     # list and use the first for matching. Placeholders normalize to "".
@@ -1559,6 +1561,11 @@ _LAUNCHER_PATH_RE = re.compile(
     r"(?P<path>.+?)\((?P<line>\d+)\)\s*:\s*(?P<func>[A-Za-z_][A-Za-z0-9_]*)\s*$",
 )
 # Placeholders for unresolved Kernel Paths; must not survive parsing.
+# ``not found`` is TraceLens' own sentinel for an unresolved launcher: it lands
+# in ``other_metrics.json`` whenever ``_find_entry_point`` cannot locate the op
+# in the call stack (every Synthetic Op), and the report agent copies it
+# verbatim into the Kernel Path cell. Letting it through makes it a truthy
+# ``source_file`` that silently skips the grep fallback downstream.
 _LAUNCHER_PATH_PLACEHOLDERS: frozenset[str] = frozenset(
     {
         "",
@@ -1567,6 +1574,9 @@ _LAUNCHER_PATH_PLACEHOLDERS: frozenset[str] = frozenset(
         "–",
         "n/a",
         "none",
+        "not found",
+        "not_found",
+        "notfound",
         "null",
         "tbd",
         "unknown",


### PR DESCRIPTION
## Problem

TraceLens writes `"Not found"` / `"AITER (vendor)"` into `source_file` whenever it cannot attribute a Synthetic Op (every hand-written Triton kernel launched outside the ATen dispatcher). Those are **non-empty strings**, so every downstream "already resolved?" check read them as a resolved source and skipped the resolution tiers entirely.

The damage was not just a missing path. `classify_patchability` then reported the nonsensical `source not under a reusable framework root: Not found`, which pointed debugging at the framework root instead of the missing lookup.

Measured across 19 MiniMax-M3-MXFP8 sessions: **76 of 101 hot-kernel candidates (75%) were dropped before reaching a backend**, including every MXFP8 hot kernel in the model.

## Approach

Resolve by **shape rather than truthiness** — a real `source_file` always carries a source extension, a producer placeholder never does. This holds for placeholder spellings nobody enumerated in advance (`AITER (vendor)` showed up 3 times in real data and was never on any list).

Four layers, deterministic first, LLM only as the last resort:

| Purpose | Where |
|---|---|
| Stop placeholders from posing as resolved sources | `_SOURCE_EXT_RE` + `looks_like_source_path()`, three call sites |
| Kill `Not found` at table-parse time | `_LAUNCHER_PATH_PLACEHOLDERS` in `tracelens_skill_runner.py` |
| Extract the source location from the runtime call stack | new `_trace_launcher_resolver.py` |
| Keep bare runtime API names out of the queue | `_RUNTIME_API_NAMES` |
| Fallback for cases the deterministic tiers cannot reach | new `_llm_source_fallback.py`, off by default |

The trace resolver reads `python_function` frames via correlation with the runtime launch event. It is exact to file, line and function, and structurally immune to the two false positives the grep fallback produces (test files and CPU implementations) because it reads runtime fact rather than matching text.

## Results

Measured on a live MiniMax-M3-MXFP8 run:

| | before | after |
|---|---|---|
| candidates detected | 101 (19 sessions) | 7 |
| reusable | 25 (24.8%) | 5 (**71.4%**) |
| hot-kernel `source_file` | `Not found` | real Triton paths |

All three MXFP8 hot kernels now resolve:

- `_mxfp8_grouped_gemm_kernel` -> `kernels/ops/moe/mxfp8_moe_amd_gfx95.py`
- `_mxfp8_linear_kernel` -> `kernels/ops/quantization/mxfp8_amd_gfx95.py`
- `_gqa_share_sparse_fwd_kernel` -> `attention/minimax_sparse/prefill/topk_sparse.py`

`runs/kernel_opt` went from empty across all 19 historical sessions to actually dispatching forge attempts.

## Scope

This PR carries **only** the source-resolution work. The collective-lane changes developed alongside it are deliberately excluded: `tracelens_analysis.py` was split hunk by hunk, dropping the three hunks that inject collective candidates (one of them a bare `from _nccl_summary_candidates import ...` that would `ImportError` without the unshipped module).

Verified before commit: the staged snapshot references no unshipped module, and all four touched modules pass `py_compile`.

## Not addressed

E2E throughput. This unblocks hot kernels from reaching a backend; whether that converts to gain depends on the quality of what forge/GEAK generates. Observed so far: candidates do reach forge, but the variants produced were only 1.38% faster and fell inside the 2% noise floor.

## Test plan

- [ ] `pytest src/hyperloom/agents/kernel/tests/test_trace_launcher_resolver.py`
- [ ] `pytest src/hyperloom/agents/kernel/tests/test_source_resolution_guards.py`
- [ ] `pytest src/hyperloom/agents/kernel/tests/test_llm_source_fallback.py`
- [ ] Replay historical `analysis.md` files and confirm hot-kernel rows no longer carry a placeholder `source_file`
- [ ] Full session on 8x MI355X: confirm `runs/kernel_opt` is non-empty and bare runtime API names are never routed

Made with [Cursor](https://cursor.com)