### PR TITLE
fix(orchestrator): gate diffusion behaviour on registry kind, not the xdit name

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
@@ -620,3 +620,14 @@ def test_steady_state_with_zero_annotations_falls_back(tmp_path):
     assert out["aggregation_scope"] == "full_trace"
     assert out.get("steady_window_status")
     assert len(out["kernels"]) == 2
+
+
+def test_reader_scriptable_detection_is_registry_driven():
+    """The steady-window threshold must apply to every scriptable framework."""
+    from hyperloom.inference_optimizer import framework_registry as fr
+
+    for name, spec in fr.FRAMEWORKS.items():
+        assert reader._is_scriptable_framework(name) is (spec.kind == fr.SCRIPTABLE), name
+    assert reader._is_scriptable_framework("hunyuan_image3") is True
+    assert reader._is_scriptable_framework("sglang") is False
+    assert reader._is_scriptable_framework(None) is False

--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -896,3 +896,48 @@ def test_single_graph_launch_low_busy_not_under_recorded(tmp_path):
     cov = bta._reader.analyze_trace(str(trace), top_k=0)["graph_coverage"]
     assert cov["graph_launch_count"] == 1
     assert cov["graph_under_recorded"] is False
+
+
+# ---- scriptable-framework detection is registry-driven -------------------
+def test_scriptable_detection_covers_every_registry_entry():
+    """Not just xdit: any kind=scriptable framework must be detected.
+
+    hunyuan_image3 ships baseline/profile configs and is registered
+    kind=scriptable, so gating on the literal "xdit" silently treated it as an
+    LLM workload.
+    """
+    from hyperloom.inference_optimizer import framework_registry as fr
+
+    for name, spec in fr.FRAMEWORKS.items():
+        assert bta._is_scriptable_framework(name) is (spec.kind == fr.SCRIPTABLE), name
+
+
+def test_scriptable_throughput_unit_matches_registry():
+    from hyperloom.inference_optimizer import framework_registry as fr
+
+    for name, spec in fr.FRAMEWORKS.items():
+        assert bta._scriptable_throughput_unit(name) == spec.throughput_unit, name
+    assert bta._scriptable_throughput_unit("hunyuan_image3") == "img/s"
+    # Unknown / empty keeps the previous tok/s default.
+    for unknown in ("", None, "not-a-framework"):
+        assert bta._scriptable_throughput_unit(unknown) == "tok/s"
+        assert bta._is_scriptable_framework(unknown) is False
+
+
+def test_scriptable_helpers_fall_back_without_the_package(monkeypatch):
+    """Standalone use (no importable inference_optimizer) still works."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_registry(name, *a, **k):
+        if "framework_registry" in name:
+            raise ImportError("simulated standalone run")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _no_registry)
+    assert bta._is_scriptable_framework("xdit") is True
+    assert bta._is_scriptable_framework("hunyuan_image3") is True
+    assert bta._is_scriptable_framework("sglang") is False
+    assert bta._scriptable_throughput_unit("hunyuan_image3") == "img/s"
+    assert bta._scriptable_throughput_unit("sglang") == "tok/s"

--- a/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
+++ b/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
@@ -273,6 +273,28 @@ def stream_events(fileobj, bufsize: int = 8 * 1024 * 1024) -> Iterator[dict]:
             pos = 0
 
 
+def _is_scriptable_framework(framework: str | None) -> bool:
+    """Return whether ``framework`` is a server-less scriptable workload.
+
+    Prefers the canonical ``framework_registry`` so every ``kind=scriptable``
+    entry is covered rather than ``xdit`` alone; falls back to a name check so
+    the reader stays usable when run standalone (outside an importable
+    ``inference_optimizer`` package).
+
+    Args:
+        framework: Framework name (matched case-insensitively).
+
+    Returns:
+        bool: ``True`` for scriptable frameworks.
+    """
+    try:
+        from hyperloom.inference_optimizer.framework_registry import is_scriptable
+
+        return is_scriptable(framework)
+    except Exception:  # noqa: BLE001 - standalone use must not hard-fail
+        return str(framework or "").strip().lower() in {"xdit", "hunyuan_image3"}
+
+
 def _union_ms(intervals: list[tuple[float, float]]) -> float:
     """Return the union length (in ms) of ``[start_us, end_us)`` intervals."""
     if not intervals:
@@ -349,8 +371,10 @@ def select_steady_window(
         is_step = 1 if _STEP_MARKER_RE.search(norm) else 0
         return (is_step, len(ws))
 
-    is_xdit = (framework or "").lower() == "xdit"
-    threshold = 2 if is_xdit else min_repeats
+    # Diffusion frameworks run few, long denoise iterations, so a lower repeat
+    # threshold is needed to find the loop. This is a property of the scriptable
+    # kind, not of xDiT specifically.
+    threshold = 2 if _is_scriptable_framework(framework) else min_repeats
     # Filter by threshold before ranking so a spurious low-count step-named
     # annotation cannot win over a real high-count loop and then be rejected.
     qualified = [(n, w) for n, w in groups.items() if len(w) >= threshold]

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -472,7 +472,42 @@ def _should_enable_steady(*, steady_state_mode: str, framework: str, env_steady:
     full-trace (with the existing warning) when no window is found.
     """
     mode = (steady_state_mode or "").strip().lower()
