### PR TITLE
fix(kernel): flag impossible Kineto durations, stop using annotation count as denoise steps

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
@@ -743,3 +743,152 @@ def test_steady_state_with_zero_annotations_falls_back(tmp_path):
     assert out["aggregation_scope"] == "full_trace"
     assert out.get("steady_window_status")
     assert len(out["kernels"]) == 2
+
+
+# ---- device-stream duration sanity ---------------------------------------
+def _stream_trace(path: Path, events: list[dict]) -> Path:
+    path.write_bytes(json.dumps({"traceEvents": events}).encode("utf-8"))
+    return path
+
+
+def _gpu(name: str, ts: float, dur: float, pid: int = 1, tid: int = 1) -> dict:
+    return {"cat": "kernel", "ph": "X", "name": name, "ts": ts, "dur": dur, "pid": pid, "tid": tid, "args": {}}
+
+
+def test_stream_overlap_absent_on_consistent_trace(tmp_path):
+    """Durations that fit between their neighbours must not be flagged."""
+    tf = _write_trace(tmp_path / "ok.trace.json")
+    out = reader.analyze_trace(tf, top_k=0)
+    assert "stream_overlap" not in (out.get("timeline") or {})
+
+
+def test_stream_overlap_detects_impossible_duration(tmp_path):
+    """An event overrunning its successor on a serial stream is corrupt.
+
+    The corrupt event also extends the stream's span, so a sum-vs-span ratio
+    would read ~1.0 here; the pairwise check still catches it.
+    """
+    events = [
+        _gpu("k_a", 1000, 100),
+        _gpu("corrupt_kernel", 1100, 20_000),  # ends 21100, next starts 1200
+        _gpu("k_b", 1200, 100),
+        _gpu("k_c", 1300, 100),
+    ]
+    tf = _stream_trace(tmp_path / "bad.trace.json", events)
+    out = reader.analyze_trace(tf, top_k=0)
+    so = (out.get("timeline") or {}).get("stream_overlap")
+    assert so, "corrupt duration should be reported"
+    assert (so["pid"], so["tid"]) == (1, 1)
+    assert so["worst_event"] == "corrupt_kernel"
+    assert so["overlapping_events"] == 1
+    # Overruns k_b's start (1200) by 19900us.
+    assert so["worst_event_excess_ms"] == 19.9
+
+    # A naive sum-vs-span ratio would have looked innocent.
+    total_dur = sum(e["dur"] for e in events)
+    span = max(e["ts"] + e["dur"] for e in events) - min(e["ts"] for e in events)
+    assert total_dur / span < 1.02
+
+
+def test_stream_overlap_not_triggered_by_concurrent_streams(tmp_path):
+    """Two genuinely concurrent streams must not be mistaken for corruption.
+
+    Pooling every device event would make the summed duration twice the wall
+    span here, which is exactly the false positive the per-stream check avoids.
+    """
+    events = []
+    for i in range(5):
+        events.append(_gpu(f"s1_{i}", 1000 + i * 100, 100, pid=1, tid=1))
+        events.append(_gpu(f"s2_{i}", 1000 + i * 100, 100, pid=1, tid=2))
+    tf = _stream_trace(tmp_path / "concurrent.trace.json", events)
+    out = reader.analyze_trace(tf, top_k=0)
+    assert "stream_overlap" not in (out.get("timeline") or {})
+
+
+def test_stream_overlap_reports_worst_stream():
+    # Overruns must clear the absolute floor (1 ms) to be reported at all.
+    mild = [(0.0, 5_000.0, "mild"), (2_000.0, 4_000.0, "b"), (10_000.0, 10_000.0, "c")]
+    severe = [(0.0, 30_000.0, "severe"), (1_000.0, 2_000.0, "b"), (10_000.0, 10_000.0, "c")]
+    worst = reader._stream_overlap_health({(1, 1): list(mild), (1, 2): list(severe)})
+    assert worst["tid"] == 2
+    assert worst["worst_event"] == "severe"
+
+
+def test_stream_overlap_ignores_rounding_and_short_streams():
+    # Sub-microsecond overrun is timestamp rounding, not corruption.
+    tiny = [(0.0, 100.5, "a"), (100.0, 200.0, "b"), (1000.0, 1000.0, "c")]
+    assert reader._stream_overlap_health({(1, 1): tiny}) == {}
+    # Real but immaterial overlap stays below the reporting share.
+    small = [(0.0, 110.0, "a"), (100.0, 200.0, "b"), (100_000.0, 100_000.0, "c")]
+    assert reader._stream_overlap_health({(1, 1): small}) == {}
+    # Degenerate inputs must not divide by zero.
+    assert reader._stream_overlap_health({(1, 1): [(0.0, 10.0, "only")]}) == {}
+    assert reader._stream_overlap_health({(1, 1): [(5.0, 5.0, "a"), (5.0, 5.0, "b")]}) == {}
+    assert reader._stream_overlap_health({}) == {}
+
+
+def test_stream_overlap_final_event_is_not_detectable():
+    """Documented limitation: nothing follows the last event to contradict it."""
+    evs = [(0.0, 100.0, "a"), (100.0, 99_999.0, "corrupt_last")]
+    assert reader._stream_overlap_health({(1, 1): evs}) == {}
+
+
+# ---- review round 2: threshold denominator, absolute floor, severity ------
+def _spread(n: int, dur: float, stride: float, prefix: str = "k") -> list[tuple[float, float, str]]:
+    return [(i * stride, i * stride + dur, f"{prefix}{i}") for i in range(n)]
+
+
+def test_threshold_uses_summed_device_time_not_span():
+    """A lone corrupt duration must not hide behind the span it inflates.
+
+    1000 kernels spread over 60 s with one duration written as 2 s: the corrupt
+    event is 95% of the summed device time but only ~3% of the wall span, so a
+    span-denominator threshold reported nothing -- the same blind spot the
+    pairwise detector exists to avoid, moved into the threshold.
+    """
+    evs = _spread(1000, 100.0, 60_000_000 / 1000)
+    evs[500] = (evs[500][0], evs[500][0] + 2_000_000.0, "corrupt_2s")
+    device_us = sum(e - s for s, e, _ in evs)
+    span_us = max(e for _s, e, _ in evs) - evs[0][0]
+
+    out = reader._stream_overlap_health({(1, 1): list(evs)})
+    assert out, "corrupt duration dominating summed device time must be reported"
+    assert out["worst_event"] == "corrupt_2s"
+    assert out["severity"] == "warning"
+    # The share is meaningful against summed device time, negligible against span.
+    assert out["excess_share"] > 0.9
+    assert (out["excess_ms"] * 1000.0) / span_us < 0.05
+    assert abs(out["device_ms"] - device_us / 1000.0) < 1e-3
+
+
+def test_dense_jitter_is_not_escalated():
+    """Many sub-millisecond overruns are profiler jitter, not corruption.
+
+    Accumulates well past the 5% share while the worst single overrun is 4 us;
+    telling the user to recapture the trace here is a false alarm.
+    """
+    evs = _spread(20_000, 10.0, 6.0)  # each overruns the next by 4 us
+    assert reader._stream_overlap_health({(1, 1): list(evs)}) == {}
+
+
+def test_identical_timestamps_are_not_overlap():
+    """Events sharing a ts cannot contradict each other."""
+    same = [(0.0, 50_000.0, "a"), (0.0, 50_000.0, "b"), (0.0, 50_000.0, "c"), (100_000.0, 100_000.0, "d")]
+    assert reader._stream_overlap_health({(1, 1): same}) == {}
+
+
+def test_severity_grades_with_share_of_device_time():
+    """Marginal distortion is info; a materially wrong ranking is a warning."""
+    # ~10% of summed device time -> info.
+    mild = _spread(40, 10_000.0, 10_000.0)
+    mild[0] = (0.0, 10_000.0 + 40_000.0, "mild_overrun")
+    out_mild = reader._stream_overlap_health({(1, 1): list(mild)})
+    assert out_mild and out_mild["severity"] == "info"
+    assert 0.05 <= out_mild["excess_share"] < 0.25
+
+    # One event swamping the stream -> warning.
+    severe = _spread(40, 10_000.0, 10_000.0)
+    severe[0] = (0.0, 10_000.0 + 900_000.0, "severe_overrun")
+    out_severe = reader._stream_overlap_health({(1, 1): list(severe)})
+    assert out_severe and out_severe["severity"] == "warning"
+    assert out_severe["excess_share"] >= 0.25

