### PR TITLE
fix(fusion): stop an LLM outage from retiring fusion for the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   `enablement_source_context` / `enablement_candidate_refs` params and are
   folded into the §1b mandate at the point of use.
 
+- **An LLM outage during forge-fusion no longer disables fusion for the rest of the
+  session.** forge-fusion reports `verdict: llm_unavailable` (manifest schema v2)
+  when discovery never reached the model, which is a fact about the gateway and not
+  about the kernel. The wrapper's `_normalize_manifest` had no case for it, so it
+  fell through to the generic no-KEEP shape — `status: complete`,
+  `micro_decision: no_improvement`, `decision: REVERT`. That was wrong twice over.
+  It recorded an outage as an optimization result, and because
+  `_fusion_required_before_kernel_opt` skips fusion once `last_fusion.status` is
+  `ok`/`complete`/`kept`, a single gateway blip marked fusion "done" and the model
+  was never fusion-optimized again in that session.
+
+  It is now shaped like the existing subprocess-timeout result — `status: failed`,
+  `micro_decision: failed`, `kept: false`, `error_class: llm_unavailable`, with the
+  manifest's error kind, attempt count and message carried through — which is how
+  Hyperloom already says "infrastructure failed, this is retryable". A real
+  `no_opportunity` (the model was asked and found nothing) is unchanged and still
+  suppresses a pointless re-run. The verdict is matched tolerantly and only honoured
+  when the manifest reports no KEEP, so it can never discard a validated fusion.
+
 ### Removed
 
 - **Kernel-agent LLM role retired** (breaking): the `kernel_agent` role has been

--- a/src/hyperloom/agents/kernel/tests/test_forge_fusion.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_fusion.py
@@ -245,6 +245,86 @@ def test_normalize_manifest_kept_writes_keep_result(tmp_path, monkeypatch):
     assert result["artifact_files"] == ["foo.py"]
 
 