-    return bool(env_steady) or (framework or "").lower() == "xdit" or mode not in _STEADY_OFF_VALUES
+    return bool(env_steady) or _is_scriptable_framework(framework) or mode not in _STEADY_OFF_VALUES
+
+
+def _is_scriptable_framework(framework: str | None) -> bool:
+    """Return whether ``framework`` is a server-less scriptable workload.
+
+    Scriptable frameworks are the diffusion-style ones: a denoise loop instead
+    of an LLM decode phase, throughput in images/sec, and a workload-level
+    diffusion roofline. Prefers the canonical ``framework_registry`` so every
+    ``kind=scriptable`` entry is covered rather than ``xdit`` alone; falls back
+    to a name check so the tool stays usable when run standalone (outside an
+    importable ``inference_optimizer`` package). Mirrors the helper of the same
+    name in ``tracelens_analysis``.
+
+    Args:
+        framework: Framework name (matched case-insensitively).
+
+    Returns:
+        bool: ``True`` for scriptable frameworks.
+    """
+    try:
+        from hyperloom.inference_optimizer.framework_registry import is_scriptable
+
+        return is_scriptable(framework)
+    except Exception:  # noqa: BLE001 - standalone use must not hard-fail
+        return str(framework or "").strip().lower() in {"xdit", "hunyuan_image3"}
+
+
+def _scriptable_throughput_unit(framework: str | None) -> str:
+    """Return the throughput unit for ``framework`` (img/s vs tok/s)."""
+    try:
+        from hyperloom.inference_optimizer.framework_registry import throughput_unit
+
+        return throughput_unit(framework)
+    except Exception:  # noqa: BLE001 - standalone use must not hard-fail
+        return "img/s" if _is_scriptable_framework(framework) else "tok/s"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -564,25 +599,28 @@ def main(argv: list[str] | None = None) -> int:
     # ``estimated`` marks shares not anchored to a real per-step window (steady
     # windowing requested but fell back to the full trace).
     estimated = enable_steady and scope != AGGREGATION_SCOPE_STEADY
-    if framework_l == "xdit" and estimated:
+    # Every scriptable (diffusion) framework has a denoise loop, so the
+    # anchored/estimated distinction applies to all of them, not just xDiT.
+    # The two code strings keep their ``xdit`` spelling for wire stability.
+    if _is_scriptable_framework(framework_l) and estimated:
         trace_health_warnings.append(
             {
                 "code": "bypass_xdit_estimated",
                 "severity": "info",
                 "message": (
-                    "xDiT analysis fell back to full-trace shares (no per-step denoising "
+                    "diffusion analysis fell back to full-trace shares (no per-step denoising "
                     "window found; trace lacks step annotations such as ProfilerStep) — "
                     "treat kernel shares / roofline as estimated."
                 ),
             }
         )