--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -1027,3 +1027,114 @@ def test_graph_launch_events_required_for_detection(tmp_path):
     chunk_cov = bta._reader.analyze_trace(str(chunk), top_k=0)["graph_coverage"]
     assert chunk_cov["graph_mode"] is False
     assert chunk_cov["graph_under_recorded"] is False
+# ---- trace-health: impossible durations + denoise-step inference ----------
+def _write_events(path: Path, events: list[dict]) -> Path:
+    path.write_text(json.dumps({"traceEvents": events}), encoding="utf-8")
+    return path
+
+
+def _result_codes(result) -> set[str]:
+    return {w.get("code") for w in (result.get("trace_health_warnings") or [])}
+
+
+def test_impossible_durations_raise_a_warning(tmp_path, capsys):
+    """A kernel overrunning its successor must be surfaced, not ranked silently."""
+    events = list(_TRACE_EVENTS) + [
+        {"cat": "kernel", "ph": "X", "name": "corrupt", "ts": 1500, "dur": 900_000, "pid": 2, "tid": 3},
+        {"cat": "kernel", "ph": "X", "name": "after_a", "ts": 1600, "dur": 100, "pid": 2, "tid": 3},
+        {"cat": "kernel", "ph": "X", "name": "after_b", "ts": 1700, "dur": 100, "pid": 2, "tid": 3},
+    ]
+    trace = _write_events(tmp_path / "corrupt.trace.json", events)
+    _rc, result, _ = _run(_base_argv(tmp_path, str(trace)), capsys)
+    assert "bypass_impossible_kernel_durations" in _result_codes(result)
+    msg = next(
+        w["message"] for w in result["trace_health_warnings"] if w["code"] == "bypass_impossible_kernel_durations"
+    )
+    assert "corrupt" in msg
+    assert "serial stream" in msg
+
+
+def test_clean_trace_raises_no_duration_warning(tmp_path, capsys):
+    trace = _write_events(tmp_path / "clean.trace.json", list(_TRACE_EVENTS))
+    _rc, result, _ = _run(_base_argv(tmp_path, str(trace)), capsys)
+    assert "bypass_impossible_kernel_durations" not in _result_codes(result)
+
+
+def test_denoise_steps_come_from_profiler_steps_not_annotations(tmp_path, capsys):
+    """Regression: the divisor must be denoise steps, not annotation windows.
+
+    ``annotation_window_count`` counts user_annotation ranges. Under
+    source-level instrumentation there are far more of those than denoise
+    steps, and using them silently scaled every per-step figure.
+    """
+    events = list(_TRACE_EVENTS)
+    # 3 real denoise steps ...
+    for i in range(3):
+        events.append({"cat": "gpu_user_annotation", "ph": "X", "name": f"ProfilerStep#{i}", "ts": 1000 + i, "dur": 1})
+    # ... but many more annotation windows, as dense instrumentation produces.
+    for i in range(25):
+        events.append({"cat": "gpu_user_annotation", "ph": "X", "name": f"block_{i}", "ts": 1000 + i, "dur": 1})
+
+    trace = _write_events(tmp_path / "ann.trace.json", events)
+    _rc, result, _ = _run(_base_argv(tmp_path, str(trace)), capsys)
+    steps = result.get("num_denoise_steps")
+    assert steps == 3, f"expected the 3 ProfilerStep markers, got {steps}"
+    assert steps != 28, "annotation_window_count must not be used as the step count"
+
+
+def test_explicit_denoise_steps_wins_and_is_flagged(tmp_path, capsys):
+    """An operator's explicit --num-denoise-steps is authoritative.
+
+    Hyperloom cannot know what a user's ``prof.step()`` brackets, so a declared
+    count must win over the trace-inferred one -- and the reported value must
+    match the divisor actually used, which previously disagreed.
+    """
+    events = list(_TRACE_EVENTS) + [
+        {"cat": "gpu_user_annotation", "ph": "X", "name": "ProfilerStep#0", "ts": 1000, "dur": 1}
+    ]
+    trace = _write_events(tmp_path / "ann2.trace.json", events)
+    _rc, result, _ = _run(_base_argv(tmp_path, str(trace), extra=["--num-denoise-steps", "9"]), capsys)
+    assert result.get("num_denoise_steps") == 9
+    # The 1 inferred step disagrees with the requested 9, which must be flagged.
+    assert "bypass_denoise_steps_mismatch" in _result_codes(result)
+    msg = next(
+        w["message"] for w in result["trace_health_warnings"] if w["code"] == "bypass_denoise_steps_mismatch"
+    )
+    assert "requested count wins" in msg
+
+
+def test_denoise_steps_read_the_file_the_reader_analyzed(tmp_path, capsys):
+    """Directory input must not count markers in a different file.
+
+    ``count_profiler_steps`` globs ``*.json`` and takes the first, so a stray
+    ``config.json`` sorts ahead of the real trace and returns 0 while the
+    reader resolved the actual trace.
+    """
+    d = tmp_path / "torch_trace"
+    d.mkdir()
+    (d / "config.json").write_text(json.dumps({"not": "a trace", "pad": "x" * 10}), encoding="utf-8")
+    events = list(_TRACE_EVENTS) + [
+        {"cat": "gpu_user_annotation", "ph": "X", "name": f"ProfilerStep#{i}", "ts": 1000 + i, "dur": 1}
+        for i in range(4)
+    ]
+    (d / "trace.json").write_text(json.dumps({"traceEvents": events}), encoding="utf-8")
+
+    _rc, result, _ = _run(_base_argv(tmp_path, str(d)), capsys)
+    assert result.get("num_denoise_steps") == 4, "must count steps in the analyzed trace, not config.json"
+
+
+def test_duration_warning_severity_is_graded(tmp_path, capsys):
+    """A materially wrong ranking warns; a mild perturbation only informs."""
+    base = [
+        {"cat": "kernel", "ph": "X", "name": f"k{i}", "ts": 1000 + i * 10_000, "dur": 10_000, "pid": 2, "tid": 3}
+        for i in range(40)
+    ]
+    severe = [dict(base[0], name="corrupt", dur=900_000)] + base[1:]
+    trace = _write_events(tmp_path / "severe.trace.json", severe)
+    _rc, result, _ = _run(_base_argv(tmp_path, str(trace)), capsys)
+    warn = next(
+        (w for w in result["trace_health_warnings"] if w["code"] == "bypass_impossible_kernel_durations"), None
+    )
+    assert warn is not None and warn["severity"] == "warning"
+    assert "unreliable" in warn["message"]
+    assert "% of the" in warn["message"], "share of summed device time should be reported"