+def test_normalize_manifest_reports_an_llm_outage_as_infrastructure(tmp_path):
+    """`llm_unavailable` means the model was never reached, so it is not a verdict.
+
+    The generic no-KEEP shape would call it ``complete``/``no_improvement``, which
+    records an outage as an optimization result AND satisfies the KERNEL-entry
+    idempotency gate -- one gateway blip would then skip fusion for the whole
+    remaining session.
+    """
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    manifest = {
+        "schema_version": 2,
+        "verdict": "llm_unavailable",
+        "diagnosis": {"is_candidate": True},
+        "fusion": None,
+        "fusion_candidates": [],
+        "fusion_loop": None,
+        "validation": None,
+        "artifacts": None,
+        "error": {
+            "stage": "discovery",
+            "class": "llm_unavailable",
+            "kind": "api_error",
+            "attempts": 4,
+            "message": "Error code: 400 - Bad Request",
+        },
+    }
+    (output_dir / "fusion_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    result = forge_fusion._normalize_manifest(str(output_dir), rc=3)
+
+    # Shaped like the timeout result: infrastructure failed, nothing was judged.
+    assert result["status"] == "failed"
+    assert result["micro_decision"] == "failed"
+    assert result["decision"] == "REVERT"
+    assert result["kept"] is False
+    assert result["requires_e2e_validation"] is False
+    assert result["error_class"] == "llm_unavailable"
+    assert result["verdict"] == "llm_unavailable"
+    assert "api_error" in result["error"]
+    assert "4 attempt(s)" in result["error"]
+    assert "Error code: 400" in result["error"]
+
+
+def test_an_llm_outage_leaves_fusion_retryable_at_the_next_kernel_entry(tmp_path):
+    """The load-bearing consequence: `status` decides whether fusion runs again.
+
+    ``_fusion_required_before_kernel_opt`` skips fusion once ``last_fusion.status``
+    is one of ok/complete/kept, so an outage must NOT report one of those.
+    """
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    (output_dir / "fusion_manifest.json").write_text(
+        json.dumps({"schema_version": 2, "verdict": "llm_unavailable", "error": {}}),
+        encoding="utf-8",
+    )
+
+    result = forge_fusion._normalize_manifest(str(output_dir), rc=3)
+
+    assert result["status"] not in ("ok", "complete", "kept")
+
+
+def test_normalize_manifest_still_reports_a_real_no_opportunity(tmp_path):
+    """A run that DID reach the model and found nothing is unchanged: it is a real
+    conclusion, and re-running it in the same session would buy nothing."""
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    (output_dir / "fusion_manifest.json").write_text(
+        json.dumps({"schema_version": 2, "verdict": "no_opportunity", "error": None}),
+        encoding="utf-8",
+    )
+
+    result = forge_fusion._normalize_manifest(str(output_dir), rc=0)
+
+    assert result["status"] == "complete"
+    assert result["micro_decision"] == "no_improvement"
+    assert result["verdict"] == "no_opportunity"
+    assert "error_class" not in result
+
+
 def test_normalize_manifest_prefers_artifacts_repo_root(tmp_path, monkeypatch):
     """kernel_repo must come from the root forge-fusion exported against (authoritative
     for a non-git pip framework), NOT a git toplevel that would break patch apply."""

--- a/src/hyperloom/agents/kernel/tests/test_forge_fusion.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_fusion.py
@@ -307,6 +307,92 @@ def test_an_llm_outage_leaves_fusion_retryable_at_the_next_kernel_entry(tmp_path
     assert result["status"] not in ("ok", "complete", "kept")
 
 
+def test_an_llm_outage_verdict_never_discards_a_validated_fusion(tmp_path):
+    """A KEEP outranks the outage verdict, however the manifest ends up shaped.
+
+    forge-fusion only overrides the verdict when discovery raised -- and then it has
+    no recipes, so no loop and no validation -- but that invariant lives in another
+    repository and nothing here can enforce it. Being wrong would throw away a
+    measured patch, so the guard is local.
+    """
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    manifest = {
+        "schema_version": 2,
+        "verdict": "llm_unavailable",
+        "fusion_loop": {"kept": True, "best": {"kernel_speedup": 1.2}},
+        "validation": {"kept": True, "kernel_speedup": 1.2},
+        "artifacts": {"patch": "diff --git a/foo.py", "changes": [{"path": "foo.py"}]},
+        "fusion": {"source_file": str(output_dir / "foo.py")},
+        "error": {"kind": "api_error", "attempts": 2, "message": "flaky"},
+    }
+    (output_dir / "fusion_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    result = forge_fusion._normalize_manifest(str(output_dir), rc=3)
+
+    assert result["kept"] is True
+    assert result["decision"] == "KEEP"
+    assert result["status"] == "ok"
+    assert result["requires_e2e_validation"] is True
+    assert result["patch"] == "diff --git a/foo.py"
+    assert "error_class" not in result
+
+
+def test_an_llm_outage_verdict_is_matched_tolerantly(tmp_path):
+    """Matching must not fail open: a stray space would fall back to the
+    no_improvement mapping, i.e. straight back into the bug this prevents."""
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    (output_dir / "fusion_manifest.json").write_text(
+        json.dumps({"schema_version": 2, "verdict": " LLM_Unavailable "}),
+        encoding="utf-8",
+    )
+
+    result = forge_fusion._normalize_manifest(str(output_dir), rc=3)
+
+    assert result["error_class"] == "llm_unavailable"
+    assert result["status"] == "failed"
+
+
+def test_main_relays_the_outage_sentinel_despite_a_non_zero_exit(tmp_path, monkeypatch, capsys):
+    """forge-fusion exits 3 for an unreachable LLM, which is the first non-zero exit
+    that still carries a valid manifest.
+
+    The wrapper mirrors the child's exit code, and the handler prefers the sentinel
+    over ``rc``; this pins that contract so a later "just trust rc" simplification
+    cannot silently degrade the outage into a generic handler failure.
+    """
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    (output_dir / "fusion_manifest.json").write_text(
+        json.dumps({
+            "schema_version": 2,
+            "verdict": "llm_unavailable",
+            "error": {"kind": "api_error", "attempts": 5, "message": "gateway 400 x5"},
+        }),
+        encoding="utf-8",
+    )
+    input_json = tmp_path / "input.json"
+    input_json.write_text(json.dumps(_payload(output_dir)), encoding="utf-8")
+
+    class Proc:
+        returncode = 3  # forge_fusion.cli.EXIT_LLM_UNAVAILABLE
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(forge_fusion, "_run_with_tree_timeout", lambda _cmd, _timeout: Proc())
+
+    rc = forge_fusion.main(["--input-json", str(input_json)])
+
+    assert rc == 3, "the child's exit code is mirrored, not swallowed"
+    result = _sentinel_payload(capsys.readouterr().out)
+    assert result["status"] == "failed"
+    assert result["error_class"] == "llm_unavailable"
+    assert result["kept"] is False
+    # The on-disk fallback has to agree with the sentinel.
+    assert json.loads((output_dir / "result.json").read_text(encoding="utf-8")) == result
+
+
 def test_normalize_manifest_still_reports_a_real_no_opportunity(tmp_path):
     """A run that DID reach the model and found nothing is unchanged: it is a real
     conclusion, and re-running it in the same session would buy nothing."""

--- a/src/hyperloom/agents/kernel/tools/forge_fusion.py
+++ b/src/hyperloom/agents/kernel/tools/forge_fusion.py
@@ -266,7 +266,11 @@ def _normalize_manifest(output_dir: str, rc: int) -> dict[str, Any]:
         result["error"] = f"fusion_manifest.json parse error: {exc!r}"
         return result
 
-    if str(m.get("verdict") or "") == LLM_UNAVAILABLE_VERDICT:
+    loop = m.get("fusion_loop") or {}
+    val = m.get("validation") or {}
+    kept = bool(loop.get("kept") or val.get("kept"))
+
+    if str(m.get("verdict") or "").strip().lower() == LLM_UNAVAILABLE_VERDICT and not kept:
         # forge-fusion never reached the model, so this run holds no opinion about the
         # kernel. The default no-KEEP shape below would report it as
         # ``complete``/``no_improvement``, which is wrong twice over: it records an
@@ -275,6 +279,13 @@ def _normalize_manifest(output_dir: str, rc: int) -> dict[str, Any]:
         # blip would skip fusion for the whole remaining session and the model would
         # never be fusion-optimized at all. The timeout shape below is the established
         # way to say "infrastructure failed, this is retryable".
+        #
+        # Guarded on ``not kept`` so this can never discard a validated fusion. That
+        # combination should be impossible -- forge-fusion only overrides the verdict
+        # when discovery raised, in which case it proposed no recipes and the loop
+        # never ran -- but that invariant lives in another repo and nothing here can
+        # enforce it, while the cost of being wrong is throwing away a measured patch.
+        #
         # ``result`` still carries its failed/REVERT/not-kept defaults from above, so
         # only the outage's identity has to be added.
         detail = m.get("error") if isinstance(m.get("error"), dict) else {}
@@ -289,10 +300,7 @@ def _normalize_manifest(output_dir: str, rc: int) -> dict[str, Any]:
         })
         return result
 
-    loop = m.get("fusion_loop") or {}
-    val = m.get("validation") or {}
     best = loop.get("best") or {}
-    kept = bool(loop.get("kept") or val.get("kept"))
     speedup = best.get("kernel_speedup") or val.get("kernel_speedup")
     best_flags = str(loop.get("best_env_flag") or "").split()
     artifacts = m.get("artifacts") or {}

--- a/src/hyperloom/agents/kernel/tools/forge_fusion.py
+++ b/src/hyperloom/agents/kernel/tools/forge_fusion.py
@@ -38,6 +38,12 @@ sys.path.pop(0)
 
 RESULT_BEGIN = "FORGE_FUSION_RESULT_BEGIN"
 RESULT_END = "FORGE_FUSION_RESULT_END"
+
+# forge-fusion's manifest verdict for "discovery never reached the model", added in
+# manifest schema v2 alongside the ``error`` block. It is NOT a statement about the
+# kernel, so it must not be normalized into an optimization outcome -- see
+# _normalize_manifest.
+LLM_UNAVAILABLE_VERDICT = "llm_unavailable"
 DEFAULT_TIMEOUT_SEC = 7200
 
 
@@ -258,6 +264,29 @@ def _normalize_manifest(output_dir: str, rc: int) -> dict[str, Any]:
         m = json.loads(manifest_path.read_text(encoding="utf-8", errors="replace"))
     except Exception as exc:  # noqa: BLE001
         result["error"] = f"fusion_manifest.json parse error: {exc!r}"
+        return result
+
+    if str(m.get("verdict") or "") == LLM_UNAVAILABLE_VERDICT:
+        # forge-fusion never reached the model, so this run holds no opinion about the
+        # kernel. The default no-KEEP shape below would report it as
+        # ``complete``/``no_improvement``, which is wrong twice over: it records an
+        # outage as an optimization result, AND ``complete`` satisfies the KERNEL-entry
+        # idempotency gate (``_fusion_required_before_kernel_opt``), so one gateway
+        # blip would skip fusion for the whole remaining session and the model would
+        # never be fusion-optimized at all. The timeout shape below is the established
+        # way to say "infrastructure failed, this is retryable".
+        # ``result`` still carries its failed/REVERT/not-kept defaults from above, so
+        # only the outage's identity has to be added.
+        detail = m.get("error") if isinstance(m.get("error"), dict) else {}
+        kind = str(detail.get("kind") or "unknown")
+        attempts = detail.get("attempts")
+        tried = f" after {attempts} attempt(s)" if attempts else ""
+        message = str(detail.get("message") or "no detail reported")
+        result.update({
+            "verdict": LLM_UNAVAILABLE_VERDICT,
+            "error_class": LLM_UNAVAILABLE_VERDICT,
+            "error": f"forge-fusion never reached the LLM ({kind}{tried}): {message}"[:1500],
+        })
         return result
 
     loop = m.get("fusion_loop") or {}


### PR DESCRIPTION
## Problem

forge-fusion is gaining a third manifest verdict, `llm_unavailable` (schema v2, KernelForge [#94](https://github.com/AMD-AGI/KernelForge/pull/94)): discovery never reached the model, so the run holds no opinion about the kernel. Previously an outage returned `""` from the LLM call and was published as `no_opportunity` — an outage recorded as an optimization conclusion.

This wrapper has no case for the new verdict, so it falls through to the generic no-KEEP shape:

```python
result.update({
    "status": "ok" if kept else "complete",
    "micro_decision": "candidate" if kept else "no_improvement",
    "decision": "KEEP" if kept else "REVERT",
    ...
})
```

Two things go wrong.

**It re-creates the bug one layer down.** `micro_decision: no_improvement` is exactly "we looked at this kernel and it cannot be improved", which is what the new verdict exists to distinguish from "we never looked".

**The heavier one: it retires fusion for the whole session.** The KERNEL-entry gate is keyed on `status`:

```2409:2412:src/hyperloom/orchestrator/phases/kernel.py
        last = getattr(self.shared_state, "last_fusion", None)
        if isinstance(last, dict) and str(last.get("status") or "").strip() in ("ok", "complete", "kept"):
            return False
        return True
```

`complete` is in that set, so a single gateway blip marks fusion "already done" and `_maybe_run_forge_fusion_before_kernel_opt` never runs it again — the model goes un-fusion-optimized for the rest of the session, with nothing in the result that says why.

## Fix

Map the verdict onto the shape this codebase already uses for a retryable infrastructure failure — the same one `_timeout_result` produces for a subprocess timeout:

| field | value | why |
|---|---|---|
| `status` | `failed` | outside the ok/complete/kept set, so the next KERNEL entry retries fusion |
| `micro_decision` | `failed` | matches `_timeout_result`; not an optimization outcome |
| `decision` / `kept` | `REVERT` / `false` | nothing was produced |
| `requires_e2e_validation` | `false` | nothing to integrate |
| `error_class` | `llm_unavailable` | auditable alongside `subprocess_timeout`, `handler_exception`, ... |
| `error` | kind + attempt count + message from the manifest's `error` block | so the outage is diagnosable from the result alone |

A genuine `no_opportunity` is untouched: the model *was* asked and found nothing, which is a real conclusion, and `complete` correctly suppresses a pointless re-run.

I checked the consumption path before picking this: `run_fusion_handler` parses the stdout sentinel (`request_handlers.py`), and `KernelPhase._handle_fusion_result` is the only business consumer — it stores `last_fusion`, posts `run_fusion_done` on the bus, and integrates only when `kept and requires_e2e_validation`. So `status: failed` has no side effect beyond making the attempt retryable, which is the intent. `error_class` is read only by `SharedState._is_integrate_fault`, on the integrate path, which requires `kept: true` and is therefore unreachable here — no integrate retry budget is touched.

## Compatibility

The mapping is inert until a manifest actually carries the verdict, so this can merge before or after KernelForge [#94](https://github.com/AMD-AGI/KernelForge/pull/94). Reading the v2 manifest needs no other change: this wrapper ignores `schema_version`, derives `kept` from `fusion_loop`/`validation` rather than from the verdict, and passes the verdict through verbatim.

## Test plan

- [x] `test_normalize_manifest_reports_an_llm_outage_as_infrastructure` — full v2 manifest with an `error` block; asserts the failed/REVERT/not-kept shape and that the kind, attempt count and message reach `error`.
- [x] `test_an_llm_outage_leaves_fusion_retryable_at_the_next_kernel_entry` — pins the load-bearing invariant directly: `status` must not be one of the values `_fusion_required_before_kernel_opt` treats as done.
- [x] `test_normalize_manifest_still_reports_a_real_no_opportunity` — a run that did reach the model is unchanged, and carries no `error_class`.
- [x] `src/hyperloom/agents/kernel/tests/test_forge_fusion.py`: 37 passed. The 3 failures are pre-existing on `main` and Windows-only — `test_git_toplevel*` compare against POSIX `/`, which resolves to `C:\` here.
- [x] `ruff check` clean. `ruff format` is not applied: both files are already non-conforming on `main`, so reformatting would bury a 30-line change in an unrelated diff.