-    elif framework_l == "xdit":
+    elif _is_scriptable_framework(framework_l):
         trace_health_warnings.append(
             {
                 "code": "bypass_xdit_steady_anchored",
                 "severity": "info",
                 "message": (
-                    f"xDiT analysis anchored to a real per-step denoising window "
+                    f"diffusion analysis anchored to a real per-step denoising window "
                     f"({(steady_window or {}).get('step_name', 'step')}×"
                     f"{(steady_window or {}).get('step_count', 0)}); per-step kernel "
                     "shares are trace-anchored (not estimated)."
@@ -680,7 +718,7 @@ def main(argv: list[str] | None = None) -> int:
     for cand in candidates.get("hot_kernels", []):
         cand["trace_report_path"] = str(analysis_md_path)
 
-    throughput_unit = "img/s" if (args.framework or "").lower() == "xdit" else "tok/s"
+    throughput_unit = _scriptable_throughput_unit(args.framework)
     write_text(
         analysis_md_path,
         _report.render_analysis_md(
@@ -760,7 +798,7 @@ def main(argv: list[str] | None = None) -> int:
     # split. Best-effort sidecar over all device kernels, independent of the
     # per-kernel high-idle gate, so still emitted in the high-idle regime.
     diffusion_roofline_path: str | None = None
-    if (args.framework or "").lower() == "xdit":
+    if _is_scriptable_framework(args.framework):
         try:
             from diffusion_roofline import build_report_from_bypass  # noqa: E402
 

--- a/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling.py
+++ b/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling.py
@@ -2888,3 +2888,51 @@ class TestDiffusionCeiling:
         bd = compute_roofline_breakdown_from_state(state, arm="baseline")
         assert bd.bound_kind == "unknown"
         assert bd.peak_tok_per_sec == 0.0
+
+
+class TestScriptableRooflineRouting:
+    """The diffusion ceiling must be chosen by registry kind, not by name."""
+
+    @staticmethod
+    def _rt(framework: str):
+        return RuntimeWorkload(
+            model_path="/x",
+            gpu_type="mi325x",
+            precision="bf16",
+            framework=framework,
+            tp=1,
+            concurrency=1,
+            isl=0,
+            osl=0,
+            server_args="",
+        )
+
+    @pytest.mark.parametrize("framework", ["xdit", "hunyuan_image3"])
+    def test_scriptable_frameworks_take_the_diffusion_path(self, monkeypatch, framework):
+        import hyperloom.orchestrator.kernel.roofline_ceiling as rc
+
+        taken: list[str] = []
+        monkeypatch.setattr(rc, "resolve_runtime_workload", lambda state, arm=None: self._rt(framework))
+        monkeypatch.setattr(
+            rc,
+            "_compute_diffusion_breakdown_from_state",
+            lambda state, runtime: taken.append("diffusion") or rc._EMPTY_BREAKDOWN,
+        )
+        monkeypatch.setattr(rc, "load_model_meta", lambda *a, **k: taken.append("llm") or None)
+        rc.compute_roofline_breakdown_from_state(object())
+        assert taken == ["diffusion"], f"{framework} should use the diffusion ceiling"
+
+    @pytest.mark.parametrize("framework", ["sglang", "vllm", "atom"])
+    def test_serving_frameworks_keep_the_decode_path(self, monkeypatch, framework):
+        import hyperloom.orchestrator.kernel.roofline_ceiling as rc
+
+        taken: list[str] = []
+        monkeypatch.setattr(rc, "resolve_runtime_workload", lambda state, arm=None: self._rt(framework))
+        monkeypatch.setattr(
+            rc,
+            "_compute_diffusion_breakdown_from_state",
+            lambda state, runtime: taken.append("diffusion") or rc._EMPTY_BREAKDOWN,
+        )
+        monkeypatch.setattr(rc, "load_model_meta", lambda *a, **k: taken.append("llm") or None)
+        rc.compute_roofline_breakdown_from_state(object())
+        assert taken == ["llm"], f"{framework} must not use the diffusion ceiling"

--- a/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
+++ b/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from hyperloom.inference_optimizer.framework_registry import is_scriptable
 from hyperloom.inference_optimizer.model_config_utils import _merge_config_scopes
 
 
@@ -1434,8 +1435,10 @@ def compute_roofline_breakdown_from_state(
         fields).
     """
     runtime = resolve_runtime_workload(state, arm=arm)
-    # Diffusion (xDiT) uses a distinct images/sec ceiling.
-    if (runtime.framework or "").strip().lower() == "xdit":
+    # Diffusion uses a distinct images/sec ceiling. Gate on the registry kind
+    # so every scriptable framework (e.g. hunyuan_image3) takes this path
+    # rather than falling through to the LLM decode roofline below.
+    if is_scriptable(runtime.framework):
         return _compute_diffusion_breakdown_from_state(state, runtime)
     meta = load_model_meta(
         runtime.model_path,

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -2408,12 +2408,17 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
     def _roofline_throughput_unit(self) -> str:
         """Return the throughput unit for roofline snapshots of this workload.
 
-        Diffusion (xDiT) ceilings are images/sec; text-gen is tokens/sec. The
-        numeric ``*_tok_per_sec`` fields keep their names for wire stability;
-        this unit tells consumers how to render them.
+        Diffusion ceilings are images/sec; text-gen is tokens/sec. The unit is
+        read from the framework registry rather than matched against ``xdit``,
+        so every ``kind=scriptable`` framework (e.g. ``hunyuan_image3``) reports
+        the unit its own registry entry declares. The numeric ``*_tok_per_sec``
+        fields keep their names for wire stability; this unit tells consumers
+        how to render them.
         """
+        from hyperloom.inference_optimizer import framework_registry
+
         framework = str(getattr(self, "framework", "") or "").strip().lower()
-        return "img/s" if framework == "xdit" else "tok/s"
+        return framework_registry.throughput_unit(framework)
 
     def record_baseline_roofline_ceiling(self) -> dict[str, Any]:
         """Compute a standalone baseline-arm roofline ceiling and cache it.


### PR DESCRIPTION
**Description: what and why**

`hunyuan_image3` is registered `kind=scriptable` with `throughput_unit="img/s"` and ships `baseline_hunyuan_image3.yaml` / `profile_hunyuan_image3.yaml` — but several call sites decide "is this a diffusion workload?" by comparing the framework name to `"xdit"`. Those sites silently treat it as an LLM workload.

Before this change a `hunyuan_image3` session:

| | behaviour | should be |
|---|---|---|
| `SharedState._roofline_throughput_unit` | `tok/s` | `img/s` (its own registry entry) |
| bypass analysis report unit | `tok/s` | `img/s` |
| bypass diffusion-roofline sidecar | not emitted | emitted |
| bypass steady-state default | off | on |
| steady-window repeat threshold | LLM threshold | diffusion threshold (2) |
| `compute_roofline_breakdown_from_state` | LLM decode roofline | diffusion ceiling |

All of these now consult `framework_registry` (`is_scriptable` / `throughput_unit`), which is already the canonical predicate in 26 other places. `executors/profile.py:632` is the pattern I followed — it calls `is_scriptable()` for the server-less branch and only *then* narrows to `xdit` for the xfuser-specific check, with a comment noting hunyuan_image3 must not trigger it.

The kernel tools keep working standalone: they try the registry and fall back to a name check, mirroring the existing `_is_scriptable_framework` helper in `tracelens_analysis.py`.

**Deliberately not changed.** I went through every `"xdit"` literal in non-test code; most are correct and are left alone: the `xfuser` pip name and xDiT git URL, `XditAdapter` registration, per-framework config paths, the PATH guard for the `xdit` console script + `hipcc`, the XDIT_* env blacklist, the xDiT default grid seeds, and the xfuser baked-profiler verification. `cli/model_gate.py` already calls `is_scriptable()` with the literal only as an import-failure fallback.

The two health-warning codes keep their `bypass_xdit_*` spelling for wire stability even though the condition is now generic; only their messages change from "xDiT" to "diffusion". Renaming those codes felt like a separate call for you to make.

**Linked issue(s)**

Addresses item 3 of #1114 (see [my correction comment](https://github.com/AMD-AGI/Hyperloom/issues/1114#issuecomment-5207776396) there — my original "15 hardcoded comparisons" was a raw grep count and overstated it; this PR covers the subset that is genuinely wrong). Does not close #1114, whose main ask is an SGLang diffusion route.

This is also the prerequisite that issue names: with the kind checks registry-driven, adding a new scriptable framework gets closer to the "single-table edit" `framework_registry`'s own docstring promises. I deliberately did **not** add an `sglang-diffusion` entry here — without a matching Magpie wrapper script (external repo) it would be dead config, and #1114 is asking you how you'd want that shaped.

**Tests: added/updated? commands run?**

No test in the tree referenced `hunyuan_image3` before this change, which is why the divergence went unnoticed. The new tests assert against **every registry entry** rather than a hardcoded list, so a future framework cannot regress the same way:

- scriptable detection and throughput unit match `FRAMEWORKS[*].kind` / `.throughput_unit` for all entries, in both the tool and the reader
- the standalone fallback path (registry import forced to fail) still classifies xdit and hunyuan_image3 correctly
- `compute_roofline_breakdown_from_state` routes xdit **and** hunyuan_image3 to the diffusion ceiling, and sglang/vllm/atom to the decode path
- unknown/empty framework still resolves to `tok/s` + decode

```
pytest src/hyperloom/agents/kernel/tests                     ->  1146 passed, 23 skipped
pytest <roofline_ceiling, framework_adapters, diffusion_roofline,
        xdit_integration_units, backend_gating>              ->   264 passed
ruff check                                                   ->  clean
ruff format --check                                          ->  identical before/after (no new debt)
```

I did not run the full suite to completion locally — it exceeds ~10 min in my environment — so I ran the kernel-agent tree plus the modules consuming these call paths.

**Breaking changes: no**

Serving frameworks and unknown/empty names are unchanged: the registry falls back to `sglang`, so they still resolve to `tok/s` and the decode roofline. The only behaviour that changes is for `kind=scriptable` frameworks other than `xdit` — i.e. `hunyuan_image3` — which now gets the diffusion treatment its registry entry already declared. Warning code strings are unchanged.