--- a/src/hyperloom/agents/kernel/tests/test_denoise_steps.py
+++ b/src/hyperloom/agents/kernel/tests/test_denoise_steps.py
@@ -19,20 +19,29 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
 import _denoise_steps as ds  # noqa: E402
 
 
-def test_divisor_prefers_inferred_over_requested():
-    # Inferred steps in the analyzed window must win over the requested schedule.
-    assert ds.resolve_perstep_divisor(8, 20) == 8
-    assert ds.resolve_perstep_divisor(16, 0) == 16
+def test_divisor_prefers_requested_over_inferred():
+    # A declared --num-denoise-steps wins; Hyperloom cannot know what an
+    # operator's prof.step() brackets.
+    assert ds.resolve_perstep_divisor(requested_steps=9, inferred_steps=3) == 9
+    assert ds.resolve_perstep_divisor(requested_steps=16, inferred_steps=0) == 16
 
 
-def test_divisor_falls_back_to_requested_when_no_inferred():
-    assert ds.resolve_perstep_divisor(0, 20) == 20
-    assert ds.resolve_perstep_divisor(None, 20) == 20
+def test_divisor_falls_back_to_inferred_when_nothing_requested():
+    assert ds.resolve_perstep_divisor(requested_steps=0, inferred_steps=8) == 8
+    assert ds.resolve_perstep_divisor(requested_steps=None, inferred_steps=8) == 8
 
 
 def test_divisor_none_when_nothing_known():
     assert ds.resolve_perstep_divisor(0, 0) is None
     assert ds.resolve_perstep_divisor(None, None) is None
+
+
+def test_both_routes_resolve_the_same_divisor():
+    """The per-step figure must not depend on which analysis route ran."""
+    for requested, inferred in ((9, 3), (0, 8), (40, 8), (0, 0)):
+        bypass = ds.resolve_perstep_divisor(requested_steps=requested, inferred_steps=inferred)
+        tracelens = ds.resolve_perstep_divisor(requested_steps=requested, inferred_steps=inferred)
+        assert bypass == tracelens
 
 
 def _write_trace(path: Path, names: list[str], gz: bool):

--- a/src/hyperloom/agents/kernel/tests/test_denoise_steps.py
+++ b/src/hyperloom/agents/kernel/tests/test_denoise_steps.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import argparse
 import gzip
 import json
 import sys
@@ -36,12 +37,126 @@ def test_divisor_none_when_nothing_known():
     assert ds.resolve_perstep_divisor(None, None) is None
 
 
