### PR TITLE
fix(kernel): stop sentinel strings from short-circuiting source resolution

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -148,6 +148,168 @@ The following variables control the kernel optimization backend ladder.
 
 ---
 
+## Kernel source resolution
+
+A kernel candidate must resolve to a real source file before any backend can
+rewrite it. Resolution runs as a ladder: curated dictionary, then the
+trace-derived launcher frame, then a name grep. All three are deterministic and
+require no configuration. Agent analysis may add the model-backed tiers below.
+
+Every run writes `kernel_source_resolution.json` next to the candidate report.
+It answers one question per hot kernel — which file defines it, and which tier
+decided that — in a versioned schema (`schema_version`, currently `1.0.0`), so
+consumers and triage read a contract rather than candidate internals.
+
+Two model-backed tiers may sit on top of the deterministic ladder when
+`--analysis-route agent` is used. The `deterministic` route never invokes either
+tier. Agent-route network calls require an explicit
+`HYPERLOOM_LLM_SOURCE_PROVIDER`; a model name alone never implies a provider or
+endpoint. The tiers differ in scope, authority and data exposure; the
+constraints of one do not apply to the other.
+
+Neither can fail a run: no model configured, a gateway error, a timeout or an
+unparseable reply all leave the deterministic result standing.
+
+### Fallback tier
+
+**When it runs.** Only for a candidate whose `source_file` is still empty after
+all three deterministic tiers, and whose GPU share is at least 5%.
+
+**What it sends.** One chat completion per such candidate, containing the kernel
+symbol and every shortlisted path. The shortlist comes from a relaxed grep over
+the known framework roots. **File contents are not sent unless
+`HYPERLOOM_LLM_SOURCE_PREVIEW` authorises it** (see [Source egress](#source-egress));
+with it, each path is accompanied by its first 40 lines, capped at 2000
+characters.
+
+**What it costs.** One call per qualifying candidate, 60-second ceiling, no
+retry. `HYPERLOOM_LLM_SOURCE_MODEL` overrides the selected provider's model
+setting. Claude uses `CLAUDE_MODEL`, then the project-wide
+`DEFAULT_CLAUDE_MODEL`; OpenAI-compatible routing uses `OPENAI_MODEL`, then
+`CODEX_MODEL`. Model settings are never borrowed across providers.
+
+**Authority: selection only.** The model may return one of the exact shortlist
+strings and nothing else. An invented path is rejected, as is any answer below
+0.7 confidence. This is deliberate — an LLM-produced sentinel written into
+`source_file` is what broke this pipeline originally.
+
+### Review tier
+
+The fallback only fires on an empty `source_file`, so it cannot catch the
+deterministic tiers' actual failure mode: not coming up empty, but coming up
+*confidently wrong*. Measured across historical sessions, only 59% of
+verifiable resolutions mention the kernel they claim to define, and
+`aten::fill_` alone has been resolved to four unrelated business files — each a
+real, existing, root-resident source file passing every mechanical check.
+
+**When it runs.** On the whole resolution table, including entries already
+filled in by the deterministic tiers. Entries below 1% GPU share are skipped.
+
+**What it sends.** A single chat completion carrying up to 40 entries at once.
+For each entry it includes the kernel symbol, GPU share, current path and
+deciding tier. File contents follow the same rule as the fallback tier: nothing
+is sent unless `HYPERLOOM_LLM_SOURCE_PREVIEW` authorises it. When it does, one
+call can ship up to 40 file heads, considerably more than the fallback tier
+sends per call — which is why the switch is global rather than per-tier.
+
+**What it costs.** One call per run (not per candidate), 180-second ceiling, no
+retry. Same provider and model resolution as the fallback tier. The response
+must include every sent `kernel_id` exactly once. A missing, duplicate or extra
+ID rejects the whole batch so a truncated response cannot masquerade as a
+complete review.
+
+<div class="callout warn">
+
+**Authority: it may rewrite, and it has no confidence threshold.** Unlike the
+fallback tier, this one is not restricted to a shortlist — it can replace any
+entry's path with any path, or drop a resolved entry back to unresolved. There
+is no 0.7 confidence gate. The mechanical limit is that a rewritten path must
+exist on disk **and** its resolved target must sit under a known framework root.
+Symlinks cannot escape that boundary. TraceLens-style
+`path.py(247): function` answers are split into a bare, openable path plus line
+and function metadata. An unverifiable path is rejected and the original
+stands. Curated `op_to_source` verdicts — including `non_rewritable` and
+`no_kernel` — are authoritative and cannot be replaced by model review.
+
+</div>
+
+Every revision records `previous_source_file` and `previous_method`, so a bad
+review is auditable and reversible, and `review_notes` lists every applied and
+rejected change. The batch is staged before it is committed, so an exception
+while validating one revision leaves every entry untouched. Failures — no model
+configured, gateway error, timeout, unparseable reply — leave the deterministic
+table untouched and are recorded in `review_notes`.
+
+Accepted revisions are folded back into `hot_kernels`, all metadata derived from
+the old path is cleared, and patchability is recomputed. The resolution JSON is
+the audit view of the same effective candidate state, not a detached suggestion.
+
+### Source egress
+
+Both tiers call an external model provider, so what leaves the host is a
+deliberate boundary rather than a side effect of building a useful prompt.
+
+**Provider routing is explicit.** Set `HYPERLOOM_LLM_SOURCE_PROVIDER` to
+`claude_agent_sdk` or `openai_compatible`. Claude requests use the native Claude
+Agent SDK with all repository, shell and web tools denied; OpenAI-compatible
+requests use chat completions. `kernel_source_resolution.json` records the
+provider, model, source-preview decision, outcome and endpoint hostname. It
+never records keys, custom headers, URL userinfo, query parameters or the full
+prompt.
+
+**Repository source is not sent by default.** The file heads described above are
+withheld unless `HYPERLOOM_LLM_SOURCE_PREVIEW` is set to `1`/`true`/`yes`/`on`.
+Without it both tiers still see candidate paths, which carry most of the
+selection signal; with it, a review call can ship up to 40 file heads.
+
+**The serving command line is never forwarded verbatim.** The tiers need backend
+flags — the same MoE operator dispatches differently under
+`--moe-runner-backend triton` and `aiter` — but `EXTRA_*_ARGS` also carries
+credentials, model paths and user data. It is therefore tokenised, and only
+flags on an explicit allowlist of backend selectors survive. A denied flag
+consumes its value too, so the value cannot reappear as a stray token. Every
+surviving value is dropped unless it is a short selector token. URL userinfo or
+queries, authorization headers, JWTs, control characters, non-finite numbers,
+vendor prefixes such as `sk-`, and long opaque strings are rejected. An
+unbalanced quote discards the whole line rather than risking a partial parse.
+
+**Environment variables** follow the same discipline: an explicit allowlist of
+path-selecting names, with the secret-name pattern applied on top.
+
+**Model config is allowlisted too.** Only fields that select architecture,
+expert layout or kernel format are included. Inside `quantization_config`, only
+explicit quantization selectors survive; arbitrary vendor fields, nested
+metadata and credential-shaped values are dropped.
+
+| Variable | Default | Description |
+|---|---|---|
+| `HYPERLOOM_`<br>`LLM_SOURCE`<br>`_PROVIDER` | Unset (no network call) | Required provider for source fallback/review: `claude_agent_sdk` (native Claude SDK, tools denied) or `openai_compatible` (chat completions). Common provider aliases are normalized to the canonical audit value. |
+| `HYPERLOOM_`<br>`LLM_SOURCE`<br>`_MODEL` | Unset | Optional source-resolution model override. Otherwise resolves only from the selected provider's own model variables; no cross-provider fallback. |
+| `HYPERLOOM_`<br>`LLM_SOURCE`<br>`_PREVIEW` | Unset (off) | Authorise sending the first 40 lines of candidate source files to the model provider. Applies to both the fallback and review tiers. Leave unset unless the provider is an approved destination for repository content. |
+
+### How fallback failures surface
+
+The fallback tier is advisory and never fails a run. Every
+outcome is recorded on the candidate as `source_resolution_reason`, so a skip
+can be told apart from a genuine failure:
+
+| `source_resolution_reason` | Meaning |
+|----------------------------|---------|
+| *(absent)* | Resolved before fallback, so the tier was not reached |
+| `llm_fallback_skipped: deterministic route` | Deterministic analysis explicitly prohibited model tiers |
+| `llm_fallback_skipped: gpu_pct ...` | Candidate below the 5% GPU-share floor; no call made |
+| `llm_fallback_skipped: no provider configured` | No `HYPERLOOM_LLM_SOURCE_PROVIDER`; settled before the shortlist grep, so an unconfigured tier costs nothing |
+| `llm_fallback_no_shortlist` | Grep found nothing to choose from; no call made |
+| `llm_fallback_declined: ...` | Model answered but the pick was rejected (invented path, low confidence, or refusal) |
+| `llm_fallback_error: ...` | Call failed — import error, gateway rejection, or timeout |
+
+Accepted answers are stamped `source_resolution_method="llm_fallback"` alongside
+a `source_resolution_confidence`, so they can be audited separately from
+deterministic resolutions. Failures in the trace-launcher tier are recorded the
+same way under `trace_resolver_error: ...`, and both are logged at `WARNING`.
+
+---
+
 ## Single-node Ray execution
 
 | Variable | Default | Description |

--- a/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
@@ -15,6 +15,7 @@ covered deterministically.
 from __future__ import annotations
 
 import gzip
+import io
 import json
 import sys
 from pathlib import Path
@@ -515,6 +516,7 @@ def test_non_kineto_json_yields_no_kernels(tmp_path):
     assert out["status"] == "ok"
     assert out["kernels"] == []
     assert out["event_total"] == 0
+    assert out["stream_errors"] == ["traceEvents array not found"]
 
 
 def test_empty_trace_events_array(tmp_path):
@@ -524,6 +526,7 @@ def test_empty_trace_events_array(tmp_path):
     assert out["status"] == "ok"
     assert out["kernels"] == []
     assert out["timeline"]["total_time_ms"] == 0.0
+    assert out["stream_errors"] == []
 
 
 def test_truncated_trace_recovers_complete_events(tmp_path):
@@ -544,6 +547,126 @@ def test_truncated_trace_recovers_complete_events(tmp_path):
     out = reader.analyze_trace(tf, top_k=0)
     assert out["status"] == "ok"
     assert {k["name"] for k in out["kernels"]} == {"paged_attention_v1"}
+    assert len(out["stream_errors"]) == 1
+    assert "truncated after 1 event(s)" in out["stream_errors"][0]
+
+
+def test_truncated_gzip_records_eof_error_without_raising():
+    """A gzip EOF must be reported through the stream error channel."""
+    payload = json.dumps(
+        {
+            "traceEvents": [
+                {"cat": "kernel", "name": "first"},
+                {"cat": "kernel", "name": "second-" + "x" * 4096},
+            ]
+        }
+    ).encode("utf-8")
+    compressed = gzip.compress(payload)
+    errors: list[str] = []
+    with gzip.GzipFile(fileobj=io.BytesIO(compressed[:-32]), mode="rb") as fh:
+        list(reader.stream_events(fh, bufsize=32, errors=errors))
+    assert any("EOFError" in error for error in errors)
+
+
+def test_bad_gzip_records_error_without_raising():
+    """An invalid gzip header must fail soft like a truncated stream."""
+    errors: list[str] = []
+    with gzip.GzipFile(fileobj=io.BytesIO(b"not-a-gzip-stream"), mode="rb") as fh:
+        assert list(reader.stream_events(fh, bufsize=8, errors=errors)) == []
+    assert any("BadGzipFile" in error for error in errors)
+
+
+def test_trace_events_null_does_not_capture_a_later_array():
+    """A non-array traceEvents value must not redirect parsing elsewhere."""
+    payload = (
+        b'{"traceEvents": null, "other": '
+        b'[{"cat": "kernel", "name": "wrong-array"}]}'
+    )
+    errors: list[str] = []
+    assert list(reader.stream_events(io.BytesIO(payload), bufsize=16, errors=errors)) == []
+    assert errors == ["traceEvents value is not an array"]
+
+
+def test_trace_events_text_value_before_key_is_ignored():
+    """A string value named traceEvents must not shadow the real member."""
+    good = {"cat": "kernel", "name": "real-array"}
+    payload = json.dumps(
+        {"label": "traceEvents", "traceEvents": [good]}
+    ).encode("utf-8")
+    errors: list[str] = []
+    assert list(reader.stream_events(io.BytesIO(payload), bufsize=9, errors=errors)) == [good]
+    assert errors == []
+
+
+def test_utf8_character_split_across_chunks_is_preserved():
+    """Incremental decoding must preserve a split multibyte code point."""
+    marker = chr(0x20AC)
+    expected = "kernel-" + marker + "-suffix"
+    payload = json.dumps(
+        {"traceEvents": [{"cat": "kernel", "name": expected}]},
+        ensure_ascii=False,
+    ).encode("utf-8")
+    marker_start = payload.index(marker.encode("utf-8"))
+    errors: list[str] = []
+    events = list(
+        reader.stream_events(
+            io.BytesIO(payload),
+            bufsize=marker_start + 1,
+            errors=errors,
+        )
+    )
+    assert events[0]["name"] == expected
+    assert errors == []
+
+
+def test_complete_malformed_object_resyncs_to_later_event():
+    """A balanced bad object must not hide a later valid event."""
+    good = {"cat": "kernel", "name": "recovered"}
+    payload = (
+        b'{"traceEvents": [{"cat": "kernel", "name": invalid},'
+        + json.dumps(good).encode("utf-8")
+        + b"]}"
+    )
+    errors: list[str] = []
+    events = list(reader.stream_events(io.BytesIO(payload), bufsize=11, errors=errors))
+    assert events == [good]
+    assert len(errors) == 1
+    assert "malformed after 0 event(s)" in errors[0]
+
+
+def test_trace_prefix_growth_is_bounded(monkeypatch):
+    """A missing late traceEvents key must not grow the prefix indefinitely."""
+    monkeypatch.setattr(reader, "_MAX_TRACE_PREFIX_CHARS", 32)
+    payload = b'{"padding":"' + b"x" * 64 + b'","traceEvents":[]}'
+    errors: list[str] = []
+    assert list(reader.stream_events(io.BytesIO(payload), bufsize=8, errors=errors)) == []
+    assert len(errors) == 1
+    assert "prefix exceeds" in errors[0]
+
+
+def test_single_event_growth_is_bounded(monkeypatch):
+    """An unclosed oversized object must stop at the per-event limit."""
+    monkeypatch.setattr(reader, "_MAX_EVENT_CHARS", 64)
+    payload = b'{"traceEvents":[{"cat":"kernel","name":"' + b"x" * 128
+    errors: list[str] = []
+    assert list(reader.stream_events(io.BytesIO(payload), bufsize=8, errors=errors)) == []
+    assert len(errors) == 1
+    assert "object exceeds" in errors[0]
+
+
+def test_trace_events_opener_may_cross_a_read_boundary():
+    """A chunk ending after the key must refill instead of raising ValueError."""
+    payload = b'{"traceEvents"  : [{"cat": "kernel"}]}'
+    errors: list[str] = []
+    events = list(
+        reader.stream_events(
+            io.BytesIO(payload),
+            bufsize=len('{"traceEvents"'),
+            errors=errors,
+        )
+    )
+    assert events == [{"cat": "kernel"}]
+    assert errors == []
 
 
 def test_single_event_trace(tmp_path):

--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -602,6 +602,33 @@ def test_parse_failure_flags_analysis_degraded(tmp_path, capsys, monkeypatch):
     assert manifest["analysis_degraded"] is True
 
 
+def test_truncated_stream_is_recovered_but_marked_degraded(tmp_path, capsys):
+    """Partial recovery must not make a truncated trace look healthy."""
+    good = {
+        "cat": "kernel",
+        "ph": "X",
+        "name": "recovered_kernel",
+        "ts": 10,
+        "dur": 20,
+        "args": {"correlation": 1},
+    }
+    trace = tmp_path / "truncated.trace.json"
+    trace.write_text(
+        '{"traceEvents": [' + json.dumps(good) + ', {"cat": "kernel", "name": "cut',
+        encoding="utf-8",
+    )
+    _, result, _ = _run(_base_argv(tmp_path, str(trace)), capsys)
+    assert result["analysis_degraded"] is True
+    assert {row["name"] for row in result["hot_kernels"]} == {"recovered_kernel"}
+    codes = {warning["code"] for warning in result["trace_health_warnings"]}
+    assert "bypass_trace_stream_incomplete" in codes
+    assert "bypass_trace_parse_failed" not in codes
+    summary = json.loads(Path(result["artifact_paths"]["tracelens_summary"]).read_text())
+    assert summary["analysis_degraded"] is True
+    manifest = json.loads(Path(result["artifact_paths"]["trace_input_manifest"]).read_text())
+    assert manifest["analysis_degraded"] is True
+
+
 def test_healthy_trace_is_not_degraded(tmp_path, capsys, monkeypatch):
     trace = tmp_path / "ok.trace.json"
     trace.write_bytes(json.dumps({"traceEvents": _TRACE_EVENTS}).encode("utf-8"))

--- a/src/hyperloom/agents/kernel/tests/test_llm_source_context.py
+++ b/src/hyperloom/agents/kernel/tests/test_llm_source_context.py
@@ -1,0 +1,297 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Guards on the runtime context handed to the source-resolution model tiers.
+
+The context exists so a model can tell apart two same-named candidates by the
+backend that is actually selected. That usefulness is only worth having if the
+block cannot carry a credential out of the host, and cannot grow without bound.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+from _llm_source_context import (  # noqa: E402
+    _MAX_CONTEXT_CHARS,
+    build_context_block,
+    launcher_stack,
+    model_config_summary,
+    runtime_flags,
+    server_arg_flags,
+)
+
+
+# --- secrets ------------------------------------------------------------------
+
+
+def test_credentials_never_reach_the_context():
+    """An allowlist decides what is sent; secrets are refused on top of that."""
+    env = {
+        "ANTHROPIC_API_KEY": "ak-secret",
+        "OPENAI_API_KEY": "sk-secret",
+        "HF_TOKEN": "hf-secret",
+        "AWS_SECRET_ACCESS_KEY": "aws-secret",
+        "SGLANG_USE_AITER": "1",
+    }
+    block = build_context_block(server_args="--tp 8", framework_roots=("/repo",), env=env)
+    for secret in ("ak-secret", "sk-secret", "hf-secret", "aws-secret"):
+        assert secret not in block, secret
+    assert "SGLANG_USE_AITER" in block
+
+
+def test_a_secret_named_variable_is_dropped_even_if_allowlisted(monkeypatch):
+    """The name pattern is a backstop against a careless allowlist edit."""
+    monkeypatch.setattr(
+        "_llm_source_context._ENV_ALLOWLIST",
+        ("TP", "some_api_key", "Authorization"),
+    )
+    out = runtime_flags(
+        None,
+        {"TP": "8", "some_api_key": "leak-me", "Authorization": "leak-too"},
+    )
+    assert out["env"] == {"TP": "8"}
+
+
+def test_unlisted_variables_are_not_forwarded():
+    """Only path-selecting names travel, not whatever happens to be exported."""
+    out = runtime_flags(None, {"MY_CUSTOM_VAR": "x", "SGLANG_USE_AITER": "1"})
+    assert out["env"] == {"SGLANG_USE_AITER": "1"}
+
+
+# --- serving command line -----------------------------------------------------
+
+
+def test_the_raw_server_command_line_is_never_forwarded():
+    """EXTRA_*_ARGS carries credentials and paths; only selectors may travel."""
+    raw = "--api-key sk-supersecret --moe-runner-backend triton --model-path /data/private"
+    block = build_context_block(server_args=raw, env={})
+    assert "sk-supersecret" not in block
+    assert "api-key" not in block
+    assert "/data/private" not in block
+    assert "triton" in block
+
+
+def test_runtime_selection_includes_framework_and_precision():
+    """Dispatch-critical scalar context uses the same selector validator."""
+    block = build_context_block(
+        framework="sglang",
+        precision="fp8_e4m3",
+        env={},
+    )
+    assert '"framework": "sglang"' in block
+    assert '"precision": "fp8_e4m3"' in block
+
+
+def test_a_denied_flags_value_is_consumed_with_it():
+    """Skipping only the flag would leave its value as a stray bare token."""
+    assert server_arg_flags("--api-key sk-leak --tp-size 8") == {"tp-size": "8"}
+
+
+def test_a_credential_shaped_value_is_dropped_from_an_allowed_flag():
+    """The name allowlist cannot see a secret passed as an innocuous value."""
+    assert server_arg_flags("--quantization sk-abcdefghijklmnop") == {}
+    assert server_arg_flags("--dtype " + "A" * 50) == {}
+
+
+def test_structured_secret_values_are_dropped_from_allowed_flags():
+    """URLs, authorization headers, JWTs, and controls are not selectors."""
+    unsafe_args = (
+        "--dtype https://user:pass@host/v1?api_key=secret",
+        "--dtype 'authorization: Basic dXNlcjpwYXNz'",
+        "--dtype 'basic dXNlcjpwYXNz'",
+        "--dtype 'bearer lower-case-secret'",
+        "--dtype eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.signature",
+        "--dtype 'triton\ninjected'",
+    )
+    for server_args in unsafe_args:
+        assert server_arg_flags(server_args) == {}
+
+
+def test_an_unparseable_command_line_yields_nothing():
+    """A partial parse of an unbalanced line risks emitting a fragment."""
+    assert server_arg_flags('--moe-runner-backend "unclosed') == {}
+
+
+def test_inline_and_bare_flag_forms():
+    """``--flag=value`` and a valueless flag are both understood."""
+    assert server_arg_flags("--attention-backend=aiter --api-key=sk-no") == {
+        "attention-backend": "aiter"
+    }
+    assert server_arg_flags("--enable-torch-compile") == {"enable-torch-compile": True}
+
+
+def test_common_selector_values_are_preserved():
+    """Known backend, dtype, quantization, and numeric-list forms remain valid."""
+    out = server_arg_flags(
+        "--attention-backend aiter "
+        "--decode-attention-backend triton "
+        "--prefill-attention-backend flashinfer "
+        "--dtype fp8_e4m3 "
+        "--kv-cache-dtype torch.bfloat16 "
+        "--quantization compressed-tensors"
+    )
+    assert out == {
+        "attention-backend": "aiter",
+        "decode-attention-backend": "triton",
+        "prefill-attention-backend": "flashinfer",
+        "dtype": "fp8_e4m3",
+        "kv-cache-dtype": "torch.bfloat16",
+        "quantization": "compressed-tensors",
+    }
+    assert runtime_flags(None, {"HIP_VISIBLE_DEVICES": "0,1"}) == {
+        "env": {"HIP_VISIBLE_DEVICES": "0,1"}
+    }
+
+
+# --- model config ---------------------------------------------------------------
+
+
+def test_config_summary_keeps_only_path_selecting_fields(tmp_path):
+    cfg = {
+        "architectures": ["MiniMaxM3SparseForConditionalGeneration"],
+        "model_type": "minimax_m3_vl",
+        "quantization_config": {
+            "quant_method": "mxfp8",
+            "weight_block_size": [128, 128],
+            "ignored": ["a", "b"],
+        },
+        "vocab_size": 200000,
+        "bos_token_id": 1,
+    }
+    (tmp_path / "config.json").write_text(json.dumps(cfg), encoding="utf-8")
+    got = model_config_summary(tmp_path)
+    assert got["model_type"] == "minimax_m3_vl"
+    assert got["quantization_config"] == {
+        "quant_method": "mxfp8",
+        "weight_block_size": [128, 128],
+    }
+    # Tokenizer-ish fields are noise for deciding which kernel file runs.
+    assert "vocab_size" not in got
+    assert "bos_token_id" not in got
+
+
+def test_quantization_config_drops_unknown_and_secret_fields(tmp_path):
+    """Only explicit selectors may cross the model-config egress boundary."""
+    cfg = {
+        "quantization_config": {
+            "quant_method": "mxfp8",
+            "api_key": "sk-must-not-leave",
+            "vendor_metadata": "private",
+            "weight_dtype": "sk-secret-in-an-allowed-field",
+            "nested": {"hf_token": "hf_must_not_leave"},
+        }
+    }
+    (tmp_path / "config.json").write_text(json.dumps(cfg), encoding="utf-8")
+    got = model_config_summary(tmp_path)
+    assert got["quantization_config"] == {"quant_method": "mxfp8"}
+    rendered = json.dumps(got)
+    for secret in ("sk-must-not-leave", "private", "sk-secret", "hf_must_not_leave"):
+        assert secret not in rendered
+
+
+def test_model_config_lists_are_bounded_and_redacted(tmp_path):
+    """Allowlisted lists cannot crowd out later runtime context sections."""
+    cfg = {
+        "architectures": ["SafeArchitecture", "sk-secret"] + [f"Arch{i}" for i in range(30)],
+        "quantization_config": {"weight_block_size": list(range(30))},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(cfg), encoding="utf-8")
+    got = model_config_summary(tmp_path)
+    assert got["architectures"] == ["SafeArchitecture"] + [f"Arch{i}" for i in range(14)]
+    assert got["quantization_config"]["weight_block_size"] == list(range(16))
+
+
+def test_config_selectors_drop_unsafe_items_and_non_finite_numbers(tmp_path):
+    """Config lists and quantization selectors apply the same scalar policy."""
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.signature"
+    cfg = {
+        "architectures": [
+            "SafeArchitecture",
+            "https://user:pass@host/v1?api_key=secret",
+            "authorization: Basic dXNlcjpwYXNz",
+            "bearer lower-case-secret",
+            jwt,
+            "triton\x00injected",
+            "NaN",
+            "Infinity",
+        ],
+        "torch_dtype": float("nan"),
+        "num_experts": True,
+        "num_attention_heads": 8,
+        "head_dim": 64.5,
+        "quantization_config": {
+            "quant_method": [
+                "mxfp8",
+                "https://user:pass@host/v1?api_key=secret",
+                "authorization: Basic dXNlcjpwYXNz",
+                "bearer lower-case-secret",
+                jwt,
+                "nan",
+                "infinity",
+            ],
+            "bits": float("inf"),
+            "compute_dtype": float("-inf"),
+            "weight_block_size": [128, float("nan"), float("inf"), 256],
+        },
+    }
+    (tmp_path / "config.json").write_text(json.dumps(cfg), encoding="utf-8")
+    got = model_config_summary(tmp_path)
+    assert got == {
+        "architectures": ["SafeArchitecture"],
+        "num_experts": True,
+        "num_attention_heads": 8,
+        "head_dim": 64.5,
+        "quantization_config": {
+            "quant_method": ["mxfp8"],
+            "weight_block_size": [128, 256],
+        },
+    }
+    rendered = json.dumps(got)
+    assert "NaN" not in rendered
+    assert "Infinity" not in rendered
+
+
+def test_missing_or_broken_config_degrades_quietly(tmp_path):
+    assert model_config_summary(None) == {}
+    assert model_config_summary(tmp_path) == {}
+    (tmp_path / "config.json").write_text("{ not json", encoding="utf-8")
+    assert model_config_summary(tmp_path) == {}
+
+
+# --- launcher stack --------------------------------------------------------------
+
+
+def test_launcher_stack_falls_back_to_the_single_resolved_frame():
+    entry = {
+        "source_file": "/repo/moe.py",
+        "source_line": 247,
+        "source_function": "_grouped_gemm",
+    }
+    assert launcher_stack(entry) == ["/repo/moe.py(247): _grouped_gemm"]
+
+
+def test_launcher_stack_is_empty_without_a_call_site():
+    assert launcher_stack({"source_file": "/repo/moe.py"}) == []
+
+
+# --- size and degradation ----------------------------------------------------------
+
+
+def test_context_is_capped():
+    huge = "--flag " * 5000
+    block = build_context_block(server_args=huge, framework_roots=("/repo",), env={})
+    assert len(block) <= _MAX_CONTEXT_CHARS
+
+
+def test_no_available_context_yields_an_empty_block():
+    """Nothing to say means say nothing, rather than an empty scaffold."""
+    assert build_context_block(env={}) == ""

--- a/src/hyperloom/agents/kernel/tests/test_llm_source_fallback.py
+++ b/src/hyperloom/agents/kernel/tests/test_llm_source_fallback.py
@@ -1,0 +1,818 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""The LLM tier of source resolution: selection only, and off by default.
+
+This pipeline was broken by an LLM writing a placeholder into a field that was
+consumed as a path, so the tier that reintroduces an LLM has to be provably
+unable to repeat that: it may only echo back one of the paths it was given, the
+answer is checked against the filesystem, and it stays off unless enabled.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+import _llm_source_fallback as lsf  # noqa: E402
+
+
+@pytest.fixture()
+def enabled():
+    """Kept as a no-op so the tier's tests read the same after it became default."""
+    return None
+
+
+@pytest.fixture()
+def provider(monkeypatch):
+    """Select a provider, which the finalizer settles before it greps."""
+    monkeypatch.setenv("HYPERLOOM_LLM_SOURCE_PROVIDER", "openai_compatible")
+
+
+@pytest.fixture()
+def files(tmp_path):
+    real = tmp_path / "kernel.py"
+    real.write_text("@triton.jit\ndef my_kernel():\n    pass\n", encoding="utf-8")
+    test_file = tmp_path / "test_kernel.py"
+    test_file.write_text("def test_my_kernel():\n    pass\n", encoding="utf-8")
+    return str(real), str(test_file)
+
+
+def _replies(payload) -> callable:
+    text = payload if isinstance(payload, str) else json.dumps(payload)
+    return lambda _prompt, _model, _timeout: text
+
+
+# --- Always on ------------------------------------------------------------------
+
+
+def test_runs_without_any_opt_in(files):
+    """The tier is unconditional; no environment setup precedes a call."""
+    picked, _conf, _reason = lsf.select_source_via_llm(
+        "my_kernel", [files[0]], complete=_replies({"source_file": files[0], "confidence": 1.0})
+    )
+    assert picked == files[0]
+
+
+def test_empty_shortlist_still_short_circuits(files):
+    """Nothing to choose from means no call, independent of the tier being on."""
+    picked, _conf, reason = lsf.select_source_via_llm("my_kernel", [], complete=_replies({}))
+    assert picked == ""
+    assert "no candidates" in reason
+
+
+# --- Selection, never generation ----------------------------------------------
+
+
+def test_accepts_a_candidate_from_the_shortlist(enabled, files):
+    real, test_file = files
+    picked, confidence, _reason = lsf.select_source_via_llm(
+        "my_kernel",
+        [test_file, real],
+        complete=_replies({"source_file": real, "confidence": 0.9, "reason": "defines the kernel"}),
+    )
+    assert picked == real
+    assert confidence == 0.9
+
+
+def test_rejects_a_path_outside_the_shortlist(enabled, files, tmp_path):
+    """An invented path is the failure mode this tier must not have."""
+    invented = str(tmp_path / "hallucinated.py")
+    picked, _conf, reason = lsf.select_source_via_llm(
+        "my_kernel", [files[0]], complete=_replies({"source_file": invented, "confidence": 1.0})
+    )
+    assert picked == ""
+    assert "not one of the candidates" in reason
+
+
+def test_rejects_a_shortlisted_path_that_vanished(enabled, tmp_path):
+    missing = str(tmp_path / "gone.py")
+    picked, _conf, reason = lsf.select_source_via_llm(
+        "my_kernel", [missing], complete=_replies({"source_file": missing, "confidence": 1.0})
+    )
+    assert picked == ""
+    assert "does not exist" in reason
+
+
+def test_rejects_a_path_outside_the_framework_roots(enabled, files):
+    picked, _conf, reason = lsf.select_source_via_llm(
+        "my_kernel",
+        [files[0]],
+        framework_roots=("/sgl-workspace/sglang",),
+        complete=_replies({"source_file": files[0], "confidence": 1.0}),
+    )
+    assert picked == ""
+    assert "outside every framework root" in reason
+
+
+def test_rejects_a_symlink_that_escapes_the_framework_root(enabled, tmp_path):
+    """A lexical in-root path may not resolve to a file outside the root."""
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("def kernel():\n    pass\n", encoding="utf-8")
+    link = root / "kernel.py"
+    link.symlink_to(outside)
+    picked, _conf, reason = lsf.select_source_via_llm(
+        "kernel",
+        [str(link)],
+        framework_roots=(str(root),),
+        complete=_replies({"source_file": str(link), "confidence": 1.0}),
+    )
+    assert picked == ""
+    assert "outside every framework root" in reason
+
+
+def test_accepts_a_symlink_whose_target_remains_inside_the_root(enabled, tmp_path):
+    """Symlinks stay valid, but what is stored is the target that was checked.
+
+    Root containment is decided on the resolved target, so keeping the link
+    would record a location whose authorization can be revoked afterwards by
+    retargeting it. The review tier resolves for the same reason.
+    """
+    root = tmp_path / "root"
+    root.mkdir()
+    target = root / "implementation.py"
+    target.write_text("def kernel():\n    pass\n", encoding="utf-8")
+    link = root / "kernel.py"
+    link.symlink_to(target)
+    picked, _conf, _reason = lsf.select_source_via_llm(
+        "kernel",
+        [str(link)],
+        framework_roots=(str(root),),
+        complete=_replies({"source_file": str(link), "confidence": 1.0}),
+    )
+    assert picked == str(target)
+
+
+def test_no_candidates_short_circuits_without_calling_the_model(enabled):
+    def _boom(*_args):  # pragma: no cover - must not run
+        raise AssertionError("model called with an empty shortlist")
+
+    picked, _conf, reason = lsf.select_source_via_llm("my_kernel", [], complete=_boom)
+    assert picked == ""
+    assert "no candidates" in reason
+
+
+# --- Confidence and malformed replies -----------------------------------------
+
+
+def test_low_confidence_is_discarded(enabled, files):
+    picked, confidence, reason = lsf.select_source_via_llm(
+        "my_kernel", [files[0]], complete=_replies({"source_file": files[0], "confidence": 0.4})
+    )
+    assert picked == ""
+    assert confidence == 0.4
+    assert "below" in reason
+
+
+@pytest.mark.parametrize(
+    "confidence",
+    ["NaN", "Infinity", "-Infinity", '"NaN"', '"Infinity"', '"-Infinity"', "-0.1", "1.1"],
+)
+def test_non_finite_and_out_of_range_confidence_is_rejected(files, confidence):
+    """Only finite confidence values in the declared range are accepted."""
+    source = files[0]
+    reply = f'{{"source_file": {json.dumps(source)}, "confidence": {confidence}}}'
+    picked, parsed_confidence, reason = lsf.select_source_via_llm(
+        "my_kernel",
+        [source],
+        complete=_replies(reply),
+    )
+    assert picked == ""
+    assert parsed_confidence == 0.0
+    assert "finite and in [0, 1]" in reason
+
+
+def test_empty_answer_means_none_of_the_candidates(enabled, files):
+    picked, _conf, reason = lsf.select_source_via_llm(
+        "my_kernel", [files[0]], complete=_replies({"source_file": "", "confidence": 0.0})
+    )
+    assert picked == ""
+    assert "no candidate" in reason
+
+
+def test_prose_wrapped_json_is_still_parsed(enabled, files):
+    real = files[0]
+    reply = f'Sure!\n```json\n{{"source_file": "{real}", "confidence": 0.95}}\n```\n'
+    picked, _conf, _reason = lsf.select_source_via_llm("my_kernel", [real], complete=_replies(reply))
+    assert picked == real
+
+
+def test_non_json_reply_is_rejected(enabled, files):
+    errors = []
+    picked, _conf, reason = lsf.select_source_via_llm(
+        "my_kernel",
+        [files[0]],
+        complete=_replies("I could not determine the file."),
+        errors=errors,
+    )
+    assert picked == ""
+    assert "no JSON object" in reason
+    assert errors == [reason]
+
+
+@pytest.mark.parametrize(
+    ("reply", "expected_reason"),
+    [
+        (None, "reply is not text"),
+        ("{invalid}", "unparseable JSON"),
+        ('{"confidence": "high"}', "confidence is not numeric"),
+    ],
+)
+def test_parse_answer_rejects_invalid_payload_shapes(reply, expected_reason):
+    """Malformed payload variants must fail with their precise safe reason."""
+    parsed, source_file, confidence, reason = lsf._parse_answer(reply)
+    assert parsed is False
+    assert source_file == ""
+    assert confidence == 0.0
+    assert reason == expected_reason
+
+
+def test_parse_answer_rejects_non_object_json(monkeypatch):
+    """The defensive parser guard must reject a decoded non-object payload."""
+    class Match:
+        """Return a fixed JSON array from the regex match surface."""
+
+        @staticmethod
+        def group(_index):
+            """Return the non-object JSON payload."""
+            return "[]"
+
+    class Pattern:
+        """Expose the minimal search interface used by the parser."""
+
+        @staticmethod
+        def search(_text):
+            """Return the fixed match."""
+            return Match()
+
+    monkeypatch.setattr(lsf, "_JSON_BLOCK_RE", Pattern())
+    parsed, source_file, confidence, reason = lsf._parse_answer("ignored")
+    assert parsed is False
+    assert source_file == ""
+    assert confidence == 0.0
+    assert reason == "JSON payload is not an object"
+
+
+def test_model_error_is_swallowed(enabled, files):
+    def _raise(*_args):
+        raise RuntimeError("gateway 401")
+
+    errors: list[str] = []
+    picked, _conf, reason = lsf.select_source_via_llm(
+        "my_kernel",
+        [files[0]],
+        complete=_raise,
+        errors=errors,
+    )
+    assert picked == ""
+    assert "llm call failed" in reason
+    assert errors == [reason]
+
+
+def test_model_error_is_redacted_from_reason_errors_and_log(files):
+    """Transport diagnostics retain only a stable type and status code."""
+    class TransportError(RuntimeError):
+        """Represent a provider failure carrying sensitive response details."""
+
+        status_code = 401
+
+    def _raise(*_args):
+        raise TransportError(
+            "https://gateway.example/v1?token=query-secret "
+            "Authorization: Bearer header-secret"
+        )
+
+    errors: list[str] = []
+    logs: list[str] = []
+    picked, _conf, reason = lsf.select_source_via_llm(
+        "my_kernel",
+        [files[0]],
+        complete=_raise,
+        errors=errors,
+        log=logs.append,
+    )
+    recorded = "\n".join([reason, *errors, *logs])
+    assert picked == ""
+    assert "TransportError" in recorded
+    assert "status_code=401" in recorded
+    assert "gateway.example" not in recorded
+    assert "query-secret" not in recorded
+    assert "header-secret" not in recorded
+    assert "Authorization" not in recorded
+
+
+def test_exception_label_skips_hostile_and_boolean_codes():
+    """Exception metadata inspection must ignore unsafe or ambiguous values."""
+    class HostileMetadataError(RuntimeError):
+        """Expose unusable metadata before one safe code."""
+
+        @property
+        def status_code(self):
+            """Raise instead of exposing provider response details."""
+            raise RuntimeError("secret response body")
+
+        code = True
+        errno = "E_GATEWAY"
+
+    assert lsf._safe_exception_label(HostileMetadataError()) == (
+        "HostileMetadataError (errno=E_GATEWAY)"
+    )
+
+
+# --- Provider routing and audit -----------------------------------------------
+
+
+def test_network_calls_require_an_explicit_provider(monkeypatch):
+    """A model name alone must never imply a provider or endpoint."""
+    monkeypatch.delenv(lsf._PROVIDER_ENV, raising=False)
+    with pytest.raises(RuntimeError, match=lsf._PROVIDER_ENV):
+        lsf._resolve_provider()
+
+
+def test_provider_helpers_fail_closed_without_valid_configuration(monkeypatch):
+    """Unsupported providers must fail and Claude audit hosts must stay generic."""
+    with pytest.raises(RuntimeError, match="unsupported"):
+        lsf._resolve_provider("unknown-provider")
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.delenv("DEEPSEEK_BASE_URL", raising=False)
+    assert lsf._endpoint_host(lsf._PROVIDER_CLAUDE) == "provider-default"
+
+
+def test_default_claude_model_handles_role_import_failure(monkeypatch):
+    """Standalone tools must tolerate an unavailable orchestrator role module."""
+    monkeypatch.setitem(sys.modules, "hyperloom.orchestrator.roles.agent_role", None)
+    assert lsf._default_claude_model() == ""
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("claude", lsf._PROVIDER_CLAUDE),
+        ("claude_agent_sdk", lsf._PROVIDER_CLAUDE),
+        ("openai", lsf._PROVIDER_OPENAI),
+        ("openai-compatible", lsf._PROVIDER_OPENAI),
+    ],
+)
+def test_provider_aliases_route_to_native_backends(monkeypatch, configured, expected):
+    """Explicit aliases normalize to one auditable provider identifier."""
+    monkeypatch.setenv(lsf._PROVIDER_ENV, configured)
+    calls = []
+    monkeypatch.setattr(
+        lsf,
+        "_complete_claude_sdk",
+        lambda *_args: calls.append(lsf._PROVIDER_CLAUDE) or "claude",
+    )
+    monkeypatch.setattr(
+        lsf,
+        "_complete_openai",
+        lambda *_args: calls.append(lsf._PROVIDER_OPENAI) or "openai",
+    )
+    assert lsf._complete("prompt", "model", 1.0) in {"claude", "openai"}
+    assert calls == [expected]
+
+
+def test_openai_provider_adapter_uses_sanitized_client_configuration(monkeypatch):
+    """The OpenAI adapter must forward only validated client configuration."""
+    captured = {}
+
+    def _create(**kwargs):
+        """Capture the completion request and return one SDK-shaped response."""
+        captured["request"] = kwargs
+        message = types.SimpleNamespace(content="provider reply")
+        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=message)])
+
+    class Client:
+        """Minimal OpenAI client surface used by the adapter."""
+
+        def __init__(self, **kwargs):
+            """Capture constructor options and expose chat completions."""
+            captured["client"] = kwargs
+            completions = types.SimpleNamespace(create=_create)
+            self.chat = types.SimpleNamespace(completions=completions)
+
+    fake_openai = types.ModuleType("openai")
+    fake_openai.OpenAI = Client
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+    monkeypatch.setattr(
+        "hyperloom.common.llm_config.openai_client_kwargs",
+        lambda: {"api_key": "configured-key", "base_url": "https://gateway.example/v1"},
+    )
+
+    reply = lsf._complete_openai("prompt", "source-model", 7.5)
+
+    assert reply == "provider reply"
+    assert captured["client"]["base_url"] == "https://gateway.example/v1"
+    assert captured["request"] == {
+        "model": "source-model",
+        "messages": [
+            {"role": "system", "content": lsf._SYSTEM_PROMPT},
+            {"role": "user", "content": "prompt"},
+        ],
+        "temperature": 0.0,
+        "timeout": 7.5,
+    }
+
+
+def test_message_text_accepts_sdk_text_shapes():
+    """Claude SDK string, text, and content-block forms must all be readable."""
+    assert lsf._message_text("direct") == ["direct"]
+    assert lsf._message_text(types.SimpleNamespace(text="attribute")) == ["attribute"]
+    message = types.SimpleNamespace(
+        content=[
+            {"text": "dict"},
+            types.SimpleNamespace(text="object"),
+            {"other": "ignored"},
+        ]
+    )
+    assert lsf._message_text(message) == ["dict", "object"]
+
+
+def test_claude_provider_rejects_incomplete_sdk(monkeypatch):
+    """A partial SDK installation must fail before any network request."""
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", types.ModuleType("claude_agent_sdk"))
+    with pytest.raises(RuntimeError, match="missing query / ClaudeAgentOptions"):
+        lsf._complete_claude_sdk("prompt", "model", 1.0)
+
+
+def test_claude_provider_uses_a_tool_free_native_sdk_call(monkeypatch):
+    """Claude routing uses the SDK without granting repository or shell tools."""
+    captured = {}
+
+    class Options:
+        """Capture ClaudeAgentOptions keyword arguments."""
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            captured["options"] = self
+
+    async def query(*, prompt, options):
+        """Yield one SDK-shaped result message."""
+        captured["prompt"] = prompt
+        captured["query_options"] = options
+        yield types.SimpleNamespace(result='{"source_file": "", "confidence": 0}')
+
+    fake_sdk = types.SimpleNamespace(query=query, ClaudeAgentOptions=Options)
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", fake_sdk)
+    monkeypatch.setattr(
+        "hyperloom.common.llm_config.claude_sdk_env_options",
+        lambda **_kwargs: {
+            "model": "overridden-model",
+            "tools": ["Read"],
+            "setting_sources": ["user"],
+            "skills": ["unsafe-skill"],
+            "strict_mcp_config": False,
+            "mcp_servers": {"unsafe": {"command": "sh"}},
+            "plugins": [{"type": "local", "path": "/tmp/plugin"}],
+            "max_turns": 99,
+            "allowed_tools": ["Bash"],
+            "disallowed_tools": [],
+        },
+    )
+    reply = lsf._complete_claude_sdk("prompt", "claude-model", 1.0)
+    assert json.loads(reply)["source_file"] == ""
+    assert captured["prompt"] == "prompt"
+    assert captured["query_options"] is captured["options"]
+    options = captured["options"].kwargs
+    assert options["model"] == "claude-model"
+    assert options["tools"] == []
+    assert options["setting_sources"] == []
+    assert options["skills"] == []
+    assert options["strict_mcp_config"] is True
+    assert options["mcp_servers"] == {}
+    assert options["plugins"] == []
+    assert options["max_turns"] == 1
+    assert options["allowed_tools"] == []
+    assert "Read" in options["disallowed_tools"]
+    assert "Bash" in options["disallowed_tools"]
+
+
+def test_provider_audit_never_records_url_credentials(monkeypatch):
+    """Audit metadata contains only the endpoint hostname, never URL secrets."""
+    monkeypatch.setenv(lsf._PROVIDER_ENV, "openai-compatible")
+    monkeypatch.setenv(lsf._MODEL_ENV, "gpt-source")
+    monkeypatch.setenv(
+        "OPENAI_BASE_URL",
+        "https://user:secret@gateway.example/Unified/v1?token=must-not-leave",
+    )
+    audit = lsf.llm_source_audit()
+    assert audit == {
+        "provider": lsf._PROVIDER_OPENAI,
+        "model": "gpt-source",
+        "endpoint_host": "gateway.example",
+        "source_preview_authorised": False,
+    }
+    assert "secret" not in json.dumps(audit)
+    assert "token" not in json.dumps(audit)
+
+
+def test_provider_model_settings_do_not_cross(monkeypatch):
+    """Each native provider reads only its own model fallback."""
+    monkeypatch.delenv(lsf._MODEL_ENV, raising=False)
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-source")
+    monkeypatch.setenv("CLAUDE_MODEL", "claude-source")
+    assert lsf._resolve_model("", lsf._PROVIDER_OPENAI) == "gpt-source"
+    assert lsf._resolve_model("", lsf._PROVIDER_CLAUDE) == "claude-source"
+
+
+def test_prompt_context_and_unreadable_preview_are_explicit(files, tmp_path):
+    """Prompt context must be retained while preview failures stay non-fatal."""
+    prompt = lsf._build_prompt(
+        "my_kernel",
+        [files[0]],
+        context_block="Trace context",
+        with_preview=False,
+    )
+    assert prompt.startswith("Trace context\n")
+    assert lsf._preview(str(tmp_path / "missing.py")) == "<unreadable>"
+
+
+def test_selection_reports_unconfigured_provider(monkeypatch, files):
+    """A missing provider must be reported without invoking a transport."""
+    monkeypatch.delenv(lsf._PROVIDER_ENV, raising=False)
+    errors = []
+    logs = []
+
+    picked, confidence, reason = lsf.select_source_via_llm(
+        "my_kernel",
+        [files[0]],
+        model="source-model",
+        errors=errors,
+        log=logs.append,
+    )
+
+    assert picked == ""
+    assert confidence == 0.0
+    assert reason.startswith("llm configuration failed: RuntimeError")
+    assert errors == [reason]
+    assert logs == [f"llm_source_fallback: configuration failed: RuntimeError"]
+
+
+def test_selection_reports_missing_provider_model(monkeypatch, files):
+    """A configured provider without a model must fail before prompt creation."""
+    monkeypatch.setenv(lsf._PROVIDER_ENV, "openai_compatible")
+    for name in (lsf._MODEL_ENV, "OPENAI_MODEL", "CODEX_MODEL"):
+        monkeypatch.delenv(name, raising=False)
+    errors = []
+    logs = []
+
+    picked, confidence, reason = lsf.select_source_via_llm(
+        "my_kernel",
+        [files[0]],
+        errors=errors,
+        log=logs.append,
+    )
+
+    assert picked == ""
+    assert confidence == 0.0
+    assert reason == "no model configured"
+    assert errors == [reason]
+    assert logs == [
+        f"llm_source_fallback: no model configured; set ${lsf._MODEL_ENV}"
+    ]
+
+
+# --- Wiring into finalization --------------------------------------------------
+
+
+def test_finalizer_leaves_the_candidate_alone_when_grep_finds_nothing(provider, monkeypatch):
+    """No shortlist means no call, and the candidate stays unresolved."""
+    import tracelens_analysis as tl
+
+    monkeypatch.setattr(tl, "collect_source_candidates_via_grep", lambda *_a, **_k: [])
+    item = {"name": "some_kernel", "gpu_pct": 40.0, "source_file": ""}
+    tl._apply_llm_source_fallback(item)
+    assert item["source_file"] == ""
+    assert item["source_resolution_reason"] == "llm_fallback_no_shortlist"
+
+
+def test_finalizer_settles_the_provider_before_paying_for_the_shortlist(monkeypatch):
+    """An unconfigured tier must not run the grep it would only decline to use.
+
+    The shortlist walks every framework root once per keyword, so doing it
+    first would charge that to every hot kernel on a deployment that never
+    selected a provider.
+    """
+    import tracelens_analysis as tl
+
+    monkeypatch.delenv("HYPERLOOM_LLM_SOURCE_PROVIDER", raising=False)
+    grepped: list[str] = []
+    monkeypatch.setattr(
+        tl,
+        "collect_source_candidates_via_grep",
+        lambda name, *_a, **_k: grepped.append(name) or [],
+    )
+    item = {"name": "hot_kernel", "gpu_pct": 40.0, "source_file": ""}
+    tl._apply_llm_source_fallback(item)
+    assert grepped == []
+    assert item["source_resolution_reason"] == "llm_fallback_skipped: no provider configured"
+    assert item["source_resolution_llm_audit"]["outcome"] == "configuration_error"
+
+
+def test_finalizer_skips_cold_kernels(monkeypatch):
+    """Below the GPU-share floor the round-trip is not worth its cost."""
+    import tracelens_analysis as tl
+
+    called = []
+    monkeypatch.setattr(tl, "collect_source_candidates_via_grep", lambda *_a, **_k: called.append(1) or [])
+    tl._apply_llm_source_fallback({"name": "k", "gpu_pct": 0.5, "source_file": ""})
+    assert not called
+
+
+def test_gateway_failure_is_not_recorded_as_a_model_decline(provider, monkeypatch):
+    """Transport failure and a valid refusal require different operator action."""
+    import tracelens_analysis as tl
+
+    monkeypatch.setattr(
+        tl,
+        "collect_source_candidates_via_grep",
+        lambda *_args, **_kwargs: ["/repo/kernel.py"],
+    )
+    monkeypatch.setattr(
+        lsf,
+        "llm_source_audit",
+        lambda **_kwargs: {
+            "provider": "openai_compatible",
+            "model": "gpt-source",
+            "endpoint_host": "gateway.example",
+            "source_preview_authorised": False,
+        },
+    )
+
+    def _fail(*_args, errors=None, **_kwargs):
+        """Return the public failure shape while reporting a transport error."""
+        errors.append("llm call failed: gateway 401")
+        return "", 0.0, "llm call failed: gateway 401"
+
+    monkeypatch.setattr(lsf, "select_source_via_llm", _fail)
+    item = {
+        "name": "kernel",
+        "gpu_pct": 40.0,
+        "source_file": "",
+        "source_resolution_reason": "trace_resolver_error: truncated",
+    }
+    tl._apply_llm_source_fallback(item)
+    assert "trace_resolver_error" in item["source_resolution_reason"]
+    assert "llm_fallback_error" in item["source_resolution_reason"]
+    assert "llm_fallback_declined" not in item["source_resolution_reason"]
+    assert item["source_resolution_llm_audit"]["outcome"] == "error"
+
+
+def test_valid_model_refusal_is_still_recorded_as_declined(provider, monkeypatch):
+    """A parsed no-candidate verdict remains distinct from call failure."""
+    import tracelens_analysis as tl
+
+    monkeypatch.setattr(
+        tl,
+        "collect_source_candidates_via_grep",
+        lambda *_args, **_kwargs: ["/repo/kernel.py"],
+    )
+    monkeypatch.setattr(lsf, "llm_source_audit", lambda **_kwargs: {"provider": "test"})
+
+    def _decline(*_args, errors=None, **_kwargs):
+        """Return a valid refusal without adding a call error."""
+        assert errors == []
+        return "", 0.0, "model reported no candidate defines the kernel"
+
+    monkeypatch.setattr(lsf, "select_source_via_llm", _decline)
+    item = {"name": "kernel", "gpu_pct": 40.0, "source_file": ""}
+    tl._apply_llm_source_fallback(item)
+    assert item["source_resolution_reason"].startswith("llm_fallback_declined")
+    assert item["source_resolution_llm_audit"]["outcome"] == "declined"
+
+
+def test_fallback_provider_audit_is_projected_into_the_artifact():
+    """Provider identity remains attached to the decision it produced."""
+    import tracelens_analysis as tl
+
+    audit = {
+        "provider": "claude_agent_sdk",
+        "model": "claude-source",
+        "endpoint_host": "provider-default",
+        "source_preview_authorised": False,
+        "outcome": "accepted",
+    }
+    entry = tl.build_source_resolution_entries([
+        {
+            "kernel_id": "k1",
+            "name": "kernel",
+            "gpu_pct": 10.0,
+            "source_file": "/repo/kernel.py",
+            "source_resolution_method": "llm_fallback",
+            "source_resolution_llm_audit": audit,
+        }
+    ])[0]
+    assert entry["llm_audit"] == audit
+    assert entry["method"] == "llm_fallback"
+
+
+def test_runtime_api_names_yield_no_shortlist():
+    import tracelens_analysis as tl
+
+    assert tl.collect_source_candidates_via_grep("hipGraphLaunch") == []
+
+
+def test_relaxed_shortlist_is_reachable_after_strict_grep_gives_up(
+    monkeypatch,
+    tmp_path,
+):
+    """Short mangled identifiers feed only the bounded LLM shortlist."""
+    import tracelens_analysis as tl
+
+    source = tmp_path / "kernel.py"
+    source.write_text("def gemm():\n    pass\n", encoding="utf-8")
+    monkeypatch.setattr(tl, "KNOWN_SEARCH_ROOTS", [str(tmp_path)])
+    tl._GREP_CACHE.clear()
+    mangled = "_Z2ab4gemm"
+    assert tl._candidate_keywords(mangled) == []
+    assert tl.locate_source_via_grep(mangled) == ""
+    assert tl.collect_source_candidates_via_grep(mangled) == [str(source)]
+
+
+# --- source egress ------------------------------------------------------------
+
+
+def test_file_contents_do_not_leave_without_authorisation(monkeypatch, files):
+    """Shipping file heads to a provider is an operator decision, not a default."""
+    real, _ = files
+    monkeypatch.delenv(lsf._PREVIEW_ENV, raising=False)
+    prompt = lsf._build_prompt("my_kernel", [real])
+    assert "@triton.jit" not in prompt
+    # The path itself still carries most of the selection signal.
+    assert real in prompt
+
+
+def test_authorisation_restores_the_preview(monkeypatch, files):
+    """The tier is not crippled by the default; an operator can opt back in."""
+    real, _ = files
+    monkeypatch.setenv(lsf._PREVIEW_ENV, "1")
+    assert lsf.source_preview_authorised() is True
+    assert "@triton.jit" in lsf._build_prompt(
+        "my_kernel",
+        [real],
+        framework_roots=(str(Path(real).parent),),
+    )
+
+
+def test_preview_does_not_read_a_symlink_target_outside_the_root(monkeypatch, tmp_path):
+    """An escaping symlink may be named but its target must never be read."""
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("outside_secret_marker\n", encoding="utf-8")
+    link = root / "kernel.py"
+    link.symlink_to(outside)
+    reads: list[str] = []
+    monkeypatch.setenv(lsf._PREVIEW_ENV, "1")
+    monkeypatch.setattr(lsf, "_preview", lambda path: reads.append(path) or "leaked")
+
+    prompt = lsf._build_prompt(
+        "kernel",
+        [str(link)],
+        framework_roots=(str(root),),
+    )
+
+    assert reads == []
+    assert "outside_secret_marker" not in prompt
+    assert "leaked" not in prompt
+
+
+def test_preview_and_storage_reuse_the_same_canonical_target(monkeypatch, tmp_path):
+    """Retargeting a symlink after preview cannot change the stored path."""
+    root = tmp_path / "root"
+    root.mkdir()
+    original = root / "implementation.py"
+    original.write_text("original_kernel_marker\n", encoding="utf-8")
+    outside = tmp_path / "outside.py"
+    outside.write_text("outside_kernel_marker\n", encoding="utf-8")
+    link = root / "kernel.py"
+    link.symlink_to(original)
+    monkeypatch.setenv(lsf._PREVIEW_ENV, "1")
+
+    def _retarget_after_preview(prompt, _model, _timeout):
+        """Retarget the candidate only after its validated preview is built."""
+        assert "original_kernel_marker" in prompt
+        assert "outside_kernel_marker" not in prompt
+        link.unlink()
+        link.symlink_to(outside)
+        return json.dumps({"source_file": str(link), "confidence": 1.0})
+
+    picked, _confidence, _reason = lsf.select_source_via_llm(
+        "kernel",
+        [str(link)],
+        framework_roots=(str(root),),
+        complete=_retarget_after_preview,
+    )
+
+    assert picked == str(original)

