### PR TITLE
fix(knowledge): preserve remote compatibility paths

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_forge_gemm_tuning.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_gemm_tuning.py
@@ -63,6 +63,26 @@ def test_build_cmd_maps_all_options():
     assert "--thorough" in cmd
 
 
+def test_build_cmd_uses_mode_selected_reads_without_enable_flag(monkeypatch):
+    payload = _payload()
+    payload.update(
+        {
+            "kb_read": True,
+            "kb_accept_candidate": True,
+            "kb_strict_lib": True,
+            "kb_current_lib": "aiter-1",
+        }
+    )
+    monkeypatch.setenv("FORGE_GEMM_TUNE_KB_READ", "1")
+
+    cmd = forge_gemm_tuning._build_cmd(payload)
+
+    assert "--kb-read" not in cmd
+    assert "--kb-accept-candidate" in cmd
+    assert "--kb-strict-lib" in cmd
+    assert cmd[cmd.index("--kb-current-lib") + 1] == "aiter-1"
+
+
 def test_build_cmd_requires_mandatory_fields():
     payload = _payload()
     payload.pop("model_path")

--- a/src/hyperloom/agents/kernel/tests/test_forge_knowledge_env.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_knowledge_env.py
@@ -30,6 +30,10 @@ def test_local_child_env_forwards_shared_contract_and_strips_credentials(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _avoid_unrelated_fellow_setup(monkeypatch)
+    monkeypatch.setenv("KNOWLEDGE_STORE_MODE", "local")
+    monkeypatch.setenv("KNOWLEDGE_LOCAL_ROOT", "/data/knowledge")
+    monkeypatch.setenv("GBRAIN_BASE_URL", "https://ambient.invalid")
+    monkeypatch.setenv("GBRAIN_TOKEN", "secret")
     env = {
         "KNOWLEDGE_STORE_MODE": "local",
         "KNOWLEDGE_LOCAL_ROOT": "/data/knowledge",
@@ -49,6 +53,10 @@ def test_remote_child_env_forwards_credentials_and_overrides_derived_flag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _avoid_unrelated_fellow_setup(monkeypatch)
+    monkeypatch.setenv("KNOWLEDGE_STORE_MODE", "remote")
+    monkeypatch.setenv("KNOWLEDGE_LOCAL_ROOT", "unchanged/root")
+    monkeypatch.setenv("GBRAIN_BASE_URL", "https://gbrain.test")
+    monkeypatch.setenv("GBRAIN_TOKEN", "token")
     env = {
         "KNOWLEDGE_STORE_MODE": "remote",
         "KNOWLEDGE_LOCAL_ROOT": "unchanged/root",
@@ -69,6 +77,10 @@ def test_remote_child_env_missing_credentials_degrades_once(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     _avoid_unrelated_fellow_setup(monkeypatch)
+    monkeypatch.setenv("KNOWLEDGE_STORE_MODE", "remote")
+    monkeypatch.setenv("KNOWLEDGE_LOCAL_ROOT", "/unused")
+    monkeypatch.setenv("GBRAIN_BASE_URL", "https://gbrain.test")
+    monkeypatch.delenv("GBRAIN_TOKEN", raising=False)
     env = {
         "KNOWLEDGE_STORE_MODE": "remote",
         "KNOWLEDGE_LOCAL_ROOT": "/unused",
@@ -109,6 +121,11 @@ def test_unset_mode_defaults_local_and_uses_user_data_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _avoid_unrelated_fellow_setup(monkeypatch)
+    monkeypatch.delenv("KNOWLEDGE_STORE_MODE", raising=False)
+    monkeypatch.delenv("KNOWLEDGE_LOCAL_ROOT", raising=False)
+    monkeypatch.setenv("USER_DATA_PATH", "/data/user")
+    monkeypatch.setenv("GBRAIN_BASE_URL", "https://ambient.invalid")
+    monkeypatch.setenv("GBRAIN_TOKEN", "secret")
     env = {
         "USER_DATA_PATH": "/data/user",
         "GBRAIN_BASE_URL": "https://ambient.invalid",
@@ -119,3 +136,29 @@ def test_unset_mode_defaults_local_and_uses_user_data_path(
     assert env["KNOWLEDGE_LOCAL_ROOT"] == "/data/user/knowledge"
     assert "GBRAIN_BASE_URL" not in env
     assert "GBRAIN_TOKEN" not in env
+
+
+def test_child_env_cannot_seed_process_config_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _avoid_unrelated_fellow_setup(monkeypatch)
+    monkeypatch.setenv("KNOWLEDGE_STORE_MODE", "local")
+    monkeypatch.setenv("KNOWLEDGE_LOCAL_ROOT", "/process/knowledge")
+    monkeypatch.delenv("GBRAIN_BASE_URL", raising=False)
+    monkeypatch.delenv("GBRAIN_TOKEN", raising=False)
+    child = {
+        "KNOWLEDGE_STORE_MODE": "remote",
+        "KNOWLEDGE_LOCAL_ROOT": "/child/knowledge",
+        "GBRAIN_BASE_URL": "https://child.invalid",
+        "GBRAIN_TOKEN": "child-secret",
+    }
+
+    forge_submit._apply_fellow_env(child)
+    cached = forge_submit._knowledge_config_for_forge()
+
+    assert cached.mode.value == "local"
+    assert str(cached.local_root) == "/process/knowledge"
+    assert child["KNOWLEDGE_STORE_MODE"] == "local"
+    assert child["KNOWLEDGE_LOCAL_ROOT"] == "/process/knowledge"
+    assert "GBRAIN_BASE_URL" not in child
+    assert "GBRAIN_TOKEN" not in child

--- a/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
+++ b/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
@@ -57,8 +57,8 @@ def _reset_knowledge_config_cache() -> None:
     _KNOWLEDGE_CONFIG_RESOLVED = False
 
 
-def _knowledge_config_for_forge(env: dict | None = None):
-    """Resolve knowledge configuration once and degrade invalid input locally."""
+def _knowledge_config_for_forge():
+    """Resolve process-level knowledge configuration once."""
 
     global _KNOWLEDGE_CONFIG_CACHE, _KNOWLEDGE_CONFIG_RESOLVED
     if _KNOWLEDGE_CONFIG_RESOLVED:
@@ -70,7 +70,7 @@ def _knowledge_config_for_forge(env: dict | None = None):
 
         from hyperloom.orchestrator.knowledge.config import KnowledgeConfig
 
-        source = dict(os.environ if env is None else env)
+        source = dict(os.environ)
         try:
             config = KnowledgeConfig.from_env(source)
         except Exception as exc:  # noqa: BLE001 - submit hot paths must remain available
@@ -2091,7 +2091,7 @@ def _apply_fellow_env(env: dict) -> None:
 
     # The process-level configuration was validated at startup/first use and is
     # cached. A malformed child mapping therefore cannot fail every submission.
-    KernelExperienceBridge(_knowledge_config_for_forge(env)).configure_child_env(env)
+    KernelExperienceBridge(_knowledge_config_for_forge()).configure_child_env(env)
 
     # Auth fallback: seed ANTHROPIC_API_KEY from the claude CLI's config.json
     # primaryApiKey when it is not already exported.

--- a/src/hyperloom/agents/kernel/tools/forge_gemm_tuning.py
+++ b/src/hyperloom/agents/kernel/tools/forge_gemm_tuning.py
@@ -76,23 +76,12 @@ def _build_cmd(args: dict[str, Any]) -> list[str]:
     tokens = str(args.get("tokens") or "").strip()
     if tokens:
         cmd.extend(["--tokens", tokens])
-    _add_kb_read_opts(cmd, args)
+    _add_kb_opts(cmd, args)
     return cmd
 
 
-def _add_kb_read_opts(cmd: list[str], args: dict[str, Any]) -> None:
-    """Forward gemm-tune-kb read-side flags from input-json or env.
-
-    The input-json takes precedence; env vars let the pipeline enable KB read
-    without populating input-json. Disabled by default.
-    """
-    kb_read = args.get("kb_read")
-    if kb_read is None:
-        kb_read = os.environ.get("FORGE_GEMM_TUNE_KB_READ", "")
-    if not truthy(kb_read):
-        return
-    cmd.append("--kb-read")
-
+def _add_kb_opts(cmd: list[str], args: dict[str, Any]) -> None:
+    """Forward optional GEMM KB quality and compatibility controls."""
     accept = args.get("kb_accept_candidate")
     if accept is None:
         accept = os.environ.get("FORGE_GEMM_TUNE_KB_ACCEPT_CANDIDATE", "")

--- a/src/hyperloom/inference_optimizer/tests/test_kg_client.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kg_client.py
@@ -549,6 +549,29 @@ def test_native_query_facts_object_anchor_uses_backlinks() -> None:
     assert facts[0].subject == "aiter_backend"
 
 
+def test_native_query_facts_reads_legacy_punctuation_slug() -> None:
+    mcp = _LinkGraphMcp(
+        pages=["foo=1", "target:2"],
+        edges=[
+            {
+                "from_slug": "foo=1",
+                "to_slug": "target:2",
+                "link_type": "improves",
+                "context": "{}",
+            }
+        ],
+    )
+    kg = KGClient(mcp, use_native_kg=True)
+
+    facts = kg.query_facts(subject="foo=1", object="target:2")
+
+    assert len(facts) == 1
+    assert facts[0].subject == "foo_1"
+    assert facts[0].object == "target_2"
+    queried = [args["slug"] for tool, args in mcp.calls if tool == "get_links"]
+    assert queried == ["foo=1", "foo_1"]
+
+
 def test_native_query_facts_conditions_filter() -> None:
     mcp = _LinkGraphMcp(
         pages=["a", "arch"],
@@ -583,6 +606,29 @@ def test_native_graph_traverse_two_hops() -> None:
     entities = {n.entity for n in nodes}
     assert "qwen2forcausallm" in entities
     assert "llamaforcausallm" in entities
+
+
+def test_native_graph_traverse_reads_legacy_punctuation_slug() -> None:
+    mcp = _LinkGraphMcp(
+        pages=["foo=1", "target:2"],
+        edges=[
+            {
+                "from_slug": "foo=1",
+                "to_slug": "target:2",
+                "link_type": "improves",
+                "context": "{}",
+            }
+        ],
+    )
+    kg = KGClient(mcp, use_native_kg=True)
+
+    nodes = kg.graph_traverse(start_entity="foo=1", max_hops=1)
+
+    assert [node.entity for node in nodes] == ["target_2"]
+    traversed = [
+        args["slug"] for tool, args in mcp.calls if tool == "traverse_graph"
+    ]
+    assert traversed == ["foo_1", "foo=1"]
 
 
 def test_native_emit_fact_materializes_nodes_and_links() -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_knowledge_plane_phase1.py
+++ b/src/hyperloom/inference_optimizer/tests/test_knowledge_plane_phase1.py
@@ -23,6 +23,7 @@ from hyperloom.orchestrator.knowledge.config import (
 from hyperloom.orchestrator.knowledge.knowledge_plane import KnowledgePlane
 from hyperloom.orchestrator.knowledge.recipe_kb import LocalRecipeStore, RecipeKB
 from hyperloom.orchestrator.knowledge.recipe_kb.gbrain_remote_client import (
+    GbrainRemoteError,
     GbrainRemoteRecipeClient,
 )
 from hyperloom.orchestrator.knowledge.recipe_kb.gbrain_store import (
@@ -387,6 +388,55 @@ def test_remote_failure_is_observable_and_audited(tmp_path: Path) -> None:
     assert audits[-1]["success"] is False
     assert audits[-1]["mode"] == "remote"
     assert audits[-1]["backend"] == "gbrain"
+
+
+class _FailingSelectedRemoteStore:
+    backend_name = "gbrain"
+    enabled = True
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def get_recipe(self, **_kwargs):
+        raise GbrainRemoteError("injected selected-store read failure")
+
+    def search(self, **_kwargs):
+        raise GbrainRemoteError("injected selected-store search failure")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_selected_remote_read_failures_degrade_and_emit_audit() -> None:
+    audits: list[dict] = []
+    failures: list[tuple[str, Exception]] = []
+    store = _FailingSelectedRemoteStore()
+    kb = RecipeKB(
+        local=store,
+        mode="remote",
+        backend_name="gbrain",
+        audit_hook=audits.append,
+        on_remote_failure=lambda method, exc: failures.append((method, exc)),
+    )
+
+    assert kb.get_recipe(canonical_id="inference:m:h:f:mt:a:v:p") is None
+    assert kb.search(label_match={"model": "m"}) == []
+
+    assert [method for method, _exc in failures] == ["get_recipe", "search"]
+    assert [event["resolution"] for event in audits] == [
+        "remote_error",
+        "remote_error",
+    ]
+    assert all(event["mode"] == "remote" and event["hit"] is False for event in audits)
+
+
+def test_close_releases_selected_remote_store() -> None:
+    store = _FailingSelectedRemoteStore()
+    kb = RecipeKB(local=store, mode="remote", backend_name="gbrain")
+
+    kb.close()
+
+    assert store.closed is True
 
 
 def test_remote_store_champion_merge_is_monotonic_and_paired(tmp_path: Path) -> None:

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/dispatcher.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/dispatcher.py
@@ -221,15 +221,14 @@ def _rerank_by_prefer(
 
 @dataclass
 class RecipeKB:
-    """Local-write / remote-read-with-fallback dispatcher.
+    """Selected-store dispatcher with a legacy remote-read fallback.
 
     Args:
-        local: Authoritative local store. REQUIRED — there is no
-            "remote-only" mode under this design (writes must
-            always have somewhere to land).
-        remote: Optional read-side central kb-service client.
+        local: Store selected by ``mode``. In exclusive remote mode this is the
+            direct GBrain store; in local mode it is the filesystem store.
+        remote: Optional legacy read-side central kb-service client.
             ``None`` (or a client with ``enabled=False``) makes
-            reads short-circuit to the local store.
+            reads use only the selected store.
         on_remote_failure: Callback invoked when a read against
             the central kb-service fails and the dispatcher falls
             back to local. Receives ``(method_name, exception)``.
@@ -766,10 +765,23 @@ class RecipeKB:
             except InvalidCanonicalIdError as exc:
                 log.warning("get_recipe: %s; local-only read", exc)
                 resolution = "remote_error"
-        local_row = self.local.get_recipe(
-            canonical_id=canonical_id,
-            version=version,
-        )
+        try:
+            local_row = self.local.get_recipe(
+                canonical_id=canonical_id,
+                version=version,
+            )
+        except RemoteRecipeClientError as exc:
+            # Exclusive remote mode stores its GBrain backend in ``local``;
+            # preserve degradation/audit behavior even though ``remote`` is None.
+            self._note_failure("get_recipe", exc)
+            resolution = "remote_error" if self.mode == "remote" else "local_error"
+            local_row = None
+        except Exception as exc:  # noqa: BLE001 - remote reads must degrade safely
+            if self.mode != "remote":
+                raise
+            self._note_failure("get_recipe", exc)
+            resolution = "remote_error"
+            local_row = None
         self._emit_audit(
             self._read_audit_event(
                 method="get_recipe",
@@ -848,13 +860,24 @@ class RecipeKB:
             except RemoteRecipeClientError as exc:
                 self._note_failure("search", exc)
                 resolution = "remote_error"
-        local_rows = self.local.search(
-            label_match=label_match,
-            metric_filters=metric_filters,
-            updated_since=updated_since,
-            order_by=order_by,
-            limit=limit,
-        )
+        try:
+            local_rows = self.local.search(
+                label_match=label_match,
+                metric_filters=metric_filters,
+                updated_since=updated_since,
+                order_by=order_by,
+                limit=limit,
+            )
+        except RemoteRecipeClientError as exc:
+            self._note_failure("search", exc)
+            resolution = "remote_error" if self.mode == "remote" else "local_error"
+            local_rows = []
+        except Exception as exc:  # noqa: BLE001 - remote reads must degrade safely
+            if self.mode != "remote":
+                raise
+            self._note_failure("search", exc)
+            resolution = "remote_error"
+            local_rows = []
         ranked_local = _rerank_by_prefer(local_rows, prefer)
         self._emit_audit(
             self._read_audit_event(
@@ -869,14 +892,19 @@ class RecipeKB:
 
     # Lifecycle
     def close(self) -> None:
-        """Release the remote client's HTTP transport (no-op for the local
-        store). Idempotent; safe to call from a CLI atexit handler.
-        """
-        if self.remote is not None:
+        """Release selected and legacy backend transports, at most once each."""
+        seen: set[int] = set()
+        for backend in (self.local, self.remote):
+            if backend is None or id(backend) in seen:
+                continue
+            seen.add(id(backend))
+            close = getattr(backend, "close", None)
+            if not callable(close):
+                continue
             try:
-                self.remote.close()
+                close()
             except Exception:  # noqa: BLE001
-                log.exception("recipe_kb: remote.close raised")
+                log.exception("recipe_kb: backend close raised")
 
 
 __all__ = [

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/kg_client.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/kg_client.py
@@ -92,6 +92,20 @@ def _entity(value: Any) -> str:
     return slug
 
 
+def _legacy_entity(value: Any) -> str:
+    """Return the pre-Phase-1 entity slug used by existing remote KG nodes."""
+    return str(value or "").strip().replace(" ", "_").replace("/", "_").lower()
+
+
+def _entity_aliases(value: Any) -> tuple[str, ...]:
+    """Return current and legacy slugs, preserving order and uniqueness."""
+    aliases: list[str] = []
+    for candidate in (_entity(value), _legacy_entity(value)):
+        if candidate and candidate not in aliases:
+            aliases.append(candidate)
+    return tuple(aliases)
+
+
 def _as_set(value: Any) -> set[str]:
     """Coerce a scalar / pipe-string / iterable of entities to a norm set.
 
@@ -113,7 +127,12 @@ def _as_set(value: Any) -> set[str]:
         items = value
     else:
         items = [value]
-    return {_entity(item) for item in items if str(item or "").strip()}
+    return {
+        alias
+        for item in items
+        if str(item or "").strip()
+        for alias in _entity_aliases(item)
+    }
 
 
 def _parse_props(raw: str | None) -> dict[str, str]:
@@ -512,13 +531,13 @@ class KGClient:
         """Return outgoing edges for ``slug`` (best-effort)."""
         if self._mcp is None or not slug:
             return []
-        return self._as_edges(self._mcp.call("get_links", {"slug": _entity(slug)}))
+        return self._as_edges(self._mcp.call("get_links", {"slug": slug}))
 
     def _get_backlinks(self, slug: str) -> list[dict[str, Any]]:
         """Return incoming edges for ``slug`` (best-effort)."""
         if self._mcp is None or not slug:
             return []
-        return self._as_edges(self._mcp.call("get_backlinks", {"slug": _entity(slug)}))
+        return self._as_edges(self._mcp.call("get_backlinks", {"slug": slug}))
 
     def _node_exists(self, slug: str) -> bool:
         """Return ``True`` when a page for ``slug`` exists."""
@@ -764,9 +783,16 @@ class KGClient:
         start = _entity(start_entity)
         pred_set = _as_set(predicate_filter)
 
-        edges = self._as_edges(
-            self._mcp.call("traverse_graph", {"slug": start, "depth": depth, "direction": native_dir})
-        )
+        edges = [
+            edge
+            for alias in _entity_aliases(start_entity)
+            for edge in self._as_edges(
+                self._mcp.call(
+                    "traverse_graph",
+                    {"slug": alias, "depth": depth, "direction": native_dir},
+                )
+            )
+        ]
 
         out: list[GraphNode] = []
         seen: set[tuple[str, str, int]] = set()


### PR DESCRIPTION
## Summary
- stop forwarding the removed `forge-gemm-tune --kb-read` gate while preserving candidate and library quality controls
- audit and safely degrade selected GBrain Recipe reads, and close the selected remote store during shutdown
- query both current and legacy native-KG entity slugs so punctuation-bearing historical nodes remain readable
- make Forge knowledge configuration process-owned so a child environment cannot seed the global cache

## Test plan
- [x] 219 relevant Recipe KB, KG, GBrain, local graph, and Forge environment tests
- [x] Ruff on all changed production and test files
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)