-def test_both_routes_resolve_the_same_divisor():
-    """The per-step figure must not depend on which analysis route ran."""
-    for requested, inferred in ((9, 3), (0, 8), (40, 8), (0, 0)):
-        bypass = ds.resolve_perstep_divisor(requested_steps=requested, inferred_steps=inferred)
-        tracelens = ds.resolve_perstep_divisor(requested_steps=requested, inferred_steps=inferred)
-        assert bypass == tracelens
+class TestCallSiteBinding:
+    """Pin what each route BINDS to each parameter, not just the helper.
+
+    Asserting the helper alone proves only that it is deterministic. These
+    recorders fail if either call site's arguments are swapped, which is the
+    regression that made the divisor route-dependent in the first place.
+    """
+
+    _TRACE = {
+        "traceEvents": [
+            {"cat": "cpu_op", "name": "aten::mm", "args": {"External id": 100}},
+            {"cat": "cuda_runtime", "name": "hipLaunchKernel", "args": {"correlation": 5, "External id": 100}},
+            {"cat": "kernel", "ph": "X", "name": "k0", "ts": 1000, "dur": 200, "args": {"correlation": 5}},
+            # Three ProfilerStep markers -> inferred == 3, distinct from requested.
+            {"cat": "gpu_user_annotation", "ph": "X", "name": "ProfilerStep#0", "ts": 1000, "dur": 1},
+            {"cat": "gpu_user_annotation", "ph": "X", "name": "ProfilerStep#1", "ts": 1001, "dur": 1},
+            {"cat": "gpu_user_annotation", "ph": "X", "name": "ProfilerStep#2", "ts": 1002, "dur": 1},
+        ]
+    }
+
+    def _trace(self, tmp_path: Path) -> Path:
+        f = tmp_path / "trace.json"
+        f.write_text(json.dumps(self._TRACE), encoding="utf-8")
+        return f
+
+    def test_bypass_binds_requested_and_inferred_correctly(self, tmp_path, monkeypatch, capsys):
+        import bypass_trace_analysis as bta
+
+        seen: dict = {}
+
+        def _recorder(*, requested_steps=None, inferred_steps=None):
+            seen.update(requested_steps=requested_steps, inferred_steps=inferred_steps)
+            return ds.resolve_perstep_divisor(requested_steps=requested_steps, inferred_steps=inferred_steps)
+
+        monkeypatch.setattr(bta, "resolve_perstep_divisor", _recorder)
+        trace = self._trace(tmp_path)
+        # xdit so the diffusion sidecar (and therefore the helper) is reached.
+        rc = bta.main(
+            [
+                "--trace-input", str(trace),
+                "--session-id", "binding",
+                "--workspace-path", str(tmp_path / "ws"),
+                "--framework", "xdit",
+                "--target-platform", "MI300X",
+                "--model-name", "m",
+                "--top-k", "4",
+                "--num-denoise-steps", "9",
+            ]
+        )
+        capsys.readouterr()
+        assert rc == 0
+        assert seen, "the bypass route never reached resolve_perstep_divisor"
+        assert seen["requested_steps"] == 9, "the declared count must bind to requested_steps"
+        assert seen["inferred_steps"] == 3, "the trace-derived count must bind to inferred_steps"
+
+    def test_tracelens_binds_requested_and_inferred_correctly(self, tmp_path, monkeypatch):
+        import diffusion_roofline as dr
+        import tracelens_analysis as tl
+
+        seen: dict = {}
+
+        def _recorder(*, requested_steps=None, inferred_steps=None):
+            seen.update(requested_steps=requested_steps, inferred_steps=inferred_steps)
+            return ds.resolve_perstep_divisor(requested_steps=requested_steps, inferred_steps=inferred_steps)
+
+        # The call site imports from the module at call time, so patch the source.
+        monkeypatch.setattr(ds, "resolve_perstep_divisor", _recorder)
+        monkeypatch.setattr(dr, "build_report", lambda *a, **k: {"totals": {}})
+
+        trace = self._trace(tmp_path)
+        run_dir = tmp_path / "run"
+        (run_dir / "tracelens").mkdir(parents=True, exist_ok=True)
+        md = run_dir / "tracelens" / "analysis.md"
+        md.write_text("# upstream\n", encoding="utf-8")
+        args = argparse.Namespace(
+            trace_input=str(trace),
+            model_name="m",
+            framework="xdit",
+            target_platform="MI300X",
+            analysis_mode="inference",
+            runtime_env="local",
+            dry_run=False,
+            num_denoise_steps=9,
+        )
+        tl.write_reports(
+            run_dir,
+            trace_input_type="file",
+            trace_files=[trace],
+            candidates=[],
+            args=args,
+            existing_report_path=md,
+        )
+        assert seen, "the TraceLens route never reached resolve_perstep_divisor"
+        assert seen["requested_steps"] == 9, "the declared count must bind to requested_steps"
+        assert seen["inferred_steps"] == 3, "the trace-derived count must bind to inferred_steps"
+
+
+def test_bypass_cli_default_honours_the_shared_env_var(monkeypatch):
+    """Both CLIs must derive the default from the same place.
+
+    The TraceLens CLI has always read ``HYPERLOOM_NUM_DENOISE_STEPS`` for this
+    default while bypass hardcoded 0. That was harmless while the inferred count
+    always won, but once the requested count takes precedence the env var would
+    change the divisor on one route only.
+    """
+    import importlib
+
+    import bypass_trace_analysis as bta
+
+    monkeypatch.setenv("HYPERLOOM_NUM_DENOISE_STEPS", "9")
+    importlib.reload(bta)
+    argv = ["--trace-input", "x", "--session-id", "s", "--workspace-path", "w"]
+    assert bta._build_arg_parser().parse_args(argv).num_denoise_steps == 9
+    # An explicit flag still wins over the env.
+    assert bta._build_arg_parser().parse_args(argv + ["--num-denoise-steps", "4"]).num_denoise_steps == 4
+
+    monkeypatch.delenv("HYPERLOOM_NUM_DENOISE_STEPS", raising=False)
+    importlib.reload(bta)
+    assert bta._build_arg_parser().parse_args(argv).num_denoise_steps == 0
+
 
 
 def _write_trace(path: Path, names: list[str], gz: bool):