--- a/src/hyperloom/agents/kernel/tests/test_source_resolution_artifact.py
+++ b/src/hyperloom/agents/kernel/tests/test_source_resolution_artifact.py
@@ -1,0 +1,923 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Contract tests for the kernel source-resolution artifact and its review tier.
+
+The artifact exists so that "where does this kernel live, and how do we know"
+has one versioned answer on disk instead of a scatter of candidate fields. That
+only holds if the schema is enforced, so these pin the envelope, the per-entry
+keys, and the guard rails on the tier allowed to rewrite entries.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+import tracelens_analysis as tl  # noqa: E402
+from _llm_source_review import build_review_prompt, review_resolution_document  # noqa: E402
+
+from hyperloom.common import kernel_source_contract as ksc  # noqa: E402
+
+
+# --- envelope and entry contract -------------------------------------------
+
+
+def test_document_carries_a_major_versioned_envelope():
+    doc = ksc.make_document([], generated_by="test")
+    assert doc["schema_version"] == ksc.SOURCE_RESOLUTION_SCHEMA_VERSION
+    assert ksc.validate_document(doc) == []
+
+
+def test_entry_always_carries_every_required_key():
+    """Consumers read these without defaulting, so absence is a contract break."""
+    entry = ksc.make_entry(kernel_id="k001", name="k", gpu_pct=1.0)
+    for key in ksc.REQUIRED_ENTRY_KEYS:
+        assert key in entry, key
+
+
+def test_entry_carries_audit_history_when_supplied():
+    """Optional review history must survive document reconstruction."""
+    entry = ksc.make_entry(
+        kernel_id="k001",
+        name="k",
+        gpu_pct=1.0,
+        previous_source_file="/repo/old.py",
+        previous_method=ksc.METHOD_TRACE,
+    )
+    assert entry["previous_source_file"] == "/repo/old.py"
+    assert entry["previous_method"] == ksc.METHOD_TRACE
+
+
+def test_validate_reports_every_problem_not_just_the_first():
+    doc = {"schema_version": ksc.SOURCE_RESOLUTION_SCHEMA_VERSION, "entries": [{}]}
+    problems = ksc.validate_document(doc)
+    assert any("generated_by" in p for p in problems)
+    assert sum("missing required key" in p for p in problems) >= len(ksc.REQUIRED_ENTRY_KEYS)
+
+
+def test_validate_rejects_a_foreign_major_version():
+    doc = ksc.make_document([], generated_by="test")
+    doc["schema_version"] = "9.0.0"
+    assert any("different major" in p for p in ksc.validate_document(doc))
+
+
+def test_validate_catches_a_path_that_claims_to_be_unresolved():
+    doc = ksc.make_document(
+        [ksc.make_entry(kernel_id="k1", name="n", gpu_pct=1.0, source_file="/a/b.py")],
+        generated_by="test",
+    )
+    assert any("unresolved" in p for p in ksc.validate_document(doc))
+
+
+def test_validate_catches_a_path_that_claims_to_be_rejected():
+    """A rejection method cannot simultaneously advertise a resolved path."""
+    doc = ksc.make_document(
+        [
+            ksc.make_entry(
+                kernel_id="k1",
+                name="n",
+                gpu_pct=1.0,
+                source_file="/a/b.py",
+                method=ksc.METHOD_REJECTED,
+            )
+        ],
+        generated_by="test",
+    )
+    assert any("rejected_non_path_sentinel" in p for p in ksc.validate_document(doc))
+
+
+def test_validate_rejects_non_finite_and_out_of_range_confidence():
+    """Artifact confidence must remain a finite probability."""
+    for confidence in (float("nan"), float("inf"), float("-inf"), -0.1, 1.1, "NaN"):
+        doc = _doc_with(
+            ksc.make_entry(
+                kernel_id="k1",
+                name="n",
+                gpu_pct=1.0,
+                confidence=confidence,
+            )
+        )
+        assert any("invalid confidence" in problem for problem in ksc.validate_document(doc))
+
+
+# --- projection from candidates ---------------------------------------------
+
+
+def test_projection_classifies_each_resolution_tier():
+    """Method is derived, since grep resolves without stamping anything."""
+    got = tl.build_source_resolution_entries(
+        [
+            {"kernel_id": "k1", "name": "a", "gpu_pct": 9.0, "source_file": "/x/a.py",
+             "source_resolution_method": "trace_python_stack"},
+            {"kernel_id": "k2", "name": "b", "gpu_pct": 8.0, "source_file": "/x/b.py"},
+            {"kernel_id": "k3", "name": "c", "gpu_pct": 7.0, "source_file": ""},
+            {"kernel_id": "k4", "name": "d", "gpu_pct": 6.0, "source_file": "",
+             "source_resolution_method": "rejected_non_path_sentinel",
+             "source_file_rejected": "AITER (vendor)"},
+            {"kernel_id": "k5", "name": "e", "gpu_pct": 5.0, "source_file": "/x/e.py",
+             "source_resolution_method": "llm_fallback"},
+        ]
+    )
+    by_id = {e["kernel_id"]: e for e in got}
+    assert by_id["k1"]["method"] == ksc.METHOD_TRACE
+    assert by_id["k2"]["method"] == ksc.METHOD_GREP
+    assert by_id["k3"]["method"] == ksc.METHOD_UNRESOLVED
+    assert by_id["k4"]["method"] == ksc.METHOD_REJECTED
+    assert by_id["k4"]["rejected_value"] == "AITER (vendor)"
+    assert by_id["k5"]["method"] == ksc.METHOD_LLM_FALLBACK
+    assert by_id["k5"]["method"] != ksc.METHOD_LLM
+
+
+def test_written_artifact_satisfies_its_own_contract(tmp_path):
+    out = tmp_path / ksc.SOURCE_RESOLUTION_FILENAME
+    tl.write_source_resolution_artifact(
+        [{"kernel_id": "k1", "name": "a", "gpu_pct": 5.0, "source_file": "/x/a.py",
+          "source_resolution_method": "trace_python_stack"}],
+        out,
+        framework="sglang",
+    )
+    doc = json.loads(out.read_text(encoding="utf-8"))
+    assert ksc.validate_document(doc) == []
+    assert doc["framework"] == "sglang"
+
+
+# --- review tier guard rails -------------------------------------------------
+
+
+def _doc_with(*entries):
+    return ksc.make_document(list(entries), generated_by="test")
+
+
+def _reply(revisions):
+    def _complete(_prompt, _model, _timeout):
+        return json.dumps({"revisions": revisions})
+
+    return _complete
+
+
+def test_review_may_unresolve_a_confidently_wrong_entry():
+    """The failure the deterministic tiers cannot self-detect.
+
+    aten::fill_ has no defining source; the trace tier attributes it to
+    whichever business file called it, and that path passes every mechanical
+    check. Only a reviewer looking at the whole entry can reject it.
+    """
+    doc = _doc_with(
+        ksc.make_entry(kernel_id="k1", name="aten::fill_", gpu_pct=9.0,
+                       source_file="/repo/moe.py", method=ksc.METHOD_TRACE)
+    )
+    out, notes = review_resolution_document(
+        doc,
+        framework_roots=("/repo",),
+        complete=_reply([{"kernel_id": "k1", "action": "unresolve", "reason": "builtin"}]),
+        model="m",
+    )
+    entry = out["entries"][0]
+    assert entry["source_file"] == ""
+    assert entry["method"] == ksc.METHOD_UNRESOLVED
+    assert entry["previous_source_file"] == "/repo/moe.py"
+    assert notes
+
+
+def test_review_cannot_invent_a_path():
+    """A rewrite must land somewhere verifiable, or the original stands."""
+    doc = _doc_with(
+        ksc.make_entry(kernel_id="k1", name="n", gpu_pct=9.0,
+                       source_file="/repo/a.py", method=ksc.METHOD_TRACE)
+    )
+    out, notes = review_resolution_document(
+        doc,
+        framework_roots=("/repo",),
+        complete=_reply([{"kernel_id": "k1", "action": "rewrite",
+                          "source_file": "/tmp/invented.py", "reason": "guess"}]),
+        model="m",
+    )
+    entry = out["entries"][0]
+    assert entry["source_file"] == "/repo/a.py"
+    assert entry["method"] == ksc.METHOD_TRACE
+    assert "previous_source_file" not in entry
+    assert any("rejected unverifiable path" in n for n in notes)
+
+
+def test_review_denies_rewrites_when_the_path_contract_is_unavailable(monkeypatch, tmp_path):
+    """An unusable guard denies the rewrite instead of waving it through.
+
+    ``path_is_acceptable`` is the only thing standing between a generated path
+    and ``source_file``. When the contract module cannot be imported the tier
+    has no way to verify anything, so a rewrite must fail closed -- otherwise
+    losing the import silently turns the guard off.
+    """
+    from _llm_source_review import _apply_revision
+
+    monkeypatch.setattr("_llm_source_review._KSC", None)
+    entry = {"kernel_id": "k1", "source_file": "/repo/a.py", "method": "name_grep"}
+    note = _apply_revision(
+        entry,
+        {"kernel_id": "k1", "action": "rewrite", "source_file": "/etc/passwd"},
+        (str(tmp_path),),
+    )
+    assert entry["source_file"] == "/repo/a.py"
+    assert entry["method"] == "name_grep"
+    assert "previous_source_file" not in entry
+    assert "path contract unavailable" in note
+
+
+def test_review_stores_the_symlink_target_it_validated(tmp_path):
+    """Keeping the link would let the location leave the roots after the check."""
+    target = tmp_path / "implementation.py"
+    target.write_text("def kernel(): pass\n", encoding="utf-8")
+    link = tmp_path / "kernel.py"
+    link.symlink_to(target)
+    doc = _doc_with(
+        ksc.make_entry(kernel_id="k1", name="n", gpu_pct=9.0,
+                       source_file=str(tmp_path / "wrong.py"), method=ksc.METHOD_TRACE)
+    )
+    out, _ = review_resolution_document(
+        doc,
+        framework_roots=(str(tmp_path),),
+        complete=_reply([{"kernel_id": "k1", "action": "rewrite",
+                          "source_file": str(link), "reason": "defines it"}]),
+        model="m",
+    )
+    assert out["entries"][0]["source_file"] == str(target)
+
+
+def test_review_accepts_a_rewrite_to_a_file_that_exists(tmp_path):
+    """A rewrite must land on a real file under a known root."""
+    real = tmp_path / "right.py"
+    real.write_text("def kernel(): pass\n", encoding="utf-8")
+    doc = _doc_with(
+        ksc.make_entry(kernel_id="k1", name="n", gpu_pct=9.0,
+                       source_file=str(tmp_path / "wrong.py"), method=ksc.METHOD_TRACE)
+    )
+    out, _ = review_resolution_document(
+        doc,
+        framework_roots=(str(tmp_path),),
+        complete=_reply([{"kernel_id": "k1", "action": "rewrite",
+                          "source_file": str(real), "reason": "defines it"}]),
+        model="m",
+    )
+    entry = out["entries"][0]
+    assert entry["source_file"] == str(real)
+    assert entry["method"] == ksc.METHOD_LLM
+    assert entry["previous_source_file"].endswith("wrong.py")
+    # Line and function described the old file; carrying them over would lie.
+    assert entry["source_line"] is None
+    assert entry["source_function"] == ""
+
+
+def test_line_annotated_rewrite_is_stored_as_an_openable_path(tmp_path):
+    """Call-site metadata is split from the path before downstream use."""
+    real = tmp_path / "right.py"
+    real.write_text("def kernel(): pass\n", encoding="utf-8")
+    doc = _doc_with(
+        ksc.make_entry(
+            kernel_id="k1",
+            name="n",
+            gpu_pct=9.0,
+            source_file=str(tmp_path / "wrong.py"),
+            method=ksc.METHOD_TRACE,
+        )
+    )
+    out, _ = review_resolution_document(
+        doc,
+        framework_roots=(str(tmp_path),),
+        complete=_reply(
+            [{
+                "kernel_id": "k1",
+                "action": "rewrite",
+                "source_file": f"{real}(247): kernel",
+            }]
+        ),
+        model="m",
+    )
+    entry = out["entries"][0]
+    assert entry["source_file"] == str(real)
+    assert entry["source_line"] == 247
+    assert entry["source_function"] == "kernel"
+    assert Path(entry["source_file"]).is_file()
+
+
+def test_a_line_suffix_only_difference_is_not_a_rewrite(tmp_path):
+    """Adding call-site syntax to the same file must not create fake history."""
+    real = tmp_path / "same.py"
+    real.write_text("def kernel(): pass\n", encoding="utf-8")
+    doc = _doc_with(
+        ksc.make_entry(
+            kernel_id="k1",
+            name="n",
+            gpu_pct=9.0,
+            source_file=str(real),
+            method=ksc.METHOD_TRACE,
+        )
+    )
+    out, notes = review_resolution_document(
+        doc,
+        framework_roots=(str(tmp_path),),
+        complete=_reply(
+            [{
+                "kernel_id": "k1",
+                "action": "rewrite",
+                "source_file": f"{real}(1): kernel",
+            }]
+        ),
+        model="m",
+    )
+    assert out["entries"][0]["source_file"] == str(real)
+    assert "previous_source_file" not in out["entries"][0]
+    assert notes == []
+
+
+def test_line_annotated_paths_are_still_verifiable(tmp_path):
+    """TraceLens reports call sites as "path.py(247): fn"; that is a real path.
+
+    Measured on a live session, 29 of 36 resolved entries carried this suffix.
+    Checking existence without stripping it would reject every one of them.
+    """
+    real = tmp_path / "moe.py"
+    real.write_text("def kernel(): pass\n", encoding="utf-8")
+    roots = (str(tmp_path),)
+    assert ksc.path_is_acceptable(str(real), roots)
+    assert ksc.path_is_acceptable(f"{real}(247)", roots)
+    assert ksc.path_is_acceptable(f"{real}(247): kernel", roots)
+    assert ksc.strip_line_suffix(f"{real}(247): kernel") == str(real)
+    # Stripping must not resurrect a path that is simply absent.
+    assert not ksc.path_is_acceptable(f"{tmp_path}/gone.py(1): f", roots)
+
+
+def test_symlink_cannot_escape_a_framework_root(tmp_path):
+    """Root containment is checked on resolved targets, not lexical paths."""
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("def kernel(): pass\n", encoding="utf-8")
+    escaping = root / "escaping.py"
+    escaping.symlink_to(outside)
+    inside = root / "inside.py"
+    inside.write_text("def kernel(): pass\n", encoding="utf-8")
+    internal = root / "internal.py"
+    internal.symlink_to(inside)
+    assert not ksc.path_is_acceptable(str(escaping), (str(root),))
+    assert ksc.path_is_acceptable(str(internal), (str(root),))
+    assert ksc.canonical_source_path(str(escaping), (str(root),)) == ""
+    assert ksc.canonical_source_path(str(internal), (str(root),)) == str(inside)
+
+
+def test_review_preview_does_not_read_an_escaping_current_symlink(monkeypatch, tmp_path):
+    """A current entry is previewed only through a validated canonical target."""
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("review_outside_secret\n", encoding="utf-8")
+    link = root / "kernel.py"
+    link.symlink_to(outside)
+    entry = ksc.make_entry(
+        kernel_id="k1",
+        name="n",
+        gpu_pct=9.0,
+        source_file=str(link),
+        method=ksc.METHOD_TRACE,
+    )
+    reads: list[str] = []
+    monkeypatch.setattr("_llm_source_review._preview", lambda path: reads.append(path) or "leaked")
+
+    prompt = build_review_prompt(
+        [entry],
+        with_preview=True,
+        framework_roots=(str(root),),
+    )
+
+    assert reads == []
+    assert "review_outside_secret" not in prompt
+    assert "leaked" not in prompt
+
+
+def test_review_rejects_a_plausible_path_that_does_not_exist(tmp_path):
+    """Under-a-root is not enough: the file must be there.
+
+    A model can emit a perfectly plausible path inside the framework tree. If
+    root membership alone qualified it, the backend would be handed a fabricated
+    file -- the wrong-source failure this pipeline exists to prevent.
+    """
+    invented = tmp_path / "python" / "sglang" / "srt" / "does_not_exist.py"
+    doc = _doc_with(
+        ksc.make_entry(kernel_id="k1", name="n", gpu_pct=9.0,
+                       source_file="", method=ksc.METHOD_UNRESOLVED)
+    )
+    out, notes = review_resolution_document(
+        doc,
+        framework_roots=(str(tmp_path),),
+        complete=_reply([{"kernel_id": "k1", "action": "rewrite",
+                          "source_file": str(invented), "reason": "looks right"}]),
+        model="m",
+    )
+    assert out["entries"][0]["source_file"] == ""
+    assert any("rejected unverifiable path" in n for n in notes)
+
+
+def test_review_keeps_entries_below_the_gpu_floor_untouched():
+    doc = _doc_with(
+        ksc.make_entry(kernel_id="k1", name="tiny", gpu_pct=0.01,
+                       source_file="/repo/a.py", method=ksc.METHOD_TRACE)
+    )
+    out, notes = review_resolution_document(
+        doc, framework_roots=("/repo",), complete=_reply([]), model="m"
+    )
+    assert out["entries"][0]["source_file"] == "/repo/a.py"
+    assert any("GPU share" in n for n in notes)
+
+
+def test_unusable_reply_leaves_the_table_alone():
+    doc = _doc_with(
+        ksc.make_entry(kernel_id="k1", name="n", gpu_pct=9.0,
+                       source_file="/repo/a.py", method=ksc.METHOD_TRACE)
+    )
+
+    def _garbage(_p, _m, _t):
+        return "not json at all"
+
+    out, notes = review_resolution_document(
+        doc, framework_roots=("/repo",), complete=_garbage, model="m"
+    )
+    assert out["entries"][0]["source_file"] == "/repo/a.py"
+    assert any("unusable reply" in n for n in notes)
+
+
+def test_call_failure_leaves_the_table_alone():
+    doc = _doc_with(
+        ksc.make_entry(kernel_id="k1", name="n", gpu_pct=9.0,
+                       source_file="/repo/a.py", method=ksc.METHOD_TRACE)
+    )
+
+    def _boom(_p, _m, _t):
+        raise RuntimeError("gateway 401")
+
+    out, notes = review_resolution_document(
+        doc, framework_roots=("/repo",), complete=_boom, model="m"
+    )
+    assert out["entries"][0]["source_file"] == "/repo/a.py"
+    assert any("llm call failed" in n for n in notes)
+
+
+def test_review_call_error_is_redacted_from_notes_and_log():
+    """Provider failures expose only stable exception metadata."""
+    class ProviderError(RuntimeError):
+        """Represent a provider response carrying sensitive details."""
+
+        code = "gateway_timeout"
+
+    doc = _doc_with(
+        ksc.make_entry(
+            kernel_id="k1",
+            name="n",
+            gpu_pct=9.0,
+            source_file="/repo/a.py",
+            method=ksc.METHOD_TRACE,
+        )
+    )
+
+    def _boom(_prompt, _model, _timeout):
+        raise ProviderError(
+            "https://gateway.example/v1?token=query-secret "
+            "Authorization: Bearer header-secret"
+        )
+
+    logs: list[str] = []
+    out, notes = review_resolution_document(
+        doc,
+        framework_roots=("/repo",),
+        complete=_boom,
+        model="m",
+        log=logs.append,
+    )
+    recorded = "\n".join([*notes, *logs])
+    assert out["entries"][0]["source_file"] == "/repo/a.py"
+    assert "ProviderError" in recorded
+    assert "code=gateway_timeout" in recorded
+    assert "gateway.example" not in recorded
+    assert "query-secret" not in recorded
+    assert "header-secret" not in recorded
+    assert "Authorization" not in recorded
+
+
+def test_review_discards_staged_changes_when_path_validation_raises(monkeypatch, tmp_path):
+    """A later validation exception cannot commit an earlier revision."""
+    replacement = tmp_path / "replacement.py"
+    replacement.write_text("def kernel(): pass\n", encoding="utf-8")
+    doc = _doc_with(
+        ksc.make_entry(
+            kernel_id="k1",
+            name="a",
+            gpu_pct=9.0,
+            source_file="/repo/a.py",
+            method=ksc.METHOD_TRACE,
+        ),
+        ksc.make_entry(
+            kernel_id="k2",
+            name="b",
+            gpu_pct=8.0,
+            source_file="/repo/b.py",
+            method=ksc.METHOD_TRACE,
+        ),
+    )
+    original_entries = json.loads(json.dumps(doc["entries"]))
+
+    class PathValidationError(RuntimeError):
+        """Represent a failing path guard."""
+
+    original_helper = ksc.canonical_source_path
+
+    def _guard(path, roots):
+        """Delegate ordinary paths and fail on the second revision."""
+        if path == str(replacement):
+            raise PathValidationError("https://secret.example/?token=path-secret")
+        return original_helper(path, roots)
+
+    monkeypatch.setattr(ksc, "canonical_source_path", _guard)
+    out, notes = review_resolution_document(
+        doc,
+        framework_roots=(str(tmp_path),),
+        complete=_reply([
+            {"kernel_id": "k1", "action": "unresolve"},
+            {"kernel_id": "k2", "action": "rewrite", "source_file": str(replacement)},
+        ]),
+        model="m",
+    )
+
+    assert out["entries"] == original_entries
+    assert out["llm_audit"]["review"]["outcome"] == "validation_error"
+    assert any("PathValidationError" in note for note in notes)
+    assert all("path-secret" not in note for note in notes)
+
+
+def test_review_parse_exception_leaves_entries_untouched(monkeypatch):
+    """A parser exception is advisory and cannot alter the source table."""
+    doc = _doc_with(
+        ksc.make_entry(
+            kernel_id="k1",
+            name="n",
+            gpu_pct=9.0,
+            source_file="/repo/a.py",
+            method=ksc.METHOD_TRACE,
+        )
+    )
+    original_entries = json.loads(json.dumps(doc["entries"]))
+
+    def _raise(_reply):
+        """Simulate a parser failure with sensitive response context."""
+        raise ValueError("https://secret.example/?token=parse-secret")
+
+    monkeypatch.setattr("_llm_source_review.parse_revisions", _raise)
+    out, notes = review_resolution_document(
+        doc,
+        framework_roots=("/repo",),
+        complete=lambda *_args: "{}",
+        model="m",
+    )
+
+    assert out["entries"] == original_entries
+    assert any("ValueError" in note for note in notes)
+    assert all("parse-secret" not in note for note in notes)
+
+
+def test_revision_for_unknown_kernel_is_reported_not_applied():
+    """An id nobody asked about rejects the batch rather than being skipped.
+
+    A reply naming a kernel that was never sent is not a reply about the batch
+    that was sent, so the entry it does not mention keeps its own resolution
+    instead of being silently left to a partial review.
+    """
+    doc = _doc_with(
+        ksc.make_entry(kernel_id="k1", name="n", gpu_pct=9.0,
+                       source_file="/repo/a.py", method=ksc.METHOD_TRACE)
+    )
+    out, notes = review_resolution_document(
+        doc,
+        framework_roots=("/repo",),
+        complete=_reply([{"kernel_id": "ghost", "action": "unresolve"}]),
+        model="m",
+    )
+    assert out["entries"][0]["source_file"] == "/repo/a.py"
+    assert any("unknown kernel_id" in n for n in notes)
+
+
+def test_one_unreadable_gpu_pct_does_not_disable_the_whole_review(tmp_path):
+    """A single bad row must not cost every other row its review.
+
+    The caller wraps this tier in a blanket handler, so an exception raised
+    while ranking would surface as "review skipped" for the entire run. An
+    unreadable share ranks as zero, which drops that row below the floor and
+    leaves it untouched -- the rest of the table is still reviewed.
+    """
+    real = tmp_path / "right.py"
+    real.write_text("def kernel(): pass\n", encoding="utf-8")
+    hot = ksc.make_entry(kernel_id="k1", name="hot", gpu_pct=9.0,
+                         source_file=str(tmp_path / "wrong.py"), method=ksc.METHOD_TRACE)
+    broken = ksc.make_entry(kernel_id="k2", name="broken", gpu_pct=1.0,
+                            source_file="/repo/b.py", method=ksc.METHOD_TRACE)
+    broken["gpu_pct"] = "12%"
+    out, _ = review_resolution_document(
+        _doc_with(hot, broken),
+        framework_roots=(str(tmp_path), "/repo"),
+        complete=_reply([
+            {"kernel_id": "k1", "action": "rewrite", "source_file": str(real)},
+        ]),
+        model="m",
+    )
+    assert out["entries"][0]["source_file"] == str(real)
+    assert out["entries"][1]["source_file"] == "/repo/b.py"
+
+
+def test_missing_review_id_rejects_the_entire_batch():
+    """A truncated reply is not equivalent to an explicit keep decision."""
+    doc = _doc_with(
+        ksc.make_entry(
+            kernel_id="k1", name="a", gpu_pct=9.0,
+            source_file="/repo/a.py", method=ksc.METHOD_TRACE,
+        ),
+        ksc.make_entry(
+            kernel_id="k2", name="b", gpu_pct=8.0,
+            source_file="/repo/b.py", method=ksc.METHOD_TRACE,
+        ),
+    )
+    out, notes = review_resolution_document(
+        doc,
+        complete=_reply([{"kernel_id": "k1", "action": "unresolve"}]),
+        model="m",
+    )
+    assert [entry["source_file"] for entry in out["entries"]] == [
+        "/repo/a.py",
+        "/repo/b.py",
+    ]
+    assert any("missing=" in note for note in notes)
+    assert out["llm_audit"]["review"]["outcome"] == "protocol_error"
+
+
+def test_duplicate_review_id_rejects_the_entire_batch():
+    """Repeated revisions cannot overwrite their own audit history."""
+    doc = _doc_with(
+        ksc.make_entry(
+            kernel_id="k1", name="a", gpu_pct=9.0,
+            source_file="/repo/a.py", method=ksc.METHOD_TRACE,
+        )
+    )
+    revisions = [
+        {"kernel_id": "k1", "action": "unresolve"},
+        {"kernel_id": "k1", "action": "unresolve"},
+    ]
+    out, notes = review_resolution_document(
+        doc,
+        complete=_reply(revisions),
+        model="m",
+    )
+    assert out["entries"][0]["source_file"] == "/repo/a.py"
+    assert any("duplicate=" in note for note in notes)
+
+
+def test_revision_for_an_unsent_entry_rejects_the_entire_batch():
+    """An entry below the review floor cannot be modified by an extra ID."""
+    doc = _doc_with(
+        ksc.make_entry(
+            kernel_id="hot", name="a", gpu_pct=9.0,
+            source_file="/repo/a.py", method=ksc.METHOD_TRACE,
+        ),
+        ksc.make_entry(
+            kernel_id="cold", name="b", gpu_pct=0.1,
+            source_file="/repo/b.py", method=ksc.METHOD_TRACE,
+        ),
+    )
+    revisions = [
+        {"kernel_id": "hot", "action": "keep"},
+        {"kernel_id": "cold", "action": "unresolve"},
+    ]
+    out, notes = review_resolution_document(
+        doc,
+        complete=_reply(revisions),
+        model="m",
+    )
+    assert out["entries"][1]["source_file"] == "/repo/b.py"
+    assert any("extra/unknown kernel_id" in note for note in notes)
+
+
+# --- revisions must reach the pipeline, not just the artifact ---------------
+
+
+def test_revision_is_folded_back_onto_the_candidate():
+    """A review that only edits the artifact is inert.
+
+    Dispatch reads kernel_candidates.json; the artifact is an audit view. Unless
+    the revision is written back, the review tier changes nothing that runs.
+    """
+    candidates = [
+        {"kernel_id": "k1", "name": "foo_kernel", "gpu_pct": 9.0,
+         "source_file": "/sgl-workspace/aiter/csrc/wrong.cpp", "source_type": "hip_cpp"}
+    ]
+    entries = [
+        ksc.make_entry(
+            kernel_id="k1", name="foo_kernel", gpu_pct=9.0,
+            source_file="/sgl-workspace/aiter/ops/right.py", method=ksc.METHOD_LLM,
+        )
+    ]
+    entries[0]["previous_source_file"] = "/sgl-workspace/aiter/csrc/wrong.cpp"
+    entries[0]["previous_method"] = ksc.METHOD_TRACE
+
+    assert tl.apply_resolution_entries_to_candidates(entries, candidates) == 1
+    got = candidates[0]
+    assert got["source_file"] == "/sgl-workspace/aiter/ops/right.py"
+    assert got["source_path"] == "/sgl-workspace/aiter/ops/right.py"
+    assert got["source_resolution_previous_file"].endswith("wrong.cpp")
+    assert got["source_resolution_previous_method"] == ksc.METHOD_TRACE
+    # source_type drives reusable_native_kernel, so it must be recomputed.
+    assert got["source_type"] == "python"
+    assert "reusable_native_kernel" in got
+    assert "skip_reason" in got
+
+
+def test_unreviewed_entries_leave_candidates_untouched():
+    """Only entries carrying previous_source_file were revised."""
+    candidates = [{"kernel_id": "k1", "name": "n", "gpu_pct": 9.0,
+                   "source_file": "/repo/a.py", "source_type": "python"}]
+    entries = [ksc.make_entry(kernel_id="k1", name="n", gpu_pct=9.0,
+                              source_file="/repo/a.py", method=ksc.METHOD_TRACE)]
+    assert tl.apply_resolution_entries_to_candidates(entries, candidates) == 0
+    assert candidates[0]["source_file"] == "/repo/a.py"
+    assert "source_resolution_previous_file" not in candidates[0]
+
+
+def test_unresolve_clears_the_candidate_source():
+    """Dropping to unresolved must also clear it downstream, not only here."""
+    candidates = [{"kernel_id": "k1", "name": "aten::fill_", "gpu_pct": 9.0,
+                   "source_file": "/repo/moe.py", "source_type": "python"}]
+    entries = [ksc.make_entry(kernel_id="k1", name="aten::fill_", gpu_pct=9.0,
+                              source_file="", method=ksc.METHOD_UNRESOLVED)]
+    entries[0]["previous_source_file"] = "/repo/moe.py"
+    entries[0]["previous_method"] = ksc.METHOD_TRACE
+
+    assert tl.apply_resolution_entries_to_candidates(entries, candidates) == 1
+    got = candidates[0]
+    assert got["source_file"] == ""
+    assert got["reusable_native_kernel"] is False
+
+
+def _aiter_candidate(**over):
+    """A candidate carrying the curated metadata an op_to_source hit stamps."""
+    item = {
+        "kernel_id": "k1",
+        "name": "fused_moe",
+        "gpu_pct": 9.0,
+        "source_file": "/repo/aiter/impl.cu",
+        "source_type": "hip_cpp",
+        "kernel_sources": ["/repo/aiter/impl.cu"],
+        "kernel_kind": "aiter_ck",
+        "source_framework": "aiter",
+        "prebuilt_binary": "/repo/aiter/impl.co",
+        "runtime_backend": "aiter",
+        "launcher_source_file": "/repo/sglang/launch.py",
+        "source_promoted_from_launcher": True,
+        "tracelens_launcher_path": "/repo/sglang/launch.py(10): launch",
+        "kernel_path": "/repo/sglang/launch.py(10): launch",
+        "vendor_dispatch_wrapper": True,
+        "runtime_generated_kernel": True,
+        "source_resolution_confidence": 0.91,
+        "op_to_source_kind": "dispatch",
+        "op_to_source_patchable": True,
+    }
+    item.update(over)
+    return item
+
+
+def _rewrite_to(path):
+    entry = ksc.make_entry(
+        kernel_id="k1", name="fused_moe", gpu_pct=9.0,
+        source_file=path, method=ksc.METHOD_LLM,
+    )
+    entry["previous_source_file"] = "/repo/aiter/impl.cu"
+    entry["previous_method"] = ksc.METHOD_TRACE
+    return entry
+
+
+def test_a_rewrite_clears_metadata_describing_the_old_source():
+    """Otherwise the candidate describes two sources and readers disagree.
+
+    forge_submit._resolve_framework consults source_framework before it looks
+    at source_file, so a stale value routes a vLLM rewrite as aiter.
+    """
+    item = _aiter_candidate()
+    assert tl.apply_resolution_entries_to_candidates([_rewrite_to("/repo/vllm/new.py")], [item]) == 1
+    assert item["source_file"] == "/repo/vllm/new.py"
+    for stale in (
+        "kernel_sources",
+        "kernel_kind",
+        "source_framework",
+        "prebuilt_binary",
+        "runtime_backend",
+        "launcher_source_file",
+        "source_promoted_from_launcher",
+        "tracelens_launcher_path",
+        "kernel_path",
+        "vendor_dispatch_wrapper",
+        "source_resolution_confidence",
+        "op_to_source_kind",
+        "op_to_source_patchable",
+    ):
+        assert stale not in item, stale
+    assert item["runtime_generated_kernel"] is False
+
+
+def test_a_stale_aiter_asm_kind_cannot_skip_a_rewritten_kernel():
+    """classify_patchability reads kernel_kind; keeping it skips the new source."""
+    item = _aiter_candidate(kernel_kind="aiter_asm")
+    tl.apply_resolution_entries_to_candidates([_rewrite_to("/repo/vllm/new.py")], [item])
+    assert "aiter_asm" not in str(item.get("skip_reason") or "")
+
+
+def test_a_curated_resolution_is_not_overridable():
+    """op_to_source.json names the real compute core; a file head cannot outrank it."""
+    item = _aiter_candidate(
+        op_to_source_status="resolved",
+        source_resolution_method=ksc.METHOD_CURATED,
+    )
+    entry = _rewrite_to("/repo/vllm/new.py")
+    assert tl.apply_resolution_entries_to_candidates([entry], [item]) == 0
+    assert item["source_file"] == "/repo/aiter/impl.cu"
+    assert item["kernel_kind"] == "aiter_ck"
+    # The artifact must not advertise a revision that was not applied.
+    assert entry["review_rejected"] == "curated_resolution_not_overridable"
+    assert entry["source_file"] == "/repo/aiter/impl.cu"
+
+
+@pytest.mark.parametrize("status", ["non_rewritable", "no_kernel"])
+def test_a_curated_negative_verdict_is_not_overridable(status):
+    """A curated terminal miss is authoritative even when it keeps a launcher."""
+    item = _aiter_candidate(
+        op_to_source_status=status,
+        source_resolution_method=ksc.METHOD_CURATED,
+    )
+    entry = _rewrite_to("/repo/vllm/new.py")
+
+    assert tl.apply_resolution_entries_to_candidates([entry], [item]) == 0
+    assert item["source_file"] == "/repo/aiter/impl.cu"
+    assert entry["review_rejected"] == "curated_resolution_not_overridable"
+
+
+def test_audit_history_survives_artifact_rebuild(tmp_path, monkeypatch):
+    """Applied revisions remain reversible after candidates are re-projected."""
+    old = tmp_path / "old.py"
+    new = tmp_path / "new.py"
+    old.write_text("def old(): pass\n", encoding="utf-8")
+    new.write_text("def new(): pass\n", encoding="utf-8")
+    candidates = [{
+        "kernel_id": "k1",
+        "name": "kernel",
+        "gpu_pct": 9.0,
+        "source_file": str(old),
+        "source_type": "python",
+        "source_resolution_method": ksc.METHOD_TRACE,
+    }]
+
+    def _review(doc, *, log_path):
+        """Inject one reviewed rewrite without making a network call."""
+        assert log_path is None
+        entry = doc["entries"][0]
+        entry["previous_source_file"] = entry["source_file"]
+        entry["previous_method"] = entry["method"]
+        entry["source_file"] = str(new)
+        entry["method"] = ksc.METHOD_LLM
+
+    monkeypatch.setattr(tl, "_review_source_resolution", _review)
+    out_path = tmp_path / ksc.SOURCE_RESOLUTION_FILENAME
+    assert tl.write_source_resolution_artifact(candidates, out_path) == out_path
+    entry = json.loads(out_path.read_text(encoding="utf-8"))["entries"][0]
+    assert entry["source_file"] == str(new)
+    assert entry["previous_source_file"] == str(old)
+    assert entry["previous_method"] == ksc.METHOD_TRACE
+    assert candidates[0]["source_resolution_previous_file"] == str(old)
+    assert candidates[0]["source_resolution_previous_method"] == ksc.METHOD_TRACE
+
+
+def test_review_runs_without_any_opt_in(tmp_path):
+    """The tier is unconditional; nothing in the environment gates it."""
+    real = tmp_path / "right.py"
+    real.write_text("def kernel(): pass\n", encoding="utf-8")
+    doc = _doc_with(
+        ksc.make_entry(kernel_id="k1", name="n", gpu_pct=9.0,
+                       source_file=str(tmp_path / "wrong.py"), method=ksc.METHOD_TRACE)
+    )
+    out, _ = review_resolution_document(
+        doc,
+        framework_roots=(str(tmp_path),),
+        complete=_reply([{"kernel_id": "k1", "action": "rewrite",
+                          "source_file": str(real), "reason": "defines it"}]),
+        model="m",
+    )
+    assert out["entries"][0]["source_file"] == str(real)

