### PR TITLE
feat(kernel): route FLUX.2 and count cross-attention Q/O projections

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_diffusion_flops.py
+++ b/src/hyperloom/agents/kernel/tests/test_diffusion_flops.py
@@ -47,6 +47,7 @@ def test_family_routing_for_each_class(tmp_path):
         "ZImageTransformer2DModel": "single",
         "SanaTransformer2DModel": "sana",
         "UNet2DConditionModel": "unet",
+        "Flux2Transformer2DModel": "flux",
     }
     for cls, fam in cases.items():
         d = _write_denoiser(
@@ -349,3 +350,160 @@ def test_main_text_and_json_and_failure(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["diffusion_flops", "--model-dir", str(bad)])
     assert df.main() == 1
     assert "could not resolve" in capsys.readouterr().out
+
+
+# ---- FLUX.2 --------------------------------------------------------------
+# Verbatim from the shipped black-forest-labs/FLUX.2-dev transformer config, so
+# the test protects the production path (notably mlp_ratio=3.0, not the 4.0 default).
+_FLUX2_CFG = {
+    "_class_name": "Flux2Transformer2DModel",
+    "num_layers": 8,
+    "num_single_layers": 48,
+    "num_attention_heads": 48,
+    "attention_head_dim": 128,
+    "in_channels": 128,
+    "out_channels": None,
+    "patch_size": 1,
+    "joint_attention_dim": 15360,
+    "mlp_ratio": 3.0,
+    "axes_dims_rope": [32, 32, 32, 32],
+    "rope_theta": 2000,
+    "eps": 1e-06,
+    "timestep_guidance_channels": 256,
+}
+
+
+def test_flux2_geometry_and_defaults(tmp_path):
+    """Real geometry from the shipped black-forest-labs/FLUX.2-dev config."""
+    g = df.resolve_geometry(_write_denoiser(tmp_path / "flux2", _FLUX2_CFG))
+    assert g is not None
+    assert (g.family, g.model_class) == ("flux", "Flux2Transformer2DModel")
+    assert g.hidden == 6144  # 48 heads x 128
+    assert (g.num_double_layers, g.num_single_layers) == (8, 48)
+    # patch_size=1 in the config, but FLUX packs 2x2 for the token count.
+    assert g.patch == 2
+    # FLUX.2-dev is guidance-distilled: one forward per step.
+    assert (g.default_cfg_batch, g.default_steps) == (1, 50)
+
+    # mlp_ratio 3.0 from the config, not the 4*hidden default.
+    assert g.intermediate == 18432
+    # FLUX.2 uses SwiGLU but exposes no gating flag; counting it as a 2-matrix
+    # FFN understates the forward by 20.7%.
+    assert g.gated_ffn is True
+
+    est = df.estimate_image_flops(_write_denoiser(tmp_path / "flux2b", _FLUX2_CFG))
+    assert est["image_tokens"] == 4096  # (1024/8/2)^2
+    assert est["layers"] == 56
+    assert est["forward_flops"] / 1e12 == pytest.approx(282.5, abs=0.5)
+
+
+def test_flux2_swiglu_is_counted(tmp_path):
+    """A 3-matrix SwiGLU FFN, not the 2-matrix default."""
+    g = df.resolve_geometry(_write_denoiser(tmp_path / "flux2", _FLUX2_CFG))
+    assert df._ffn_per_token(g) == pytest.approx(3 * df._linear_flops(1.0, g.hidden, g.intermediate))
+
+    ungated = df.DenoiserGeometry(**{**g.__dict__, "gated_ffn": False})
+    forward_gated = df.forward_flops(g, 1024, 1024)["forward_flops"]
+    forward_ungated = df.forward_flops(ungated, 1024, 1024)["forward_flops"]
+    assert forward_ungated / 1e12 == pytest.approx(224.0, abs=0.5)
+    # Counting SwiGLU raises the forward 1.261x; equivalently the 2-matrix
+    # count was 20.7% below the correct value.
+    assert forward_gated / forward_ungated == pytest.approx(1.261, abs=0.005)
+    assert (forward_gated - forward_ungated) / forward_gated == pytest.approx(0.207, abs=0.005)
+
+
+def test_flux1_ffn_stays_ungated(tmp_path):
+    """The SwiGLU set must not catch FLUX.1."""
+    cfg = {
+        "_class_name": "FluxTransformer2DModel",
+        "num_layers": 19,
+        "num_single_layers": 38,
+        "num_attention_heads": 24,
+        "attention_head_dim": 128,
+    }
+    g = df.resolve_geometry(_write_denoiser(tmp_path / "flux1g", cfg))
+    assert g.gated_ffn is False
+    assert g.intermediate == 4 * g.hidden
+
+
+def test_flux1_is_unaffected_by_the_flux2_entry(tmp_path):
+    cfg = {
+        "_class_name": "FluxTransformer2DModel",
+        "num_layers": 19,
+        "num_single_layers": 38,
+        "num_attention_heads": 24,
+        "attention_head_dim": 128,
+    }
+    g = df.resolve_geometry(_write_denoiser(tmp_path / "flux1", cfg))
+    assert g.hidden == 3072
+    assert (g.num_double_layers, g.num_single_layers) == (19, 38)
+    assert (g.default_cfg_batch, g.default_steps) == (1, 28)
+
+
+# ---- cross-attention completeness ----------------------------------------
+def _cross_geom(**kw):
+    base = dict(
+        model_class="x",
+        family="sana",
+        hidden=5120,
+        num_double_layers=1,
+        num_single_layers=0,
+        head_dim=128,
+        intermediate=13824,
+        gated_ffn=False,
+    )
+    base.update(kw)
+    return df.DenoiserGeometry(**base)
+
+
+def test_cross_attention_counts_q_and_o_projections():
+    """All four projections, not just K and V.
+
+    The query stream needs its own Q and O matmuls, charged to the query token
+    count. They were previously omitted, understating a cross-attending block.
+    """
+    g = _cross_geom()
+    q_tokens, tt = 75_600, 512
+    total = df._cross_attention_block_flops(g, q_tokens, tt)
+
+    attn = df._cross_attention_flops(q_tokens, tt, g.hidden)
+    kv = tt * df._linear_flops(1.0, g.hidden, g.hidden) * 2
+    qo = q_tokens * df._linear_flops(1.0, g.hidden, g.hidden) * 2
+    assert total == pytest.approx(attn + kv + qo)
+    # Q/O scale with the query tokens, so they dominate the K/V term here.
+    assert qo > kv * 100
+
+
+def test_cross_attention_qo_scales_with_query_tokens():
+    """Q/O scale with the queries; K/V does not, so growth is sub-linear."""
+    g, tt = _cross_geom(), 512
+    small = df._cross_attention_block_flops(g, 1_000, tt)
+    large = df._cross_attention_block_flops(g, 2_000, tt)
+
+    # The K/V projection is charged to the text length and is invariant in q,
+    # so the delta is exactly the q-proportional attention + Q/O terms.
+    attn_delta = df._cross_attention_flops(2_000, tt, g.hidden) - df._cross_attention_flops(1_000, tt, g.hidden)
+    qo_delta = 1_000 * df._linear_flops(1.0, g.hidden, g.hidden) * 2
+    assert large - small == pytest.approx(attn_delta + qo_delta)
+    # Sub-linear overall precisely because K/V stays put.
+    assert 1.0 < large / small < 2.0
+
+
+def test_sana_layer_includes_cross_attention_projections(tmp_path):
+    cfg = {
+        "_class_name": "SanaTransformer2DModel",
+        "num_layers": 2,
+        "num_attention_heads": 8,
+        "attention_head_dim": 32,
+    }
+    g = df.resolve_geometry(_write_denoiser(tmp_path / "sana", cfg))
+    ffn_pt = df._ffn_per_token(g)
+    ti, tt = 1024, g.text_tokens
+    layer = df._sana_layer(g, ti, tt, ffn_pt)
+    # The layer must contain the full cross-attention block, Q/O included.
+    assert layer == pytest.approx(
+        ti * df._qkvo_flops(1.0, g.hidden)
+        + ti * ffn_pt
+        + df._linear_attention_flops(ti, g.hidden, g.head_dim or 32)
+        + df._cross_attention_block_flops(g, ti, tt)
+    )

--- a/src/hyperloom/agents/kernel/tools/diffusion_flops.py
+++ b/src/hyperloom/agents/kernel/tools/diffusion_flops.py
@@ -155,6 +155,8 @@ _CLASS_FAMILY: dict[str, str] = {
     "ZImageTransformer2DModel": "single",
     "SanaTransformer2DModel": "sana",
     "UNet2DConditionModel": "unet",
+    # FLUX.2 keeps FLUX.1's dual + single stream structure, only wider.
+    "Flux2Transformer2DModel": "flux",
 }
 
 # Per-class overrides for constants the config does not expose (diffusers
@@ -162,6 +164,8 @@ _CLASS_FAMILY: dict[str, str] = {
 _CLASS_DEFAULTS: dict[str, dict[str, Any]] = {
     "SD3Transformer2DModel": {"text_tokens": 333, "default_steps": 28, "default_cfg_batch": 2},
     "FluxTransformer2DModel": {"text_tokens": 512, "default_steps": 28, "default_cfg_batch": 1},
+    # FLUX.2-dev is guidance-distilled like FLUX.1-dev, so one forward per step.
+    "Flux2Transformer2DModel": {"text_tokens": 512, "default_steps": 50, "default_cfg_batch": 1},
     "QwenImageTransformer2DModel": {"text_tokens": 256, "default_steps": 30, "default_cfg_batch": 2},
     "AuraFlowTransformer2DModel": {"text_tokens": 256, "default_steps": 50, "default_cfg_batch": 2},
     "HunyuanImageTransformer2DModel": {"text_tokens": 256, "default_steps": 50, "default_cfg_batch": 2},
@@ -173,6 +177,9 @@ _CLASS_DEFAULTS: dict[str, dict[str, Any]] = {
     "SanaTransformer2DModel": {"text_tokens": 300, "default_steps": 20, "default_cfg_batch": 2, "vae_spatial": 32},
     "UNet2DConditionModel": {"text_tokens": 77, "default_steps": 40, "default_cfg_batch": 2},
 }
+
+# Denoisers with a SwiGLU FFN whose config exposes no gating flag.
+_GATED_FFN_CLASSES = frozenset({"Flux2Transformer2DModel"})
 
 # Per-model-basename step/cfg refinements (turbo / schnell / fast distilled).
 _BASENAME_HINTS: dict[str, dict[str, Any]] = {
@@ -361,8 +368,8 @@ def resolve_geometry(model_dir: str | Path) -> DenoiserGeometry | None:
     if num_experts and not moe_inter:
         moe_inter = intermediate
 
-    # gated FFN heuristic: Sana / Z-Image style use gated MLP; MMDiT/Flux GELU are not.
-    gated = family in ("sana",) or bool(cfg.get("use_gated_mlp"))
+    # gated FFN: Sana / Z-Image style, plus classes that use SwiGLU without saying so.
+    gated = family in ("sana",) or model_class in _GATED_FFN_CLASSES or bool(cfg.get("use_gated_mlp"))
 
     defaults = dict(_CLASS_DEFAULTS.get(model_class, {}))
     basename = d.name.lower()
@@ -443,12 +450,22 @@ def _single_stream_layer(g: DenoiserGeometry, s: int, ffn_pt: float) -> float:
     return lin + attn
 
 
+def _cross_attention_block_flops(g: DenoiserGeometry, q_tokens: int, tt: int) -> float:
+    """Cross-attention over ``q_tokens`` queries against ``tt`` text tokens.
+
+    Counts all four projections: Q and O scale with the queries, K and V with
+    the text length.
+    """
+    qo = q_tokens * _linear_flops(1.0, g.hidden, g.hidden) * 2
+    kv = tt * _linear_flops(1.0, g.hidden, g.hidden) * 2
+    return _cross_attention_flops(q_tokens, tt, g.hidden) + qo + kv
+
+
 def _sana_layer(g: DenoiserGeometry, ti: int, tt: int, ffn_pt: float) -> float:
     """Sana block: linear self-attention over image tokens + cross-attn to text."""
     lin = ti * _qkvo_flops(1.0, g.hidden) + ti * ffn_pt
     self_attn = _linear_attention_flops(ti, g.hidden, g.head_dim or 32)
-    cross = _cross_attention_flops(ti, tt, g.hidden) + tt * _linear_flops(1.0, g.hidden, g.hidden) * 2
-    return lin + self_attn + cross
+    return lin + self_attn + _cross_attention_block_flops(g, ti, tt)
 
 
 def _unet_forward_flops(g: DenoiserGeometry, height: int, width: int) -> float:


### PR DESCRIPTION
**Description: what and why**

Narrowed from the original scope at review request: the Wan 3D/video frame axis is split out to #1140 (draft), since nothing in the tree can currently point at a Wan workload. What remains is immediately usable on the `xdit` path.

### 1. FLUX.2 routing

`Flux2Transformer2DModel` had no `_CLASS_FAMILY` entry, so FLUX.2-dev fell through to the safetensors-header fallback instead of reading its own config. It keeps FLUX.1's dual + single stream structure, so it reuses the `flux` formula:

| | FLUX.1-dev | FLUX.2-dev |
|---|---|---|
| double + single layers | 19 + 38 | 8 + 48 |
| hidden | 3072 | 6144 (48 heads × 128) |
| `mlp_ratio` | absent → 4×hidden | **3.0** → 18432 |
| FFN | GELU (2 matmuls) | **SwiGLU (3 matmuls)** |
| forwards/step | 1 (guidance-distilled) | 1 (guidance-distilled) |

### 2. FLUX.2 SwiGLU

FLUX.2 uses a SwiGLU FFN but exposes no gating flag, so the `use_gated_mlp` heuristic counted it as a 2-matrix FFN. On the shipped config that is **224.0 TF vs a correct 282.5 TF** per forward — the 2-matrix count is 20.7% low (equivalently, correcting it raises the forward 1.261×). Classes in that position are now listed in `_GATED_FFN_CLASSES`. FLUX.1 and every other family are unaffected.

### 3. Cross-attention Q and O

The block counted only K and V. The query stream also needs Q and O (`q_tokens × h → h` each), charged to the query token count rather than the much shorter text length, so the omission grows with resolution — 7.93 TFLOP on a 75600-query block, **4.86%** of that layer. The module docstring only licenses dropping softmax and element-wise work.

The four-projection form is factored into `_cross_attention_block_flops`.

**Scope:** this fixes the **DiT/Sana-style** cross-attention path. `_sana_layer` is its only caller and is fixed here. `_unet_forward_flops` builds its cross-attention inline against a per-level channel count (`cout`) rather than the model hidden size, so **UNet still omits Q/O**. That is pre-existing on `main` and is left for a separate change, which would need the helper parameterized on `cout`.

**Behaviour change on a shipped model:** Sana's per-layer FLOPs rise **10.73%** at 1024² (4.7887e10 → 5.3025e10), because its 300 text tokens are close to its 256 image tokens (`vae_spatial=32`). The ceiling moves the honest way, but any Sana session's `ideal_ms` and `analytic_within_pct` shift with it.

**Tests: added/updated? commands run?**

The FLUX.2 test config is now the shipped config verbatim, including `mlp_ratio=3.0` — the previous one omitted it and silently validated the 4.0 default. Tests assert the resolved intermediate (18432), that gating is detected, the 282.5 TF forward, the 1.261× SwiGLU delta, that FLUX.1 stays ungated at 4×hidden, and the cross-attention decomposition (Q/O scale with queries, K/V with text length).

```
pytest src/hyperloom/agents/kernel/tests   ->  1618 passed, 29 skipped
ruff check                                 ->  clean
```

I did not run the full suite to completion locally (it exceeds ~10 min in my environment), so I ran the kernel-agent tree plus the modules that consume these call paths.

**Breaking changes: no**

FLUX.1 and every non-cross-attending family produce identical output. The two intended numeric changes are FLUX.2 (previously unrouted) and Sana (+10.73%/layer), both stated above.

Related: #1149 (`analytic_ceiling` has no `num_gpus`).