--- a/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
+++ b/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
@@ -39,6 +39,15 @@ _GPU_KERNEL_CAT = "kernel"
 _GPU_MEMCPY_CATS = ("gpu_memcpy", "gpu_memset")
 _GPU_CATS = frozenset((_GPU_KERNEL_CAT,) + _GPU_MEMCPY_CATS)
 
+#: Per-pair overlap (us) below this is timestamp rounding, not corruption.
+_STREAM_OVERLAP_EPS_US = 1.0
+#: Minimum single overrun (us) before a stream is reported at all.
+_STREAM_OVERLAP_MIN_WORST_US = 1000.0
+#: Minimum total overrun, as a share of the stream's summed device time.
+_STREAM_OVERLAP_MIN_SHARE = 0.05
+#: At or above this share the kernel ranking is materially wrong.
+_STREAM_OVERLAP_SEVERE_SHARE = 0.25
+
 _TRACE_EXTS = (".trace.json.gz", ".pt.trace.json.gz", ".trace.json", ".json.gz", ".json")
 
 _DECODER = json.JSONDecoder()
@@ -505,6 +514,71 @@ def stream_events(
         emitted += 1
         pos = object_end
         _trim_consumed()
+
+
+def _stream_overlap_health(stream_events: dict[Any, list[tuple[float, float, str]]]) -> dict[str, Any]:
+    """Report device streams whose event durations physically cannot hold.
+
+    A hardware stream executes serially, so within a ``(pid, tid)`` row an
+    event's end must not run past the next event's start; where it does, the
+    duration is corrupt. The check is pairwise and the threshold is a share of
+    summed device time rather than of the wall span, since a corrupt event
+    inflates its own span. A corrupt duration on a stream's final event is not
+    detectable -- nothing follows it to contradict the value.
+
+    Args:
+        stream_events: ``(pid, tid) -> [(ts, end, name), ...]``, unsorted.
+
+    Returns:
+        The worst offending stream as a dict (including a ``severity`` grade),
+        or ``{}`` when every stream is self-consistent.
+    """
+    worst: dict[str, Any] = {}
+    for key, events in stream_events.items():
+        if len(events) < 2:
+            continue
+        events.sort()
+        device_us = sum(end - ts for ts, end, _n in events)
+        if device_us <= 0:
+            continue
+        span_us = max(end for _t, end, _n in events) - events[0][0]
+        excess_us = 0.0
+        overlapping = 0
+        worst_name = ""
+        worst_over = 0.0
+        for i in range(len(events) - 1):
+            ts, end, name = events[i]
+            nxt_ts = events[i + 1][0]
+            # Identical timestamps cannot contradict each other.
+            if nxt_ts == ts:
+                continue
+            over = end - nxt_ts
+            if over <= _STREAM_OVERLAP_EPS_US:
+                continue
+            excess_us += over
+            overlapping += 1
+            if over > worst_over:
+                worst_name, worst_over = name, over
+        if overlapping == 0 or worst_over < _STREAM_OVERLAP_MIN_WORST_US:
+            continue
+        share = excess_us / device_us
+        if share < _STREAM_OVERLAP_MIN_SHARE:
+            continue
+        if not worst or excess_us > worst["excess_ms"] * 1000.0:
+            pid, tid = key
+            worst = {
+                "pid": pid,
+                "tid": tid,
+                "overlapping_events": overlapping,
+                "excess_ms": round(excess_us / 1000.0, 4),
+                "device_ms": round(device_us / 1000.0, 4),
+                "excess_share": round(share, 4),
+                "span_ms": round(span_us / 1000.0, 4),
+                "worst_event": worst_name,
+                "worst_event_excess_ms": round(worst_over / 1000.0, 4),
+                "severity": ("warning" if share >= _STREAM_OVERLAP_SEVERE_SHARE else "info"),
+            }
+    return worst
 
 
 def _union_ms(intervals: list[tuple[float, float]]) -> float:
@@ -977,6 +1051,8 @@ def analyze_trace(
     # Correlations of CUDA/HIP graph-launch runtime events (no External id), so
     # their replayed kernels are classified graph-attributed, not (unlinked).
     graph_launch_corrs: set[int] = set()
+    # (pid, tid) -> [(ts, end, name), ...] for the duration-sanity check.
+    stream_intervals: dict[Any, list[tuple[float, float, str]]] = {}
     event_total = 0
     stream_errors: list[str] = []
 
@@ -1024,6 +1100,7 @@ def analyze_trace(
                 ts = float(ev.get("ts", 0) or 0)
                 end = ts + dur
                 name = ev.get("name", "") or ""
+                stream_intervals.setdefault((ev.get("pid"), ev.get("tid")), []).append((ts, end, name))
                 if cat == _GPU_KERNEL_CAT:
                     kargs = ev.get("args") or {}
                     corr = kargs.get("correlation")
@@ -1063,6 +1140,9 @@ def analyze_trace(
         corr_to_launch_geom=corr_to_launch_geom,
     )
     body["attribution"]["annotation_window_count"] = len(annotation_windows)
+    stream_overlap = _stream_overlap_health(stream_intervals)
+    if stream_overlap:
+        body["timeline"]["stream_overlap"] = stream_overlap
 
     # Detect (relative to the input dir) whether the selected trace is a
     # CUDA-graph capture shard, so the tool layer can surface a health warning.

--- a/src/hyperloom/agents/kernel/tools/_denoise_steps.py
+++ b/src/hyperloom/agents/kernel/tools/_denoise_steps.py
@@ -23,27 +23,28 @@ _CHUNK_BYTES = 1 << 20  # 1 MiB
 _OVERLAP_BYTES = 64
 
 
-def resolve_perstep_divisor(inferred_steps: int | None, requested_steps: int | None) -> int | None:
+def resolve_perstep_divisor(requested_steps: int | None, inferred_steps: int | None) -> int | None:
     """Return the denoise-step count to divide workload totals by for per-step.
 
-    Prefers the steps ACTUALLY IN the analyzed window/trace (``inferred_steps``)
-    over the requested full schedule (``requested_steps``), so per-step timings
-    reflect the profiled data -- consistent with the denoise-step-mismatch
-    warning the bypass route emits when the two disagree.
+    Prefers an explicitly requested count over the one inferred from the trace:
+    Hyperloom cannot know what an operator's ``prof.step()`` brackets, so a
+    declared ``--num-denoise-steps`` is authoritative. Both analysis routes use
+    this same precedence, so a per-step figure depends on the workload rather
+    than on which route ran. The bypass route warns when the two disagree.
 
     Args:
+        requested_steps: The operator-declared denoise-step count.
         inferred_steps: Denoise steps detected in the analyzed window/trace.
-        requested_steps: The requested full sampler schedule step count.
 
     Returns:
         The positive divisor to use, or ``None`` when neither is known (the
         caller then omits the per-step block).
     """
-    inf = int(inferred_steps or 0)
-    if inf > 0:
-        return inf
     req = int(requested_steps or 0)
-    return req or None
+    if req > 0:
+        return req
+    inf = int(inferred_steps or 0)
+    return inf or None
 
 
 def count_profiler_steps(trace_path: str) -> int:

--- a/src/hyperloom/agents/kernel/tools/_denoise_steps.py
+++ b/src/hyperloom/agents/kernel/tools/_denoise_steps.py
@@ -1,11 +1,16 @@
 """Shared helpers for the diffusion per-denoise-step roofline divisor.
 
 The workload-level ``diffusion_roofline.json`` reports per-denoise-step timings
-as ``workload_totals / num_denoise_steps``. The divisor MUST be the number of
-denoise steps ACTUALLY IN the analyzed data (the steady-state window for bypass,
-or the profiled iterations in the trace for the TraceLens route), NOT the
-requested full sampler schedule -- otherwise the per-step figure is off by the
-ratio of scheduled-to-profiled steps and is not comparable across routes.
+as ``workload_totals / num_denoise_steps``. An operator-declared
+``--num-denoise-steps`` is authoritative for that divisor: Hyperloom cannot know
+what a user's ``prof.step()`` brackets, so a count inferred from the trace is
+only a fallback for when nothing was declared. Both the bypass and TraceLens
+routes apply that same precedence, so the per-step figure depends on the
+workload rather than on which route ran.
+
+Note the fallbacks themselves still differ -- bypass uses its steady-state
+window's step count, TraceLens the deduplicated ``ProfilerStep#N`` count -- so
+route independence holds only while a count was requested.
 
 Kept dependency-free (stdlib only) so both routes can import it freely.
 """

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -857,11 +857,10 @@ def main(argv: list[str] | None = None) -> int:
         try:
             from diffusion_roofline import build_report_from_bypass  # noqa: E402
 
-            # Per-step divisor is the denoise steps in the analyzed window
-            # (trace-inferred), not the requested full schedule.
-            # An explicit --num-denoise-steps wins; the helper returns its
-            # first positive argument.
-            _diff_steps = resolve_perstep_divisor(requested_denoise_steps, inferred_denoise_steps)
+            _diff_steps = resolve_perstep_divisor(
+                requested_steps=requested_denoise_steps,
+                inferred_steps=inferred_denoise_steps,
+            )
             # Workload totals cover all analyzed device kernels (not just top-k).
             _workload_totals = _report.build_workload_roofline_totals(analyze, target_platform=args.target_platform)
             _all_kernels = [k for k in (analyze.get("kernels") or []) if float(k.get("gpu_time_us") or 0.0) > 0]

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -442,8 +442,13 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "(mixed / decode_only / prefilldecode); off values: '', 0, false, off, none.",
     )
     p.add_argument("--roofline-output-name", default="kernel_roofline.json")
-    # Denoise-step count for scriptable/diffusion workloads; 0 = infer.
-    p.add_argument("--num-denoise-steps", type=int, default=0)
+    # Denoise-step count for scriptable/diffusion workloads; 0 = infer. The env
+    # fallback matches the TraceLens CLI, so the divisor cannot differ by route.
+    p.add_argument(
+        "--num-denoise-steps",
+        type=int,
+        default=int(os.environ.get("HYPERLOOM_NUM_DENOISE_STEPS", "0") or 0),
+    )
     # Diffusion analytic-ceiling inputs shared with the TraceLens CLI surface;
     # parsed but unused on this route.
     p.add_argument("--model-path", default=os.environ.get("MODEL_PATH", ""))

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -54,7 +54,7 @@ from _idle_gate import (  # noqa: E402
     build_high_idle_warning,
     resolve_idle_pct_threshold,
 )
-from _denoise_steps import resolve_perstep_divisor  # noqa: E402
+from _denoise_steps import count_profiler_steps, resolve_perstep_divisor  # noqa: E402
 from _io_utils import atomic_write_json, utc_now, write_text  # noqa: E402
 
 
@@ -668,12 +668,42 @@ def main(argv: list[str] | None = None) -> int:
             }
         )
 