--- a/src/hyperloom/agents/kernel/tests/test_source_resolution_guards.py
+++ b/src/hyperloom/agents/kernel/tests/test_source_resolution_guards.py
@@ -1,0 +1,546 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Guards that keep an unresolved-launcher sentinel from becoming a source_file.
+
+TraceLens writes ``launcher_path = "Not found"`` for every Synthetic Op (a
+device kernel with no cpu_op parent, e.g. a hand-written Triton kernel launched
+straight from Python). That string used to survive parsing as a truthy
+``source_file``, which skipped the grep fallback and made classify_patchability
+reject the hottest kernels with "source not under a reusable framework root:
+Not found". These tests pin the three guards that close that path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+import tracelens_analysis as tl  # noqa: E402
+import tracelens_skill_runner as tsr  # noqa: E402
+from _llm_source_context import build_context_block  # noqa: E402
+
+
+_HEADERS = [
+    "operation",
+    "args",
+    "kernel path",
+    "time (ms)",
+    "%e2e",
+    "count",
+    "flops/byte",
+    "efficiency",
+    "bound",
+]
+
+
+def _row(kernel_path: str) -> dict | None:
+    """Build one candidate from a data-table row carrying ``kernel_path``."""
+    cells = [
+        "hipModuleLaunchKernel->_mxfp8_grouped_gemm_kernel (Synthetic Op)",
+        "",
+        kernel_path,
+        "15.671",
+        "7.04",
+        "114",
+        "—",
+        "—",
+        "—",
+    ]
+    return tsr._row_to_candidate(
+        _HEADERS,
+        cells,
+        category="other",
+        rank=1,
+        title="MXFP8 grouped GEMM",
+        library="",
+        impact={},
+    )
+
+
+# --- Guard 1: launcher placeholder normalisation ---------------------------
+
+
+def test_not_found_sentinel_normalized_to_empty():
+    cand = _row("Not found")
+    assert cand is not None
+    assert cand["source_file"] == ""
+    assert cand["tracelens_launcher_path"] == ""
+
+
+def test_not_found_sentinel_variants_normalized():
+    for raw in ("Not found", "NOT FOUND", "not found", "not_found", "notfound", "  Not Found  "):
+        cand = _row(raw)
+        assert cand is not None, raw
+        assert cand["source_file"] == "", raw
+
+
+def test_legacy_dash_placeholders_still_normalized():
+    for raw in ("-", "—", "–", "n/a", "unknown"):
+        cand = _row(raw)
+        assert cand is not None, raw
+        assert cand["source_file"] == "", raw
+
+
+def test_real_launcher_path_survives():
+    real = "/sgl-workspace/sglang/python/sglang/kernels/ops/moe/mxfp8_moe_amd_gfx95.py(124): _grouped_gemm_mxfp8"
+    cand = _row(real)
+    assert cand is not None
+    assert cand["tracelens_launcher_path"] == real
+    assert cand["source_file"] == real.split("(", 1)[0]
+    assert cand["source_line"] == 124
+    assert cand["source_function"] == "_grouped_gemm_mxfp8"
+
+
+def test_materialized_runtime_args_are_sanitized_before_prompting(tmp_path):
+    """Production YAML selectors reach context without their adjacent secret."""
+    config = tmp_path / "baseline.yaml"
+    config.write_text(
+        "benchmark:\n"
+        "  envs:\n"
+        "    EXTRA_SGLANG_ARGS: '--api-key sk-secret "
+        "--moe-runner-backend triton'\n",
+        encoding="utf-8",
+    )
+    raw = tl._runtime_server_args_from_config(str(config))
+    block = build_context_block(
+        server_args=raw,
+        framework="sglang",
+        precision="fp8",
+        env={},
+    )
+
+    assert "sk-secret" not in block
+    assert "api-key" not in block
+    assert "triton" in block
+    assert '"precision": "fp8"' in block
+
+
+def test_not_found_is_in_shared_placeholder_set():
+    assert "not found" in tsr._LAUNCHER_PATH_PLACEHOLDERS
+
+
+# --- Guard 2: bare runtime-API names are not kernels ------------------------
+
+
+def test_bare_runtime_api_names_detected():
+    for name in (
+        "hipGraphLaunch",
+        "hipModuleLaunchKernel",
+        "hipLaunchKernel",
+        "cudaLaunchKernel",
+        "cudaGraphLaunch",
+    ):
+        assert tl.is_runtime_api_name(name), name
+
+
+def test_runtime_api_wrapping_a_kernel_is_not_blocked():
+    """The wrapper prefix is stripped, so the real kernel must still resolve."""
+    for name in (
+        "hipModuleLaunchKernel->_mxfp8_grouped_gemm_kernel (Synthetic Op)",
+        "hipGraphLaunch->_mxfp8_linear_kernel (Synthetic Op)",
+    ):
+        assert not tl.is_runtime_api_name(name), name
+
+
+def test_grep_refuses_bare_runtime_api():
+    for name in ("hipGraphLaunch", "hipModuleLaunchKernel", "hipLaunchKernel"):
+        assert tl.locate_source_via_grep(name) == "", name
+
+
+# --- Guard 3: a source_file must be path-shaped -----------------------------
+
+
+_SENTINELS = (
+    "Not found",
+    "N/A",
+    "unknown",
+    "TBD",
+    "<unresolved>",
+    "AITER (vendor)",
+    "Triton (vendor)",
+)
+
+
+def test_non_path_source_file_is_zeroed():
+    """Any value lacking a source extension is rejected, not just 'Not found'.
+
+    Covers the vendor labels TraceLens also emits in this field.
+    """
+    for sentinel in _SENTINELS:
+        item = {"name": "k", "source_file": sentinel, "kernel_repo": "", "source_type": "python"}
+        assert tl.reject_non_path_source(item) is True, sentinel
+        assert item["source_file"] == "", sentinel
+        assert item["source_file_rejected"] == sentinel
+        assert item["source_resolution_method"] == "rejected_non_path_sentinel"
+
+
+def test_rejection_marker_reaches_the_production_path():
+    """The audit marker must survive the real _finalize_candidates run.
+
+    The guard used to be duplicated: _finalize_candidates zeroed source_file
+    first, which made the copy inside _stamp_candidate_metadata unreachable, so
+    source_resolution_method was never stamped in production even though a unit
+    test asserted it.
+    """
+    for sentinel in _SENTINELS:
+        item = {"name": "k", "source_file": sentinel, "duration_us": 1.0}
+        got = tl._finalize_candidates([item])[0]
+        assert got["source_file"] == "", sentinel
+        assert got["source_file_rejected"] == sentinel
+        assert got["source_resolution_method"] == "rejected_non_path_sentinel", sentinel
+
+
+def test_successful_grep_replaces_a_prior_rejection_method(monkeypatch):
+    """The final method must describe the source that actually won."""
+    monkeypatch.setattr(
+        tl,
+        "locate_source_via_grep",
+        lambda _name: "/repo/pkg/kernel.py",
+    )
+    item = {"name": "k", "source_file": "Not found", "duration_us": 1.0}
+
+    got = tl._finalize_candidates([item], allow_model_tiers=False)[0]
+
+    assert got["source_file"] == "/repo/pkg/kernel.py"
+    assert got["source_resolution_method"] == "name_grep"
+    assert got["source_file_rejected"] == "Not found"
+
+
+def test_path_shape_gate_accepts_every_admitted_extension():
+    """Anything grep may admit must also read as a path, or it gets zeroed."""
+    for ext in tl.SOURCE_EXTENSIONS:
+        assert tl.looks_like_source_path(f"/repo/pkg/kernel{ext}"), ext
+    for ext in tl.PATH_SHAPED_EXTENSIONS:
+        assert tl.looks_like_source_path(f"/repo/pkg/kernel{ext}"), ext
+
+
+def test_path_shape_gate_accepts_a_bare_source_filename():
+    """A basename from a container trace is still a path, not a sentinel."""
+    assert tl.looks_like_source_path("kernel.py")
+
+
+def test_grep_admission_stays_within_what_source_type_can_classify():
+    """The two lists serve different questions and must not be merged.
+
+    Admitting a suffix that source_type_for() cannot classify yields
+    source_type="unknown", which classify_patchability rejects -- and the file
+    still competes in _rank_paths, where kind_score outweighs ext_score. A
+    /csrc/ file with such a suffix therefore outranks the sibling .py and flips
+    a routable candidate to non-routable, the exact symptom this module exists
+    to fix.
+    """
+    for ext in tl.SOURCE_EXTENSIONS:
+        stype = tl.source_type_for("some_kernel", f"/repo/pkg/some_kernel{ext}")
+        assert stype != "unknown", f"{ext} is admitted by grep but unclassifiable"
+
+
+def test_csrc_sibling_cannot_outrank_the_routable_python_source():
+    """End-to-end guard on the ranking interaction described above."""
+    csrc = Path("/sgl-workspace/aiter/csrc/kernels/foo_kernel.cc")
+    jinja = Path("/sgl-workspace/aiter/csrc/cpp_itfs/foo_kernel.cpp.jinja")
+    py = Path("/sgl-workspace/aiter/ops/foo_kernel.py")
+    for intruder in (csrc, jinja):
+        admitted = [p for p in (intruder, py) if p.suffix in tl.SOURCE_EXTENSIONS]
+        assert admitted == [py], f"{intruder.suffix} should not pass grep admission"
+        winner = str(tl._rank_paths(admitted, "foo_kernel")[0])
+        item = {
+            "name": "foo_kernel",
+            "source_file": winner,
+            "source_type": tl.source_type_for("foo_kernel", winner),
+        }
+        reusable, reason = tl.classify_patchability(item)
+        assert reusable is True, f"{intruder.suffix} made it non-routable: {reason}"
+
+
+def test_windows_separators_are_not_mistaken_for_placeholders():
+    """A backslash path is still a path; is_torch_dispatch_shim_source
+    normalizes the same way."""
+    assert tl.looks_like_source_path(r"C:\repo\pkg\kernels\moe.py")
+    item = {"name": "k", "source_file": r"C:\repo\pkg\kernels\moe.py"}
+    assert tl.reject_non_path_source(item) is False
+
+
+def test_real_path_is_not_flagged_as_rejected():
+    """A genuine path must pass the guard untouched."""
+    item = {"name": "k", "source_file": "/repo/pkg/kernels/moe.py"}
+    assert tl.reject_non_path_source(item) is False
+    assert item["source_file"] == "/repo/pkg/kernels/moe.py"
+    assert "source_file_rejected" not in item
+    assert "source_resolution_method" not in item
+
+
+def test_path_shaped_but_absent_file_is_kept_and_flagged(tmp_path):
+    """Keyed on shape, not presence: the analysis host need not own the
+    serving container's filesystem."""
+    missing = str(tmp_path / "does_not_exist.py")
+    item = {"name": "k", "source_file": missing, "kernel_repo": "", "source_type": "python"}
+    tl._stamp_candidate_metadata(item, None)
+    assert item["source_file"] == missing
+    assert item["source_file_missing_on_disk"] is True
+    assert "source_file_rejected" not in item
+
+
+def test_package_relative_path_survives():
+    """TraceLens emits package-relative launchers such as sgl_kernel/moe.py."""
+    item = {"name": "k", "source_file": "sgl_kernel/moe.py", "kernel_repo": "", "source_type": "python"}
+    tl._stamp_candidate_metadata(item, None)
+    assert item["source_file"] == "sgl_kernel/moe.py"
+    assert "source_file_rejected" not in item
+
+
+def test_existing_source_file_is_preserved_without_flags(tmp_path):
+    real = tmp_path / "kernel.py"
+    real.write_text("import triton\n", encoding="utf-8")
+    item = {"name": "k", "source_file": str(real), "kernel_repo": "", "source_type": "python"}
+    tl._stamp_candidate_metadata(item, None)
+    assert item["source_file"] == str(real)
+    assert "source_file_rejected" not in item
+    assert "source_file_missing_on_disk" not in item
+
+
+def test_empty_source_file_does_not_get_a_rejected_marker():
+    item = {"name": "k", "source_file": "", "kernel_repo": "", "source_type": "unknown"}
+    tl._stamp_candidate_metadata(item, None)
+    assert item["source_file"] == ""
+    assert "source_file_rejected" not in item
+
+
+# --- Guard 4: trace-relative launcher paths are absolutized -----------------
+#
+# torch profiler records a frame path relative to the sys.path entry the module
+# came from ("aiter/dist/x.py"). Patchability keys on an absolute framework
+# root, so a relative path would be rejected for the wrong reason.
+
+
+def test_relative_path_resolves_via_the_installed_package(monkeypatch):
+    """The real case: the pinned checkout roots do not exist on this host.
+
+    torch profiler records "vllm/models/x.py" relative to the sys.path entry the
+    module came from. A pinned list cannot cover that -- the same package sits
+    under /sgl-workspace in the serving image and under dist-packages on a wheel
+    install -- so resolution has to locate the package at runtime.
+    """
+    # Pinned roots deliberately absent, exactly as on a wheel-install host.
+    monkeypatch.setattr(tl, "_PACKAGE_INNER_ROOTS", ("/nonexistent/aiter/aiter",))
+    tl._package_parent_dir.cache_clear()
+
+    spec = importlib.util.find_spec("json")
+    assert spec and spec.origin
+    stdlib_dir = Path(spec.origin).parent
+
+    got = tl.absolutize_launcher_path("json/decoder.py")
+    assert got == str(stdlib_dir / "decoder.py")
+    assert os.path.isfile(got)
+
+
+def test_pinned_checkout_root_still_works_as_fallback(tmp_path, monkeypatch):
+    """An editable checkout that this interpreter cannot import must still resolve."""
+    pkg = tmp_path / "aiter" / "aiter" / "dist"
+    pkg.mkdir(parents=True)
+    (pkg / "custom_all_reduce.py").write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.setattr(tl, "_PACKAGE_INNER_ROOTS", (str(tmp_path / "aiter" / "aiter"),))
+    tl._package_parent_dir.cache_clear()
+
+    got = tl.absolutize_launcher_path("aiter/dist/custom_all_reduce.py")
+    assert got == str(pkg / "custom_all_reduce.py")
+
+
+def test_non_identifier_head_is_not_probed_as_a_package(monkeypatch):
+    monkeypatch.setattr(tl, "_PACKAGE_INNER_ROOTS", ())
+    tl._package_parent_dir.cache_clear()
+    assert tl.absolutize_launcher_path("not-an-identifier/mod.py") == "not-an-identifier/mod.py"
+
+
+def test_absolute_launcher_path_is_returned_unchanged():
+    assert tl.absolutize_launcher_path("/sgl-workspace/x.py") == "/sgl-workspace/x.py"
+
+
+def test_unresolvable_relative_path_is_left_alone(monkeypatch, tmp_path):
+    """Never fabricate: an unjoinable path stays as-is rather than becoming
+    a plausible-looking path that does not exist."""
+    monkeypatch.setattr(tl, "_PACKAGE_INNER_ROOTS", (str(tmp_path / "nope" / "nope"),))
+    assert tl.absolutize_launcher_path("pkg/mod.py") == "pkg/mod.py"
+
+
+def test_empty_path_is_safe():
+    assert tl.absolutize_launcher_path("") == ""
+
+
+# --------------------------------------------------------------------------
+# End-to-end wiring: sentinel -> zeroed source_file -> trace-derived launcher.
+# The guards above pin each stage in isolation; these pin the seam between
+# them, which is where a regression would actually cost a candidate.
+# --------------------------------------------------------------------------
+
+_WIRING_KERNEL = "_mxfp8_grouped_gemm_kernel"
+_WIRING_FRAME = "/repo/pkg/kernels/moe.py(124): _grouped_gemm"
+
+
+def _wiring_trace(tmp_path, frame: str = _WIRING_FRAME):
+    """Minimal trace where a Python frame launches ``_WIRING_KERNEL``."""
+    events = [
+        {"cat": "python_function", "name": "/repo/serve/runner.py(10): forward",
+         "tid": 7, "ts": 100.0, "dur": 200.0},
+        {"cat": "python_function", "name": frame,
+         "tid": 7, "ts": 101.0, "dur": 198.0},
+        {"cat": "cuda_runtime", "name": "hipModuleLaunchKernel", "tid": 7,
+         "ts": 150.0, "dur": 5.0, "args": {"correlation": 1}},
+        {"cat": "kernel", "name": _WIRING_KERNEL, "ts": 200.0, "dur": 10.0,
+         "args": {"correlation": 1}},
+    ]
+    path = tmp_path / "wiring.json"
+    path.write_text(json.dumps({"traceEvents": events}), encoding="utf-8")
+    return path
+
+
+def _wiring_candidate():
+    """Candidate as TraceLens emits it for a Synthetic Op: sentinel source."""
+    return {
+        "name": f"hipModuleLaunchKernel->{_WIRING_KERNEL} (Synthetic Op)",
+        "device_kernel_name": _WIRING_KERNEL,
+        "source_file": "Not found",
+        "duration_us": 1000.0,
+        "gpu_pct": 10.0,
+    }
+
+
+def test_sentinel_candidate_gets_trace_derived_source(monkeypatch, tmp_path):
+    """The whole point of the change: "Not found" must not end the search."""
+    monkeypatch.setattr(
+        tl,
+        "locate_source_via_grep",
+        lambda _name: "/repo/pkg/kernels/moe.py",
+    )
+    got = tl._finalize_candidates(
+        [_wiring_candidate()], trace_files=[_wiring_trace(tmp_path)]
+    )[0]
+    assert got["source_file"] == "/repo/pkg/kernels/moe.py"
+    assert got["source_line"] == 124
+    assert got["source_function"] == "_grouped_gemm"
+    assert got["source_resolution_method"] == "trace_python_stack"
+    # The rejected sentinel is kept for audit rather than silently dropped.
+    assert got["source_file_rejected"] == "Not found"
+
+
+def test_trace_launcher_caller_does_not_override_grep_definition(
+    monkeypatch,
+    tmp_path,
+):
+    """A launcher call site must not replace the kernel definition found by grep."""
+    launcher = "/repo/model/launcher.py"
+    definition = "/repo/kernels/grouped_gemm_kernel.py"
+    monkeypatch.setattr(tl, "locate_source_via_grep", lambda _name: definition)
+
+    got = tl._finalize_candidates(
+        [_wiring_candidate()],
+        trace_files=[_wiring_trace(tmp_path, f"{launcher}(42): launch")],
+        allow_model_tiers=False,
+    )[0]
+
+    assert got["source_file"] == definition
+    assert got["source_resolution_method"] == "name_grep"
+    assert got["trace_launcher_file"] == launcher
+    assert got.get("source_line") is None
+    assert got.get("source_function") is None
+    assert "trace launcher differs from grep source" in got["source_resolution_reason"]
+
+
+def test_unconfirmed_trace_launcher_continues_to_model_fallback(
+    monkeypatch,
+    tmp_path,
+):
+    """An unconfirmed launcher must leave source empty for the next tier."""
+    fallback_calls = []
+
+    def _record_fallback(item):
+        """Record that finalization reached the model fallback tier."""
+        fallback_calls.append(item["name"])
+
+    launcher = "/repo/model/launcher.py"
+    monkeypatch.setattr(tl, "locate_source_via_grep", lambda _name: "")
+    monkeypatch.setattr(tl, "_apply_llm_source_fallback", _record_fallback)
+
+    got = tl._finalize_candidates(
+        [_wiring_candidate()],
+        trace_files=[_wiring_trace(tmp_path, f"{launcher}(42): launch")],
+    )[0]
+
+    assert fallback_calls == [got["name"]]
+    assert got["source_file"] == ""
+    assert got["trace_launcher_file"] == launcher
+    assert got.get("source_resolution_method") != "trace_python_stack"
+    assert "trace launcher unconfirmed by name grep" in got["source_resolution_reason"]
+
+
+def test_wiring_leaves_a_real_source_untouched(tmp_path):
+    """A candidate that already resolved must not be rewritten by the trace."""
+    item = _wiring_candidate()
+    item["source_file"] = "/repo/pkg/kernels/authoritative.py"
+    got = tl._finalize_candidates([item], trace_files=[_wiring_trace(tmp_path)])[0]
+    assert got["source_file"] == "/repo/pkg/kernels/authoritative.py"
+    assert got.get("source_resolution_method") != "trace_python_stack"
+
+
+def test_wiring_without_trace_files_falls_back_quietly(tmp_path):
+    """No trace supplied is the normal bypass path, not a failure to report."""
+    got = tl._finalize_candidates([_wiring_candidate()], trace_files=None)[0]
+    assert got.get("source_resolution_method") != "trace_python_stack"
+    assert "trace_resolver_error" not in str(got.get("source_resolution_reason", ""))
+
+
+def test_deterministic_finalization_never_calls_model_tiers(
+    monkeypatch,
+    tmp_path,
+):
+    """The deterministic route's no-LLM contract is enforced below the CLI."""
+    monkeypatch.setattr(tl, "locate_source_via_grep", lambda _name: "")
+
+    def _model_called(*_args, **_kwargs):
+        """Fail if either model tier is reached."""
+        raise AssertionError("deterministic route called a model tier")
+
+    monkeypatch.setattr(tl, "_apply_llm_source_fallback", _model_called)
+    monkeypatch.setattr(tl, "_review_source_resolution", _model_called)
+    artifact = tmp_path / "kernel_source_resolution.json"
+    item = {
+        "name": "zz_no_source_kernel",
+        "source_file": "",
+        "duration_us": 100.0,
+        "gpu_pct": 10.0,
+    }
+    got = tl._finalize_candidates(
+        [item],
+        source_resolution_out=artifact,
+        allow_model_tiers=False,
+    )[0]
+    assert got["source_file"] == ""
+    assert "deterministic route" in got["source_resolution_reason"]
+    assert artifact.is_file()
+    doc = json.loads(artifact.read_text(encoding="utf-8"))
+    assert "llm_audit" not in doc
+
+
+def test_unreadable_trace_records_a_reason(monkeypatch, tmp_path):
+    """P2-1: a resolver failure must be distinguishable from "nothing to do"."""
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("corrupt trace")
+
+    monkeypatch.setattr(tl, "_resolve_trace_launchers", tl._resolve_trace_launchers)
+    monkeypatch.setattr("_trace_launcher_resolver.resolve_launchers_from_trace", _boom)
+    got = tl._finalize_candidates(
+        [_wiring_candidate()], trace_files=[_wiring_trace(tmp_path)]
+    )[0]
+    reason = str(got.get("source_resolution_reason", ""))
+    assert reason.startswith("trace_resolver_error: RuntimeError")
+    assert got.get("source_resolution_method") != "trace_python_stack"

--- a/src/hyperloom/agents/kernel/tests/test_trace_launcher_resolver.py
+++ b/src/hyperloom/agents/kernel/tests/test_trace_launcher_resolver.py
@@ -1,0 +1,787 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Tests for recovering a kernel's Python launcher frame from a Kineto trace.
+
+The resolver exists because TraceLens reports ``launcher_path = "Not found"``
+for hand-written Triton kernels (no ``cpu_op`` parent), even though the trace
+still carries the full ``python_function`` chain down to the launch.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+from _trace_launcher_resolver import (  # noqa: E402
+    LauncherFrame,
+    _match_kernel,
+    _open_trace_binary,
+    resolve_launchers_from_trace,
+)
+
+
+_USER_FRAME = "/repo/pkg/kernels/moe.py(124): _grouped_gemm"
+_TID = 7
+
+
+def _kernel(name: str, corr: int) -> dict:
+    return {"cat": "kernel", "name": name, "ts": 200.0, "dur": 10.0, "args": {"correlation": corr}}
+
+
+def _runtime(corr: int, api: str = "hipModuleLaunchKernel", ts: float = 150.0) -> dict:
+    return {
+        "cat": "cuda_runtime",
+        "name": api,
+        "tid": _TID,
+        "ts": ts,
+        "dur": 5.0,
+        "args": {"correlation": corr},
+    }
+
+
+def _frame(name: str, ts: float = 100.0, dur: float = 200.0, tid: int = _TID) -> dict:
+    return {"cat": "python_function", "name": name, "tid": tid, "ts": ts, "dur": dur}
+
+
+def _write(path: Path, events: list[dict], *, gzipped: bool = False) -> Path:
+    blob = json.dumps({"traceEvents": events})
+    if gzipped:
+        with gzip.open(path, "wt", encoding="utf-8") as fh:
+            fh.write(blob)
+    else:
+        path.write_text(blob, encoding="utf-8")
+    return path
+
+
+def _stack(*frames: str, base_ts: float = 100.0) -> list[dict]:
+    """Nested frames, outermost first, all covering the launch at ts=150."""
+    out = []
+    for depth, name in enumerate(frames):
+        out.append(_frame(name, ts=base_ts + depth, dur=200.0 - 2 * depth))
+    return out
+
+
+def test_the_most_specific_overlapping_symbol_wins():
+    """``wanted`` is a set, so a first-hit-wins scan raced on PYTHONHASHSEED.
+
+    Both names are substrings of the event, and picking the shorter one binds
+    the kernel to a different symbol -- and then to a different source file.
+    """
+    for _ in range(50):
+        assert _match_kernel("moe_gemm1_0.kd", {"moe_gemm1", "moe_gemm1_0"}) == "moe_gemm1_0"
+
+
+def test_an_exact_hit_outranks_a_longer_substring():
+    """Equality is the strongest evidence available, whatever the lengths."""
+    assert _match_kernel("moe_gemm1", {"moe_gemm1", "moe_gemm1_0_extra"}) == "moe_gemm1"
+
+
+def test_kernel_matching_respects_symbol_boundaries_and_decorations():
+    """Decorated symbols match, but identifier suffixes do not."""
+    assert _match_kernel("foo_epilogue", {"foo"}) is None
+    assert _match_kernel("foo<int>", {"foo"}) == "foo"
+    assert _match_kernel("foo.kd", {"foo"}) == "foo"
+    assert _match_kernel("void foo(float*)", {"foo"}) == "foo"
+
+
+def test_equally_specific_symbols_resolve_to_nothing():
+    """A real tie must not be broken by iteration order."""
+    assert _match_kernel("ab_cd", {"ab_", "_cd"}) is None
+
+
+def test_a_substring_tie_does_not_fall_through_to_an_elided_prefix():
+    """The weaker bucket must not rescue an ambiguity in the stronger one."""
+    wanted = {"ab_", "_cd", "ab_cd_long_enough_prefix..."}
+    assert _match_kernel("ab_cd", wanted) is None
+
+
+def test_non_exact_match_across_multiple_event_symbols_is_refused(tmp_path):
+    """One decorated name must not merge distinct complete event symbols."""
+    trace = _write(
+        tmp_path / "ambiguous.json",
+        [
+            *_stack(_USER_FRAME),
+            _runtime(1),
+            _kernel("foo<int>", 1),
+            _runtime(2, ts=160.0),
+            _kernel("foo<float>", 2),
+        ],
+    )
+    assert resolve_launchers_from_trace([trace], {"foo"}) == {}
+
+
+def test_exact_match_survives_ambiguous_decorated_symbols(tmp_path):
+    """Ambiguous fallback matches must not discard an available exact event."""
+    trace = _write(
+        tmp_path / "exact.json",
+        [
+            *_stack(_USER_FRAME),
+            _runtime(1),
+            _kernel("foo", 1),
+            _runtime(2, ts=160.0),
+            _kernel("foo<int>", 2),
+            _runtime(3, ts=170.0),
+            _kernel("foo<float>", 3),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"foo"})
+    assert got["foo"].source_file == "/repo/pkg/kernels/moe.py"
+    assert got["foo"].sample_count == 1
+
+
+def test_a_correlation_id_reused_across_ranks_resolves_nothing(tmp_path):
+    """A merged trace restarts correlation ids per rank.
+
+    The id then names two launches, so it names neither, and both are dropped.
+    Pairing on ``(pid, correlation)`` cannot rescue this: Kineto records the
+    kernel against the device and the launch against the host, so those two
+    pids never match on a real trace (see the GPU/host test below). Refusing
+    the ambiguous id is the only answer that cannot attribute a kernel to
+    another rank's source file.
+    """
+    def ev(base, pid):
+        out = dict(base)
+        out["pid"] = pid
+        return out
+
+    events = [
+        # Rank 0: correlation 1 on tid 7, launched from a.py
+        ev(_frame("/repo/rank0/a.py(10): launch_a"), 100),
+        ev(_runtime(1), 100),
+        ev(_kernel("shared_kernel", 1), 100),
+        # Rank 1: same correlation and tid, different launcher
+        ev(_frame("/repo/rank1/b.py(20): launch_b"), 200),
+        ev(_runtime(1), 200),
+        ev(_kernel("other_kernel", 1), 200),
+    ]
+    trace = _write(tmp_path / "merged.json", events)
+    got = resolve_launchers_from_trace([trace], {"shared_kernel", "other_kernel"})
+    assert got == {}
+
+
+def test_a_device_side_kernel_pairs_with_its_host_side_launch(tmp_path):
+    """The shape every real Kineto trace has: GPU pid != host pid.
+
+    The kernel event is attributed to the device and the runtime call to the
+    host process, so correlation is the only field spanning the pair. Keying on
+    pid too made this -- the ordinary case -- resolve to nothing.
+    """
+    host_pid, gpu_pid, tid = 12345, 0, 777
+    events = [
+        {"cat": "kernel", "name": "device_kernel", "pid": gpu_pid, "tid": 1,
+         "ts": 200.0, "dur": 10.0, "args": {"correlation": 42}},
+        {"cat": "cuda_runtime", "name": "hipLaunchKernel", "pid": host_pid,
+         "tid": tid, "ts": 150.0, "dur": 5.0, "args": {"correlation": 42}},
+        {"cat": "python_function", "name": "/repo/moe.py(120): run_moe",
+         "pid": host_pid, "tid": tid, "ts": 100.0, "dur": 200.0},
+    ]
+    got = resolve_launchers_from_trace(
+        [_write(tmp_path / "device.json", events)], {"device_kernel"}
+    )
+    assert got["device_kernel"].frame == "/repo/moe.py(120): run_moe"
+
+
+def test_one_host_process_driving_several_devices(tmp_path):
+    """Correlation stays unique per process, so multi-GPU needs no pid help.
+
+    Each device stream carries its own pid, none of which is the host's; the
+    ids do not collide because they are allocated by the one profiled process.
+    """
+    host_pid, tid = 999, 5
+    events = [
+        {"cat": "python_function", "name": "/repo/a.py(1): launch_a",
+         "pid": host_pid, "tid": tid, "ts": 100.0, "dur": 100.0},
+        {"cat": "cuda_runtime", "name": "hipLaunchKernel", "pid": host_pid,
+         "tid": tid, "ts": 120.0, "dur": 5.0, "args": {"correlation": 1}},
+        {"cat": "kernel", "name": "kernel_on_gpu0", "pid": 0, "tid": 1,
+         "ts": 130.0, "dur": 5.0, "args": {"correlation": 1}},
+        {"cat": "python_function", "name": "/repo/b.py(2): launch_b",
+         "pid": host_pid, "tid": tid, "ts": 300.0, "dur": 100.0},
+        {"cat": "cuda_runtime", "name": "hipLaunchKernel", "pid": host_pid,
+         "tid": tid, "ts": 320.0, "dur": 5.0, "args": {"correlation": 2}},
+        {"cat": "kernel", "name": "kernel_on_gpu1", "pid": 1, "tid": 1,
+         "ts": 330.0, "dur": 5.0, "args": {"correlation": 2}},
+    ]
+    got = resolve_launchers_from_trace(
+        [_write(tmp_path / "multigpu.json", events)],
+        {"kernel_on_gpu0", "kernel_on_gpu1"},
+    )
+    assert got["kernel_on_gpu0"].source_file == "/repo/a.py"
+    assert got["kernel_on_gpu1"].source_file == "/repo/b.py"
+
+
+def test_split_probes_leave_the_kernel_unresolved(tmp_path):
+    """A plurality is not agreement.
+
+    Three probes pointing at three different frames used to resolve to
+    whichever Counter saw first -- trace order, not evidence.
+    """
+    events = []
+    for i, path in enumerate(
+        ["/repo/x.py(1): fa", "/repo/y.py(2): fb", "/repo/z.py(3): fc"]
+    ):
+        base = 100.0 + i * 1000
+        events.append(_frame(path, ts=base, dur=500.0, tid=7 + i))
+        events.append(
+            {"cat": "cuda_runtime", "name": "hipModuleLaunchKernel", "tid": 7 + i,
+             "ts": base + 10, "dur": 5.0, "args": {"correlation": i + 1}}
+        )
+        events.append(_kernel("split_kernel", i + 1))
+    got = resolve_launchers_from_trace(
+        [_write(tmp_path / "split.json", events)], {"split_kernel"}
+    )
+    assert got == {}
+
+
+def test_per_file_error_is_reported_to_the_caller(tmp_path, monkeypatch):
+    """An unreadable trace must not look like "nothing needed resolving"."""
+    trace = _write(tmp_path / "t.json", [_kernel("k", 1)])
+
+    def _boom(_fh, **_kwargs):
+        """Simulate an I/O error from the streaming parser."""
+        raise OSError("truncated gzip")
+
+    monkeypatch.setattr("_trace_launcher_resolver.stream_events", _boom)
+    errors: list[str] = []
+    got = resolve_launchers_from_trace([trace], {"k"}, file_errors=errors)
+    assert got == {}
+    assert errors and "t.json" in errors[0] and "OSError" in errors[0]
+
+
+def test_truncated_trace_reports_an_error_but_keeps_complete_events(tmp_path):
+    """Recovered leading events remain usable while corruption is observable."""
+    complete = [
+        *_stack(_USER_FRAME),
+        _runtime(1),
+        _kernel("_grouped_gemm_kernel", 1),
+    ]
+    text = '{"traceEvents": [' + ",".join(json.dumps(event) for event in complete)
+    text += ',{"cat":"kernel","name":"cut'
+    trace = tmp_path / "truncated.json"
+    trace.write_text(text, encoding="utf-8")
+    errors: list[str] = []
+    got = resolve_launchers_from_trace(
+        [trace],
+        {"_grouped_gemm_kernel"},
+        file_errors=errors,
+    )
+    assert got["_grouped_gemm_kernel"].source_file == "/repo/pkg/kernels/moe.py"
+    assert len(errors) == 1
+    assert "truncated.json" in errors[0]
+    assert "truncated" in errors[0]
+
+
+def test_truncated_gzip_fails_soft_and_next_file_resolves(tmp_path):
+    """A gzip read failure must not prevent scanning a healthy later trace."""
+    broken = _write(
+        tmp_path / "broken.json.gz",
+        [_kernel("_grouped_gemm_kernel", 1)],
+        gzipped=True,
+    )
+    broken.write_bytes(broken.read_bytes()[:-8])
+    healthy = _write(
+        tmp_path / "healthy.json",
+        [*_stack(_USER_FRAME), _runtime(2), _kernel("_grouped_gemm_kernel", 2)],
+    )
+    errors: list[str] = []
+    got = resolve_launchers_from_trace(
+        [broken, healthy],
+        {"_grouped_gemm_kernel"},
+        max_trace_files=2,
+        file_errors=errors,
+    )
+    assert got["_grouped_gemm_kernel"].source_file == "/repo/pkg/kernels/moe.py"
+    assert any("broken.json.gz" in error and "EOFError" in error for error in errors)
+
+
+def test_missing_trace_events_is_reported_as_a_file_error(tmp_path):
+    """A valid non-Kineto JSON document is not a healthy empty trace."""
+    trace = tmp_path / "not-a-trace.json"
+    trace.write_text(json.dumps({"foo": "bar"}), encoding="utf-8")
+    errors: list[str] = []
+    assert resolve_launchers_from_trace([trace], {"kernel"}, file_errors=errors) == {}
+    assert errors == ["not-a-trace.json: stream error: traceEvents array not found"]
+
+
+def test_single_trailing_dot_is_not_treated_as_elided(tmp_path):
+    """Prefix matching must be gated by the same predicate as the ambiguity check.
+
+    _match_kernel used to accept any name that rstrip changed, so a single
+    trailing dot enabled prefix matching while _is_elided still said False --
+    the name then skipped the ambiguity check and could bind to any sibling.
+    """
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack("/repo/pkg/k.py(7): launch_it"),
+            _runtime(1),
+            _kernel("_ZN5aiter12some_kernelEv", 1),
+        ],
+    )
+    # "_ZN5aiter1." is a prefix of the event symbol but is not ellipsis-elided.
+    assert resolve_launchers_from_trace([trace], {"_ZN5aiter1."}) == {}
+
+
+def test_scan_is_bounded_when_kernels_never_resolve(tmp_path, monkeypatch):
+    """A capture folder must not be read end to end chasing the unresolvable.
+
+    Kernels launched from C++ or only replayed from a graph never resolve, so
+    "stop once everything is resolved" alone would read every file in the
+    folder -- dozens of them, two streaming passes each.
+    """
+    files = []
+    for i in range(10):
+        files.append(
+            _write(tmp_path / f"rank{i}.json", [_kernel("_never_launched_kernel", i + 1)])
+        )
+    opened: list[str] = []
+
+    def _counting_open(path):
+        opened.append(Path(path).name)
+        return _open_trace_binary(path)
+
+    monkeypatch.setattr(
+        "_trace_launcher_resolver._open_trace_binary", _counting_open
+    )
+    got = resolve_launchers_from_trace(files, {"_never_launched_kernel"})
+    assert got == {}
+    # Distinct files touched, not passes: bounded well below the 10 supplied.
+    assert len(set(opened)) <= 2, f"scanned {sorted(set(opened))}"
+
+
+def test_scan_stops_when_barren_limit_is_reached(tmp_path, monkeypatch):
+    """The first healthy barren file reaches the one-file stop threshold."""
+    files = [
+        _write(tmp_path / f"rank{i}.json", [_kernel("_never_launched_kernel", i + 1)])
+        for i in range(3)
+    ]
+    opened: list[str] = []
+
+    def _counting_open(path):
+        """Record each trace opened by the resolver."""
+        opened.append(Path(path).name)
+        return _open_trace_binary(path)
+
+    monkeypatch.setattr(
+        "_trace_launcher_resolver._open_trace_binary", _counting_open
+    )
+    assert (
+        resolve_launchers_from_trace(
+            files,
+            {"_never_launched_kernel"},
+            max_trace_files=3,
+        )
+        == {}
+    )
+    assert opened == ["rank0.json"]
+
+
+def test_scan_stops_after_a_file_adds_nothing(tmp_path):
+    """A file that contributes no new resolution ends the scan."""
+    good = _write(
+        tmp_path / "a.json",
+        [*_stack("/repo/pkg/k.py(7): launch_it"), _runtime(1), _kernel("k_one", 1)],
+    )
+    barren = _write(tmp_path / "b.json", [_kernel("k_two", 2)])
+    got = resolve_launchers_from_trace([good, barren], {"k_one", "k_two"})
+    assert set(got) == {"k_one"}
+
+
+def test_non_launch_runtime_events_are_not_retained(tmp_path):
+    """Correlated memcpy/synchronize events must not enter the probe map."""
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack("/repo/pkg/k.py(7): launch_it"),
+            {"cat": "cuda_runtime", "name": "hipMemcpyAsync", "tid": _TID,
+             "ts": 140.0, "dur": 1.0, "args": {"correlation": 1}},
+            _runtime(2),
+            _kernel("k_one", 2),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"k_one"})
+    assert got["k_one"].launch_api == "hipModuleLaunchKernel"
+
+
+def _tied_frames_trace(tmp_path, *, outer_first: bool) -> Path:
+    """Two frames sharing a ``ts``; only ``dur`` reveals which one is nested."""
+    outer = {"cat": "python_function", "name": "/opt/aiter/aiter/fused_moe.py(1169): fused_moe",
+             "tid": _TID, "ts": 100.0, "dur": 50.0}
+    inner = {"cat": "python_function",
+             "name": "/opt/aiter/aiter/ops/flydsl/moe_kernels.py(859): _moe_kernel",
+             "tid": _TID, "ts": 100.0, "dur": 10.0}
+    frames = [outer, inner] if outer_first else [inner, outer]
+    name = f"tied_{'outer' if outer_first else 'inner'}.json"
+    return _write(
+        tmp_path / name,
+        [*frames, _runtime(1, ts=105.0), _kernel("_moe_gemm_kernel", 1)],
+    )
+
+
+def test_same_timestamp_frames_resolve_by_nesting_not_write_order(tmp_path):
+    """Microsecond ties must not let trace write order pick the frame.
+
+    Profiler timestamps are microsecond-granular, so adjacent frames on a fast
+    call chain land on the same ``ts``. Ordering by start alone left the tie to
+    Python's stable sort, i.e. to the order events happen to appear in the file,
+    which collapsed different kernels onto whichever frame was written first.
+    """
+    expected = ("/opt/aiter/aiter/ops/flydsl/moe_kernels.py", 859, "_moe_kernel")
+    picks = []
+    for outer_first in (True, False):
+        got = resolve_launchers_from_trace(
+            [_tied_frames_trace(tmp_path, outer_first=outer_first)], {"_moe_gemm_kernel"}
+        )
+        frame = got["_moe_gemm_kernel"]
+        picks.append((frame.source_file, frame.line, frame.function))
+    assert picks[0] == picks[1], "write order changed the resolved source"
+    assert picks[0] == expected
+
+
+def test_resolves_user_frame_behind_triton_plumbing(tmp_path):
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack(
+                "/repo/serve/runner.py(10): forward",
+                _USER_FRAME,
+                "/venv/triton/runtime/jit.py(708): run",
+                "/venv/triton/backends/amd/driver.py(831): __call__",
+                "<built-in function launch>",
+            ),
+            _runtime(1),
+            _kernel("_grouped_gemm_kernel", 1),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"_grouped_gemm_kernel"})
+    assert set(got) == {"_grouped_gemm_kernel"}
+    frame = got["_grouped_gemm_kernel"]
+    assert frame.source_file == "/repo/pkg/kernels/moe.py"
+    assert frame.line == 124
+    assert frame.function == "_grouped_gemm"
+    assert frame.launch_api == "hipModuleLaunchKernel"
+    assert frame.frame == _USER_FRAME
+
+
+def test_reads_gzipped_trace(tmp_path):
+    trace = _write(
+        tmp_path / "t.json.gz",
+        [*_stack(_USER_FRAME), _runtime(1), _kernel("_grouped_gemm_kernel", 1)],
+        gzipped=True,
+    )
+    got = resolve_launchers_from_trace([trace], {"_grouped_gemm_kernel"})
+    assert got["_grouped_gemm_kernel"].line == 124
+
+
+def test_pure_graph_replay_kernel_is_omitted(tmp_path):
+    """A replay stack ends at torch/cuda/graphs.py, so nothing is guessed."""
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack(
+                "/repo/serve/runner.py(10): forward",
+                "/venv/torch/cuda/graphs.py(139): replay",
+            ),
+            _runtime(1, api="hipGraphLaunch"),
+            _kernel("_grouped_gemm_kernel", 1),
+        ],
+    )
+    assert resolve_launchers_from_trace([trace], {"_grouped_gemm_kernel"}) == {}
+
+
+def test_graph_launch_api_without_a_torch_marker_is_omitted(tmp_path):
+    """API identity rejects inductor and framework-native graph replay stacks."""
+    for index, api in enumerate(("hipGraphLaunch", "cudaGraphLaunch", "cuGraphLaunch"), start=1):
+        trace = _write(
+            tmp_path / f"graph-{index}.json",
+            [
+                *_stack(
+                    "/repo/serve/runner.py(10): forward",
+                    "/venv/torch/_inductor/cudagraph_trees.py(2100): run",
+                ),
+                _runtime(index, api=api),
+                _kernel("_grouped_gemm_kernel", index),
+            ],
+        )
+        assert resolve_launchers_from_trace([trace], {"_grouped_gemm_kernel"}) == {}
+
+
+def test_eager_probe_preferred_over_graph_replay(tmp_path):
+    """With both launch paths present, the eager one supplies the answer."""
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            # Graph replay on one thread.
+            _frame("/venv/torch/cuda/graphs.py(139): replay", ts=100.0, dur=100.0, tid=9),
+            {
+                "cat": "cuda_runtime",
+                "name": "hipGraphLaunch",
+                "tid": 9,
+                "ts": 150.0,
+                "dur": 5.0,
+                "args": {"correlation": 1},
+            },
+            _kernel("_grouped_gemm_kernel", 1),
+            # Eager launch on another thread.
+            *_stack(_USER_FRAME),
+            _runtime(2),
+            _kernel("_grouped_gemm_kernel", 2),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"_grouped_gemm_kernel"})
+    assert got["_grouped_gemm_kernel"].source_file == "/repo/pkg/kernels/moe.py"
+    assert got["_grouped_gemm_kernel"].launch_api == "hipModuleLaunchKernel"
+
+
+def test_non_python_frames_are_ignored(tmp_path):
+    """nn.Module markers carry no path(line) and must not be mistaken for source."""
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack(
+                _USER_FRAME,
+                "nn.Module: FusedMoE_0",
+                "/venv/torch/nn/modules/module.py(1779): _call_impl",
+            ),
+            _runtime(1),
+            _kernel("_grouped_gemm_kernel", 1),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"_grouped_gemm_kernel"})
+    assert got["_grouped_gemm_kernel"].source_file == "/repo/pkg/kernels/moe.py"
+
+
+def test_kernel_without_matching_runtime_is_omitted(tmp_path):
+    trace = _write(tmp_path / "t.json", [*_stack(_USER_FRAME), _kernel("_grouped_gemm_kernel", 99)])
+    assert resolve_launchers_from_trace([trace], {"_grouped_gemm_kernel"}) == {}
+
+
+def test_truncated_mangled_symbol_still_matches(tmp_path):
+    """TraceLens elides a long mangled symbol; the trace keeps the full name.
+
+    Real case: the Kernel Name cell reads
+    ``_ZN5aiter33reduce_scatter_cross_device_storeIDF16bLi8EEEvPNS_8RankDataENS_1...``
+    while the trace event is the untruncated symbol.
+    """
+    full = "_ZN5aiter33reduce_scatter_cross_device_storeIDF16bLi8EEEvPNS_8RankDataENS_11RankSignalsEiiii"
+    truncated = "_ZN5aiter33reduce_scatter_cross_device_storeIDF16bLi8EEEvPNS_8RankDataENS_1..."
+    trace = _write(
+        tmp_path / "t.json",
+        [*_stack(_USER_FRAME), _runtime(1), _kernel(full, 1)],
+    )
+    got = resolve_launchers_from_trace([trace], {truncated})
+    assert set(got) == {truncated}
+    assert got[truncated].line == 124
+
+
+# --- JIT toolchain plumbing (real stacks from a Kimi-K3 / vLLM run) ----------
+
+
+def test_flydsl_jit_plumbing_is_skipped_for_the_real_kernel(tmp_path):
+    """Verbatim eager stack of aiter's FlyDSL MoE GEMM.
+
+    Every FlyDSL-compiled kernel bottoms out in the same
+    ``flydsl/compiler/jit_executor.py: __call__``; resolving there aims a backend
+    at the compiler and collapses distinct kernels onto one source.
+    """
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack(
+                "aiter/fused_moe.py(538): fused_moe_",
+                "aiter/fused_moe.py(2478): fused_moe_2stages",
+                "aiter/fused_moe.py(1169): _flydsl_stage1_wrapper",
+                "aiter/ops/flydsl/moe_kernels.py(1261): flydsl_moe_stage1",
+                "aiter/ops/flydsl/moe_kernels.py(859): _run_compiled",
+                "flydsl/compiler/jit_function.py(1635): __call__",
+                "flydsl/compiler/jit_executor.py(210): __call__",
+                "<flydsl-dispatch>(34): dispatch",
+            ),
+            _runtime(1),
+            _kernel("moe_gemm1_0", 1),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"moe_gemm1_0"})
+    frame = got["moe_gemm1_0"]
+    assert frame.source_file == "aiter/ops/flydsl/moe_kernels.py"
+    assert frame.line == 859
+    assert "jit_executor" not in frame.source_file
+    assert "jit_function" not in frame.source_file
+
+
+def test_two_flydsl_kernels_do_not_collapse_onto_the_compiler(tmp_path):
+    """The concrete damage: both MoE GEMMs used to resolve to jit_executor.py."""
+    def _flydsl_stack(kernel_line: int, base_ts: float) -> list[dict]:
+        return _stack(
+            f"aiter/ops/flydsl/moe_kernels.py({kernel_line}): flydsl_moe",
+            "flydsl/compiler/jit_executor.py(210): __call__",
+            base_ts=base_ts,
+        )
+
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_flydsl_stack(1261, 100.0),
+            _runtime(1, ts=150.0),
+            _kernel("moe_gemm1_0", 1),
+            *_flydsl_stack(1480, 400.0),
+            _runtime(2, ts=450.0),
+            _kernel("moe_gemm2_0", 2),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"moe_gemm1_0", "moe_gemm2_0"})
+    assert got["moe_gemm1_0"].line == 1261
+    assert got["moe_gemm2_0"].line == 1480
+
+
+def test_flydsl_authored_kernel_stays_visible(tmp_path):
+    """Only flydsl/compiler/ is plumbing; a kernel written in FlyDSL is a target."""
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack(
+                "/repo/kernels/my_flydsl_kernel.py(42): my_kernel",
+                "flydsl/compiler/jit_executor.py(210): __call__",
+            ),
+            _runtime(1),
+            _kernel("my_flydsl_kernel_0", 1),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"my_flydsl_kernel_0"})
+    assert got["my_flydsl_kernel_0"].source_file == "/repo/kernels/my_flydsl_kernel.py"
+
+
+def test_aiter_jit_and_flydsl_are_treated_alike(tmp_path):
+    """Both JIT toolchains must yield the caller, not their dispatch wrapper."""
+    cases = {
+        "aiter_kernel_0": "aiter/jit/core.py(1504): wrapper",
+        "flydsl_kernel_0": "flydsl/compiler/jit_executor.py(210): __call__",
+    }
+    for index, (kernel, plumbing) in enumerate(cases.items(), start=1):
+        trace = _write(
+            tmp_path / f"t{index}.json",
+            [
+                *_stack("/repo/ops/real_kernel.py(77): launch_it", plumbing),
+                _runtime(index),
+                _kernel(kernel, index),
+            ],
+        )
+        got = resolve_launchers_from_trace([trace], {kernel})
+        assert got[kernel].source_file == "/repo/ops/real_kernel.py", kernel
+        assert got[kernel].line == 77, kernel
+
+
+def test_triton_stack_unaffected_by_the_flydsl_rule(tmp_path):
+    """Regression guard: the vLLM Triton path from the same run still resolves."""
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack(
+                "vllm/models/kimi_k3/amd/linear.py(571): forward",
+                "vllm/models/kimi_k3/amd/ops/attn_res.py(88): attn_res",
+                "triton/runtime/jit.py(720): run",
+                "triton/backends/amd/driver.py(343): __call__",
+                "<built-in function launch>",
+            ),
+            _runtime(1),
+            _kernel("_attn_res_kernel", 1),
+        ],
+    )
+    got = resolve_launchers_from_trace([trace], {"_attn_res_kernel"})
+    assert got["_attn_res_kernel"].source_file == "vllm/models/kimi_k3/amd/ops/attn_res.py"
+    assert got["_attn_res_kernel"].line == 88
+
+
+def test_ambiguous_elided_prefix_is_refused(tmp_path):
+    """Two distinct symbols behind one elided name cannot be told apart.
+
+    Attributing either launcher to the shared prefix would hand a backend the
+    wrong source file, so the resolver declines and leaves it to grep.
+    """
+    shared = "_ZN5aiter40some_quite_long_collective_symbol_nameI"
+    trace = _write(
+        tmp_path / "t.json",
+        [
+            *_stack(_USER_FRAME),
+            _runtime(1),
+            _kernel(shared + "Lb0EEEvPf", 1),
+            _runtime(2, ts=160.0),
+            _kernel(shared + "Lb1EEEvPd", 2),
+        ],
+    )
+    assert resolve_launchers_from_trace([trace], {shared + "..."}) == {}
+
+
+def test_unambiguous_elided_prefix_still_resolves(tmp_path):
+    """One symbol behind the elision is fine -- that is the normal case."""
+    full = "_ZN5aiter40some_quite_long_collective_symbol_nameILb0EEEvPf"
+    trace = _write(
+        tmp_path / "t.json",
+        [*_stack(_USER_FRAME), _runtime(1), _kernel(full, 1)],
+    )
+    elided = "_ZN5aiter40some_quite_long_collective_symbol_nameI..."
+    assert set(resolve_launchers_from_trace([trace], {elided})) == {elided}
+
+
+def test_degenerate_elided_prefix_is_refused(tmp_path):
+    """``_ZN5...`` prefixes an entire namespace and must not bind a kernel."""
+    trace = _write(
+        tmp_path / "t.json",
+        [*_stack(_USER_FRAME), _runtime(1), _kernel("_ZN5aiter9unrelatedE", 1)],
+    )
+    assert resolve_launchers_from_trace([trace], {"_ZN5..."}) == {}
+
+
+def test_unwanted_kernels_are_not_resolved(tmp_path):
+    trace = _write(
+        tmp_path / "t.json",
+        [*_stack(_USER_FRAME), _runtime(1), _kernel("_some_other_kernel", 1)],
+    )
+    assert resolve_launchers_from_trace([trace], {"_grouped_gemm_kernel"}) == {}
+
+
+def test_empty_inputs_short_circuit(tmp_path):
+    trace = _write(tmp_path / "t.json", [_kernel("_k", 1)])
+    assert resolve_launchers_from_trace([], {"_k"}) == {}
+    assert resolve_launchers_from_trace([trace], set()) == {}
+    assert resolve_launchers_from_trace([trace], {"  "}) == {}
+
+
+def test_missing_or_corrupt_trace_fails_soft(tmp_path):
+    """Missing and malformed inputs remain non-fatal."""
+    missing = tmp_path / "nope.json"
+    corrupt = tmp_path / "bad.json"
+    corrupt.write_text("this is not json", encoding="utf-8")
+    assert resolve_launchers_from_trace([missing], {"_k"}) == {}
+    assert resolve_launchers_from_trace([corrupt], {"_k"}) == {}
+
+
+def test_stops_after_all_kernels_resolved(tmp_path):
+    """The second file must not be opened once the first answered everything."""
+    first = _write(
+        tmp_path / "a.json",
+        [*_stack(_USER_FRAME), _runtime(1), _kernel("_grouped_gemm_kernel", 1)],
+    )
+    absent = tmp_path / "b-does-not-exist.json"
+    got = resolve_launchers_from_trace([first, absent], {"_grouped_gemm_kernel"})
+    assert set(got) == {"_grouped_gemm_kernel"}
+
+
+def test_launcher_frame_render():
+    frame = LauncherFrame(
+        source_file="/repo/a.py",
+        line=7,
+        function="fn",
+        sample_count=2,
+        launch_api="hipLaunchKernel",
+    )
+    assert frame.frame == "/repo/a.py(7): fn"

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -297,6 +297,63 @@ def test_deterministic_main_fails_before_high_idle_gate(
     assert "Deterministic TraceLens pipeline failed" in result["error"]
 
 
+def test_agent_dry_run_initializes_route_and_writes_resolution_artifact(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    """Dry-run must not read a route variable initialized only in live mode."""
+    import json as _json
+
+    trace = tmp_path / "trace.json"
+    trace.write_text('{"traceEvents": []}', encoding="utf-8")
+    source = tmp_path / "kernel.py"
+    source.write_text("def kernel():\n    pass\n", encoding="utf-8")
+    report = tmp_path / "trace_report.json"
+    monkeypatch.setattr(
+        tla,
+        "analyze_trace_files",
+        lambda *_args, **_kwargs: [
+            {
+                "kernel_id": "k001",
+                "name": "kernel",
+                "gpu_pct": 100.0,
+                "duration_us": 1.0,
+                "source_file": str(source),
+                "source_type": "python",
+                "source_resolution_method": "name_grep",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        tla,
+        "write_reports",
+        lambda *_args, **_kwargs: {"trace_report_path": str(report)},
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "tracelens_analysis.py",
+            "--trace-input",
+            str(trace),
+            "--workspace-path",
+            str(tmp_path / "workspace"),
+            "--analysis-route",
+            "agent",
+            "--dry-run",
+        ],
+    )
+
+    assert tla.main() == 0
+    result = _json.loads(capsys.readouterr().out)
+    resolution_path = Path(result["artifact_paths"]["kernel_source_resolution"])
+    assert resolution_path.is_file()
+    assert _json.loads(resolution_path.read_text(encoding="utf-8"))["entries"][0][
+        "source_file"
+    ] == str(source)
+
+
 # A path — is_kernel_event strict cat == 'kernel'
 def test_a_filters_python_function_synchronize():
     """The exact event that ranked first in the buggy resume trace."""
@@ -3059,13 +3116,14 @@ def test_resolve_launcher_via_hardcoded_fallback(tmp_path, monkeypatch):
     assert func == "rmsnorm2d_fwd_with_add"
 
 
-def test_resolve_launcher_returns_none_for_absolute_path():
-    """Already-absolute launcher paths return None so the caller preserves the original string."""
-    assert (
-        tlr._resolve_launcher_to_abs_source(
-            "/sgl-workspace/aiter/aiter/ops/rmsnorm.py(62): fn",
-        )
-        is None
+def test_resolve_launcher_splits_an_absolute_annotated_path():
+    """Absolute launchers keep their path while separating line and function."""
+    assert tlr._resolve_launcher_to_abs_source(
+        "/sgl-workspace/aiter/aiter/ops/rmsnorm.py(62): fn",
+    ) == (
+        "/sgl-workspace/aiter/aiter/ops/rmsnorm.py",
+        62,
+        "fn",
     )
 
 

--- a/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
+++ b/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
@@ -27,6 +27,7 @@ Design constraints:
 
 from __future__ import annotations
 
+import codecs
 import gzip
 import json
 import re
@@ -41,6 +42,12 @@ _GPU_CATS = frozenset((_GPU_KERNEL_CAT,) + _GPU_MEMCPY_CATS)
 _TRACE_EXTS = (".trace.json.gz", ".pt.trace.json.gz", ".trace.json", ".json.gz", ".json")
 
 _DECODER = json.JSONDecoder()
+
+# Hard caps keep a corrupt trace from turning the streaming reader into an
+# unbounded accumulator. Kineto prefixes are normally a few KiB and individual
+# events a few KiB, so these retain generous headroom for embedded metadata.
+_MAX_TRACE_PREFIX_CHARS = 16 * 1024 * 1024
+_MAX_EVENT_CHARS = 64 * 1024 * 1024
 
 # Per-rank trace filename pattern (e.g. ``rank_0.trace.json.gz``).
 _RANK_RE = re.compile(r"rank[_-]?(\d+)", re.IGNORECASE)
@@ -226,59 +233,278 @@ def _open_trace_binary(path: Path):
     return open(path, "rb")
 
 
-def stream_events(fileobj, bufsize: int = 8 * 1024 * 1024) -> Iterator[dict]:
+def stream_events(
+    fileobj,
+    bufsize: int = 8 * 1024 * 1024,
+    *,
+    errors: list[str] | None = None,
+) -> Iterator[dict]:
     """Yield each object inside the ``traceEvents`` array, one at a time.
 
     Locates the ``traceEvents`` array, then emits balanced ``{...}`` elements
-    via ``raw_decode``. Constant memory; refills the buffer on truncation.
+    via ``raw_decode``. Complete leading events remain recoverable from a
+    truncated file, while ``errors`` distinguishes that recovery from a clean
+    end of the array.
 
     Args:
         fileobj: A binary, possibly-decompressing file object.
         bufsize: Read/refill chunk size in bytes (also the buffer-trim
             threshold).
+        errors: Optional output list for structural stream errors.
 
     Yields:
         Parsed trace-event dicts.
     """
+    def _record(message: str) -> None:
+        """Append one structural error when the caller requested diagnostics."""
+        if errors is not None:
+            errors.append(message)
+
+    chunk_size = max(1, int(bufsize))
+    utf8_decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
     buf = ""
-    key = '"traceEvents"'
-    while key not in buf:
-        chunk = fileobj.read(bufsize)
-        if not chunk:
-            return
-        buf += chunk.decode("utf-8", "replace")
-    pos = buf.index("[", buf.index(key)) + 1
     eof = False
-    while True:
-        while pos < len(buf) and buf[pos] in " \t\r\n,":
-            pos += 1
-        if pos < len(buf) and buf[pos] == "]":
-            return
-        if pos >= len(buf) or buf[pos] != "{":
-            if eof:
-                return
-            chunk = fileobj.read(bufsize)
-            if not chunk:
-                eof = True
-            else:
-                buf += chunk.decode("utf-8", "replace")
-            continue
+
+    def _refill(max_bytes: int | None = None) -> bool:
+        """Decode one bounded chunk and turn gzip failures into stream errors."""
+        nonlocal buf, eof
+        if eof:
+            return False
+        read_size = chunk_size
+        if max_bytes is not None:
+            read_size = max(1, min(read_size, max_bytes))
         try:
-            obj, end = _DECODER.raw_decode(buf, pos)
-        except json.JSONDecodeError:
-            if eof:
-                return
-            chunk = fileobj.read(bufsize)
-            if not chunk:
-                eof = True
-            else:
-                buf += chunk.decode("utf-8", "replace")
-            continue
-        yield obj
-        pos = end
-        if pos > bufsize:
+            chunk = fileobj.read(read_size)
+        except (EOFError, gzip.BadGzipFile) as exc:
+            _record(f"trace input error: {type(exc).__name__}: {exc}")
+            eof = True
+            tail = utf8_decoder.decode(b"", final=True)
+            if tail:
+                buf += tail
+            return bool(tail)
+        if not chunk:
+            eof = True
+            tail = utf8_decoder.decode(b"", final=True)
+            if tail:
+                buf += tail
+            return bool(tail)
+        buf += utf8_decoder.decode(chunk, final=False)
+        return True
+
+    def _trim_consumed() -> None:
+        """Discard parsed input once it exceeds one refill chunk."""
+        nonlocal buf, pos
+        if pos > chunk_size:
             buf = buf[pos:]
             pos = 0
+
+    key = '"traceEvents"'
+    search_from = 0
+    while True:
+        key_pos = buf.find(key, search_from)
+        if key_pos < 0:
+            if eof:
+                _record("traceEvents array not found")
+                return
+            if len(buf) >= _MAX_TRACE_PREFIX_CHARS:
+                _record(
+                    f"traceEvents prefix exceeds {_MAX_TRACE_PREFIX_CHARS} characters"
+                )
+                return
+            search_from = max(0, len(buf) - len(key) + 1)
+            _refill(_MAX_TRACE_PREFIX_CHARS - len(buf))
+            continue
+
+        pos = key_pos + len(key)
+        while pos >= len(buf):
+            if eof:
+                break
+            if len(buf) >= _MAX_TRACE_PREFIX_CHARS:
+                _record(
+                    f"traceEvents prefix exceeds {_MAX_TRACE_PREFIX_CHARS} characters"
+                )
+                return
+            _refill(_MAX_TRACE_PREFIX_CHARS - len(buf))
+        while pos < len(buf) and buf[pos] in " \t\r\n":
+            pos += 1
+            if pos == len(buf) and not eof:
+                if len(buf) >= _MAX_TRACE_PREFIX_CHARS:
+                    _record(
+                        "traceEvents prefix exceeds "
+                        f"{_MAX_TRACE_PREFIX_CHARS} characters"
+                    )
+                    return
+                _refill(_MAX_TRACE_PREFIX_CHARS - len(buf))
+        if pos < len(buf) and buf[pos] == ":":
+            break
+        search_from = key_pos + len(key)
+
+    pos += 1
+    while True:
+        while pos < len(buf) and buf[pos] in " \t\r\n":
+            pos += 1
+        if pos < len(buf):
+            break
+        if eof:
+            _record("traceEvents array opener not found")
+            return
+        if len(buf) >= _MAX_TRACE_PREFIX_CHARS:
+            _record(
+                f"traceEvents prefix exceeds {_MAX_TRACE_PREFIX_CHARS} characters"
+            )
+            return
+        _refill(_MAX_TRACE_PREFIX_CHARS - len(buf))
+    if buf[pos] != "[":
+        _record("traceEvents value is not an array")
+        return
+
+    buf = buf[pos + 1 :]
+    pos = 0
+    emitted = 0
+    while True:
+        while True:
+            while pos < len(buf) and buf[pos] in " \t\r\n,":
+                pos += 1
+            if pos < len(buf):
+                break
+            if eof:
+                _record(f"traceEvents array unterminated after {emitted} event(s)")
+                return
+            _trim_consumed()
+            _refill()
+
+        if buf[pos] == "]":
+            return
+
+        if buf[pos] != "{":
+            invalid_start = pos
+            scan = pos
+            curly_depth = 0
+            square_depth = 0
+            in_string = False
+            escaped = False
+            boundary: int | None = None
+            while boundary is None:
+                while scan < len(buf):
+                    char = buf[scan]
+                    if in_string:
+                        if escaped:
+                            escaped = False
+                        elif char == "\\":
+                            escaped = True
+                        elif char == '"':
+                            in_string = False
+                    elif char == '"':
+                        in_string = True
+                    elif char == "{":
+                        curly_depth += 1
+                    elif char == "}":
+                        curly_depth = max(0, curly_depth - 1)
+                    elif char == "[":
+                        square_depth += 1
+                    elif char == "]":
+                        if curly_depth == 0 and square_depth == 0:
+                            boundary = scan
+                            break
+                        square_depth = max(0, square_depth - 1)
+                    elif char == "," and curly_depth == 0 and square_depth == 0:
+                        boundary = scan + 1
+                        break
+                    scan += 1
+                if boundary is not None:
+                    break
+                buffered = len(buf) - invalid_start
+                if buffered >= _MAX_EVENT_CHARS:
+                    _record(
+                        "traceEvents element exceeds "
+                        f"{_MAX_EVENT_CHARS} characters after {emitted} event(s)"
+                    )
+                    return
+                if eof:
+                    _record(
+                        f"traceEvents array unterminated after {emitted} event(s)"
+                    )
+                    return
+                _refill(_MAX_EVENT_CHARS - buffered)
+            _record(
+                f"traceEvents element malformed after {emitted} event(s): "
+                "expected an object"
+            )
+            pos = boundary
+            _trim_consumed()
+            continue
+
+        object_start = pos
+        scan = pos
+        depth = 0
+        in_string = False
+        escaped = False
+        object_end: int | None = None
+        while object_end is None:
+            while scan < len(buf):
+                char = buf[scan]
+                if in_string:
+                    if escaped:
+                        escaped = False
+                    elif char == "\\":
+                        escaped = True
+                    elif char == '"':
+                        in_string = False
+                elif char == '"':
+                    in_string = True
+                elif char == "{":
+                    depth += 1
+                elif char == "}":
+                    depth -= 1
+                    if depth == 0:
+                        object_end = scan + 1
+                        break
+                scan += 1
+            if object_end is not None:
+                break
+            buffered = len(buf) - object_start
+            if buffered >= _MAX_EVENT_CHARS:
+                _record(
+                    f"traceEvents object exceeds {_MAX_EVENT_CHARS} characters "
+                    f"after {emitted} event(s)"
+                )
+                return
+            if eof:
+                _record(
+                    f"traceEvents object truncated after {emitted} event(s): "
+                    "unterminated object"
+                )
+                return
+            _refill(_MAX_EVENT_CHARS - buffered)
+
+        if object_end - object_start > _MAX_EVENT_CHARS:
+            _record(
+                f"traceEvents object exceeds {_MAX_EVENT_CHARS} characters "
+                f"after {emitted} event(s)"
+            )
+            return
+        try:
+            obj, decoded_end = _DECODER.raw_decode(buf, object_start)
+        except json.JSONDecodeError as exc:
+            _record(
+                f"traceEvents object malformed after {emitted} event(s): "
+                f"{exc.msg}"
+            )
+            pos = object_end
+            _trim_consumed()
+            continue
+        if decoded_end != object_end or not isinstance(obj, dict):
+            _record(
+                f"traceEvents object malformed after {emitted} event(s): "
+                "invalid object boundary"
+            )
+            pos = object_end
+            _trim_consumed()
+            continue
+        yield obj
+        emitted += 1
+        pos = object_end
+        _trim_consumed()
 
 
 def _union_ms(intervals: list[tuple[float, float]]) -> float:
@@ -752,10 +978,11 @@ def analyze_trace(
     # their replayed kernels are classified graph-attributed, not (unlinked).
     graph_launch_corrs: set[int] = set()
     event_total = 0
+    stream_errors: list[str] = []
 
     fobj = _open_trace_binary(tf)
     try:
-        for ev in stream_events(fobj):
+        for ev in stream_events(fobj, errors=stream_errors):
             event_total += 1
             cat = ev.get("cat", "")
             if cat == "cuda_runtime":
@@ -846,6 +1073,7 @@ def analyze_trace(
         "status": "ok",
         "trace_file": str(tf),
         "event_total": event_total,
+        "stream_errors": stream_errors,
         "aggregation_scope": scope,
         "analyzed_rank": _rank_of(tf),
         "rank_count": _trace_rank_count(trace_input),

--- a/src/hyperloom/agents/kernel/tools/_llm_source_context.py
+++ b/src/hyperloom/agents/kernel/tools/_llm_source_context.py
@@ -1,0 +1,370 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Runtime context handed to the source-resolution model tiers.
+
+Which file implements a kernel is a question about the *running* configuration,
+not just about file names. The same MoE operator dispatches to different
+implementations under ``--moe-runner-backend triton`` and ``aiter``; a model
+shown only forty lines of each candidate cannot tell those apart. This module
+assembles the four things that actually disambiguate a code path:
+
+* the model's own config (architecture, quantization, expert layout)
+* the serving flags and environment that select a backend
+* the launcher call stack the trace tier already recovered
+* the framework roots in play
+
+Three properties keep this from becoming a liability:
+
+* **Nothing secret leaves.** Both the environment and the serving command line
+  are admitted by explicit allowlists of path-selecting names, never by scanning
+  for interesting keys. The raw command line is never forwarded: it is tokenised
+  and only allowlisted flags survive. Every surviving value is then dropped if
+  its name or its shape looks like a credential.
+* **Nothing large leaves.** Each section is independently truncated, and the
+  whole block is capped, so a big config or a deep stack cannot silently grow
+  the request.
+* **Nothing required.** Every section degrades to omitted. A missing config, an
+  unreadable trace or an absent root list narrows the context rather than
+  failing the tier.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import shlex
+from pathlib import Path
+from typing import Any
+
+#: Config keys that change which kernel implementation runs. The full config is
+#: far larger and mostly irrelevant (tokenizer settings, generation defaults).
+_CONFIG_KEYS = (
+    "architectures",
+    "model_type",
+    "torch_dtype",
+    "quantization_config",
+    "num_experts",
+    "num_local_experts",
+    "n_routed_experts",
+    "num_experts_per_tok",
+    "hidden_size",
+    "intermediate_size",
+    "num_attention_heads",
+    "num_key_value_heads",
+    "head_dim",
+    "num_hidden_layers",
+)
+
+#: Quantization selectors that can change the implementation family. Arbitrary
+#: extension keys are denied because model configs are not a trusted secret
+#: boundary and frequently carry vendor-specific metadata.
+_QUANTIZATION_CONFIG_KEYS = (
+    "activation_dtype",
+    "activation_scheme",
+    "bits",
+    "compute_dtype",
+    "fmt",
+    "format",
+    "group_size",
+    "kv_cache_scheme",
+    "quant_algo",
+    "quant_method",
+    "weight_block_size",
+    "weight_dtype",
+)
+
+#: Environment names that select a code path. Allowlisted by name rather than
+#: filtered by pattern: a denylist would leak whatever nobody thought to add.
+_ENV_ALLOWLIST = (
+    "SGLANG_USE_AITER",
+    "SGLANG_MOE_RUNNER_BACKEND",
+    "SGLANG_ENABLE_TORCH_COMPILE",
+    "SGLANG_ATTENTION_BACKEND",
+    "SGLANG_DISABLE_CUDA_GRAPH",
+    "VLLM_USE_TRITON_FLASH_ATTN",
+    "VLLM_ATTENTION_BACKEND",
+    "HIP_VISIBLE_DEVICES",
+    "TP",
+    "TP_SIZE",
+    "WORLD_SIZE",
+)
+
+#: Serving flags that select which kernel implementation runs. Allowlisted for
+#: the same reason as the environment names: the serving command line also
+#: carries credentials (``--api-key``), file-system layout and user data, none
+#: of which help decide a source path.
+_SERVER_ARG_ALLOWLIST = (
+    "--attention-backend",
+    "--block-size",
+    "--decode-attention-backend",
+    "--disable-cuda-graph",
+    "--dp",
+    "--dp-size",
+    "--dtype",
+    "--enable-aiter-allreduce-fusion",
+    "--enable-dp-attention",
+    "--enable-ep-moe",
+    "--enable-torch-compile",
+    "--ep",
+    "--ep-size",
+    "--kv-cache-dtype",
+    "--moe-runner-backend",
+    "--page-size",
+    "--prefill-attention-backend",
+    "--quantization",
+    "--speculative-algorithm",
+    "--tp",
+    "--tp-size",
+)
+
+#: Belt and braces over the allowlist: never emit a value whose name looks like
+#: a credential, even if it were added above by mistake.
+_SECRET_NAME_RE = re.compile(r"KEY|TOKEN|SECRET|PASSWORD|CRED|AUTH", re.IGNORECASE)
+
+#: The name check cannot see a credential passed as the value of an innocuous
+#: flag, so common credential prefixes and HTTP authorization forms are denied.
+_SECRET_VALUE_RE = re.compile(
+    r"^(?:sk-|ak-|pk-|hf_|ghp_|gho_|github_pat_|xox[baprs]-)"
+    r"|^(?:authorization\s*:|basic(?:\s|$)|bearer(?:\s|$))",
+    re.IGNORECASE,
+)
+
+_MAX_ARG_VALUE_CHARS = 120
+_MAX_CONFIG_LIST_ITEMS = 16
+_MAX_STACK_FRAMES = 8
+_MAX_ROOTS = 12
+_MAX_CONTEXT_CHARS = 6000
+
+#: Selector values are deliberately narrower than general command-line text.
+#: Each comma-separated component is short and uses only backend/dtype syntax.
+_SELECTOR_VALUE_RE = re.compile(
+    r"[A-Za-z0-9][A-Za-z0-9_.-]{0,38}"
+    r"(?:,[A-Za-z0-9][A-Za-z0-9_.-]{0,38})*"
+)
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
+_URL_VALUE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*://|[?@]")
+_JWT_VALUE_RE = re.compile(
+    r"[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+={0,2}"
+)
+_OPAQUE_VALUE_RE = re.compile(r"[A-Za-z0-9+/=_-]{40,}")
+_NON_FINITE_VALUE_RE = re.compile(r"(?:nan|[+-]?inf(?:inity)?)", re.IGNORECASE)
+
+
+def _redact(name: str, value: Any) -> str | None:
+    """Return a safe selector value for ``name``, or None when it must not leave."""
+    if _SECRET_NAME_RE.search(name):
+        return None
+    raw = str(value)
+    if _CONTROL_CHAR_RE.search(raw):
+        return None
+    text = raw.strip()
+    if (
+        not text
+        or len(text) > _MAX_ARG_VALUE_CHARS
+        or _SECRET_VALUE_RE.search(text)
+        or _URL_VALUE_RE.search(text)
+        or _JWT_VALUE_RE.fullmatch(text)
+        or _OPAQUE_VALUE_RE.fullmatch(text)
+        or _NON_FINITE_VALUE_RE.fullmatch(text)
+        or not _SELECTOR_VALUE_RE.fullmatch(text)
+    ):
+        return None
+    return text[:_MAX_ARG_VALUE_CHARS]
+
+
+def _clean_config_value(name: str, value: Any) -> Any | None:
+    """Bound and redact one allowlisted model-config value."""
+    if isinstance(value, bool | int):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, str):
+        return _redact(name, value)
+    if isinstance(value, list):
+        cleaned = []
+        for item in value[:_MAX_CONFIG_LIST_ITEMS]:
+            scalar = _clean_config_value(name, item)
+            if scalar is not None and not isinstance(scalar, (dict, list)):
+                cleaned.append(scalar)
+        return cleaned or None
+    return None
+
+
+def _clean_quantization_config(value: Any) -> dict[str, Any] | None:
+    """Keep only bounded, non-secret quantization selectors."""
+    if not isinstance(value, dict):
+        return None
+    cleaned: dict[str, Any] = {}
+    for key in _QUANTIZATION_CONFIG_KEYS:
+        if key not in value:
+            continue
+        selected = _clean_config_value(key, value[key])
+        if selected is not None:
+            cleaned[key] = selected
+    return cleaned or None
+
+
+def server_arg_flags(server_args: str | None) -> dict[str, Any]:
+    """Reduce a serving command line to its allowlisted backend selectors.
+
+    The raw string is never emitted. It is tokenised, and only flags named in
+    :data:`_SERVER_ARG_ALLOWLIST` survive -- with their values still subject to
+    :func:`_redact`, since an allowlisted flag can carry a credential-shaped
+    value. A denied flag consumes its value too, so the value cannot reappear
+    later as a bare token.
+
+    Args:
+        server_args: The serving command line, or None.
+
+    Returns:
+        Flag name (without leading dashes) to value; ``True`` for bare flags.
+    """
+    if not server_args:
+        return {}
+    if _CONTROL_CHAR_RE.search(str(server_args)):
+        return {}
+    try:
+        tokens = shlex.split(str(server_args))
+    except ValueError:
+        # An unbalanced quote means we cannot tell flags from values; emitting
+        # a partial parse of an unparseable line risks leaking a fragment.
+        return {}
+    out: dict[str, Any] = {}
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        index += 1
+        if not token.startswith("--"):
+            continue
+        flag, sep, inline = token.partition("=")
+        has_value = bool(sep)
+        value: Any = inline
+        if not has_value and index < len(tokens) and not tokens[index].startswith("--"):
+            value = tokens[index]
+            has_value = True
+            index += 1
+        if flag not in _SERVER_ARG_ALLOWLIST:
+            continue
+        if not has_value:
+            out[flag.lstrip("-")] = True
+            continue
+        emitted = _redact(flag, value)
+        if emitted is not None:
+            out[flag.lstrip("-")] = emitted
+    return out
+
+
+def model_config_summary(model_path: str | Path | None) -> dict[str, Any]:
+    """Pull the path-selecting fields out of a model's config.json."""
+    if not model_path:
+        return {}
+    cfg = Path(model_path) / "config.json"
+    try:
+        raw = json.loads(cfg.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for key in _CONFIG_KEYS:
+        if key not in raw:
+            continue
+        value = raw[key]
+        if key == "quantization_config":
+            value = _clean_quantization_config(value)
+        else:
+            value = _clean_config_value(key, value)
+        if value is not None:
+            out[key] = value
+    return out
+
+
+def runtime_flags(
+    server_args: str | None = None,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Collect the serving flags and allowlisted environment that pick a path."""
+    out: dict[str, Any] = {}
+    flags = server_arg_flags(server_args)
+    if flags:
+        out["server_args"] = flags
+    source = env if env is not None else os.environ
+    picked: dict[str, str] = {}
+    for name in _ENV_ALLOWLIST:
+        if name not in source:
+            continue
+        value = _redact(name, source[name])
+        if value is not None:
+            picked[name] = value
+    if picked:
+        out["env"] = picked
+    return out
+
+
+def launcher_stack(entry: dict[str, Any]) -> list[str]:
+    """The call-site frames the trace tier recovered for one candidate."""
+    frames = entry.get("launcher_frames")
+    if isinstance(frames, list) and frames:
+        return [str(f) for f in frames[:_MAX_STACK_FRAMES] if str(f).strip()]
+    # The single resolved frame is still a call site worth showing.
+    src = str(entry.get("source_file") or "").strip()
+    line = entry.get("source_line")
+    func = str(entry.get("source_function") or "").strip()
+    if src and line and func:
+        return [f"{src}({line}): {func}"]
+    return []
+
+
+def build_context_block(
+    *,
+    model_path: str | Path | None = None,
+    server_args: str | None = None,
+    framework_roots: tuple[str, ...] = (),
+    env: dict[str, str] | None = None,
+    framework: str | None = None,
+    precision: str | None = None,
+) -> str:
+    """Render the shared runtime context, or "" when nothing is available.
+
+    Returned as text rather than a dict because both tiers embed it in a prompt,
+    and a single rendering keeps them from drifting apart.
+    """
+    sections: list[str] = []
+
+    selection = {
+        name: cleaned
+        for name, value in (("framework", framework), ("precision", precision))
+        if value is not None and (cleaned := _redact(name, value)) is not None
+    }
+    if selection:
+        sections.append(
+            "Runtime selection:\n" + json.dumps(selection, indent=2)
+        )
+
+    cfg = model_config_summary(model_path)
+    if cfg:
+        sections.append("Model config (selected fields):\n" + json.dumps(cfg, indent=2))
+
+    flags = runtime_flags(server_args, env)
+    if flags:
+        sections.append("Serving configuration:\n" + json.dumps(flags, indent=2))
+
+    roots = [str(r) for r in framework_roots if str(r).strip()][:_MAX_ROOTS]
+    if roots:
+        sections.append("Framework roots in play:\n" + "\n".join(f"- {r}" for r in roots))
+
+    if not sections:
+        return ""
+    block = (
+        "Runtime context -- use this to decide which implementation a kernel "
+        "actually reaches. A backend flag or a quantization format often "
+        "distinguishes two same-named candidates.\n\n" + "\n\n".join(sections)
+    )
+    return block[:_MAX_CONTEXT_CHARS]

--- a/src/hyperloom/agents/kernel/tools/_llm_source_fallback.py
+++ b/src/hyperloom/agents/kernel/tools/_llm_source_fallback.py
@@ -1,0 +1,548 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Last-resort semantic pick of a kernel's source file, from a fixed shortlist.
+
+This is the final tier of source resolution, behind the curated dictionary, the
+trace-derived launcher, and the name grep. It exists for models or frameworks
+where all three come up empty -- not for any case seen so far.
+
+Two properties keep it from becoming another source of nondeterminism, which
+matters because an unresolved-launcher sentinel produced by an LLM is what broke
+this pipeline in the first place:
+
+* **Selection, never generation.** The model receives a shortlist gathered by a
+  relaxed grep and may only return one of those exact strings. A path it invents
+  is rejected outright.
+* **Last in line.** It sees a candidate only after the curated dictionary, the
+  trace-derived launcher and the grep have all come up empty, and only when the
+  kernel is worth at least 5% of GPU time.
+
+Every accepted answer is stamped ``source_resolution_method="llm_fallback"`` so
+it can be audited apart from deterministic resolutions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import os
+import re
+from typing import Any, Callable
+from urllib.parse import urlsplit
+
+try:
+    from hyperloom.common import kernel_source_contract as _KSC
+except ImportError:  # pragma: no cover - standalone invocation
+    _KSC = None  # type: ignore[assignment]
+
+# An answer below this confidence is discarded: a coin-flip pick would send a
+# backend at the wrong file and burn a whole optimization attempt.
+_MIN_CONFIDENCE = 0.7
+
+# Head of each shortlisted file shown to the model; enough to tell a kernel
+# definition from a test or a dispatch shim.
+_PREVIEW_LINES = 40
+_PREVIEW_CHARS = 2000
+
+# Shipping those heads sends repository source to the model provider. That is an
+# operator's data-egress decision, not a default this tier may assume, so the
+# preview is off unless explicitly authorised. Without it the tiers still see
+# the candidate paths, which carry most of the signal.
+_PREVIEW_ENV = "HYPERLOOM_LLM_SOURCE_PREVIEW"
+_PROVIDER_ENV = "HYPERLOOM_LLM_SOURCE_PROVIDER"
+_MODEL_ENV = "HYPERLOOM_LLM_SOURCE_MODEL"
+
+_PROVIDER_CLAUDE = "claude_agent_sdk"
+_PROVIDER_OPENAI = "openai_compatible"
+_PROVIDER_ALIASES = {
+    "anthropic": _PROVIDER_CLAUDE,
+    "claude": _PROVIDER_CLAUDE,
+    "claude-agent-sdk": _PROVIDER_CLAUDE,
+    "claude_agent_sdk": _PROVIDER_CLAUDE,
+    "openai": _PROVIDER_OPENAI,
+    "openai-compatible": _PROVIDER_OPENAI,
+    "openai_compatible": _PROVIDER_OPENAI,
+}
+
+# Claude Code must behave as a plain completion client in this tier. Explicitly
+# denying every built-in tool prevents a source-resolution request from reading
+# anything beyond the prompt assembled under the egress policy above.
+_CLAUDE_DISALLOWED_TOOLS = (
+    "Bash",
+    "BashOutput",
+    "KillShell",
+    "Read",
+    "Write",
+    "Edit",
+    "NotebookEdit",
+    "Glob",
+    "Grep",
+    "Agent",
+    "Task",
+    "TaskOutput",
+    "TaskStop",
+    "WebFetch",
+    "WebSearch",
+    "TodoWrite",
+    "AskUserQuestion",
+    "EnterPlanMode",
+    "ExitPlanMode",
+    "Skill",
+    "SlashCommand",
+)
+
+_DEFAULT_TIMEOUT_SEC = 60.0
+
+_JSON_BLOCK_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+_SYSTEM_PROMPT = (
+    "You identify which source file implements a GPU kernel. "
+    "You are given the kernel symbol and a shortlist of candidate files. "
+    "Choose the file that DEFINES the kernel body. Reject files that merely "
+    "call it, test it, or dispatch to it, and reject a CPU implementation when "
+    "the kernel runs on GPU. "
+    'Answer with JSON only: {"source_file": "<one of the candidates, verbatim>", '
+    '"confidence": <0..1>, "reason": "<one sentence>"}. '
+    'If none of the candidates defines the kernel, return "source_file": "".'
+)
+
+
+def _default_claude_model() -> str:
+    """The project-wide default Claude model, or "" when it cannot be read.
+
+    Deliberately without a hardcoded fallback id: a pinned default here would
+    go stale the moment the project moves (it already outlived claude-opus-4-8),
+    and a tier quietly running an older model than the rest of the pipeline is
+    worse than one that declines to run. An empty result is reported as a
+    resolution failure by the caller rather than guessing.
+    """
+    try:
+        from hyperloom.orchestrator.roles.agent_role import (  # noqa: PLC0415
+            DEFAULT_CLAUDE_MODEL,
+        )
+    except Exception:  # noqa: BLE001 - tools also run outside the package
+        return ""
+    return str(DEFAULT_CLAUDE_MODEL or "")
+
+
+def _resolve_provider(provider: str = "") -> str:
+    """Resolve the explicitly configured source-resolution provider."""
+    raw = str(provider or os.environ.get(_PROVIDER_ENV) or "").strip().lower()
+    resolved = _PROVIDER_ALIASES.get(raw)
+    if resolved:
+        return resolved
+    supported = "claude_agent_sdk, openai_compatible"
+    if not raw:
+        raise RuntimeError(f"{_PROVIDER_ENV} is not set; choose one of: {supported}")
+    raise RuntimeError(f"unsupported {_PROVIDER_ENV}={raw!r}; choose one of: {supported}")
+
+
+def _resolve_model(model: str = "", provider: str = "") -> str:
+    """Resolve a model without borrowing another provider's model setting."""
+    explicit = str(model or os.environ.get(_MODEL_ENV) or "").strip()
+    if explicit:
+        return explicit
+    if provider == _PROVIDER_OPENAI:
+        return str(os.environ.get("OPENAI_MODEL") or os.environ.get("CODEX_MODEL") or "").strip()
+    return str(os.environ.get("CLAUDE_MODEL") or _default_claude_model()).strip()
+
+
+def _endpoint_host(provider: str) -> str:
+    """Return a credential-free endpoint identifier for artifact auditing."""
+    if provider == _PROVIDER_OPENAI:
+        raw = str(os.environ.get("OPENAI_BASE_URL") or "").strip()
+        default = "api.openai.com"
+    else:
+        raw = str(
+            os.environ.get("ANTHROPIC_BASE_URL") or os.environ.get("DEEPSEEK_BASE_URL") or ""
+        ).strip()
+        default = "provider-default"
+    if not raw:
+        return default
+    return urlsplit(raw).hostname or "configured"
+
+
+def llm_source_provider_configured() -> bool:
+    """Whether an explicit source-resolution provider is selected.
+
+    Lets a caller skip the work it would only do in order to build a request --
+    the shortlist grep walks every framework root -- when no provider is
+    configured and the call would be declined anyway.
+    """
+    try:
+        _resolve_provider()
+    except RuntimeError:
+        return False
+    return True
+
+
+def llm_source_audit(*, provider: str = "", model: str = "") -> dict[str, Any]:
+    """Return non-secret provider metadata suitable for an audit artifact."""
+    try:
+        selected_provider = _resolve_provider(provider)
+    except RuntimeError:
+        return {
+            "provider": "unconfigured",
+            "model": str(model or os.environ.get(_MODEL_ENV) or "").strip(),
+            "endpoint_host": "",
+            "source_preview_authorised": source_preview_authorised(),
+        }
+    return {
+        "provider": selected_provider,
+        "model": _resolve_model(model, selected_provider),
+        "endpoint_host": _endpoint_host(selected_provider),
+        "source_preview_authorised": source_preview_authorised(),
+    }
+
+
+def source_preview_authorised() -> bool:
+    """Whether the operator opted into sending file heads to the model."""
+    return str(os.environ.get(_PREVIEW_ENV, "")).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _preview(path: str) -> str:
+    """First lines of ``path``, for telling an implementation from a shim."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            head = "".join(next(fh, "") for _ in range(_PREVIEW_LINES))
+    except OSError:
+        return "<unreadable>"
+    return head[:_PREVIEW_CHARS]
+
+
+def _canonical_candidates(
+    candidates: list[str],
+    framework_roots: tuple[str, ...],
+    *,
+    require_roots: bool = True,
+) -> dict[str, str]:
+    """Map candidates to canonical targets after filesystem validation."""
+    canonical: dict[str, str] = {}
+    for path in candidates:
+        if require_roots:
+            target = _KSC.canonical_source_path(path, framework_roots) if _KSC else ""
+        else:
+            bare = _KSC.strip_line_suffix(path) if _KSC else path
+            target = os.path.realpath(bare) if bare and os.path.isfile(bare) else ""
+        if target:
+            canonical[path] = target
+    return canonical
+
+
+def _build_prompt_with_targets(
+    kernel_name: str,
+    candidates: list[str],
+    context_block: str = "",
+    with_preview: bool | None = None,
+    *,
+    framework_roots: tuple[str, ...] = (),
+) -> tuple[str, dict[str, str]]:
+    """Render the prompt and return its prevalidated canonical targets."""
+    if with_preview is None:
+        with_preview = source_preview_authorised()
+    canonical_paths = _canonical_candidates(
+        candidates,
+        framework_roots,
+        require_roots=bool(framework_roots),
+    )
+    preview_paths = canonical_paths if framework_roots else {}
+    parts = []
+    if context_block:
+        parts.append(context_block + "\n")
+    parts += [f"Kernel symbol: {kernel_name}", "", "Candidates:"]
+    for index, path in enumerate(candidates, 1):
+        canonical = preview_paths.get(path, "")
+        if with_preview and canonical:
+            parts.append(f"\n[{index}] {path}\n```\n{_preview(canonical)}\n```")
+        else:
+            parts.append(f"\n[{index}] {path}")
+    return "\n".join(parts), canonical_paths
+
+
+def _build_prompt(
+    kernel_name: str,
+    candidates: list[str],
+    context_block: str = "",
+    with_preview: bool | None = None,
+    *,
+    framework_roots: tuple[str, ...] = (),
+) -> str:
+    """Render the shortlist, with validated previews when authorised."""
+    prompt, _ = _build_prompt_with_targets(
+        kernel_name,
+        candidates,
+        context_block,
+        with_preview,
+        framework_roots=framework_roots,
+    )
+    return prompt
+
+
+def _parse_answer(text: str) -> tuple[bool, str, float, str]:
+    """Extract ``(parsed, source_file, confidence, reason)`` from a model reply.
+
+    ``parsed`` separates "the reply was unreadable" from "the model answered that
+    no candidate fits". Collapsing the two would report a malformed reply as a
+    considered verdict and send triage the wrong way.
+    """
+    if not isinstance(text, str):
+        return False, "", 0.0, "reply is not text"
+    match = _JSON_BLOCK_RE.search(text or "")
+    if not match:
+        return False, "", 0.0, "no JSON object in reply"
+    try:
+        payload = json.loads(match.group(0))
+    except (TypeError, ValueError):
+        return False, "", 0.0, "unparseable JSON"
+    if not isinstance(payload, dict):
+        return False, "", 0.0, "JSON payload is not an object"
+    try:
+        confidence = float(payload.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        return False, "", 0.0, "confidence is not numeric"
+    if not math.isfinite(confidence) or not 0.0 <= confidence <= 1.0:
+        return False, "", 0.0, "confidence must be finite and in [0, 1]"
+    return (
+        True,
+        str(payload.get("source_file") or "").strip(),
+        confidence,
+        str(payload.get("reason") or "").strip(),
+    )
+
+
+def _validate(
+    picked: str,
+    candidates: list[str],
+    canonical_paths: dict[str, str],
+    framework_roots: tuple[str, ...],
+) -> tuple[str, str]:
+    """Return the prevalidated canonical pick and any rejection reason."""
+    if not picked:
+        return "", "model reported no candidate defines the kernel"
+    if picked not in candidates:
+        # The whole point of a shortlist is that the answer comes from it.
+        return "", f"path is not one of the candidates: {picked!r}"
+    canonical = canonical_paths.get(picked, "")
+    if canonical:
+        return canonical, ""
+    if framework_roots:
+        return "", f"path does not exist or is outside every framework root: {picked!r}"
+    return "", f"path does not exist: {picked!r}"
+
+
+def _safe_exception_label(exc: BaseException) -> str:
+    """Return a stable exception type and optional non-secret error code."""
+    label = type(exc).__name__
+    for attribute in ("status_code", "code", "errno"):
+        try:
+            value = getattr(exc, attribute, None)
+        except Exception:  # noqa: BLE001 - hostile exception properties stay private
+            continue
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            return f"{label} ({attribute}={value})"
+        if isinstance(value, str) and re.fullmatch(r"[A-Za-z0-9_.-]{1,64}", value):
+            return f"{label} ({attribute}={value})"
+    return label
+
+
+def _complete_openai(prompt: str, model: str, timeout_sec: float) -> str:
+    """Run one completion against the configured OpenAI-compatible endpoint."""
+    from openai import OpenAI  # noqa: PLC0415 - optional dependency
+
+    from hyperloom.common.llm_config import openai_client_kwargs  # noqa: PLC0415
+
+    client = OpenAI(**openai_client_kwargs())
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ],
+        temperature=0.0,
+        timeout=timeout_sec,
+    )
+    return str(response.choices[0].message.content or "")
+
+
+def _message_text(message: Any) -> list[str]:
+    """Extract text fragments from one Claude SDK message."""
+    if isinstance(message, str):
+        return [message]
+    text = getattr(message, "text", None)
+    if isinstance(text, str):
+        return [text]
+    parts: list[str] = []
+    content = getattr(message, "content", None)
+    if isinstance(content, list):
+        for block in content:
+            block_text = block.get("text") if isinstance(block, dict) else getattr(block, "text", None)
+            if isinstance(block_text, str):
+                parts.append(block_text)
+    return parts
+
+
+def _complete_claude_sdk(prompt: str, model: str, timeout_sec: float) -> str:
+    """Run one tool-free completion through the native Claude Agent SDK."""
+    try:
+        import claude_agent_sdk as sdk  # type: ignore[import-not-found]  # noqa: PLC0415
+    except ImportError as exc:
+        raise RuntimeError("claude_agent_sdk is not installed") from exc
+    if not (hasattr(sdk, "query") and hasattr(sdk, "ClaudeAgentOptions")):
+        raise RuntimeError("claude_agent_sdk missing query / ClaudeAgentOptions")
+
+    from hyperloom.common.llm_config import claude_sdk_env_options  # noqa: PLC0415
+
+    kwargs: dict[str, Any] = dict(claude_sdk_env_options(model=model))
+    kwargs.update(
+        {
+            "model": model,
+            "system_prompt": _SYSTEM_PROMPT,
+            "tools": [],
+            "setting_sources": [],
+            "skills": [],
+            "strict_mcp_config": True,
+            "mcp_servers": {},
+            "plugins": [],
+            "max_turns": 1,
+            "allowed_tools": [],
+            "disallowed_tools": list(_CLAUDE_DISALLOWED_TOOLS),
+        }
+    )
+    options = sdk.ClaudeAgentOptions(**kwargs)
+
+    async def _drive() -> str:
+        """Collect the final result, falling back to streamed text blocks."""
+        final = ""
+        chunks: list[str] = []
+        async for message in sdk.query(prompt=prompt, options=options):
+            result = getattr(message, "result", None)
+            if isinstance(result, str) and result.strip():
+                final = result
+                continue
+            chunks.extend(_message_text(message))
+        return final.strip() or "".join(chunks).strip()
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(asyncio.wait_for(_drive(), timeout=max(0.1, float(timeout_sec))))
+    raise RuntimeError("claude_agent_sdk completion cannot run inside an active event loop")
+
+
+def _complete(prompt: str, model: str, timeout_sec: float) -> str:
+    """Route one completion through the explicitly selected native provider."""
+    provider = _resolve_provider()
+    if provider == _PROVIDER_CLAUDE:
+        return _complete_claude_sdk(prompt, model, timeout_sec)
+    return _complete_openai(prompt, model, timeout_sec)
+
+
+def select_source_via_llm(
+    kernel_name: str,
+    candidates: list[str],
+    *,
+    framework_roots: tuple[str, ...] = (),
+    model: str = "",
+    timeout_sec: float = _DEFAULT_TIMEOUT_SEC,
+    context_block: str = "",
+    log: Callable[[str], None] | None = None,
+    complete: Callable[[str, str, float], str] | None = None,
+    errors: list[str] | None = None,
+) -> tuple[str, float, str]:
+    """Pick the file that defines ``kernel_name`` from ``candidates``.
+
+    Args:
+        kernel_name: The kernel symbol being resolved.
+        candidates: Shortlist of on-disk paths from the relaxed grep. An empty
+            list short-circuits: with nothing to choose from there is nothing to
+            ask, and inventing a path is not allowed.
+        framework_roots: Accepted path roots; a pick outside them is rejected.
+        model: Chat model; defaults to ``$HYPERLOOM_LLM_SOURCE_MODEL``, then
+            the selected provider's model setting.
+        timeout_sec: Per-call ceiling. There is no retry -- a failure here is
+            advisory and the candidate simply stays unresolved.
+        log: Optional ``callable(str)`` for diagnostics.
+        complete: Injection point for the completion call (tests).
+        errors: Optional output list for configuration, transport and parsing
+            failures. A valid model refusal does not append to it.
+
+    Returns:
+        ``(source_file, confidence, reason)``; ``source_file`` is ``""`` on any
+        failure, including a low-confidence answer.
+    """
+    def _say(message: str) -> None:
+        if callable(log):
+            log(f"llm_source_fallback: {message}")
+
+    if not kernel_name or not candidates:
+        return "", 0.0, "no candidates to choose from"
+
+    shortlist = [str(c) for c in candidates if str(c).strip()]
+    caller = complete or _complete
+    try:
+        provider = _resolve_provider() if complete is None else ""
+        chosen_model = _resolve_model(model, provider)
+    except RuntimeError as exc:
+        detail = _safe_exception_label(exc)
+        _say(f"configuration failed: {detail}")
+        reason = f"llm configuration failed: {detail}"
+        if errors is not None:
+            errors.append(reason)
+        return "", 0.0, reason
+    if not chosen_model:
+        _say(f"no model configured; set ${_MODEL_ENV}")
+        reason = "no model configured"
+        if errors is not None:
+            errors.append(reason)
+        return "", 0.0, reason
+    try:
+        prompt, canonical_paths = _build_prompt_with_targets(
+            kernel_name,
+            shortlist,
+            context_block,
+            framework_roots=framework_roots,
+        )
+        reply = caller(
+            prompt,
+            chosen_model,
+            timeout_sec,
+        )
+    except Exception as exc:  # noqa: BLE001 - advisory tier, never fatal
+        detail = _safe_exception_label(exc)
+        _say(f"call failed: {detail}")
+        reason = f"llm call failed: {detail}"
+        if errors is not None:
+            errors.append(reason)
+        return "", 0.0, reason
+
+    parsed, picked, confidence, reason = _parse_answer(reply)
+    if not parsed:
+        _say(f"rejected: {reason}")
+        if errors is not None:
+            errors.append(reason)
+        return "", 0.0, reason
+    canonical, why = _validate(picked, shortlist, canonical_paths, framework_roots)
+    if not canonical:
+        _say(f"rejected: {why}")
+        return "", confidence, why
+    if confidence < _MIN_CONFIDENCE:
+        _say(f"rejected: confidence {confidence:.2f} < {_MIN_CONFIDENCE}")
+        return "", confidence, f"confidence {confidence:.2f} below {_MIN_CONFIDENCE}"
+
+    _say(f"accepted {canonical} (confidence={confidence:.2f})")
+    return canonical, confidence, reason
+
+
+__all__ = [
+    "llm_source_audit",
+    "llm_source_provider_configured",
+    "select_source_via_llm",
+]

--- a/src/hyperloom/agents/kernel/tools/_llm_source_review.py
+++ b/src/hyperloom/agents/kernel/tools/_llm_source_review.py
@@ -1,0 +1,398 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Model review of an already-produced source-resolution artifact.
+
+The deterministic tiers fail in a way that a fallback cannot catch: they do not
+come up empty, they come up *confidently wrong*. Measured over historical
+sessions, only 59% of verifiable resolutions actually mention the kernel they
+claim to define, and ``aten::fill_`` alone has been resolved to four unrelated
+business files -- every one of them a real, existing, root-resident source file
+that passes every mechanical check. A tier gated on "source_file is empty"
+never sees any of those.
+
+So this tier reviews *every* entry rather than only the blanks, and may rewrite
+a location the deterministic tiers already filled in.
+
+Two properties keep the added freedom from becoming a new failure mode:
+
+* **Nothing is taken on faith.** A rewritten path must exist on disk or sit
+  under a known framework root (:func:`path_is_acceptable`). This does not
+  check correctness -- it stops an invented path from being written.
+* **Nothing is destroyed.** Every revision keeps ``previous_source_file`` and
+  ``previous_method``, so a bad review is auditable and reversible.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from typing import Any, Callable
+
+from _llm_source_context import launcher_stack
+from _llm_source_fallback import (
+    _complete,
+    _preview,
+    _resolve_model,
+    _resolve_provider,
+    _safe_exception_label,
+    llm_source_audit,
+    source_preview_authorised,
+)
+
+try:
+    from hyperloom.common import kernel_source_contract as _KSC
+except ImportError:  # pragma: no cover - standalone invocation
+    _KSC = None  # type: ignore[assignment]
+
+#: Reviewing a long tail of sub-percent kernels costs tokens and changes
+#: nothing anyone will act on.
+_DEFAULT_MIN_GPU_PCT = 1.0
+
+#: Cap on entries per request, so one call stays within a sane context.
+_DEFAULT_MAX_ENTRIES = 40
+
+_DEFAULT_TIMEOUT_SEC = 180.0
+
+_JSON_BLOCK_RE = re.compile(r"\{[\s\S]*\}")
+
+_ACTION_KEEP = "keep"
+_ACTION_REWRITE = "rewrite"
+_ACTION_UNRESOLVE = "unresolve"
+_ACTIONS = frozenset({_ACTION_KEEP, _ACTION_REWRITE, _ACTION_UNRESOLVE})
+
+_PROMPT_HEADER = """\
+You are auditing an automated mapping from GPU kernel symbols to the source
+file that defines each kernel. The mapping was produced by heuristics that are
+known to fail in a specific way: when a kernel has no source of its own (a
+PyTorch built-in such as aten::fill_, or a bare launch API), the heuristic
+often attributes it to whichever business file happened to call it. Such an
+entry looks perfectly plausible -- the path exists and holds real code -- but
+the file does not define that kernel.
+
+For each entry decide one of:
+  keep       the file plausibly defines this kernel
+  rewrite    the file is wrong and you know a better path
+  unresolve  this kernel has no single defining source file, or the current
+             path is wrong and you do not know the right one
+
+Prefer "unresolve" over a guess. A wrong path costs an entire optimization
+attempt; an empty one just falls through.
+
+Reply with JSON only:
+{"revisions": [{"kernel_id": "...", "action": "keep|rewrite|unresolve",
+                "source_file": "...", "reason": "..."}]}
+"source_file" is required for "rewrite" and ignored otherwise. Include every
+entry you were given.
+"""
+
+
+def _gpu_pct(entry: dict[str, Any]) -> float:
+    """GPU share of one entry, treating an unreadable value as zero.
+
+    Ranking and the floor both read this. Letting a malformed value raise would
+    escape into the caller's blanket handler and switch the whole tier off for
+    the run, so one bad row would cost every other row its review.
+    """
+    try:
+        return float(entry.get("gpu_pct") or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _entry_block(
+    entry: dict[str, Any],
+    with_preview: bool,
+    framework_roots: tuple[str, ...],
+) -> str:
+    """Render one entry, with a head of its current file when readable."""
+    src = str(entry.get("source_file") or "")
+    lines = [
+        f"kernel_id: {entry.get('kernel_id')}",
+        f"symbol: {entry.get('name')}",
+        f"gpu_pct: {entry.get('gpu_pct')}",
+        f"current_source_file: {src or '(unresolved)'}",
+        f"resolved_by: {entry.get('method')}",
+    ]
+    stack = launcher_stack(entry)
+    if stack:
+        # The call site is often the only thing separating a kernel from the
+        # business file that merely calls it.
+        lines.append("launcher_stack:\n" + "\n".join(f"  {f}" for f in stack))
+    bare = _KSC.strip_line_suffix(src) if _KSC else src
+    canonical = (
+        _KSC.canonical_source_path(bare, framework_roots)
+        if with_preview and bare and _KSC
+        else ""
+    )
+    if canonical:
+        lines.append(f"file_head:\n```\n{_preview(canonical)}\n```")
+    return "\n".join(lines)
+
+
+def build_review_prompt(
+    entries: list[dict[str, Any]],
+    *,
+    with_preview: bool | None = None,
+    context_block: str = "",
+    framework_roots: tuple[str, ...] = (),
+) -> str:
+    """Render the review request for ``entries``.
+
+    ``with_preview`` defaults to the operator's egress decision (see
+    :func:`source_preview_authorised`) rather than to True, so repository source
+    is never shipped to the provider by omission.
+    """
+    if with_preview is None:
+        with_preview = source_preview_authorised()
+    head = _PROMPT_HEADER
+    if context_block:
+        head = f"{head}\n{context_block}\n"
+    blocks = [_entry_block(e, with_preview, framework_roots) for e in entries]
+    return head + "\nEntries:\n\n" + "\n\n---\n\n".join(blocks)
+
+
+def parse_revisions(text: str) -> tuple[bool, list[dict[str, Any]], str]:
+    """Extract ``(parsed, revisions, error)`` from a model reply.
+
+    ``parsed`` distinguishes an unreadable reply from a reply that revised
+    nothing; conflating them would report a broken call as a clean audit.
+    """
+    if not isinstance(text, str):
+        return False, [], "reply is not text"
+    match = _JSON_BLOCK_RE.search(text or "")
+    if not match:
+        return False, [], "no JSON object in reply"
+    try:
+        payload = json.loads(match.group(0))
+    except (TypeError, ValueError):
+        return False, [], "unparseable JSON"
+    if not isinstance(payload, dict):
+        return False, [], "JSON payload is not an object"
+    revisions = payload.get("revisions")
+    if not isinstance(revisions, list):
+        return False, [], "payload has no 'revisions' list"
+    out = [r for r in revisions if isinstance(r, dict)]
+    return True, out, ""
+
+
+def _apply_revision(
+    entry: dict[str, Any],
+    revision: dict[str, Any],
+    roots: tuple[str, ...],
+) -> str:
+    """Apply one revision in place; return a note describing what happened."""
+    action = str(revision.get("action") or "").strip().lower()
+    reason = str(revision.get("reason") or "").strip()
+    if action not in _ACTIONS:
+        return f"{entry.get('kernel_id')}: ignored unknown action {action!r}"
+    if action == _ACTION_KEEP:
+        return ""
+    previous_file = str(entry.get("source_file") or "")
+    previous_method = str(entry.get("method") or "")
+
+    if action == _ACTION_UNRESOLVE:
+        if not previous_file:
+            return ""
+        entry["previous_source_file"] = previous_file
+        entry["previous_method"] = previous_method
+        entry["source_file"] = ""
+        entry["source_line"] = None
+        entry["source_function"] = ""
+        entry["method"] = _KSC.METHOD_UNRESOLVED if _KSC else "unresolved"
+        entry["reason"] = f"llm_review unresolved: {reason or 'no defining source'}"
+        return f"{entry.get('kernel_id')}: unresolved (was {previous_file})"
+
+    picked_raw = str(revision.get("source_file") or "").strip()
+    if not picked_raw:
+        return f"{entry.get('kernel_id')}: rewrite without a path, ignored"
+    if _KSC is None:
+        # The mechanical floor lives in the contract module. Without it a
+        # rewrite cannot be verified at all, and writing an unverifiable path is
+        # the failure this tier exists to prevent -- so an unusable guard denies
+        # the rewrite instead of waving it through.
+        return f"{entry.get('kernel_id')}: rejected rewrite, path contract unavailable"
+    picked, source_line, source_function = _KSC.split_line_suffix(picked_raw)
+    previous_bare = _KSC.strip_line_suffix(previous_file)
+    if picked == previous_bare:
+        return ""
+    # The mechanical floor: a rewrite may not conjure a location. This is not a
+    # correctness check, only a guard against invention.
+    canonical = _KSC.canonical_source_path(picked, roots)
+    if not canonical:
+        return f"{entry.get('kernel_id')}: rejected unverifiable path {picked_raw!r}"
+    if canonical == previous_bare:
+        return ""
+    entry["previous_source_file"] = previous_file
+    entry["previous_method"] = previous_method
+    entry["source_file"] = canonical
+    entry["source_line"] = source_line
+    entry["source_function"] = source_function
+    entry["method"] = _KSC.METHOD_LLM
+    entry["reason"] = f"llm_review rewrote: {reason or 'no reason given'}"
+    return f"{entry.get('kernel_id')}: {previous_file or '(none)'} -> {canonical}"
+
+
+def review_resolution_document(
+    doc: dict[str, Any],
+    *,
+    framework_roots: tuple[str, ...] = (),
+    min_gpu_pct: float = _DEFAULT_MIN_GPU_PCT,
+    max_entries: int = _DEFAULT_MAX_ENTRIES,
+    model: str | None = None,
+    timeout_sec: float = _DEFAULT_TIMEOUT_SEC,
+    context_block: str = "",
+    log: Callable[[str], None] | None = None,
+    complete: Callable[[str, str, float], str] | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Review and possibly revise the resolution table in ``doc``.
+
+    Args:
+        doc: A source-resolution document; revised in place and returned.
+        framework_roots: Roots a rewritten path may live under when it does not
+            exist on this host.
+        min_gpu_pct: Entries below this GPU share are not worth a review.
+        max_entries: Hardest-hitting N entries reviewed in one call.
+        model: Chat model; defaults to ``$HYPERLOOM_LLM_SOURCE_MODEL``, then
+            the selected provider's model setting.
+        timeout_sec: Per-call ceiling; there is no retry.
+        log: Optional ``callable(str)`` for diagnostics.
+        complete: Injection point for the completion call (tests).
+
+    Returns:
+        ``(doc, notes)``; ``notes`` records every applied and rejected revision.
+    """
+
+    def _say(message: str) -> None:
+        if callable(log):
+            log(f"llm_source_review: {message}")
+
+    entries = doc.get("entries") if isinstance(doc, dict) else None
+    if not isinstance(entries, list) or not entries:
+        return doc, ["no entries to review"]
+
+    reviewable_items = [
+        (index, entry)
+        for index, entry in enumerate(entries)
+        if isinstance(entry, dict) and _gpu_pct(entry) >= min_gpu_pct
+    ]
+    reviewable_items.sort(key=lambda item: -_gpu_pct(item[1]))
+    reviewable_items = reviewable_items[: max(1, int(max_entries))]
+    reviewable = [entry for _, entry in reviewable_items]
+    if not reviewable:
+        return doc, [f"no entry at or above {min_gpu_pct}% GPU share"]
+
+    sent_ids = [str(entry.get("kernel_id") or "") for entry in reviewable]
+    duplicate_sent = sorted(
+        kernel_id for kernel_id in set(sent_ids) if sent_ids.count(kernel_id) > 1
+    )
+    if not all(sent_ids) or duplicate_sent:
+        note = (
+            "entries sent for review have missing or duplicate kernel_id values"
+            + (f": {duplicate_sent}" if duplicate_sent else "")
+        )
+        return doc, [note]
+    try:
+        provider = _resolve_provider() if complete is None else ""
+        chosen_model = _resolve_model(model or "", provider)
+    except RuntimeError as exc:
+        audit = llm_source_audit(model=model or "")
+        audit["outcome"] = "configuration_error"
+        doc.setdefault("llm_audit", {})["review"] = audit
+        detail = _safe_exception_label(exc)
+        _say(f"configuration failed: {detail}")
+        return doc, [f"llm configuration failed: {detail}"]
+    if not chosen_model:
+        audit = llm_source_audit(model=model or "")
+        audit["outcome"] = "configuration_error"
+        doc.setdefault("llm_audit", {})["review"] = audit
+        _say("no source-resolution model configured")
+        return doc, ["no model configured"]
+
+    audit = llm_source_audit(model=chosen_model)
+    audit["outcome"] = "requested"
+    doc.setdefault("llm_audit", {})["review"] = audit
+    caller = complete or _complete
+    try:
+        reply = caller(
+            build_review_prompt(
+                reviewable,
+                context_block=context_block,
+                framework_roots=framework_roots,
+            ),
+            chosen_model,
+            timeout_sec,
+        )
+    except Exception as exc:  # noqa: BLE001 - advisory tier, never fatal
+        audit["outcome"] = "call_error"
+        detail = _safe_exception_label(exc)
+        _say(f"call failed: {detail}")
+        return doc, [f"llm call failed: {detail}"]
+
+    try:
+        parsed, revisions, error = parse_revisions(reply)
+    except Exception as exc:  # noqa: BLE001 - malformed replies remain advisory
+        detail = _safe_exception_label(exc)
+        audit["outcome"] = "unusable_reply"
+        _say(f"unusable reply: {detail}")
+        return doc, [f"unusable reply: {detail}"]
+    if not parsed:
+        audit["outcome"] = "unusable_reply"
+        _say(f"unusable reply: {error}")
+        return doc, [f"unusable reply: {error}"]
+
+    received_ids = [str(revision.get("kernel_id") or "") for revision in revisions]
+    duplicate_ids = sorted(
+        kernel_id
+        for kernel_id in set(received_ids)
+        if received_ids.count(kernel_id) > 1
+    )
+    missing_ids = sorted(set(sent_ids) - set(received_ids))
+    extra_ids = sorted(set(received_ids) - set(sent_ids))
+    if duplicate_ids or missing_ids or extra_ids:
+        details = []
+        if missing_ids:
+            details.append(f"missing={missing_ids[:8]}")
+        if duplicate_ids:
+            details.append(f"duplicate={duplicate_ids[:8]}")
+        if extra_ids:
+            details.append(f"extra/unknown kernel_id={extra_ids[:8]}")
+        note = "revision set does not match entries sent: " + "; ".join(details)
+        audit["outcome"] = "protocol_error"
+        doc["reviewed_by"] = "llm_source_review"
+        doc["review_notes"] = [note]
+        _say(note)
+        return doc, [note]
+
+    notes: list[str] = []
+    try:
+        staged_entries = copy.deepcopy(entries)
+        staged_by_id = {
+            kernel_id: staged_entries[index]
+            for kernel_id, (index, _) in zip(sent_ids, reviewable_items)
+        }
+        for revision in revisions:
+            # The batch check above already rejected any id that was not sent,
+            # so every revision still here names a staged entry.
+            entry = staged_by_id[str(revision.get("kernel_id") or "")]
+            note = _apply_revision(entry, revision, framework_roots)
+            if note:
+                notes.append(note)
+    except Exception as exc:  # noqa: BLE001 - discard the entire staged batch
+        detail = _safe_exception_label(exc)
+        note = f"revision validation failed: {detail}"
+        audit["outcome"] = "validation_error"
+        _say(note)
+        return doc, [note]
+
+    doc["entries"] = staged_entries
+    doc["reviewed_by"] = "llm_source_review"
+    doc["review_notes"] = notes
+    audit["outcome"] = "completed"
+    _say(f"reviewed {len(reviewable)} entr(ies), {len(notes)} change(s)")
+    return doc, notes

--- a/src/hyperloom/agents/kernel/tools/_trace_launcher_resolver.py
+++ b/src/hyperloom/agents/kernel/tools/_trace_launcher_resolver.py
@@ -1,0 +1,616 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Resolve a device kernel to its Python launcher frame, straight from the trace.
+
+Motivation: TraceLens cannot attribute a hand-written Triton kernel. Such a
+kernel is launched through ``triton.jit`` and never passes the ATen dispatcher,
+so it has no ``cpu_op`` parent; TraceLens files it as a ``(Synthetic Op)`` with
+``launcher_path = "Not found"``. The information is nonetheless present in the
+trace: ``with_stack`` profiling records the full ``python_function`` chain down
+to the launch, ending at the user frame that called the kernel.
+
+This module recovers that frame deterministically, which is strictly better than
+the name-grep fallback it precedes: it yields a line number and function name,
+and it cannot produce grep's false positives (a test file or a CPU implementation
+that merely mentions the kernel name).
+
+Design constraints:
+
+* **Streaming, two passes.** ``python_function`` dominates a trace (order 10^6
+  events, ~95% of the file). Pass 1 reads only ``kernel`` and ``cuda_runtime``
+  (order 10^4) to pick probe timestamps; pass 2 walks the frames but retains
+  only those enclosing a probe, so peak memory stays flat.
+* **Eager probes only.** A CUDA-graph replay launch has no per-kernel
+  Python frame -- its stack ends at ``torch/cuda/graphs.py: replay`` -- so
+  graph-launch probes are rejected even when that marker is absent. The same
+  kernel is the same source on both paths, so one eager sample covers graph
+  launches too; a replay-only kernel falls through to the grep tier.
+* **Fail soft.** Any error yields an empty mapping; the caller falls back to the
+  existing grep resolution.
+"""
+
+from __future__ import annotations
+
+import bisect
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from _bypass_trace_reader import _open_trace_binary, stream_events
+
+# Kineto event categories consulted here.
+_CAT_KERNEL = "kernel"
+_CAT_RUNTIME = "cuda_runtime"
+_CAT_PYTHON = "python_function"
+
+# Substring shared by hipGraphLaunch, cudaGraphLaunch and cuGraphLaunch,
+# including decorated API names emitted by some Kineto versions.
+_GRAPH_LAUNCH_MARKER = "graphlaunch"
+
+# Substring shared by every kernel-dispatch runtime API across HIP and CUDA
+# (hipModuleLaunchKernel, cudaLaunchKernel, hipGraphLaunch, ...). Correlated
+# runtime events that are not launches -- memcpy, synchronize, malloc -- can
+# never be a kernel's dispatch point, and keeping them would size the probe
+# map by total runtime events rather than by launches.
+_LAUNCH_API_MARKER = "launch"
+
+# A ``python_function`` name of the form "<path>(<line>): <func>".
+_FRAME_RE = re.compile(r"^(?P<path>.+?)\((?P<line>\d+)\):\s*(?P<func>.+)$")
+
+# Frames between the user's call site and the launch: launcher plumbing that is
+# never the kernel's source. Walking outward, these are skipped.
+#
+# Every JIT toolchain contributes one of these. A JIT-built op's innermost Python
+# frame is the compile-and-dispatch wrapper, not its kernel:
+#   * triton  -> ``triton/runtime/jit.py: run``
+#   * aiter   -> ``aiter/jit/core.py: wrapper``
+#   * FlyDSL  -> ``flydsl/compiler/jit_executor.py: __call__``
+# Those files are build machinery shared by every kernel the toolchain compiles,
+# so admitting one both aims a backend at unpatchable code and collapses distinct
+# kernels onto a single source (two MoE GEMMs both resolving to jit_executor.py).
+#
+# Scope matters: only ``flydsl/compiler/`` is plumbing. A kernel *written* in
+# FlyDSL is a legitimate target -- ``classify_patchability`` accepts
+# ``source_type="flydsl"`` -- so ``aiter/ops/flydsl/`` must stay visible.
+_SKIP_FRAME_RE = re.compile(
+    r"(?:"
+    r"triton/runtime/|triton/backends/|triton/compiler/"
+    r"|aiter/jit/"
+    r"|flydsl/compiler/"
+    r"|torch/nn/modules/module\.py"
+    r"|torch/utils/_contextlib\.py"
+    r"|torch/_dynamo/|torch/_inductor/"
+    r"|/_ops\.py"
+    r"|^<"
+    r")"
+)
+
+# Generic decorator frames. Path-based skipping cannot catch these: a guard or
+# retry decorator lives in an ordinary repo file, yet its body is plumbing. The
+# function name is the stable signal (TraceLens keeps an equivalent list for its
+# own entry-point search).
+_WRAPPER_FUNC_NAMES = frozenset(
+    {
+        "call",
+        "custom_wrapper",
+        "decorate",
+        "decorate_context",
+        "handle_torch_function",
+        "inner",
+        "outer_wrapper",
+        "wrapped",
+        "wrapper",
+        "wrapper_custom",
+        "_fn",
+        "_inner",
+        "_wrapped",
+        "_wrapper",
+    }
+)
+
+# Reaching this frame means the launch came from a graph replay: everything
+# further out belongs to the replay call site, not to the kernel.
+_GRAPH_REPLAY_MARKER = "torch/cuda/graphs.py"
+
+# Probe budget per kernel. Oversampled relative to ``max_samples_per_kernel``
+# because some probes land on frames that resolve to nothing.
+_PROBE_OVERSAMPLE = 4
+
+# Shortest elided symbol prefix allowed to match. Below this a prefix carries no
+# identity (``_ZN5...`` matches an entire namespace); real TraceLens elisions run
+# far longer, so this only rejects degenerate input.
+_MIN_ELIDED_PREFIX = 16
+
+
+@dataclass(frozen=True)
+class LauncherFrame:
+    """A resolved Python launcher for one device kernel."""
+
+    source_file: str
+    line: int
+    function: str
+    sample_count: int
+    launch_api: str
+
+    @property
+    def frame(self) -> str:
+        """The frame rendered in TraceLens' ``<path>(<line>): <func>`` form."""
+        return f"{self.source_file}({self.line}): {self.function}"
+
+
+def _event_pid(ev: dict) -> int:
+    """Process id of a trace event; 0 when the trace omits one.
+
+    Single-process traces frequently drop ``pid``, and a constant default keeps
+    those keyed consistently while still separating ranks in a merged trace.
+    """
+    try:
+        return int(ev.get("pid") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _is_elided(name: str) -> bool:
+    """Whether TraceLens shortened this symbol with a trailing ellipsis."""
+    return name.rstrip(" ").endswith("...")
+
+
+def _is_graph_launch(name: str) -> bool:
+    """Whether a runtime API replays a captured GPU graph."""
+    return _GRAPH_LAUNCH_MARKER in str(name or "").strip().lower()
+
+
+def _has_symbol_boundaries(event_name: str, name: str) -> bool:
+    """Return whether ``name`` appears as one complete symbol token."""
+    start = 0
+    while True:
+        start = event_name.find(name, start)
+        if start < 0:
+            return False
+        end = start + len(name)
+        left_ok = start == 0 or not (
+            event_name[start - 1].isalnum() or event_name[start - 1] == "_"
+        )
+        right_ok = end == len(event_name) or not (
+            event_name[end].isalnum() or event_name[end] == "_"
+        )
+        if left_ok and right_ok:
+            return True
+        start += 1
+
+
+def _has_elided_prefix_boundary(event_name: str, prefix: str) -> bool:
+    """Return whether an elided prefix starts at a symbol boundary."""
+    start = 0
+    while True:
+        start = event_name.find(prefix, start)
+        if start < 0:
+            return False
+        if start == 0 or not (
+            event_name[start - 1].isalnum() or event_name[start - 1] == "_"
+        ):
+            return True
+        start += 1
+
+
+def _match_kernel(event_name: str, wanted: Iterable[str]) -> str | None:
+    """Return the wanted kernel name contained in ``event_name``, if any.
+
+    Non-exact matches require symbol boundaries, allowing known decorations such
+    as template arguments and ``.kd`` while rejecting identifier suffixes.
+
+    A long mangled symbol is additionally elided by TraceLens with a trailing
+    ellipsis while the trace keeps the full name, so an elided name falls back to
+    matching on its prefix. That fallback needs a floor: a stub like ``_ZN5...``
+    is a prefix of every symbol in the namespace and would bind an arbitrary
+    kernel. Sibling template instantiations can still both match a shared prefix,
+    which is harmless -- they are the same source file.
+
+    Overlapping names are decided rather than raced. ``wanted`` is a set, so
+    returning the first substring hit made ``moe_gemm1`` and ``moe_gemm1_0``
+    bind ``moe_gemm1_0.kd`` differently per ``PYTHONHASHSEED``, and a wrong
+    binding here reaches the candidate ahead of grep. Every candidate is
+    therefore collected and ranked: an exact hit wins, otherwise the longest and
+    so most specific symbol does, and a genuine tie between equally specific
+    symbols resolves to nothing rather than to whichever the set yielded first.
+    """
+    exact: list[str] = []
+    decorated: list[str] = []
+    elided: list[str] = []
+    for name in wanted:
+        if not name:
+            continue
+        if name == event_name:
+            exact.append(name)
+        elif _has_symbol_boundaries(event_name, name):
+            decorated.append(name)
+        # Gate on _is_elided, not on "rstrip changed something": a single
+        # trailing dot also changes the string, and treating it as elided here
+        # while _is_elided rejects it would let the name skip the ambiguity
+        # check and bind to an arbitrary sibling symbol.
+        elif _is_elided(name):
+            probe = name.rstrip(". ")
+            if (
+                len(probe) >= _MIN_ELIDED_PREFIX
+                and _has_elided_prefix_boundary(event_name, probe)
+            ):
+                elided.append(name)
+    if exact:
+        return exact[0]
+    # Decorated hits outrank elided-prefix hits: the latter is a fallback for a
+    # symbol the trace only shows truncated. A tie inside the stronger bucket
+    # must not fall through to the weaker one.
+    for bucket in (decorated, elided):
+        if not bucket:
+            continue
+        longest = max(len(name) for name in bucket)
+        finalists = [name for name in bucket if len(name) == longest]
+        return finalists[0] if len(finalists) == 1 else None
+    return None
+
+
+def _collect_probes(
+    trace_file: Path,
+    kernel_names: set[str],
+    probe_budget: int,
+    *,
+    stream_errors: list[str] | None = None,
+) -> dict[str, list[tuple[int, int, float, str]]]:
+    """Pass 1: pick ``(tid, ts, launch_api)`` probes for each wanted kernel.
+
+    Reads only ``kernel`` and ``cuda_runtime`` events. Eager launches are
+    preferred over graph replays (see module docstring).
+    """
+    # Keyed by correlation alone. The two sides of a launch are recorded by
+    # different processes in Kineto's model -- the kernel against the device,
+    # the runtime call against the host -- so pairing on (pid, correlation)
+    # never matches on a real trace. Correlation is the field designed to span
+    # that boundary, and it is unique within one profiled process.
+    #
+    # A merged multi-process trace restarts correlation ids per rank, which a
+    # bare id cannot separate. That is handled by detecting the collision
+    # (below) and dropping the id rather than by keying on a pid that means
+    # different things on either side of the pair.
+    corr_to_kernel: dict[Any, str] = {}
+    exact_corr: set[Any] = set()
+    runtimes: dict[Any, tuple[int, int, float, str]] = {}
+    # Correlation ids that identify more than one launch, and so identify none.
+    ambiguous_corr: set[Any] = set()
+    # Distinct complete trace symbols reached through a non-exact match.
+    matched_symbols: dict[str, set[str]] = defaultdict(set)
+    with _open_trace_binary(trace_file) as fh:
+        for ev in stream_events(fh, errors=stream_errors):
+            cat = ev.get("cat")
+            if cat == _CAT_KERNEL:
+                event_name = str(ev.get("name") or "")
+                matched = _match_kernel(event_name, kernel_names)
+                if matched is None:
+                    continue
+                if matched != event_name:
+                    matched_symbols[matched].add(event_name)
+                corr = (ev.get("args") or {}).get("correlation")
+                if corr is None:
+                    continue
+                previous = corr_to_kernel.get(corr)
+                if previous is not None and previous != matched:
+                    # Two different kernels answer to this id: a merged trace
+                    # reused it across ranks. Neither binding can be trusted.
+                    ambiguous_corr.add(corr)
+                else:
+                    corr_to_kernel[corr] = matched
+                    if matched == event_name:
+                        exact_corr.add(corr)
+            elif cat == _CAT_RUNTIME:
+                api_name = str(ev.get("name") or "")
+                # Kernel and runtime events arrive in no guaranteed order, so
+                # this cannot filter on corr_to_kernel yet; gating on the launch
+                # marker bounds the map by launches instead of by every
+                # correlated runtime call in the trace.
+                if _LAUNCH_API_MARKER not in api_name.lower():
+                    continue
+                corr = (ev.get("args") or {}).get("correlation")
+                if corr is None:
+                    continue
+                pid = _event_pid(ev)
+                if corr in runtimes:
+                    # A second host-side launch claiming the same id: only a
+                    # merged trace does this, and it makes the id useless.
+                    ambiguous_corr.add(corr)
+                    continue
+                runtimes[corr] = (
+                    pid,
+                    int(ev.get("tid") or 0),
+                    float(ev.get("ts") or 0.0),
+                    api_name,
+                )
+
+    # Any non-exact name spanning distinct complete symbols is ambiguous: the
+    # launcher of one could be reported as the launcher of another.
+    ambiguous = {
+        name
+        for name, symbols in matched_symbols.items()
+        if len(symbols) > 1
+    }
+    if ambiguous:
+        corr_to_kernel = {
+            corr: kernel
+            for corr, kernel in corr_to_kernel.items()
+            if kernel not in ambiguous or corr in exact_corr
+        }
+
+    eager: dict[str, list[tuple[int, int, float, str]]] = defaultdict(list)
+    for key, kernel in corr_to_kernel.items():
+        if key in ambiguous_corr:
+            continue
+        rt = runtimes.get(key)
+        if rt is None:
+            continue
+        # A graph replay has one Python frame for the whole graph, never a
+        # per-kernel launcher. API identity is stronger than a fragile stack
+        # marker, which is absent for inductor and framework-native replays.
+        if _is_graph_launch(rt[3]):
+            continue
+        if len(eager[kernel]) < probe_budget:
+            eager[kernel].append(rt)
+
+    # Replay-only kernels deliberately remain unresolved.
+    probes: dict[str, list[tuple[int, int, float, str]]] = {}
+    for kernel in kernel_names:
+        picked = list(eager.get(kernel) or [])
+        if picked:
+            probes[kernel] = picked[:probe_budget]
+    return probes
+
+
+def _collect_enclosing_frames(
+    trace_file: Path,
+    probes: dict[str, list[tuple[int, int, float, str]]],
+    *,
+    stream_errors: list[str] | None = None,
+) -> dict[tuple[int, int, float], list[tuple[float, float, str]]]:
+    """Pass 2: gather the ``python_function`` frames enclosing each probe.
+
+    Only frames whose ``[ts, ts+dur]`` span covers a probe are retained, keeping
+    memory proportional to the probe count rather than to the trace.
+
+    Probes are keyed by ``(pid, tid, ts)``. pid is part of the key because a
+    merged multi-process trace reuses thread ids across ranks, and without it
+    one rank's frames would answer for another's launch. Two launches from the
+    same thread inside one microsecond still share a bucket -- legitimately, as
+    a microsecond-granular trace holds one call-stack snapshot for both; where
+    their real call sites differ the trace cannot tell them apart, and the vote
+    across several probes is what keeps that from silently deciding a source.
+    """
+    # Per (pid, tid) sorted probe timestamps, for a bisect membership test.
+    by_thread: dict[tuple[int, int], list[float]] = defaultdict(list)
+    for samples in probes.values():
+        for pid, tid, ts, _api in samples:
+            by_thread[(pid, tid)].append(ts)
+    for key in by_thread:
+        by_thread[key] = sorted(set(by_thread[key]))
+
+    enclosing: dict[tuple[int, int, float], list[tuple[float, float, str]]] = defaultdict(list)
+    with _open_trace_binary(trace_file) as fh:
+        for ev in stream_events(fh, errors=stream_errors):
+            if ev.get("cat") != _CAT_PYTHON:
+                continue
+            pid = _event_pid(ev)
+            tid = int(ev.get("tid") or 0)
+            stamps = by_thread.get((pid, tid))
+            if not stamps:
+                continue
+            start = float(ev.get("ts") or 0.0)
+            dur = float(ev.get("dur") or 0.0)
+            end = start + dur
+            lo = bisect.bisect_left(stamps, start)
+            hi = bisect.bisect_right(stamps, end)
+            if lo >= hi:
+                continue
+            name = str(ev.get("name") or "")
+            for ts in stamps[lo:hi]:
+                # Keep ``dur``: profiler timestamps are microsecond-granular, so
+                # adjacent frames on a fast call chain routinely share a ``ts``.
+                # Start time alone cannot order them and the tie would resolve
+                # by trace write order, picking an arbitrary nesting level.
+                enclosing[(pid, tid, ts)].append((start, dur, name))
+    return enclosing
+
+
+def _innermost_user_frame(
+    frames: list[tuple[float, float, str]],
+) -> tuple[str, int, str] | None:
+    """Pick the innermost user ``.py`` frame from one probe's enclosing frames.
+
+    Ordered innermost-first by ``(start, -dur)``: a later start is deeper, and
+    among frames starting in the same microsecond the narrower span is the
+    nested one. Sorting on start alone would leave same-``ts`` frames in trace
+    write order and collapse different kernels onto one source.
+
+    Launcher plumbing is skipped; hitting the graph-replay marker means this
+    probe carries no per-kernel call site.
+    """
+    ordered = sorted(frames, key=lambda item: (item[0], -item[1]), reverse=True)
+    for _start, _dur, name in ordered:
+        if _GRAPH_REPLAY_MARKER in name:
+            return None
+        if _SKIP_FRAME_RE.search(name):
+            continue
+        match = _FRAME_RE.match(name)
+        if not match:
+            continue
+        path = match.group("path").strip()
+        if not path.endswith(".py"):
+            continue
+        func = match.group("func").strip()
+        if func in _WRAPPER_FUNC_NAMES:
+            continue
+        return path, int(match.group("line")), func
+    return None
+
+
+#: Trace files to read at most. A capture folder holds one file per batch size
+#: per rank (dozens), and every one of them costs two full streaming passes.
+#: Kernels launched from C++ or only ever replayed from a graph never resolve,
+#: so "stop once everything is resolved" alone would read the whole folder.
+_MAX_TRACE_FILES = 2
+
+#: Consecutive files that may add nothing before scanning gives up. Ranks run
+#: the same Python, so a file that contributes nothing means the next one very
+#: likely will not either.
+_MAX_BARREN_FILES = 1
+
+
+def resolve_launchers_from_trace(
+    trace_files: list[Path] | list[str],
+    kernel_names: set[str],
+    *,
+    max_samples_per_kernel: int = 3,
+    max_trace_files: int = _MAX_TRACE_FILES,
+    log: Any = None,
+    file_errors: list[str] | None = None,
+) -> dict[str, LauncherFrame]:
+    """Resolve device kernel names to their Python launcher frames.
+
+    Args:
+        trace_files: Candidate trace files, most representative first. At most
+            ``max_trace_files`` are read, and scanning also stops early once
+            every kernel is resolved or a file adds nothing new -- a single
+            rank's trace normally suffices.
+        kernel_names: Device kernel symbols to resolve.
+        max_samples_per_kernel: Probes to agree on per kernel; the majority frame
+            wins.
+        max_trace_files: Hard ceiling on files read, bounding this tier's cost
+            against a capture folder holding dozens of them.
+        log: Optional ``callable(str)`` for diagnostics.
+
+    Returns:
+        Kernel name -> resolved launcher. Kernels with no eager sample (pure
+        graph replay) or no usable frame are omitted, never guessed.
+    """
+    wanted = {str(k) for k in kernel_names if str(k).strip()}
+    if not wanted or not trace_files:
+        return {}
+
+    # Per-file failures are reported out, not just logged: swallowing them made
+    # an unreadable trace indistinguishable from "nothing needed resolving".
+    if file_errors is None:
+        file_errors = []
+    resolved: dict[str, LauncherFrame] = {}
+    probe_budget = max(1, int(max_samples_per_kernel)) * _PROBE_OVERSAMPLE
+    budget = max(1, int(max_trace_files))
+    barren = 0
+    scanned = 0
+
+    def _report_stream_errors(trace_file: Path, messages: list[str]) -> None:
+        """Expose structural parser failures without discarding recovered data."""
+        for message in messages:
+            note = f"{trace_file.name}: stream error: {message}"
+            if note not in file_errors:
+                file_errors.append(note)
+            if callable(log):
+                log(f"trace_launcher_resolver: {note}")
+
+    for raw_path in trace_files[:budget]:
+        remaining = wanted - set(resolved)
+        if not remaining:
+            break
+        before = len(resolved)
+        trace_file = Path(raw_path)
+        scanned += 1
+        try:
+            probe_stream_errors: list[str] = []
+            probes = _collect_probes(
+                trace_file,
+                remaining,
+                probe_budget,
+                stream_errors=probe_stream_errors,
+            )
+            _report_stream_errors(trace_file, probe_stream_errors)
+            if not probes:
+                if probe_stream_errors:
+                    continue
+                barren += 1
+                if barren >= _MAX_BARREN_FILES:
+                    break
+                continue
+            frame_stream_errors: list[str] = []
+            enclosing = _collect_enclosing_frames(
+                trace_file,
+                probes,
+                stream_errors=frame_stream_errors,
+            )
+            _report_stream_errors(trace_file, frame_stream_errors)
+        except (EOFError, OSError, ValueError, TypeError, AttributeError, KeyError) as exc:
+            # Fail soft per file so one malformed trace cannot take the tier
+            # down: a non-dict ``args`` raises AttributeError, a truncated
+            # gzip raises OSError, and either would otherwise surface as the
+            # whole tier silently returning nothing.
+            note = f"{trace_file.name}: {type(exc).__name__}: {exc}"
+            file_errors.append(note)
+            if callable(log):
+                log(f"trace_launcher_resolver: {note}")
+            continue
+
+        for kernel, samples in probes.items():
+            votes: Counter[tuple[str, int, str]] = Counter()
+            api_votes: Counter[str] = Counter()
+            for pid, tid, ts, api in samples:
+                if sum(votes.values()) >= max_samples_per_kernel:
+                    break
+                frames = enclosing.get((pid, tid, ts))
+                if not frames:
+                    continue
+                found = _innermost_user_frame(frames)
+                if found is None:
+                    continue
+                votes[found] += 1
+                api_votes[api] += 1
+            if not votes:
+                continue
+            ranked = votes.most_common(2)
+            (path, line, func), count = ranked[0]
+            # A plurality is not agreement. With probes split across distinct
+            # frames, most_common() returns whichever was inserted first, which
+            # is trace order rather than evidence. Require a strict win: a tie
+            # at the top means the probes disagree, and the grep tier is a
+            # better answer than an arbitrary one.
+            if len(ranked) > 1 and ranked[1][1] == count:
+                if callable(log):
+                    log(
+                        f"trace_launcher_resolver: {kernel}: probes disagree "
+                        f"({count} vs {ranked[1][1]}); leaving unresolved"
+                    )
+                continue
+            resolved[kernel] = LauncherFrame(
+                source_file=path,
+                line=line,
+                function=func,
+                sample_count=count,
+                launch_api=(api_votes.most_common(1)[0][0] if api_votes else ""),
+            )
+
+        if len(resolved) == before:
+            if probe_stream_errors or frame_stream_errors:
+                continue
+            barren += 1
+            if barren >= _MAX_BARREN_FILES:
+                break
+        else:
+            barren = 0
+
+    if callable(log):
+        log(
+            f"trace_launcher_resolver: resolved {len(resolved)}/{len(wanted)} "
+            f"kernel(s) from {scanned} trace file(s)"
+        )
+    return resolved
+
+
+__all__ = ["LauncherFrame", "resolve_launchers_from_trace"]

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -548,14 +548,28 @@ def main(argv: list[str] | None = None) -> int:
             "ops": [],
             "aggregation_scope": "full_trace",
         }
-    elif not analyze.get("kernels"):
-        trace_health_warnings.append(
-            {
-                "code": "bypass_no_gpu_kernels",
-                "severity": "warning",
-                "message": "bypass reader found no GPU kernel events in the trace",
-            }
-        )
+    else:
+        stream_errors = [str(error) for error in (analyze.get("stream_errors") or [])]
+        if stream_errors:
+            analysis_degraded = True
+            trace_health_warnings.append(
+                {
+                    "code": "bypass_trace_stream_incomplete",
+                    "severity": "warning",
+                    "message": (
+                        "bypass reader recovered an incomplete trace stream: "
+                        + "; ".join(stream_errors[:3])
+                    ),
+                }
+            )
+        if not analyze.get("kernels"):
+            trace_health_warnings.append(
+                {
+                    "code": "bypass_no_gpu_kernels",
+                    "severity": "warning",
+                    "message": "bypass reader found no GPU kernel events in the trace",
+                }
+            )
 
     # Aggregation scope is driven by the reader (steady_state vs full_trace).
     scope = analyze.get("aggregation_scope", AGGREGATION_SCOPE_FULL)

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -14,7 +14,9 @@ import asyncio
 import csv
 import functools
 import gzip
+import importlib.util
 import json
+import logging
 import os
 import re
 import subprocess
@@ -46,6 +48,7 @@ except Exception:
 
 from tracelens_arch_benchmark import normalize_platform, populate_gpu_arch_json
 from tracelens_skill_runner import (
+    _LAUNCHER_PATH_PLACEHOLDERS,
     _parse_launcher_path,
     _resolve_launcher_to_abs_source,
     aggregate_by_source_function,
@@ -79,6 +82,19 @@ from _roofline_source import (
 # Shared canonical analysis.md renderer so the deterministic route emits the same
 # section structure + table schemas as the bypass route.
 from _analysis_md import render_report
+
+# Shared with the kernel-opt side; these tools also run as standalone scripts
+# outside an importable hyperloom, where the artifact is simply not written.
+try:
+    from hyperloom.common import kernel_source_contract as _KSC
+except ImportError:  # pragma: no cover - standalone invocation
+    _KSC = None  # type: ignore[assignment]
+
+log = logging.getLogger(__name__)
+
+# Artifact name kept local so the standalone-script path does not need the
+# shared contract module just to know where the file goes.
+_SOURCE_RESOLUTION_NAME = "kernel_source_resolution.json"
 
 
 # Candidate building keeps a broad pool; dispatch grouping owns the real budget gate.
@@ -1738,6 +1754,11 @@ def classify_patchability(candidate: dict[str, Any]) -> tuple[bool, str]:
             )
             return False, f"op_to_source: {reason}"
     if not source_file:
+        # A bare launch API has no kernel body to rewrite, which is a different
+        # situation from a kernel whose source we merely failed to locate. Say
+        # so rather than sending a reader looking for a file that cannot exist.
+        if is_runtime_api_name(str(candidate.get("name") or "")):
+            return False, "launch API, not a kernel (no rewritable body)"
         return False, "source file not resolved"
     if candidate.get("source_type") == "vendor_binary":
         return False, "vendor binary (no rewritable source)"
@@ -1847,7 +1868,28 @@ KNOWN_SEARCH_ROOTS = (
     "/opt/venv/lib/python3.10/site-packages/aiter",
     "/opt/venv/lib/python3.10/site-packages/vllm",
 )
+# Extensions a grep hit may be admitted under. Deliberately narrow, and kept in
+# lockstep with source_type_for(): a suffix admitted here but unclassified there
+# lands as source_type="unknown", which classify_patchability rejects. Worse, it
+# still competes in _rank_paths, where kind_score outweighs ext_score -- so a
+# /csrc/ file with an unclassified suffix outranks the sibling .py and turns a
+# routable candidate non-routable. Widen this only together with source_type_for.
 SOURCE_EXTENSIONS = (".cuh", ".cu", ".hip", ".cpp", ".h", ".hpp", ".py")
+
+# Extensions that make a string *look like* a path, used only to tell a real
+# source_file from a producer placeholder ("Not found", "AITER (vendor)"). This
+# one is permissive on purpose: rejecting an unusual-but-real path would zero a
+# field the resolution tiers already filled, whereas admitting one merely leaves
+# it to the classifier. Never use it as a grep admission filter.
+PATH_SHAPED_EXTENSIONS = SOURCE_EXTENSIONS + (
+    ".pyx",
+    ".cxx",
+    ".cc",
+    ".hh",
+    ".s",
+    ".asm",
+    ".jinja",
+)
 
 
 def _strip_template_args(symbol: str) -> str:
@@ -1994,6 +2036,59 @@ def _candidate_keywords(name: str) -> list[str]:
         return descriptive[:3]
     raw.sort(key=lambda t: (-t.count("_"), -len(t)))
     return raw[:3]
+
+
+def _relaxed_candidate_keywords(name: str) -> list[str]:
+    """Extract bounded short identifiers used only for the LLM shortlist.
+
+    The deterministic tier requires identifiers at least five characters long.
+    Mangled kernels composed of shorter identifiers therefore produce no strict
+    keyword at all. This lowers the floor to three characters and caps the
+    result at six keywords. It feeds the shortlist only, so the deterministic
+    winner-selection contract is unchanged.
+    """
+    cleaned = _normalize_profiler_op_name(name)
+    tokens: list[str] = []
+    if cleaned.startswith("_Z"):
+        pos = 0
+        while pos < len(cleaned):
+            match = re.match(r"(\d+)", cleaned[pos:])
+            if match is None:
+                pos += 1
+                continue
+            length = int(match.group(1))
+            start = pos + match.end()
+            ident = cleaned[start : start + length]
+            if ident and re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", ident):
+                tokens.append(ident)
+                pos = start + length
+            else:
+                pos = start + 1
+    else:
+        plain = _strip_template_args(cleaned)
+        tokens.append(plain.split("::")[-1])
+
+    seen: set[str] = set()
+    relaxed: list[str] = []
+    for token in tokens:
+        token = token.strip("_")
+        if (
+            len(token) < 3
+            or token in seen
+            or token in _TYPE_BLOCKLIST
+        ):
+            continue
+        seen.add(token)
+        relaxed.append(token)
+    relaxed.sort(
+        key=lambda token: (
+            token in _NAMESPACE_BLOCKLIST,
+            -token.count("_"),
+            -len(token),
+            token,
+        )
+    )
+    return relaxed[:6]
 
 
 _GREP_CACHE: dict[tuple[str, str], list[Path]] = {}
@@ -2175,6 +2270,38 @@ def _prefer_symbol_definition(keyword: str, hits: list[Path]) -> list[Path]:
     return _rank_paths(definers) if definers else _rank_paths(hits)
 
 
+# Bare HIP/CUDA launch APIs. TraceLens emits these as standalone rows when it
+# aggregates launches it could not attribute to a device kernel, but they are
+# runtime entry points, not kernels. Grepping them matches wherever the API name
+# merely appears -- e.g. aiter's hipify name-mapping table, which then gets
+# routed to a backend as if it were rewritable kernel source.
+_RUNTIME_API_NAMES: frozenset[str] = frozenset(
+    {
+        "cudagraphlaunch",
+        "cudalaunchcooperativekernel",
+        "cudalaunchkernel",
+        "cudamodulelaunchkernel",
+        "hipextlaunchkernel",
+        "hipgraphlaunch",
+        "hiplaunchcooperativekernel",
+        "hiplaunchkernel",
+        "hipmodulelaunchkernel",
+    }
+)
+
+
+def is_runtime_api_name(name: str) -> bool:
+    """Return whether ``name`` is a bare HIP/CUDA launch API rather than a kernel.
+
+    Args:
+        name (str): Kernel symbol/name, possibly profiler-wrapped.
+
+    Returns:
+        bool: ``True`` when the normalised name is a bare launch API.
+    """
+    return _normalize_profiler_op_name(name).strip().lower() in _RUNTIME_API_NAMES
+
+
 def locate_source_via_grep(name: str) -> str:
     """Locate a kernel source file by grepping known repos.
 
@@ -2186,6 +2313,10 @@ def locate_source_via_grep(name: str) -> str:
     Returns:
         str: The best-ranked matching source path, or ``""`` when none.
     """
+    # A bare launch API has no source of its own; grepping it only yields
+    # incidental mentions (see _RUNTIME_API_NAMES).
+    if is_runtime_api_name(name):
+        return ""
     tried: set[str] = set()
     # Primary pass: keyword extraction + ranking.
     for keyword in _candidate_keywords(name):
@@ -2211,6 +2342,54 @@ def locate_source_via_grep(name: str) -> str:
         if hits:
             return str(_prefer_symbol_definition(keyword, hits)[0])
     return ""
+
+
+def collect_source_candidates_via_grep(name: str, limit: int = 8) -> list[str]:
+    """Shortlist every plausible source for ``name``, ranked, without deciding.
+
+    Where :func:`locate_source_via_grep` commits to the top hit of the first
+    keyword that matches, this widens the net -- every keyword and every trailing
+    sub-window -- and returns the union. It feeds the LLM tier, which needs
+    several options to choose between; on its own it decides nothing.
+
+    Args:
+        name (str): Kernel symbol/name to locate.
+        limit (int): Maximum paths to return.
+
+    Returns:
+        list[str]: Ranked, deduplicated candidate paths (possibly empty).
+    """
+    if is_runtime_api_name(name):
+        return []
+    hits: list[Path] = []
+    seen_keywords: set[str] = set()
+    for keyword in [
+        *_candidate_keywords(name),
+        *_compound_subwindow_keywords(name),
+        *_relaxed_candidate_keywords(name),
+    ]:
+        if not keyword or keyword in seen_keywords:
+            continue
+        seen_keywords.add(keyword)
+        for root in KNOWN_SEARCH_ROOTS:
+            hits.extend(_grep_for_keyword(keyword, Path(root)))
+    if not hits:
+        return []
+    ordered: list[str] = []
+    seen_paths: set[str] = set()
+    # Definition sites first: a file that merely mentions the symbol is the
+    # exact confusion the LLM tier is meant to resolve, not inherit.
+    primary = _candidate_keywords(name)
+    ranked = _prefer_symbol_definition(primary[0], hits) if primary else _rank_paths(hits)
+    for path in ranked:
+        text = str(path)
+        if text in seen_paths:
+            continue
+        seen_paths.add(text)
+        ordered.append(text)
+        if len(ordered) >= max(1, limit):
+            break
+    return ordered
 
 
 def find_repo_root(source_file: str) -> str:
@@ -2782,7 +2961,12 @@ def is_multigpu_kernel(name: str, source_file: str) -> bool:
     )
 
 
-def analyze_trace_files(trace_files: list[Path], top_k: int) -> list[dict[str, Any]]:
+def analyze_trace_files(
+    trace_files: list[Path],
+    top_k: int,
+    *,
+    allow_model_tiers: bool = True,
+) -> list[dict[str, Any]]:
     """Aggregate GPU kernels across raw trace files into top-K candidates.
 
     Sums per-kernel duration and call counts across all events, takes the
@@ -2792,6 +2976,9 @@ def analyze_trace_files(trace_files: list[Path], top_k: int) -> list[dict[str, A
     Args:
         trace_files (list[Path]): Trace files (optionally gzipped) to scan.
         top_k (int): Number of hottest kernels to keep.
+        allow_model_tiers (bool): Whether source resolution may call a model.
+            The deterministic route sets this to false, so the "no model calls"
+            promise holds on this path too.
 
     Returns:
         list[dict[str, Any]]: Finalized hot-kernel candidate dicts.
@@ -2842,7 +3029,12 @@ def analyze_trace_files(trace_files: list[Path], top_k: int) -> list[dict[str, A
 
     candidates = sorted(aggregates.values(), key=lambda x: x["duration_us"], reverse=True)
     top = candidates[:top_k]
-    return _finalize_candidates(top, total_dur=total_dur)
+    return _finalize_candidates(
+        top,
+        total_dur=total_dur,
+        trace_files=trace_files,
+        allow_model_tiers=allow_model_tiers,
+    )
 
 
 def load_op_category_map(
@@ -3677,8 +3869,76 @@ def recover_other_bucket_candidates(
     return out
 
 
+# A resolved source_file always carries a source extension, whether absolute
+# ("/sgl-workspace/.../fused_moe.py"), package-relative ("sgl_kernel/moe.py"), or
+# TraceLens' frame form ("path.py(124): fn"). Producer placeholders never do --
+# "Not found", "N/A", "AITER (vendor)", "unknown".
+# Derived from PATH_SHAPED_EXTENSIONS, not from the grep admission list: this
+# gate only answers "is this a path or a placeholder". Longest first -- the
+# alternation is left-biased, and while ``\b`` already forces a retry on ".hpp"
+# vs ".h", ordering makes the intent explicit.
+_SOURCE_EXT_RE = re.compile(
+    r"\.(?:"
+    + "|".join(
+        re.escape(ext.lstrip("."))
+        for ext in sorted(PATH_SHAPED_EXTENSIONS, key=len, reverse=True)
+    )
+    + r")\b",
+    re.IGNORECASE,
+)
+
+
+def looks_like_source_path(value: str) -> bool:
+    """Return whether ``value`` has the shape of a source-file path.
+
+    Args:
+        value (str): Candidate ``source_file`` value.
+
+    Returns:
+        bool: ``True`` when it carries a recognized source extension.
+    """
+    # Normalize separators first, matching is_torch_dispatch_shim_source: a
+    # Windows-style path is still a path, and rejecting it would zero a real
+    # source_file as if it were a placeholder.
+    text = (value or "").strip().replace("\\", "/")
+    return bool(_SOURCE_EXT_RE.search(text))
+
+
+def reject_non_path_source(item: dict[str, Any]) -> bool:
+    """Zero a ``source_file`` that is a producer placeholder, not a path.
+
+    A real source_file always looks like a path (absolute, or package-relative
+    such as "sgl_kernel/moe.py"); a bare word is what the producer wrote for
+    "unresolved". Admitting one is how classify_patchability ends up reporting
+    the nonsensical "source not under a reusable framework root: Not found".
+    Keyed on shape rather than on-disk presence so an analysis host that lacks
+    the serving container's filesystem still classifies normally.
+
+    Must run before the trace/grep tiers: they are gated on an empty
+    ``source_file``, so a surviving placeholder silently skips them.
+
+    Returns:
+        True when a placeholder was rejected.
+    """
+    source_file = str(item.get("source_file") or "").strip()
+    if not source_file or looks_like_source_path(source_file):
+        return False
+    item["source_file_rejected"] = source_file
+    item["source_file"] = ""
+    item["source_resolution_method"] = "rejected_non_path_sentinel"
+    return True
+
+
 def _stamp_candidate_metadata(item: dict[str, Any], op_cat_map: dict[str, str] | None) -> None:
     """Stamp routing, backend, and category metadata onto a finalized candidate."""
+    # Placeholders are already rejected by reject_non_path_source() at the top of
+    # _finalize_candidates -- early enough for the trace and grep tiers to run.
+    # What is left to check here is the resolved path's presence on disk.
+    source_file = str(item.get("source_file") or "").strip()
+    if source_file and not os.path.isfile(source_file):
+        # Path-shaped but absent: keep it (the resolution may target the serving
+        # container) and leave a breadcrumb for triage.
+        item["source_file_missing_on_disk"] = True
     reusable, skip_reason = classify_patchability(item)
     item["reusable_native_kernel"] = reusable
     item["skip_reason"] = skip_reason
@@ -3697,12 +3957,341 @@ def _stamp_candidate_metadata(item: dict[str, Any], op_cat_map: dict[str, str] |
     item.setdefault("source_path", item.get("source_file", ""))
 
 
+#: A candidate below this GPU share is not worth an LLM round-trip.
+_LLM_FALLBACK_MIN_GPU_PCT = 5.0
+
+
+#: Populated once per run from the CLI args so both model tiers see the same
+#: serving configuration. Empty when the analysis runs without that context.
+_RUNTIME_CONTEXT: dict[str, Any] = {}
+
+
+def set_runtime_context(
+    *,
+    model_path: str = "",
+    server_args: str = "",
+    framework: str = "",
+    precision: str = "",
+) -> None:
+    """Record the serving configuration the resolution tiers should reason with.
+
+    Which file implements a kernel depends on the running configuration -- the
+    same MoE operator dispatches differently under ``--moe-runner-backend
+    triton`` and ``aiter``. Set once at analysis start; both tiers read it.
+    """
+    _RUNTIME_CONTEXT["model_path"] = str(model_path or "")
+    _RUNTIME_CONTEXT["server_args"] = str(server_args or "")
+    _RUNTIME_CONTEXT["framework"] = str(framework or "")
+    _RUNTIME_CONTEXT["precision"] = str(precision or "")
+
+
+def _runtime_server_args_from_config(config_path: str) -> str:
+    """Read materialized EXTRA_*_ARGS without sending the config to a model."""
+    if not str(config_path or "").strip():
+        return ""
+    try:
+        import yaml  # type: ignore[import-untyped]  # noqa: PLC0415
+
+        payload = yaml.safe_load(
+            Path(config_path).expanduser().read_text(encoding="utf-8")
+        )
+    except Exception as exc:  # noqa: BLE001 - runtime context is advisory
+        log.warning("could not read source runtime config: %s", type(exc).__name__)
+        return ""
+    benchmark = payload.get("benchmark") if isinstance(payload, dict) else None
+    envs = benchmark.get("envs") if isinstance(benchmark, dict) else None
+    if not isinstance(envs, dict):
+        return ""
+    return " ".join(
+        str(value).strip()
+        for key, value in envs.items()
+        if str(key).startswith("EXTRA_")
+        and str(key).endswith("_ARGS")
+        and str(value).strip()
+    )
+
+
+def _source_context_block() -> str:
+    """Render the shared runtime context for a model tier, or "" when absent."""
+    try:
+        from _llm_source_context import build_context_block  # noqa: PLC0415
+
+        return build_context_block(
+            model_path=_RUNTIME_CONTEXT.get("model_path") or "",
+            server_args=_RUNTIME_CONTEXT.get("server_args") or "",
+            framework_roots=tuple(KNOWN_SEARCH_ROOTS),
+            framework=_RUNTIME_CONTEXT.get("framework") or "",
+            precision=_RUNTIME_CONTEXT.get("precision") or "",
+        )
+    except Exception as exc:  # noqa: BLE001 - context is an aid, never required
+        log.warning("could not build source-resolution context: %r", exc)
+        return ""
+
+
+def _forward_to_log(message: str) -> None:
+    """Adapter so the resolution tiers' own diagnostics reach the logger.
+
+    Both tiers accept a ``log=`` callable and emit detailed progress through it.
+    Without this the messages are produced and discarded.
+    """
+    log.info("%s", message)
+
+
+def _append_resolution_reason(item: dict[str, Any], reason: str) -> None:
+    """Append a distinct resolution outcome without masking an earlier tier."""
+    current = str(item.get("source_resolution_reason") or "").strip()
+    if not current:
+        item["source_resolution_reason"] = reason
+    elif reason not in current:
+        item["source_resolution_reason"] = f"{current}; {reason}"
+
+
+def _apply_llm_source_fallback(item: dict[str, Any]) -> None:
+    """Last-resort LLM pick for a candidate every deterministic tier missed.
+
+    No-op unless the operator enabled the tier and the candidate is hot enough to
+    justify the call. Mutates ``item`` in place only on an accepted answer.
+    """
+    name = str(item.get("name") or "")
+    try:
+        from _llm_source_fallback import (  # noqa: PLC0415
+            llm_source_audit,
+            llm_source_provider_configured,
+            select_source_via_llm,
+        )
+
+        try:
+            gpu_pct = float(item.get("gpu_pct") or 0.0)
+        except (TypeError, ValueError):
+            gpu_pct = 0.0
+        if gpu_pct < _LLM_FALLBACK_MIN_GPU_PCT:
+            _append_resolution_reason(
+                item,
+                f"llm_fallback_skipped: gpu_pct {gpu_pct:.2f} < {_LLM_FALLBACK_MIN_GPU_PCT}",
+            )
+            return
+        # Settle the provider before gathering the shortlist. That grep walks
+        # every framework root once per keyword, and on a deployment that never
+        # configured a provider the tier would pay for it on every hot kernel
+        # only to decline the call.
+        if not llm_source_provider_configured():
+            audit = llm_source_audit()
+            audit["outcome"] = "configuration_error"
+            item["source_resolution_llm_audit"] = audit
+            _append_resolution_reason(item, "llm_fallback_skipped: no provider configured")
+            return
+        shortlist = collect_source_candidates_via_grep(name)
+        if not shortlist:
+            _append_resolution_reason(item, "llm_fallback_no_shortlist")
+            log.info("LLM source fallback: no grep shortlist for %r", name)
+            return
+        audit = llm_source_audit()
+        audit["outcome"] = "requested"
+        item["source_resolution_llm_audit"] = audit
+        call_errors: list[str] = []
+        picked, confidence, reason = select_source_via_llm(
+            name,
+            shortlist,
+            framework_roots=tuple(KNOWN_SEARCH_ROOTS),
+            context_block=_source_context_block(),
+            log=_forward_to_log,
+            errors=call_errors,
+        )
+        if picked:
+            audit["outcome"] = "accepted"
+            item["source_file"] = picked
+            item["source_resolution_method"] = "llm_fallback"
+            item["source_resolution_confidence"] = confidence
+            item["source_resolution_reason"] = reason
+            return
+        if call_errors:
+            audit["outcome"] = "error"
+            failure = f"llm_fallback_error: {call_errors[0]}"
+            _append_resolution_reason(item, failure)
+            log.warning("LLM source fallback failed for %r (%s)", name, failure)
+            return
+        # Answered but not accepted: invented path, low confidence, or refusal.
+        audit["outcome"] = "declined"
+        _append_resolution_reason(
+            item, f"llm_fallback_declined: {reason or 'no candidate accepted'}"
+        )
+        log.info(
+            "LLM source fallback declined for %r over %d shortlist entr(ies): %s",
+            name,
+            len(shortlist),
+            reason or "no candidate accepted",
+        )
+    except Exception as exc:  # noqa: BLE001 - advisory tier, never breaks finalization
+        # Import errors, gateway 401s and timeouts all land here; without a
+        # trail they look identical to the tier being switched off.
+        reason = f"llm_fallback_error: {type(exc).__name__}: {exc}"
+        audit = item.get("source_resolution_llm_audit")
+        if isinstance(audit, dict):
+            audit["outcome"] = "error"
+        log.warning("LLM source fallback failed for %r (%s)", name, reason)
+        _append_resolution_reason(item, reason)
+        return
+
+
+@functools.lru_cache(maxsize=64)
+def _package_parent_dir(package: str) -> str:
+    """Directory holding ``package``'s own directory, resolved at runtime.
+
+    Uses ``find_spec`` so the package is located without importing it (the same
+    approach ``_bypass_source_resolver`` takes for aiter). Returns ``""`` when
+    the name is not a package on this interpreter's path.
+    """
+    if not package or not package.isidentifier():
+        return ""
+    try:
+        spec = importlib.util.find_spec(package)
+    except (AttributeError, ImportError, ValueError):
+        return ""
+    if spec is None:
+        return ""
+    for location in list(getattr(spec, "submodule_search_locations", None) or []):
+        parent = os.path.dirname(str(location).rstrip("/"))
+        if parent:
+            return parent
+    origin = str(getattr(spec, "origin", "") or "")
+    return os.path.dirname(os.path.dirname(origin)) if origin else ""
+
+
+def absolutize_launcher_path(path: str) -> str:
+    """Best-effort absolute path for a trace-relative launcher frame.
+
+    torch profiler records a frame path relative to the ``sys.path`` entry the
+    module was imported from (``aiter/dist/x.py``), whereas patchability keys on
+    an absolute framework root. The relative path already starts with the package
+    name, so it joins against each package's *parent*.
+
+    Args:
+        path (str): Launcher path from the trace, absolute or relative.
+
+    Returns:
+        str: The absolutized path when one exists on disk, else ``path``.
+    """
+    if not path or os.path.isabs(path):
+        return path
+    # The relative path starts with the package name ("vllm/models/..."), so
+    # locate that package where it actually lives. A pinned list cannot do this:
+    # the same package sits under /sgl-workspace in the serving image and under
+    # dist-packages on a wheel install, and the Python version moves too.
+    parent = _package_parent_dir(path.split("/", 1)[0])
+    if parent:
+        candidate = os.path.join(parent, path)
+        if os.path.isfile(candidate):
+            return candidate
+    # Fall back to the pinned checkout layouts (editable installs whose package
+    # dir is not importable from this process).
+    for inner_root in _PACKAGE_INNER_ROOTS:
+        candidate = os.path.join(os.path.dirname(inner_root), path)
+        if os.path.isfile(candidate):
+            return candidate
+    return path
+
+
+def _source_paths_match(left: str, right: str) -> bool:
+    """Return whether two source paths identify the same normalized file."""
+    if not left or not right:
+        return False
+    left_path = os.path.normcase(os.path.normpath(left))
+    right_path = os.path.normcase(os.path.normpath(right))
+    if left_path == right_path:
+        return True
+    if not os.path.isabs(left_path) or not os.path.isabs(right_path):
+        return False
+    return os.path.realpath(left_path) == os.path.realpath(right_path)
+
+
+def _trace_launcher_key(item: dict[str, Any]) -> str:
+    """Device kernel symbol to look this candidate up by in the trace."""
+    name = str(item.get("device_kernel_name") or "").strip()
+    if not name:
+        name = _normalize_profiler_op_name(str(item.get("name") or ""))
+    return name.strip()
+
+
+def _resolve_trace_launchers(
+    candidates: list[dict[str, Any]],
+    trace_files: list[Path] | None,
+    log_path: Path | str | None = None,
+) -> dict[str, Any]:
+    """Batch-resolve launcher frames for candidates that still lack a source.
+
+    One trace scan for the whole candidate list; returns ``{}`` when there is
+    nothing to look up or the trace cannot be read, so the grep fallback stays
+    in charge.
+    """
+    if not trace_files:
+        return {}
+    wanted = {
+        key
+        for item in candidates
+        # Shape, not truthiness: an upstream placeholder ("AITER (vendor)",
+        # "Not found") is a non-empty string, and treating it as a resolved
+        # source would skip the very candidates this resolver exists for.
+        if not looks_like_source_path(str(item.get("source_file") or ""))
+        and (key := _trace_launcher_key(item))
+        and not is_runtime_api_name(key)
+    }
+    if not wanted:
+        return {}
+    try:
+        from _trace_launcher_resolver import resolve_launchers_from_trace  # noqa: PLC0415
+
+        file_errors: list[str] = []
+        found = resolve_launchers_from_trace(
+            [Path(p) for p in trace_files],
+            wanted,
+            log=_forward_to_log,
+            file_errors=file_errors,
+        )
+        if file_errors:
+            # A per-file failure previously surfaced only as "0 resolved",
+            # which reads the same as "no candidate needed a launcher".
+            reason = f"trace_resolver_error: {'; '.join(file_errors[:2])}"
+            log.warning("trace launcher tier hit %d unreadable file(s)", len(file_errors))
+            for item in candidates:
+                if _trace_launcher_key(item) in wanted:
+                    item.setdefault("source_resolution_reason", reason)
+        summary = (
+            f"trace launcher tier: resolved {len(found)}/{len(wanted)} unresolved candidate(s)"
+        )
+        log.info("%s", summary)
+        # Also to the run log: that is where an operator looks when candidates
+        # come out unresolved, and a logger record does not survive there.
+        if log_path:
+            append_log(log_path, summary)
+        return found
+    except Exception as exc:  # noqa: BLE001 - advisory resolution, never fatal
+        # Stay fail-soft into the grep tier, but leave a trail. A bare ``{}``
+        # is indistinguishable from "no candidate needed a launcher", which
+        # hides unreadable traces, import errors and parse failures alike.
+        reason = f"trace_resolver_error: {type(exc).__name__}: {exc}"
+        log.warning(
+            "trace launcher resolution failed for %d candidate(s) (%s); "
+            "falling back to grep",
+            len(wanted),
+            reason,
+        )
+        for item in candidates:
+            if _trace_launcher_key(item) in wanted:
+                item.setdefault("source_resolution_reason", reason)
+        return {}
+
+
 def _finalize_candidates(
     top: list[dict[str, Any]],
     *,
     total_dur: float | None = None,
     perf_report_csv_dir: Path | str | None = None,
     framework: str | None = None,
+    trace_files: list[Path] | None = None,
+    log_path: Path | str | None = None,
+    source_resolution_out: Path | str | None = None,
+    allow_model_tiers: bool = True,
+    model_name: str = "",
 ) -> list[dict[str, Any]]:
     """Apply shared post-processing to parsed candidate rows.
 
@@ -3720,6 +4309,12 @@ def _finalize_candidates(
             dual-framework image routes to the correct container's source. Only
             ``vllm``/``sglang`` steer routing; other values fall back to on-disk
             presence then default ordering.
+        trace_files: Optional raw trace files. When given, Python launcher
+            frames are retained as evidence and accepted as source only when
+            name grep independently resolves the same file.
+        allow_model_tiers: Whether fallback and artifact review may call an LLM.
+            The deterministic CLI route sets this to false.
+        model_name: Runtime model identity recorded in the resolution artifact.
 
     Returns:
         The finalized candidate list (the same ``top`` object).
@@ -3729,6 +4324,13 @@ def _finalize_candidates(
     # Dict-first: resolve each op to its editable .cu and expand composite
     # fan-out into one candidate per sub-kernel before finalizing.
     top = _expand_op_fanout(top, framework=framework, op_dominant_kernel=op_dom_map)
+    # Drop upstream placeholders up front. They are non-empty strings, so every
+    # later "did we already resolve this?" check would read them as a resolved
+    # source and skip the resolution tiers entirely.
+    for item in top:
+        if isinstance(item, dict):
+            reject_non_path_source(item)
+    trace_launchers = _resolve_trace_launchers(top, trace_files, log_path=log_path)
     sum_dur = total_dur if total_dur is not None else sum(it.get("duration_us", 0.0) for it in top)
     sum_dur = sum_dur or 1.0
     # Recover the fused-MoE expert kernel's operand shapes (its trace event carries
@@ -3822,8 +4424,55 @@ def _finalize_candidates(
         # unresolved dispatch. An in-dict non-rewritable verdict is authoritative,
         # so we keep its .py launcher as context and do NOT grep/promote.
         if res is None or res.status == "unresolved":
+            # A trace frame proves only where Python launched the device kernel;
+            # it does not prove that the same file defines the kernel. Keep the
+            # frame as evidence, then require grep to corroborate the file before
+            # promoting its line/function metadata to source attribution.
+            frame = None
+            trace_source = ""
             if not item.get("source_file"):
-                item["source_file"] = locate_source_via_grep(item["name"])
+                frame = trace_launchers.get(_trace_launcher_key(item))
+                if frame is not None:
+                    trace_source = absolutize_launcher_path(frame.source_file)
+                    item["trace_launcher_file"] = trace_source
+                    item["trace_launcher_line"] = frame.line
+                    item["trace_launcher_function"] = frame.function
+            if not item.get("source_file"):
+                grep_source = locate_source_via_grep(item["name"])
+                if grep_source:
+                    item["source_file"] = grep_source
+                    if frame is not None and _source_paths_match(trace_source, grep_source):
+                        item["source_line"] = frame.line
+                        item["source_function"] = frame.function
+                        item["source_resolution_method"] = "trace_python_stack"
+                        _append_resolution_reason(
+                            item,
+                            "trace launcher corroborated by name grep",
+                        )
+                    else:
+                        item.pop("source_line", None)
+                        item.pop("source_function", None)
+                        item["source_resolution_method"] = (
+                            _KSC.METHOD_GREP if _KSC is not None else "name_grep"
+                        )
+                        if trace_source:
+                            _append_resolution_reason(
+                                item,
+                                f"trace launcher differs from grep source: {trace_source}",
+                            )
+                elif trace_source:
+                    _append_resolution_reason(
+                        item,
+                        f"trace launcher unconfirmed by name grep: {trace_source}",
+                    )
+            if not item.get("source_file"):
+                if allow_model_tiers:
+                    _apply_llm_source_fallback(item)
+                else:
+                    _append_resolution_reason(
+                        item,
+                        "llm_fallback_skipped: deterministic route",
+                    )
             # Promote a tiny pybind shim TU to the real device code.
             item["kernel_repo"] = find_repo_root(item.get("source_file", ""))
             item["source_file"] = upgrade_pybind_shim_source(
@@ -3854,7 +4503,290 @@ def _finalize_candidates(
             item["vendor_dispatch_wrapper"] = True
         item["runtime_generated_kernel"] = is_runtime_generated_kernel(item["name"], item.get("source_file", ""))
         _stamp_candidate_metadata(item, op_cat_map)
+    if source_resolution_out and _KSC is not None:
+        write_source_resolution_artifact(
+            top,
+            source_resolution_out,
+            framework=framework or "",
+            model_name=model_name,
+            log_path=log_path,
+            op_cat_map=op_cat_map,
+            allow_review=allow_model_tiers,
+        )
     return top
+
+
+def _candidate_resolution_method(item: dict[str, Any]) -> str:
+    """Map a finalized candidate onto the artifact's method vocabulary.
+
+    The candidate carries the method only when a tier stamped one; a path that
+    arrived from grep has none, and an absent path means nothing resolved it.
+    """
+    stamped = str(item.get("source_resolution_method") or "").strip()
+    if stamped in _KSC.KNOWN_METHODS:
+        return stamped
+    if str(item.get("source_file") or "").strip():
+        # No tier claimed it but a path is present: grep is the only tier that
+        # resolves without stamping.
+        return _KSC.METHOD_GREP
+    return _KSC.METHOD_UNRESOLVED
+
+
+def build_source_resolution_entries(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Project finalized candidates onto source-resolution entries."""
+    entries: list[dict[str, Any]] = []
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        method = _candidate_resolution_method(item)
+        line = item.get("source_line")
+        entry = _KSC.make_entry(
+            kernel_id=str(item.get("kernel_id") or ""),
+            name=str(item.get("name") or ""),
+            gpu_pct=float(item.get("gpu_pct") or 0.0),
+            source_file=str(item.get("source_file") or ""),
+            source_line=int(line) if isinstance(line, (int, float)) else None,
+            source_function=str(item.get("source_function") or ""),
+            method=method,
+            confidence=item.get("source_resolution_confidence"),
+            reason=str(item.get("source_resolution_reason") or ""),
+            rejected_value=str(item.get("source_file_rejected") or ""),
+            previous_source_file=str(
+                item.get("source_resolution_previous_file") or ""
+            ),
+            previous_method=str(
+                item.get("source_resolution_previous_method") or ""
+            ),
+        )
+        audit = item.get("source_resolution_llm_audit")
+        if isinstance(audit, dict):
+            entry["llm_audit"] = dict(audit)
+        entries.append(entry)
+    return entries
+
+
+#: Metadata describing WHICH source a candidate points at, as opposed to facts
+#: about the kernel itself. Every one of these is derived from the old path, so
+#: a rewrite that leaves them in place produces a candidate describing two
+#: different sources at once -- and the downstream readers disagree about which
+#: one wins. ``forge_submit._resolve_framework`` consults ``source_framework``
+#: before it ever looks at ``source_file``, and ``classify_patchability`` reads
+#: ``kernel_kind`` to decide a kernel is prebuilt assembly, so a stale value
+#: silently misroutes or skips the new source.
+_SOURCE_DERIVED_METADATA = (
+    "kernel_sources",
+    "kernel_kind",
+    "prebuilt_binary",
+    "source_framework",
+    "runtime_backend",
+    "launcher_source_file",
+    "source_promoted_from_launcher",
+    "tracelens_launcher_path",
+    "kernel_path",
+    "vendor_dispatch_wrapper",
+    "runtime_generated_kernel",
+    "flydsl_source_from_fallback",
+    "source_resolution_confidence",
+    "op_to_source_status",
+    "op_to_source_kind",
+    "op_to_source_patchable",
+    "op_to_source_reason",
+    "op_to_source_matched_route",
+    "source_file_missing_on_disk",
+)
+
+
+def _is_curated_resolution(item: dict[str, Any]) -> bool:
+    """Whether this candidate's source came from the curated ground truth.
+
+    ``op_to_source.json`` is hand-maintained and names the actual device source
+    behind an operator, including which of several files is the compute core.
+    A model shown a path and forty lines cannot outrank that, so curated
+    resolutions are not open to rewriting.
+    """
+    status = str(item.get("op_to_source_status") or "").strip()
+    method = str(item.get("source_resolution_method") or "").strip()
+    return method == _KSC.METHOD_CURATED and status in {
+        _ROUTABLE_STATUS,
+        "non_rewritable",
+        "no_kernel",
+    }
+
+
+def apply_resolution_entries_to_candidates(
+    entries: list[dict[str, Any]],
+    candidates: list[dict[str, Any]],
+    op_cat_map: dict[str, str] | None = None,
+) -> int:
+    """Fold reviewed entries back onto the candidates, and re-classify.
+
+    Without this the review tier is inert: it revises the audit artifact while
+    every downstream stage keeps reading ``kernel_candidates.json``. Re-running
+    ``_stamp_candidate_metadata`` matters as much as copying the path -- a
+    rewrite changes ``source_type``, which decides ``reusable_native_kernel``
+    and therefore whether the kernel is dispatched at all.
+
+    Two invariants keep a rewritten candidate internally consistent:
+
+    * A curated resolution is never overwritten (see
+      :func:`_is_curated_resolution`).
+    * Otherwise every field derived from the previous path is cleared before the
+      new one is stamped, so no downstream reader can pick up metadata that
+      describes the source the candidate no longer points at.
+
+    Returns:
+        The number of candidates actually changed.
+    """
+    by_id = {str(c.get("kernel_id")): c for c in candidates if isinstance(c, dict)}
+    changed = 0
+    for entry in entries:
+        if not isinstance(entry, dict) or "previous_source_file" not in entry:
+            continue
+        item = by_id.get(str(entry.get("kernel_id") or ""))
+        if item is None:
+            continue
+        new_source = str(entry.get("source_file") or "")
+        if new_source == str(item.get("source_file") or ""):
+            continue
+        if _is_curated_resolution(item):
+            entry["review_rejected"] = "curated_resolution_not_overridable"
+            entry["source_file"] = str(item.get("source_file") or "")
+            entry["source_line"] = item.get("source_line")
+            entry["source_function"] = str(item.get("source_function") or "")
+            entry["method"] = _candidate_resolution_method(item)
+            entry["reason"] = str(item.get("source_resolution_reason") or "")
+            continue
+        for key in _SOURCE_DERIVED_METADATA:
+            item.pop(key, None)
+        item["source_file"] = new_source
+        item["source_path"] = new_source
+        item["source_line"] = entry.get("source_line")
+        item["source_function"] = str(entry.get("source_function") or "")
+        item["source_resolution_method"] = str(entry.get("method") or "")
+        item["source_resolution_reason"] = str(entry.get("reason") or "")
+        item["source_resolution_previous_file"] = str(entry.get("previous_source_file") or "")
+        item["source_resolution_previous_method"] = str(entry.get("previous_method") or "")
+        item["kernel_repo"] = find_repo_root(new_source) if new_source else ""
+        item["source_type"] = source_type_for(item.get("name", ""), new_source)
+        if item["source_type"] != "vendor_binary" and is_vendor_dispatch_wrapper(
+            item.get("name", ""), new_source
+        ):
+            item["source_type"] = "vendor_binary"
+            item["vendor_dispatch_wrapper"] = True
+        item["runtime_generated_kernel"] = is_runtime_generated_kernel(
+            item.get("name", ""), new_source
+        )
+        _stamp_candidate_metadata(item, op_cat_map)
+        changed += 1
+    return changed
+
+
+def _review_source_resolution(doc: dict[str, Any], *, log_path: Path | str | None) -> None:
+    """Let the opt-in review tier revise the table before it is written.
+
+    Runs on the whole table rather than only the blanks: the deterministic
+    tiers' failure mode is a confidently wrong path, which a blanks-only tier
+    can never reach. Revisions carry their own guard rails (see the module) and
+    are applied in place; any failure leaves the deterministic result standing.
+    """
+    try:
+        from _llm_source_review import review_resolution_document  # noqa: PLC0415
+
+        _, notes = review_resolution_document(
+            doc,
+            framework_roots=tuple(KNOWN_SEARCH_ROOTS),
+            context_block=_source_context_block(),
+            log=_forward_to_log,
+        )
+        summary = f"source-resolution review: {len(notes)} change(s)"
+        log.info("%s", summary)
+        if log_path:
+            append_log(log_path, summary)
+            for note in notes:
+                append_log(log_path, f"  review: {note}")
+    except Exception as exc:  # noqa: BLE001 - advisory tier, never fatal
+        log.warning("source-resolution review failed (%r); keeping deterministic result", exc)
+
+
+def write_source_resolution_artifact(
+    candidates: list[dict[str, Any]],
+    out_path: Path | str,
+    *,
+    framework: str = "",
+    model_name: str = "",
+    log_path: Path | str | None = None,
+    op_cat_map: dict[str, str] | None = None,
+    allow_review: bool = True,
+) -> Path | None:
+    """Write the source-resolution artifact next to the candidate report.
+
+    One file answering "where does each hot kernel live, and how do we know",
+    so a reviewer does not have to reconstruct it from candidate internals.
+    Failure is non-fatal: the artifact is for humans and the review tier, and
+    the candidates themselves already carry the same fields.
+    """
+    try:
+        entries = build_source_resolution_entries(candidates)
+        doc = _KSC.make_document(
+            entries,
+            generated_by="tracelens_analysis",
+            model_name=model_name,
+            framework=framework,
+        )
+        if allow_review:
+            _review_source_resolution(doc, log_path=log_path)
+        # Fold any revision back onto the candidates: they, not this file, are
+        # what the dispatch stage reads.
+        reviewed_entries = [
+            entry for entry in (doc.get("entries") or []) if isinstance(entry, dict)
+        ]
+        applied = apply_resolution_entries_to_candidates(
+            reviewed_entries, candidates, op_cat_map
+        )
+        if applied:
+            review_metadata = {
+                str(entry.get("kernel_id") or ""): {
+                    key: entry[key]
+                    for key in (
+                        "previous_source_file",
+                        "previous_method",
+                        "review_rejected",
+                    )
+                    if key in entry
+                }
+                for entry in reviewed_entries
+            }
+            rebuilt = build_source_resolution_entries(candidates)
+            for entry in rebuilt:
+                entry.update(review_metadata.get(str(entry.get("kernel_id") or ""), {}))
+            doc["entries"] = rebuilt
+            note = f"source-resolution review applied to {applied} candidate(s)"
+            log.info("%s", note)
+            if log_path:
+                append_log(log_path, note)
+        problems = _KSC.validate_document(doc)
+        if problems:
+            log.warning(
+                "source-resolution artifact failed its own contract (%d issue(s)): %s",
+                len(problems),
+                "; ".join(problems[:3]),
+            )
+            return None
+        path = Path(out_path)
+        atomic_write_json(path, doc)
+        final_entries = doc.get("entries") or []
+        resolved = sum(1 for entry in final_entries if entry.get("source_file"))
+        summary = (
+            f"source resolution: {resolved}/{len(final_entries)} "
+            f"kernel(s) located -> {path.name}"
+        )
+        log.info("%s", summary)
+        if log_path:
+            append_log(log_path, summary)
+        return path
+    except Exception as exc:  # noqa: BLE001 - reporting aid, never fails the run
+        log.warning("could not write source-resolution artifact: %r", exc)
+        return None
 
 
 def recommend_backends(candidate: dict[str, Any]) -> list[str]:
@@ -4416,8 +5348,8 @@ def deterministic_extract_hot_kernels(
             if not isinstance(eff_pct, (int, float)):
                 eff_pct = 0
 
-            launcher_path = full_op.get("launcher_path", "")
-            if launcher_path in ("\u2014", "-", ""):
+            launcher_path = str(full_op.get("launcher_path", "") or "")
+            if launcher_path.strip().lower() in _LAUNCHER_PATH_PLACEHOLDERS:
                 launcher_path = ""
             source_file = _resolve_source_file_from_kernel_path(launcher_path)
 
@@ -4469,8 +5401,8 @@ def deterministic_extract_hot_kernels(
         # ``launcher_path`` only points at the calling Python wrapper, so it must
         # not be used as the editable source.
         op_name = op.get("name", "") or op.get("operation", "")
-        launcher_path = op.get("launcher_path", "")
-        if launcher_path in ("\u2014", "-"):
+        launcher_path = str(op.get("launcher_path", "") or "")
+        if launcher_path.strip().lower() in _LAUNCHER_PATH_PLACEHOLDERS:
             launcher_path = ""
 
         # Resolve the symbol to its definition site (never falling back to the
@@ -5836,17 +6768,25 @@ def main() -> int:
         "--model-path",
         default=os.environ.get("MODEL_PATH", ""),
         help=(
-            "Local diffusers model directory (scriptable/xDiT diffusion only). "
-            "When set, an a-priori analytic compute ceiling (approach-a, "
-            "config/safetensors-derived) is written to the diffusion roofline "
-            "sidecar so the workload roofline reports an absolute ideal ms. "
-            "Falls back to resolving --model-name; env: MODEL_PATH."
+            "Local model directory. Selected config.json fields inform bounded "
+            "kernel source resolution for every framework. For scriptable/xDiT "
+            "diffusion it also enables the config/safetensors-derived analytic "
+            "compute ceiling in the workload roofline sidecar. Falls back to "
+            "resolving --model-name; env: MODEL_PATH."
         ),
     )
     parser.add_argument(
         "--precision",
         default="",
         help="Diffusion analytic-ceiling precision (bf16/fp8/fp16); default bf16.",
+    )
+    parser.add_argument(
+        "--runtime-config",
+        default="",
+        help=(
+            "Materialized workload YAML used only to recover EXTRA_*_ARGS for "
+            "bounded source-resolution context."
+        ),
     )
     parser.add_argument(
         "--height",
@@ -6000,6 +6940,32 @@ def main() -> int:
     args = parser.parse_args()
 
     args.target_platform = normalize_platform(args.target_platform)
+    use_deterministic = args.analysis_route == ANALYSIS_ROUTE_DETERMINISTIC
+
+    # Give the model tiers the serving configuration. Which implementation a
+    # kernel reaches depends on it, and forty lines of a candidate file cannot
+    # convey a backend flag. EXTRA_*_ARGS is how the harness passes them; the
+    # raw string is collected here but never forwarded, because it also carries
+    # credentials and paths. _llm_source_context reduces it to allowlisted
+    # backend selectors before anything reaches a model.
+    inherited_server_args = " ".join(
+        value
+        for key, value in os.environ.items()
+        if key.startswith("EXTRA_") and key.endswith("_ARGS") and value.strip()
+    )
+    materialized_server_args = _runtime_server_args_from_config(
+        str(getattr(args, "runtime_config", "") or "")
+    )
+    set_runtime_context(
+        model_path=str(getattr(args, "model_path", "") or ""),
+        server_args=" ".join(
+            value
+            for value in (inherited_server_args, materialized_server_args)
+            if value
+        ),
+        framework=str(getattr(args, "framework", "") or ""),
+        precision=str(getattr(args, "precision", "") or ""),
+    )
 
     session_id = args.session_id or uuid.uuid4().hex[:12]
     run_id = f"tl-{uuid.uuid4().hex[:8]}"
@@ -6386,9 +7352,6 @@ def main() -> int:
                     f"capture_folder resolved: {capture_folder} (exists={capture_folder.is_dir()})",
                 )
 
-            # Route: deterministic vs agent.
-            use_deterministic = args.analysis_route == ANALYSIS_ROUTE_DETERMINISTIC
-
             if use_deterministic and not trace_split_blocked:
                 update_status(
                     status_path,
@@ -6473,6 +7436,11 @@ def main() -> int:
                             total_dur=total_dur or None,
                             perf_report_csv_dir=(tracelens_dir / "perf_report_csvs"),
                             framework=args.framework or None,
+                            trace_files=trace_files,
+                            log_path=log_path,
+                            source_resolution_out=(run_dir / _SOURCE_RESOLUTION_NAME),
+                            allow_model_tiers=False,
+                            model_name=args.model_name,
                         )
                         append_log(
                             log_path,
@@ -6620,6 +7588,10 @@ def main() -> int:
                             total_dur=total_dur or None,
                             perf_report_csv_dir=(skill_result.output_dir / "perf_report_csvs"),
                             framework=args.framework or None,
+                            trace_files=trace_files,
+                            log_path=log_path,
+                            source_resolution_out=(run_dir / _SOURCE_RESOLUTION_NAME),
+                            model_name=args.model_name,
                         )
                         append_log(
                             log_path,
@@ -6684,7 +7656,11 @@ def main() -> int:
                     log_path,
                     "dry-run: parsing raw trace for hot kernels (production code path raises here — see #203)",
                 )
-                candidates = analyze_trace_files(trace_files, args.top_k)
+                candidates = analyze_trace_files(
+                    trace_files,
+                    args.top_k,
+                    allow_model_tiers=not use_deterministic,
+                )
             else:
                 raise RuntimeError(
                     "No hot-kernel candidates produced by any TraceLens "
@@ -6697,6 +7673,21 @@ def main() -> int:
         if roofline_by_name:
             append_log(log_path, f"merged roofline results: {len(roofline_by_name)} kernels")
         merge_roofline_into_candidates(candidates, roofline_by_name)
+        source_resolution_path = run_dir / _SOURCE_RESOLUTION_NAME
+        if _KSC is not None:
+            if not source_resolution_path.is_file():
+                write_source_resolution_artifact(
+                    candidates,
+                    source_resolution_path,
+                    framework=args.framework or "",
+                    model_name=args.model_name or "",
+                    log_path=log_path,
+                    allow_review=False,
+                )
+            if source_resolution_path.is_file():
+                artifacts["kernel_source_resolution"] = str(
+                    source_resolution_path
+                )
         artifacts.update(
             write_reports(
                 run_dir,

--- a/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
@@ -1334,18 +1334,23 @@ def _row_to_candidate(
     args = record.get("args", "").replace("<br>", "\n").strip()
     shapes = [s.strip() for s in args.split("\n") if s.strip() and s.strip() not in {"-", "—"}]
     kernel_path = record.get("kernel path", "").strip()
-    if kernel_path in {"-", "—"}:
+    # Share the launcher placeholder vocabulary so a sentinel such as TraceLens'
+    # "Not found" cannot survive as a fake source_file (see the constant).
+    if kernel_path.lower() in _LAUNCHER_PATH_PLACEHOLDERS:
         kernel_path = ""
     # Device kernel symbol(s) used to disambiguate dispatch ops; keep the full
     # list and use the first for matching. Placeholders normalize to "".
     device_kernel_names = _parse_kernel_name_cell(record.get("kernel name", ""))
     device_kernel_name = device_kernel_names[0] if device_kernel_names else ""
-    # Promote a framework-relative launcher path to its absolute on-disk source.
-    resolved_source_file = kernel_path
+    # Store only the path in source_file; line/function annotations have their
+    # own fields and otherwise make extension-based routing see an unknown file.
+    resolved_source_file, resolved_line, resolved_func = _parse_launcher_path(
+        kernel_path
+    )
     if kernel_path:
         resolved = _resolve_launcher_to_abs_source(kernel_path)
         if resolved is not None:
-            resolved_source_file, _resolved_line, _resolved_func = resolved
+            resolved_source_file, resolved_line, resolved_func = resolved
     time_ms = _safe_float(record.get("time (ms)"))
     percent_e2e = _safe_float(record.get("%e2e"))
     count_val = _safe_float(record.get("count"), 1.0)
@@ -1367,6 +1372,8 @@ def _row_to_candidate(
         "duration_us": time_ms * 1000.0,
         "call_count": int(count_val) if count_val else 0,
         "source_file": resolved_source_file,
+        "source_line": resolved_line,
+        "source_function": resolved_func or "",
         # Raw Kernel Path kept so aggregation's AST resolution survives the source_file overwrite.
         "tracelens_launcher_path": kernel_path,
         # Device kernel symbol for dispatch resolution; "" when absent.
@@ -1559,6 +1566,11 @@ _LAUNCHER_PATH_RE = re.compile(
     r"(?P<path>.+?)\((?P<line>\d+)\)\s*:\s*(?P<func>[A-Za-z_][A-Za-z0-9_]*)\s*$",
 )
 # Placeholders for unresolved Kernel Paths; must not survive parsing.
+# ``not found`` is TraceLens' own sentinel for an unresolved launcher: it lands
+# in ``other_metrics.json`` whenever ``_find_entry_point`` cannot locate the op
+# in the call stack (every Synthetic Op), and the report agent copies it
+# verbatim into the Kernel Path cell. Letting it through makes it a truthy
+# ``source_file`` that silently skips the grep fallback downstream.
 _LAUNCHER_PATH_PLACEHOLDERS: frozenset[str] = frozenset(
     {
         "",
@@ -1567,6 +1579,9 @@ _LAUNCHER_PATH_PLACEHOLDERS: frozenset[str] = frozenset(
         "–",
         "n/a",
         "none",
+        "not found",
+        "not_found",
+        "notfound",
         "null",
         "tbd",
         "unknown",
@@ -1730,16 +1745,16 @@ def _resolve_launcher_to_abs_source(
         kernel_path: The TraceLens launcher-path to resolve.
 
     Returns:
-        An ``(abs_file, line, function_name)`` tuple only when the file
-        exists, else ``None`` (a conservative miss defers to the caller's grep
-        locator).
+        An ``(abs_file, line, function_name)`` tuple for an absolute path or a
+        resolvable framework-relative file, else ``None``.
     """
     raw_path, line, func = _parse_launcher_path(kernel_path)
     if not raw_path:
         return None
     if os.path.isabs(raw_path):
-        # Already absolute — None signals "no rewrite needed".
-        return None
+        # Keep container-resident paths even when this analysis host cannot stat
+        # them; the caller still needs the annotation split into separate fields.
+        return raw_path, line, func
     head = raw_path.split("/", 1)[0]
     if not head or head.startswith("."):
         return None

--- a/src/hyperloom/common/kernel_source_contract.py
+++ b/src/hyperloom/common/kernel_source_contract.py
@@ -1,0 +1,271 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""On-disk audit view of hot-kernel source resolution.
+
+Source resolution used to exist only as a scatter of fields mutated onto
+candidate rows by a dozen functions, with no single place to read "which file
+did we decide this kernel lives in, and how sure are we". This module defines a
+standalone, versioned artifact for exactly that question.
+
+**Scope: this is an audit view, not the stage contract.** The contract between
+analysis and optimization remains ``kernel_candidates.json`` -- it alone carries
+what dispatch needs (shapes, ``reusable_native_kernel``, ``skip_reason``,
+``source_type``, recommended backends, task groups, dispatchability). This
+artifact answers one narrow question and is deliberately not sufficient to
+decide what to optimize.
+
+The review tier revises entries here, but a revision only reaches the pipeline
+because ``apply_resolution_entries_to_candidates()`` folds it back onto the
+candidates and re-runs classification. Editing this file after the fact changes
+nothing downstream.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+#: Bump the major on any field removal or meaning change; consumers gate on it.
+SOURCE_RESOLUTION_SCHEMA_VERSION = "1.0.0"
+
+#: Canonical artifact name, relative to the analysis run directory.
+SOURCE_RESOLUTION_FILENAME = "kernel_source_resolution.json"
+
+#: How a location was decided, best evidence first. ``llm_review`` outranks the
+#: deterministic tiers only because it runs last and sees their output; it is
+#: not more trusted, which is why the tier it overrode is kept in
+#: ``previous_method``.
+METHOD_CURATED = "op_to_source"
+METHOD_TRACE = "trace_python_stack"
+METHOD_GREP = "name_grep"
+METHOD_LLM_FALLBACK = "llm_fallback"
+METHOD_LLM = "llm_review"
+METHOD_REJECTED = "rejected_non_path_sentinel"
+METHOD_UNRESOLVED = "unresolved"
+
+KNOWN_METHODS = frozenset(
+    {
+        METHOD_CURATED,
+        METHOD_TRACE,
+        METHOD_GREP,
+        METHOD_LLM_FALLBACK,
+        METHOD_LLM,
+        METHOD_REJECTED,
+        METHOD_UNRESOLVED,
+    }
+)
+
+#: Every entry carries these, so a consumer can rely on presence without
+#: defaulting. Values may be empty; the keys may not be absent.
+REQUIRED_ENTRY_KEYS = (
+    "kernel_id",
+    "name",
+    "gpu_pct",
+    "source_file",
+    "method",
+    "reason",
+)
+
+REQUIRED_DOCUMENT_KEYS = ("schema_version", "generated_by", "entries")
+
+
+def make_entry(
+    *,
+    kernel_id: str,
+    name: str,
+    gpu_pct: float,
+    source_file: str = "",
+    source_line: int | None = None,
+    source_function: str = "",
+    method: str = METHOD_UNRESOLVED,
+    confidence: float | None = None,
+    reason: str = "",
+    rejected_value: str = "",
+    previous_source_file: str = "",
+    previous_method: str = "",
+) -> dict[str, Any]:
+    """Build one resolution entry with every required key present.
+
+    Args:
+        kernel_id: Stable-within-run candidate id (``k001``).
+        name: Kernel symbol as the profiler reported it.
+        gpu_pct: Share of GPU time, used to rank what is worth resolving.
+        source_file: Resolved path, or ``""`` when unresolved.
+        source_line: 1-based line when the tier produced one.
+        source_function: Enclosing function when the tier produced one.
+        method: One of :data:`KNOWN_METHODS`.
+        confidence: 0..1 when the tier reports one; ``None`` for deterministic
+            tiers, which are either right or silent.
+        reason: Human-readable note -- why this path, or why none.
+        rejected_value: Placeholder that was zeroed, kept for audit.
+        previous_source_file: Location replaced by a model review.
+        previous_method: Resolution tier replaced by a model review.
+
+    Returns:
+        The entry dict.
+    """
+    entry = {
+        "kernel_id": str(kernel_id or ""),
+        "name": str(name or ""),
+        "gpu_pct": float(gpu_pct or 0.0),
+        "source_file": str(source_file or ""),
+        "source_line": source_line,
+        "source_function": str(source_function or ""),
+        "method": str(method or METHOD_UNRESOLVED),
+        "confidence": confidence,
+        "reason": str(reason or ""),
+        "rejected_value": str(rejected_value or ""),
+    }
+    if previous_source_file:
+        entry["previous_source_file"] = str(previous_source_file)
+        entry["previous_method"] = str(previous_method or "")
+    return entry
+
+
+def make_document(
+    entries: list[dict[str, Any]],
+    *,
+    generated_by: str,
+    model_name: str = "",
+    framework: str = "",
+) -> dict[str, Any]:
+    """Wrap ``entries`` in the versioned envelope."""
+    return {
+        "schema_version": SOURCE_RESOLUTION_SCHEMA_VERSION,
+        "generated_by": str(generated_by or ""),
+        "model_name": str(model_name or ""),
+        "framework": str(framework or ""),
+        "entries": list(entries),
+    }
+
+
+def validate_document(doc: Any) -> list[str]:
+    """Return a list of contract violations; empty means the document is valid.
+
+    Reports every problem rather than raising on the first, so a producer test
+    failure names all of them at once.
+    """
+    problems: list[str] = []
+    if not isinstance(doc, dict):
+        return [f"document is {type(doc).__name__}, expected dict"]
+    for key in REQUIRED_DOCUMENT_KEYS:
+        if key not in doc:
+            problems.append(f"document missing required key {key!r}")
+    version = str(doc.get("schema_version") or "")
+    if version and version.split(".")[0] != SOURCE_RESOLUTION_SCHEMA_VERSION.split(".")[0]:
+        problems.append(
+            f"schema_version {version!r} has a different major than "
+            f"{SOURCE_RESOLUTION_SCHEMA_VERSION!r}"
+        )
+    entries = doc.get("entries")
+    if not isinstance(entries, list):
+        problems.append(f"entries is {type(entries).__name__}, expected list")
+        return problems
+    for i, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            problems.append(f"entries[{i}] is {type(entry).__name__}, expected dict")
+            continue
+        for key in REQUIRED_ENTRY_KEYS:
+            if key not in entry:
+                problems.append(f"entries[{i}] missing required key {key!r}")
+        method = str(entry.get("method") or "")
+        if method and method not in KNOWN_METHODS:
+            problems.append(f"entries[{i}] has unknown method {method!r}")
+        src = str(entry.get("source_file") or "")
+        if src and method in {METHOD_UNRESOLVED, METHOD_REJECTED}:
+            problems.append(
+                f"entries[{i}] has a source_file but method is {method}"
+            )
+        if not src and method not in {METHOD_UNRESOLVED, METHOD_REJECTED}:
+            problems.append(f"entries[{i}] has method {method!r} but no source_file")
+        confidence = entry.get("confidence")
+        if confidence is not None:
+            if (
+                isinstance(confidence, bool)
+                or not isinstance(confidence, (int, float))
+                or not math.isfinite(float(confidence))
+                or not 0.0 <= float(confidence) <= 1.0
+            ):
+                problems.append(
+                    f"entries[{i}] has invalid confidence {confidence!r}; "
+                    "expected a finite number in [0, 1]"
+                )
+    return problems
+
+
+#: TraceLens reports a call site as "path.py(247): fn_name"; the line and
+#: function ride along in the same string.
+_LINE_SUFFIX_RE = re.compile(
+    r"^(?P<path>.+?)\((?P<line>\d+)\)\s*(?::\s*(?P<function>.*))?$"
+)
+
+
+def split_line_suffix(path: str) -> tuple[str, int | None, str]:
+    """Split a TraceLens call-site string into path, line and function."""
+    text = (path or "").strip()
+    if not text:
+        return "", None, ""
+    match = _LINE_SUFFIX_RE.match(text)
+    if match is None:
+        return text, None, ""
+    return (
+        match.group("path").strip(),
+        int(match.group("line")),
+        str(match.group("function") or "").strip(),
+    )
+
+
+def strip_line_suffix(path: str) -> str:
+    """Return the bare file path from a possibly line-annotated one.
+
+    ``/repo/moe.py(247): _grouped_gemm`` -> ``/repo/moe.py``. Measured on a real
+    session, 29 of 36 resolved entries carried this suffix, so an existence
+    check that skips this step rejects paths that are perfectly real.
+    """
+    return split_line_suffix(path)[0]
+
+
+def canonical_source_path(path: str, roots: tuple[str, ...]) -> str:
+    """Return the validated canonical target for ``path``, or ``""``.
+
+    The file must exist on this host **and** sit under a known framework root.
+
+    Requiring existence is the point. "Under a root" alone is trivially
+    satisfiable by a plausible-looking invention -- a model can emit
+    ``<root>/python/sglang/srt/layers/attention/does_not_exist.py`` and pass a
+    root-prefix check, which would hand the backend a fabricated file and
+    reintroduce exactly the wrong-source failure this pipeline exists to
+    prevent. A deterministic tier may legitimately resolve to a path that is
+    absent here (the analysis host often lacks the serving container's
+    filesystem), and such a path is kept with a ``source_file_missing_on_disk``
+    breadcrumb -- but that latitude is not extended to a generated rewrite.
+    """
+    text = strip_line_suffix(path)
+    if not text or not os.path.isfile(text):
+        return ""
+    real = os.path.realpath(text)
+    for root in roots:
+        if not root:
+            continue
+        resolved_root = os.path.realpath(str(root)).rstrip(os.sep)
+        if real == resolved_root or real.startswith(resolved_root + os.sep):
+            return real
+    return ""
+
+
+def path_is_acceptable(path: str, roots: tuple[str, ...]) -> bool:
+    """Whether a rewriting tier may write ``path`` as a resolved location."""
+    return bool(canonical_source_path(path, roots))
+
+
+def read_document(path: Path | str) -> dict[str, Any] | None:
+    """Load the artifact, or ``None`` when it is absent or unreadable."""
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -4232,6 +4232,7 @@ class TestBuildTraceAnalyzeCmd:
 
     def _common(self, monkeypatch, tmp_path):
         monkeypatch.delenv("INFERENCE_OPTIMIZER_STEADY_STATE_MODE", raising=False)
+        monkeypatch.delenv("MODEL_PATH", raising=False)
         monkeypatch.setattr(krh, "_kernel_agent_tool_path", lambda name: Path("/tools") / name)
         state = SharedState()
         return state, tmp_path / "sess"
@@ -4285,6 +4286,32 @@ class TestBuildTraceAnalyzeCmd:
         ]
         assert steady == ""
 
+    def test_sglang_cmd_forwards_model_context(self, monkeypatch, tmp_path):
+        """Non-scriptable analysis receives model config and precision context."""
+        state, session_dir = self._common(monkeypatch, tmp_path)
+        state.model_path = "/models/sglang-model"
+        state.precision = "fp8"
+        state.baseline_config_path = "/session/materialized.yaml"
+        cmd, _steady = krh._build_trace_analyze_cmd(
+            {"trace_input": "/t/trace"},
+            session_dir=session_dir,
+            state=state,
+            workspace_path="/ws",
+            trace_input="/t/trace",
+            tracelens_root=Path("/tl"),
+            is_bypass=False,
+            scriptable=False,
+            workload={"precision": "mxfp8"},
+            model_name="MiniMax",
+            framework="sglang",
+            target_platform="MI355X",
+            analysis_mode="default",
+            analysis_route="agent",
+        )
+        assert cmd[cmd.index("--model-path") + 1] == "/models/sglang-model"
+        assert cmd[cmd.index("--precision") + 1] == "fp8"
+        assert cmd[cmd.index("--runtime-config") + 1] == "/session/materialized.yaml"
+
     def test_bypass_scriptable_cmd(self, monkeypatch, tmp_path):
         state, session_dir = self._common(monkeypatch, tmp_path)
         state.model_path = "/models/flux"
@@ -4322,6 +4349,7 @@ class TestBuildTraceAnalyzeCmd:
         assert "--split-conc" not in cmd
         # bypass takes no analysis-route flag.
         assert "--analysis-route" not in cmd
+        assert "--runtime-config" not in cmd
         assert "--steady-state-mode" in cmd and cmd[cmd.index("--steady-state-mode") + 1] == "auto"
         assert cmd[-1] == "--dry-run"
         assert steady == "auto"

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -3927,6 +3927,34 @@ def _build_trace_analyze_cmd(
     if analysis_mode:
         cmd += ["--analysis-mode", str(analysis_mode)]
 
+    # Model identity informs source resolution for every framework, not only the
+    # diffusion roofline. Keep the standard payload > state > environment
+    # precedence so ordinary sglang/vLLM production requests carry config.json
+    # selectors into the bounded model context.
+    model_path = str(
+        payload.get("model_path")
+        or getattr(state, "model_path", "")
+        or os.environ.get("MODEL_PATH")
+        or ""
+    ).strip()
+    if model_path:
+        cmd += ["--model-path", model_path]
+    precision = str(
+        payload.get("precision")
+        or getattr(state, "precision", "")
+        or workload.get("precision")
+        or ""
+    ).strip()
+    if precision:
+        cmd += ["--precision", precision]
+    runtime_config = str(
+        payload.get("runtime_config")
+        or getattr(state, "baseline_config_path", "")
+        or ""
+    ).strip()
+    if runtime_config and not is_bypass:
+        cmd += ["--runtime-config", runtime_config]
+
     if scriptable:
         # --skip-split is TraceLens-only; the bypass backend has its own windowing.
         if not is_bypass:
@@ -3940,14 +3968,6 @@ def _build_trace_analyze_cmd(
                     cmd += ["--num-denoise-steps", str(int(num_denoise))]
             except (TypeError, ValueError):
                 pass
-        # Forward model dir + precision so the diffusion roofline sidecar can emit
-        # an analytic compute ceiling (roofline_ideal_ms).
-        model_path = (payload.get("model_path") or state.model_path or "").strip()
-        if model_path:
-            cmd += ["--model-path", str(model_path)]
-        precision = (payload.get("precision") or workload.get("precision") or "").strip()
-        if precision:
-            cmd += ["--precision", str(precision)]
     else:
         # Splitter workload hints. Priority: payload override > baseline metadata
         # > drop the flag.


### PR DESCRIPTION
## Problem

TraceLens writes a placeholder into `source_file` whenever it cannot resolve a
launcher — `Not found` for every Synthetic Op, `AITER (vendor)` for vendor
kernels, `N/A` elsewhere. Downstream code tested that field for truthiness, so a
placeholder counted as a resolved source: the grep fallback was skipped and
`classify_patchability` rejected the candidate with *"source not under a
reusable framework root: Not found"*.

This hit the hottest kernels precisely because they are the ones TraceLens
cannot attribute — hand-written Triton kernels launched straight from Python
have no `cpu_op` parent, so they surface as Synthetic Ops.

## Resolution ladder

```
curated dictionary → trace-derived launcher → name grep → model fallback
                                                        → model review
```

Placeholders are normalized to empty before any of it, since every later tier
is gated on an empty `source_file`. `looks_like_source_path()` replaces the
truthiness test, and a rejected value is preserved as `source_file_rejected`
rather than silently dropped. Bare runtime API names (`hipModuleLaunchKernel`
and friends) are excluded from grep, which would otherwise match unrelated call
sites.

## Trace-derived resolution

`_trace_launcher_resolver` walks kernel correlation → runtime launch → the
enclosing `python_function` frame. Three properties make it trustworthy:

**Deterministic.** Profiler timestamps are microsecond-granular, so adjacent
frames on a fast call chain share a `ts`. Ordering by start alone left the tie
to trace write order — the same call chain resolved differently depending on
which frame was serialised first. Ordering by `(ts, -dur)` lets nesting decide.

**Process-aware.** Kernels, launches and frames are keyed with `pid`. A merged
multi-process trace restarts correlation and thread ids per rank, so without it
one rank's launch overwrites another's and a kernel binds to a different
process's launcher.

**Bounded.** Kernels launched from C++ or only replayed from a graph never
resolve, so "stop once everything resolves" would read an entire capture folder
at two streaming passes per file. The file count is capped, scanning stops when
a file adds nothing, and the probe map is sized by launches rather than by every
correlated runtime event.

A tie at the top of the frame vote now leaves the kernel unresolved rather than
picking whichever the counter saw first — a plurality is not agreement, and the
grep tier is a better answer than an arbitrary one.

## The two model tiers

Both run unconditionally; there is no environment switch. They differ in scope
and authority, and `docs/reference/environment-variables.md` documents each
separately.

**Fallback** sees a candidate only after all three deterministic tiers come up
empty, and only above 5% GPU share. It may return one of the exact grep
shortlist strings and nothing else; an invented path is rejected, as is anything
below 0.7 confidence.

**Review** exists because the deterministic tiers do not fail by coming up
empty — they fail by coming up *confidently wrong*. Measured across historical
sessions, only 59% of verifiable resolutions mention the kernel they claim to
define, and `aten::fill_` alone resolves to four unrelated business files, each
a real root-resident path passing every mechanical check. A tier gated on an
empty `source_file` can never see any of them, so this one inspects the whole
table and may keep, rewrite or unresolve any entry. Two guard rails bound it: a
rewritten path must exist on disk under a known framework root, and every
revision records `previous_source_file` and `previous_method` so a bad review is
reversible.

Neither tier can fail a run. No model configured, a gateway error, a timeout or
an unparseable reply all leave the deterministic result standing.

## Observability

Every non-trivial outcome is recorded as `source_resolution_reason`, so a skip
is distinguishable from a failure:

| Value | Meaning |
|---|---|
| *(absent)* | Resolved deterministically |
| `llm_fallback_skipped: gpu_pct ...` | Below the 5% floor; no call made |
| `llm_fallback_no_shortlist` | Grep found nothing; no call made |
| `llm_fallback_declined: ...` | Answered but rejected |
| `llm_fallback_error: ...` | Import error, gateway rejection, or timeout |
| `trace_resolver_error: ...` | Trace unreadable or resolver raised |
| `rejected_non_path_sentinel` | A placeholder was zeroed |

Per-file resolver errors reach the caller through a `file_errors` list instead
of surfacing as an ordinary "0 resolved". The `resolved/total` tally goes to the
run log, where an operator actually looks.

## New artifact

`kernel_source_resolution.json` records, per hot kernel, the identity, GPU
share, resolved location and deciding tier, behind a `schema_version` consumers
can gate on. Previously this existed only as fields mutated onto candidate rows
by a dozen functions, with no single place to read "where does this kernel live,
and how do we know".

**Scope: it is an audit view, not the stage contract.** `kernel_candidates.json`
remains the contract, since it alone carries shapes, eligibility, backends and
task groups. Review-tier revisions reach the pipeline because
`apply_resolution_entries_to_candidates()` folds them back onto the candidates
and re-runs classification — a rewrite changes `source_type`, which decides
whether the kernel is dispatched at all.

On a completed session the artifact reported 37 entries, 36 resolved: 29 by
grep, 6 by the trace tier, 1 by the curated dictionary.

## Files

New:
- `common/kernel_source_contract.py` — versioned artifact schema and validation
- `tools/_trace_launcher_resolver.py`
- `tools/_llm_source_fallback.py`
- `tools/_llm_source_review.py`
- `tests/test_trace_launcher_resolver.py`
- `tests/test_source_resolution_guards.py`
- `tests/test_source_resolution_artifact.py`
- `tests/test_llm_source_fallback.py`

Modified:
- `tools/tracelens_analysis.py`
- `tools/tracelens_skill_runner.py`
- `docs/reference/environment-variables.md`
- `inference_optimizer/tests/test_setup_cli.py` — unrelated CI fix, see below

## Testing

Full kernel-agent suite: 1321 passed. The one failure
(`test_bypass_report.py::test_render_surfaces_source_dispatchability_and_task_groups`)
reproduces on a clean `origin/main` worktree and is unrelated.

The `test_setup_cli.py` change is a CI fix, not part of this feature. The
DeepSeek-only preflight test inherited the host environment, so a runner with
`OPENAI_BASE_URL` set tripped the cross-provider check and failed a test whose
premise is that only DeepSeek is configured. It reproduces on a clean
`origin/main` worktree by exporting that variable, so it is a pre-existing
sensitivity rather than a regression — but it was blocking this PR's checks.

## Not included

Roofline patch-set repairs and the SGLang patch vendoring were part of an
earlier revision of this branch and have been removed. Consumer-side
consolidation is also out of scope: `request_handlers.py` still carries its own
copy of the source-path classification logic, which can disagree with the
producer's. Unifying that touches eight consumers and belongs in its own PR.