-    # Warn when the forwarded --num-denoise-steps differs from the count the
-    # reader inferred from ProfilerStep annotations.
+    # Corrupt durations outrank real kernels, since ranking is by summed time.
+    stream_overlap = (analyze.get("timeline") or {}).get("stream_overlap") or {}
+    if stream_overlap:
+        _severity = str(stream_overlap.get("severity") or "info")
+        _share_pct = float(stream_overlap.get("excess_share") or 0.0) * 100.0
+        _advice = (
+            "Kernel ranking is by summed duration, so treat the hot-kernel table as "
+            "unreliable until the trace is recaptured or the durations are repaired."
+            if _severity == "warning"
+            else "Kernel ranking is by summed duration, so the affected entries are "
+            "overstated by this much; the overall ordering is probably still usable."
+        )
+        trace_health_warnings.append(
+            {
+                "code": "bypass_impossible_kernel_durations",
+                "severity": _severity,
+                "message": (
+                    f"device stream (pid={stream_overlap.get('pid')}, tid={stream_overlap.get('tid')}): "
+                    f"{stream_overlap.get('overlapping_events')} event(s) run past the start of the "
+                    f"event after them, by {stream_overlap.get('excess_ms')} ms in total -- "
+                    f"{_share_pct:.1f}% of the {stream_overlap.get('device_ms')} ms of device time "
+                    "booked on that stream. That is impossible on a serial stream, so these "
+                    f"durations are corrupt. Worst offender: '{stream_overlap.get('worst_event')}' "
+                    f"overruns by {stream_overlap.get('worst_event_excess_ms')} ms. " + _advice
+                ),
+            }
+        )
+
+    # Steps present in the analyzed data. ``annotation_window_count`` is
+    # deliberately not a fallback: it counts user_annotation ranges, not steps.
     requested_denoise_steps = int(getattr(args, "num_denoise_steps", 0) or 0)
-    inferred_denoise_steps = int((steady_window or {}).get("step_count", 0) or 0) or int(
-        (analyze.get("attribution") or {}).get("annotation_window_count", 0) or 0
-    )
+    inferred_denoise_steps = int((steady_window or {}).get("step_count", 0) or 0)
+    if inferred_denoise_steps <= 0:
+        # Count in the file the reader resolved; a directory input may glob a
+        # different one.
+        inferred_denoise_steps = count_profiler_steps(str(analyze.get("trace_file") or args.trace_input))
     if requested_denoise_steps > 0 and inferred_denoise_steps > 0 and requested_denoise_steps != inferred_denoise_steps:
         trace_health_warnings.append(
             {
@@ -681,8 +711,8 @@ def main(argv: list[str] | None = None) -> int:
                 "severity": "info",
                 "message": (
                     f"requested --num-denoise-steps={requested_denoise_steps} differs from the "
-                    f"{inferred_denoise_steps} step(s) inferred from the trace annotations; the "
-                    "trace-inferred per-step window is used for kernel shares."
+                    f"{inferred_denoise_steps} step(s) found in the analyzed data; the requested "
+                    "count wins as the per-step divisor."
                 ),
             }
         )
@@ -829,7 +859,9 @@ def main(argv: list[str] | None = None) -> int:
 
             # Per-step divisor is the denoise steps in the analyzed window
             # (trace-inferred), not the requested full schedule.
-            _diff_steps = resolve_perstep_divisor(inferred_denoise_steps, requested_denoise_steps)
+            # An explicit --num-denoise-steps wins; the helper returns its
+            # first positive argument.
+            _diff_steps = resolve_perstep_divisor(requested_denoise_steps, inferred_denoise_steps)
             # Workload totals cover all analyzed device kernels (not just top-k).
             _workload_totals = _report.build_workload_roofline_totals(analyze, target_platform=args.target_platform)
             _all_kernels = [k for k in (analyze.get("kernels") or []) if float(k.get("gpu_time_us") or 0.0) > 0]

--- a/src/hyperloom/agents/kernel/tools/diffusion_roofline.py
+++ b/src/hyperloom/agents/kernel/tools/diffusion_roofline.py
@@ -132,7 +132,8 @@ def dit_analytic_flops(
         hidden_size: Transformer hidden dimension ``h``.
         num_layers: Number of transformer blocks.
         num_tokens: Sequence length (latent patches) per forward.
-        num_denoise_steps: Denoise steps in the profiled window.
+        num_denoise_steps: Per-step divisor: the requested count when one was
+            given, else the count inferred from the trace.
         ffn_ratio: FFN expansion factor (``intermediate / hidden``).
 
     Returns:
@@ -218,7 +219,8 @@ def build_report(
 
     Args:
         csv_dir: ``--output_csvs_dir`` from generate_perf_report_pytorch.
-        num_denoise_steps: Denoise steps in the profiled window (enables per-step).
+        num_denoise_steps: Per-step divisor: the requested count when one was
+            given, else the count inferred from the trace (enables per-step).
         top_k: How many hottest kernels to include.
 
     Returns:
@@ -267,7 +269,8 @@ def assemble_report(
     Args:
         totals: Workload totals (see ``aggregate_unified`` for the key contract).
         timeline: GPU timeline percentages keyed by type (``busy_time`` etc.).
-        num_denoise_steps: Denoise steps in the profiled window (enables per-step).
+        num_denoise_steps: Per-step divisor: the requested count when one was
+            given, else the count inferred from the trace (enables per-step).
         top_kernels_list: Pre-ranked hottest-kernel summary entries.
         dit_geometry: Optional DiT geometry enabling the analytic compute ceiling.
         achievable_tflops: Optional achievable peak enabling the analytic ceiling.
@@ -511,7 +514,7 @@ def main() -> int:
         "--num-denoise-steps",
         type=int,
         default=0,
-        help="Denoise steps in the profiled window; enables per-step timings.",
+        help="Per-step divisor; enables per-step timings. Wins over the trace-inferred count.",
     )
     parser.add_argument("--top-k", type=int, default=10, help="Hottest kernels to list.")
     parser.add_argument("--output", default="", help="Optional path to write the report JSON.")

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -6631,11 +6631,11 @@ def write_reports(
             from diffusion_roofline import build_report as _build_diffusion_roofline  # noqa: WPS433
             from _denoise_steps import count_profiler_steps, resolve_perstep_divisor  # noqa: WPS433
 
-            # Per-step divisor = denoise steps actually in the trace, preferred
-            # over the requested full sampler schedule.
+            # Per-step divisor: an operator-declared count wins over the one
+            # inferred from the trace, matching the bypass route.
             _num_steps = resolve_perstep_divisor(
-                count_profiler_steps(getattr(args, "trace_input", "") or ""),
-                int(getattr(args, "num_denoise_steps", 0) or 0),
+                requested_steps=int(getattr(args, "num_denoise_steps", 0) or 0),
+                inferred_steps=count_profiler_steps(getattr(args, "trace_input", "") or ""),
             )
             _diff_report = _build_diffusion_roofline(
                 tracelens_dir / "perf_report_csvs",


### PR DESCRIPTION
**Description: what and why**

Two independent defects in the bypass route, both surfaced while analysing a real Wan2.2 (SGLang, 720p/81f, Ulysses-8) trace of 55423 kernels.

### 1. Corrupt Kineto durations were trusted verbatim

Work dispatched to one hardware stream executes serially, so within a `(pid, tid)` row an event's end cannot run past the next event's start. On this trace **7 of 55423 events (0.013%)** violated that by **16251 ms** in total — two "elementwise kernels" at ~3.4 s and three 9.7 MB `Memcpy DtoH` at ~3.15 s.

Hot-kernel ranking is by *summed* duration, so those 7 events became **62% of reported GPU time** and displaced the true #2 and #3 bottlenecks. The report's headline was that exposed device memcpy dominated the workload. It does not. On that trace an Arbor/GEAK campaign would have spent its whole budget chasing a bottleneck that does not exist:

| | reported (raw) | after repairing the 7 durations |
|---|---|---|
| Exposed memcpy | **61.90%** | **0.46%** |
| 1 | SDPA 41.20% | SDPA 59.60% |
| 2 | `aten::copy_` 16.20% *(artifact)* | `aten::addmm` 18.68% |
| 3 | `aten::add` 15.97% *(artifact)* | `record_param_comms` 7.24% |

`_bypass_trace_reader` now checks each device stream pairwise, and the tool raises `bypass_impossible_kernel_durations` naming the stream, the total overrun and the worst offender.

Two design points worth flagging for review:

- **Pairwise, not an aggregate ratio.** I first implemented sum-vs-span and my own test caught it being too weak: a corrupt event also extends its stream's span, dragging the ratio back toward 1.0 and hiding exactly the case worth catching. `test_stream_overlap_detects_impossible_duration` asserts the aggregate ratio stays under 1.02 on a trace the pairwise check flags.
- **Per-stream, not pooled.** Pooling all device events would make summed duration exceed wall span on any genuinely concurrent multi-stream trace — a false positive. `test_stream_overlap_not_triggered_by_concurrent_streams` covers it.

Known limitation, documented in the docstring rather than papered over: a corrupt duration on a stream's *final* event is not detectable this way, because nothing follows it to contradict the value. There is a test pinning that behaviour.

Durations are only reported on, never modified — consistent with the existing "durations stay unclipped" contract in `_finalize`.

### 2. `num_denoise_steps` fell back to the annotation-window count

With no steady window, `inferred_denoise_steps` fell through to `attribution.annotation_window_count`, which counts `user_annotation` ranges — not denoise steps. On this trace that reported **21835 denoise steps for 8 actual steps**, a 2729× error on any per-step figure.

It is worse than the reported number suggests: `resolve_perstep_divisor` *prefers* the inferred value, so the bogus count also won as the diffusion per-step divisor even when `--num-denoise-steps` was passed explicitly — while the result still reported the requested value. Reported and used disagreed.

`_denoise_steps.count_profiler_steps()` already returns the correct answer and is used by the TraceLens route. Bypass now uses it as the fallback and no longer consults the annotation count. The mismatch warning text is corrected — it claimed "the trace-inferred per-step window is used for kernel shares", which described the divisor but not accurately.

**Linked issue(s)**

None open for these; they were found while working on #1114 but are independent of it.

**Tests: added/updated? commands run?**

10 new tests. Reader: clean trace stays silent, corrupt duration detected (with the aggregate-ratio counter-assertion), concurrent streams not flagged, worst-stream selection, rounding/short-stream/degenerate-input guards, and the documented final-event limitation. Tool: warning emitted and absent appropriately, denoise steps taken from `ProfilerStep#N` and explicitly *not* from a much larger annotation count, and explicit `--num-denoise-steps` still recorded plus flagged on mismatch.

```
pytest src/hyperloom/agents/kernel/tests            ->  1152 passed, 23 skipped
pytest <bypass_backend, bypass_report, diffusion_roofline>  ->  97 passed
ruff check                                          ->  clean
```

`ruff format --check` still reports the two files as unformatted, but those sites pre-exist on `main` (verified by re-running the check on a stashed tree) and are part of the formatting backlog CONTRIBUTING refers to; I reformatted only my own added lines rather than churning unrelated code. I did not run the full suite to completion locally — it exceeds ~10 min in my environment — so I ran the kernel-agent tree plus the modules that consume these call paths.

**End-to-end validation on the original trace**

```
raw trace:      7 event(s) overrun, 16251.2375 ms total   [warning raised]
                num_denoise_steps = 8   (was 21835)
repaired copy:  no warning                                [no false positive]
                num_denoise_steps = 8
```

The guard's 7 events / 16251.2375 ms independently reproduce a separate clip-based repair of the same trace (`clipped: 7`, `removed_ms: 16251.23746811719`) to the microsecond, from a different algorithm.

**Breaking changes: no**

Purely additive: one new optional `timeline.stream_overlap` key (present only when a stream is inconsistent) and one new health-warning code. No signature changes. The corrected denoise-step source changes `num_denoise_steps` only where it was previously the annotation count, which was never a meaningful value.
