### PR TITLE
feat(knowledge): bind replay artifacts to champion recipes

### DIFF
--- a/docs/knowledge-plane-phase1.md
+++ b/docs/knowledge-plane-phase1.md
@@ -75,8 +75,43 @@ filesystem. Startup fails when `fcntl` is unavailable, and writes fail clearly
 when the lock directory/file cannot be safely created or locked. A pod-local
 volume does not provide cross-pod serialization.
 
-Recipe identity, T0 matching tiers, champion selection, and warm-replay policy
-are unchanged.
+Recipe identity and T0 matching tiers are unchanged.
+
+## Replay bundles and legacy Recipes
+
+A replayable champion is one atomic value: the final effective server argv,
+environment variables, source patches, measured throughput, and integrity
+metadata all describe the same validated state. `best_config` remains a
+compatibility projection of that bundle's config; a writer must not advance
+`best_config` or `best_throughput` while carrying forward an older bundle.
+
+Source modifications from every retained `source_patch` stack entry are
+squashed per repository/base commit. Local Recipes keep those diffs inline;
+remote Recipes externalize large diffs to content-addressed GBrain pages.
+Both readers verify artifact hashes and the bundle digest before warm replay.
+Environment values that point at a captured file are stored as
+`{repo, path}` references and resolved only after that repository patch is
+applied; uncaptured absolute paths make the bundle non-replayable.
+Patch application is reversed patch-by-patch after benchmarking and never uses
+`git reset --hard` or `git clean` on a shared framework checkout.
+For replayed AITER C/C++/HIP sources, Hyperloom invokes KernelForge's
+source-keyed JIT preparation before launch and fails closed when that integration
+is unavailable; after reversing the patch it rekeys the cache to the restored
+source state.
+
+An authored-kernel overlay represented only by a host-local `PYTHONPATH`
+directory is not portable. Until that overlay is flattened to a source patch
+or resolved by a stable KernelForge artifact API, the Recipe is retained as
+reference material with `replayable=false` and reason
+`overlay_not_flattened_to_patch`.
+
+Recipes written before replay bundles remain readable for history, lessons,
+and anti-priors, but their unbound `best_config` is not executed
+automatically. Operators will see `legacy_recipe_without_bundle` rather than a
+generic empty-config reason. Backfilling such a row as executable requires an
+explicit migration that can prove the config, patches, environment, and
+throughput came from the same measured champion; copying only `best_config`
+does not establish that guarantee.
 
 ## Local knowledge graph
 

--- a/src/hyperloom/inference_optimizer/tests/test_cli_workload_envs.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_workload_envs.py
@@ -245,6 +245,27 @@ def test_json_serve_arg_survives_append_merge_as_valid_json(tmp_path):
         json.loads(blob)  # must parse: broken JSON was repaired, not passed through
 
 
+def test_shell_quoted_json_is_normalized_for_magpie_env_expansion(tmp_path):
+    """Quotes in an env value are data, so outer shell quotes must be removed."""
+    src = tmp_path / "cfg.yaml"
+    _write_yaml_with_envs(src, "vllm", {})
+    out = materialize_config_with_envs(
+        src,
+        tmp_path / "out",
+        extra_server_args=(
+            """--compilation-config '{"cudagraph_mode":"FULL"}' """
+            "--max-num-seqs 64"
+        ),
+    )
+    args = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
+    assert args == (
+        '--compilation-config {"cudagraph_mode":"FULL"} --max-num-seqs 64'
+    )
+    assert json.loads(args.split("--compilation-config ", 1)[1].split(" ", 1)[0]) == {
+        "cudagraph_mode": "FULL"
+    }
+
+
 def test_json_serve_arg_survives_shape_capture_port_removal(tmp_path):
     """The shape-capture materialization path must remove its inherited port
     without corrupting a sibling JSON-valued server flag."""

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_gemm_promote_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_gemm_promote_units.py
@@ -280,6 +280,34 @@ class TestPromoteGemmTuningKeep:
         assert coord.shared_state.cumulative_gain == pytest.approx(25.0)
         assert coord.shared_state.cumulative_gain_validated == pytest.approx(25.0)
 
+    def test_forge_backend_carries_source_snapshot_into_stack(self, tmp_path):
+        snapshot = tmp_path / "snapshot"
+        snapshot.mkdir()
+        (snapshot / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "framework_root": "/opt/aiter",
+                    "base_sha": "abc123",
+                    "files": [{"rel": "configs/tuned.csv", "op": "upsert"}],
+                }
+            )
+        )
+        coord = _coord(tmp_path, baseline_tput=100.0)
+        coord._promote_gemm_tuning_keep(
+            {
+                "status": "ok",
+                "decision": "KEEP",
+                "best_speedup": 1.25,
+                "backend": "forge",
+                "extra_envs": {"AITER_CONFIG": "/opt/aiter/configs/tuned.csv"},
+                "source_snapshot": str(snapshot),
+            }
+        )
+        top = coord.shared_state.optimization_stack[-1]
+        assert top["scope"] == "source_patch"
+        assert top["source_snapshot"] == str(snapshot)
+        assert top["target_files"] == ["configs/tuned.csv"]
+
     def test_geak_backend_uses_tuned_file(self, tmp_path):
         coord = _coord(tmp_path, baseline_tput=200.0)
         coord._promote_gemm_tuning_keep(
@@ -362,6 +390,11 @@ class TestPromoteFusionIntegrateKeep:
                 "gain_pct": 80.0,
                 "workspace": "/tmp/run",
                 "extra_server_args": "--moe-runner-backend aiter",
+                "source_snapshot": "/session/src/fusion",
+                "source_manifest": "/session/src/fusion/manifest.json",
+                "target_files": ["aiter/csrc/fusion.hip"],
+                "framework_root": "/opt/aiter",
+                "base_sha": "abc123",
             },
             extra_envs={"SGLANG_USE_AITER": "1", "ZAYA_FUSED_HYBRID_RESIDUAL": "1"},
         )
@@ -375,6 +408,8 @@ class TestPromoteFusionIntegrateKeep:
         assert stack[0]["extra_envs"]["SGLANG_USE_AITER"] == "1"
         assert stack[0]["extra_envs"]["ZAYA_FUSED_HYBRID_RESIDUAL"] == "1"
         assert stack[0]["kernel_speedup"] == 3.05
+        assert stack[0]["scope"] == "source_patch"
+        assert stack[0]["source_snapshot"] == "/session/src/fusion"
         assert coord.shared_state.current_best["action"] == "fusion"
         assert coord.shared_state.current_best["backend"] == "forge"
         assert coord.shared_state.current_best["engine"] == "forge_fusion"

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_kb_writes.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_kb_writes.py
@@ -467,6 +467,15 @@ def test_close_overwrites_best_when_validated_win(tmp_path: Path) -> None:
     row = coord.recipe_kb.get_recipe(canonical_id=cid)
     assert row["best_throughput"] == 2200.0
     assert "--page-size 32" in row["best_config"].get("extra_server_args", "")
+    bundle = row["replay_bundle"]
+    assert bundle["replayable"] is True
+    assert bundle["config"]["argv"] == [
+        "--page-size",
+        "32",
+        "--schedule-policy",
+        "lpm",
+    ]
+    assert bundle["measurement"]["optimized_throughput"] == 2200.0
 
 
 # kernel_optimizations[].e2e_decision must carry the integrate verdict, not

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_kb_writes.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_kb_writes.py
@@ -435,6 +435,37 @@ def test_best_config_reads_stack_args_from_canonical_server_key(
     )
 
 
+def test_best_config_and_bundle_share_full_effective_argv(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    coord = _make_coordinator(tmp_path)
+    ss = coord.shared_state
+    ss.current_best = {
+        "name": "tuned",
+        "extra_server_args": "--page-size 32",
+        "tput": 2200.0,
+    }
+    ss.optimization_stack = [
+        {
+            "action": "explore",
+            "variant_name": "page32",
+            "extra_server_args": "--page-size 32",
+        }
+    ]
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.loop.writeback._scrape_resolved_launch_flags",
+        lambda *_args, **_kwargs: "--schedule-policy lpm",
+    )
+    attrs = coord._build_recipe_attrs_from_state()
+    expected = ["--schedule-policy", "lpm", "--page-size", "32"]
+    assert attrs["replay_bundle"]["config"]["argv"] == expected
+    assert attrs["best_config"]["argv"] == expected
+    assert attrs["best_config"]["extra_server_args"] == (
+        "--schedule-policy lpm --page-size 32"
+    )
+
+
 def test_close_overwrites_best_when_validated_win(tmp_path: Path) -> None:
     """Counterpart guard: a genuine validated win DOES update best_config/best_throughput."""
     coord = _make_coordinator(tmp_path)

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_executor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_executor.py
@@ -358,6 +358,10 @@ async def test_executor_keep_when_delta_above_threshold(tmp_path: Path):
     assert len(result["patches_applied"]) == 1
     assert result["patches_reverted"] == []
     assert (repo / "src.py").read_text().endswith("return 2\n")
+    assert result["scope"] == "source_patch"
+    assert result["framework_root"] == str(repo)
+    assert result["target_files"] == ["src.py"]
+    assert Path(result["source_snapshot"]).is_dir()
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/inference_optimizer/tests/test_gbrain_ingest_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_gbrain_ingest_unit.py
@@ -10,6 +10,10 @@ import json
 import yaml
 
 from hyperloom.orchestrator.knowledge.recipe_kb import gbrain_ingest as gi
+from hyperloom.orchestrator.knowledge.recipe_kb.replay_bundle import (
+    refresh_bundle_digest,
+    validate_replay_bundle,
+)
 
 
 # -- _emit_yaml ------------------------------------------------------------
@@ -54,7 +58,7 @@ def test_recipe_to_page_emits_fingerprint_and_negatives(monkeypatch) -> None:
     assert "kind:recipe" in content
 
 
-def test_recipe_json_strips_secrets_and_internal_paths_but_keeps_safe_replay_fields() -> None:
+def test_recipe_json_strips_secrets_and_internal_paths() -> None:
     _slug, content = gi.recipe_to_page(
         {
             "canonical_id": "inference:qwen:mi300x:sglang:qwen:qwen:1.0:fp8",
@@ -62,8 +66,7 @@ def test_recipe_json_strips_secrets_and_internal_paths_but_keeps_safe_replay_fie
             "hardware": "mi300x",
             "best_config": {
                 "extra_server_args": (
-                    "--tp 8 --token top-secret --token-budget 4096 "
-                    "--tokenizer /workspace/replay/tokenizer"
+                    "--tp 8 --token top-secret --token-budget 4096 --tokenizer /workspace/replay/tokenizer"
                 ),
                 "extra_envs": {
                     "ROCM_VERSION": "7.0",
@@ -94,12 +97,9 @@ def test_recipe_json_strips_secrets_and_internal_paths_but_keeps_safe_replay_fie
 
     frontmatter = yaml.safe_load(content.split("---", 2)[1])
     decoded = json.loads(frontmatter["attrs"]["recipe_json"])
-    assert decoded["best_config"]["extra_server_args"] == (
-        "--tp 8 --token-budget 4096 --tokenizer /workspace/replay/tokenizer"
-    )
+    assert decoded["best_config"]["extra_server_args"] == "--tp 8 --token-budget 4096"
     assert decoded["best_config"]["extra_envs"] == {
         "ROCM_VERSION": "7.0",
-        "AITER_CONFIG": "/workspace/replay/tuned.csv",
     }
     assert decoded["provenance"] == {"generator": "close", "details": {"safe": "kept"}}
     assert decoded["evidence_refs"] == [{"kind": "report", "url": "https://reports.example/safe"}]
@@ -115,3 +115,58 @@ def test_recipe_json_strips_secrets_and_internal_paths_but_keeps_safe_replay_fie
         "/tmp/session/",
     ):
         assert secret_or_path not in content
+
+
+def test_replay_argv_is_sanitized_and_bundle_is_resigned_fail_closed() -> None:
+    bundle = refresh_bundle_digest(
+        {
+            "schema_version": 1,
+            "replayable": True,
+            "reason": "",
+            "config": {
+                "argv": [
+                    "--tp",
+                    "8",
+                    "--api-key",
+                    "top-secret",
+                    "--tokenizer",
+                    "/workspace/private/tokenizer",
+                ],
+                "extra_envs": {
+                    "USE_AITER": "1",
+                    "HF_TOKEN": "env-secret",
+                },
+            },
+            "source_artifacts": [],
+            "measurement": {
+                "optimized_throughput": 1000.0,
+                "measured_with_complete_bundle": True,
+            },
+        }
+    )
+    _slug, content = gi.recipe_to_page(
+        {
+            "canonical_id": "inference:qwen:mi300x:vllm:qwen:qwen:1.0:fp8",
+            "model": "qwen",
+            "hardware": "mi300x",
+            "framework_name": "vllm",
+            "best_config": {
+                "argv": bundle["config"]["argv"],
+                "extra_envs": bundle["config"]["extra_envs"],
+            },
+            "best_throughput": 1000.0,
+            "replay_bundle": bundle,
+        }
+    )
+    frontmatter = yaml.safe_load(content.split("---", 2)[1])
+    decoded = json.loads(frontmatter["attrs"]["recipe_json"])
+    cleaned = decoded["replay_bundle"]
+    assert cleaned["config"]["argv"] == ["--tp", "8"]
+    assert cleaned["config"]["extra_envs"] == {"USE_AITER": "1"}
+    assert cleaned["replayable"] is False
+    assert cleaned["reason"] == "gbrain_replay_data_sanitized"
+    assert cleaned["measurement"]["measured_with_complete_bundle"] is False
+    checked = validate_replay_bundle(cleaned)
+    assert checked["reason"] == "gbrain_replay_data_sanitized"
+    for forbidden in ("top-secret", "env-secret", "/workspace/private"):
+        assert forbidden not in content

--- a/src/hyperloom/inference_optimizer/tests/test_kb_unified_interface.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kb_unified_interface.py
@@ -231,6 +231,22 @@ def test_build_warm_start_context_hit() -> None:
         },
         "best_throughput": 5430.9,
         "validated_gain_pct": 7.8,
+        "replay_bundle": {
+            "schema_version": 1,
+            "replayable": True,
+            "bundle_sha256": "bundle",
+            "producer_session_id": "donor-session",
+            "config": {
+                "argv": ["--cuda-graph-max-bs", "256"],
+                "extra_envs": {"FOO": "1"},
+            },
+            "source_artifacts": [],
+            "measurement": {
+                "baseline_throughput": 5038.0,
+                "optimized_throughput": 5430.9,
+                "gain_pct": 7.8,
+            },
+        },
         "sessions": [
             {
                 "session_id": "donor-session",
@@ -351,6 +367,21 @@ def test_t0_status_hit_when_actionable_row_present(tmp_path: Path) -> None:
         precision="fp8",
         best_config={"extra_server_args": "--x 1", "extra_envs": {"A": "1"}},
         best_throughput=2000.0,
+        extras={
+            "replay_bundle": {
+                "schema_version": 1,
+                "replayable": True,
+                "bundle_sha256": "bundle",
+                "producer_session_id": "prior",
+                "config": {"argv": ["--x", "1"], "extra_envs": {"A": "1"}},
+                "source_artifacts": [],
+                "measurement": {
+                    "baseline_throughput": 1800.0,
+                    "optimized_throughput": 2000.0,
+                    "gain_pct": 11.111,
+                },
+            }
+        },
     )
     run_t0_anchor(
         kb,

--- a/src/hyperloom/inference_optimizer/tests/test_kb_unified_interface.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kb_unified_interface.py
@@ -38,6 +38,9 @@ from hyperloom.orchestrator.knowledge.recipe_kb.dispatcher import (
     _prefer_score,
     _rerank_by_prefer,
 )
+from hyperloom.orchestrator.knowledge.recipe_kb.replay_bundle import (
+    refresh_bundle_digest,
+)
 
 
 class _NestedRemote:
@@ -231,22 +234,23 @@ def test_build_warm_start_context_hit() -> None:
         },
         "best_throughput": 5430.9,
         "validated_gain_pct": 7.8,
-        "replay_bundle": {
-            "schema_version": 1,
-            "replayable": True,
-            "bundle_sha256": "bundle",
-            "producer_session_id": "donor-session",
-            "config": {
-                "argv": ["--cuda-graph-max-bs", "256"],
-                "extra_envs": {"FOO": "1"},
-            },
-            "source_artifacts": [],
-            "measurement": {
-                "baseline_throughput": 5038.0,
-                "optimized_throughput": 5430.9,
-                "gain_pct": 7.8,
-            },
-        },
+        "replay_bundle": refresh_bundle_digest(
+            {
+                "schema_version": 1,
+                "replayable": True,
+                "producer_session_id": "donor-session",
+                "config": {
+                    "argv": ["--cuda-graph-max-bs", "256"],
+                    "extra_envs": {"FOO": "1"},
+                },
+                "source_artifacts": [],
+                "measurement": {
+                    "baseline_throughput": 5038.0,
+                    "optimized_throughput": 5430.9,
+                    "gain_pct": 7.8,
+                },
+            }
+        ),
         "sessions": [
             {
                 "session_id": "donor-session",
@@ -277,14 +281,69 @@ def test_build_warm_start_context_hit() -> None:
     assert ctx["recommended_replay"]["donor_session_id"] == "donor-session"
     assert ctx["recommended_replay"]["donor_family_tags"] == ["moe", "mla"]
     assert ctx["recommended_replay"]["donor_gain_pct"] == 7.8
-    assert (
-        ctx["recommended_replay"]["donor_breakdown_link"]
-        == "https://example.test/session/donor-session"
-    )
+    assert ctx["recommended_replay"]["donor_breakdown_link"] == "https://example.test/session/donor-session"
     assert ctx["proven_prior"] == [{"id": "w1"}]
     assert ctx["do_not_repeat"] == [{"id": "f1"}]
     assert ctx["lessons"] == [{"attrs": {"statement": "x"}}]
     assert ctx["pitfalls"] == [{"attrs": {"description": "y"}}]
+
+
+def test_build_warm_start_context_rejects_tampered_local_bundle() -> None:
+    bundle = refresh_bundle_digest(
+        {
+            "schema_version": 1,
+            "replayable": True,
+            "config": {"argv": ["--safe"], "extra_envs": {}},
+            "source_artifacts": [],
+            "measurement": {"optimized_throughput": 100.0},
+        }
+    )
+    bundle["config"]["argv"] = ["--tampered"]
+    recipe = {
+        "canonical_id": "inference:m:h:f:mt:a:v:p",
+        "best_config": {"extra_server_args": "--tampered"},
+        "best_throughput": 100.0,
+        "replay_bundle": bundle,
+    }
+    ctx = _build_warm_start_context(
+        status="hit",
+        tier="exact",
+        confidence=1.0,
+        canonical_id=recipe["canonical_id"],
+        source="local",
+        recipe=recipe,
+    )
+    assert ctx["recommended_replay"] == {}
+    assert ctx["replay_unavailable_reason"] == "bundle_sha_mismatch"
+
+
+def test_build_warm_start_context_rejects_tampered_local_bundle() -> None:
+    bundle = refresh_bundle_digest(
+        {
+            "schema_version": 1,
+            "replayable": True,
+            "config": {"argv": ["--safe"], "extra_envs": {}},
+            "source_artifacts": [],
+            "measurement": {"optimized_throughput": 100.0},
+        }
+    )
+    bundle["config"]["argv"] = ["--tampered"]
+    recipe = {
+        "canonical_id": "inference:m:h:f:mt:a:v:p",
+        "best_config": {"extra_server_args": "--tampered"},
+        "best_throughput": 100.0,
+        "replay_bundle": bundle,
+    }
+    ctx = _build_warm_start_context(
+        status="hit",
+        tier="exact",
+        confidence=1.0,
+        canonical_id=recipe["canonical_id"],
+        source="local",
+        recipe=recipe,
+    )
+    assert ctx["recommended_replay"] == {}
+    assert ctx["replay_unavailable_reason"] == "bundle_sha_mismatch"
 
 
 @pytest.mark.parametrize("status", ["seed_only", "miss", "error"])
@@ -368,19 +427,20 @@ def test_t0_status_hit_when_actionable_row_present(tmp_path: Path) -> None:
         best_config={"extra_server_args": "--x 1", "extra_envs": {"A": "1"}},
         best_throughput=2000.0,
         extras={
-            "replay_bundle": {
-                "schema_version": 1,
-                "replayable": True,
-                "bundle_sha256": "bundle",
-                "producer_session_id": "prior",
-                "config": {"argv": ["--x", "1"], "extra_envs": {"A": "1"}},
-                "source_artifacts": [],
-                "measurement": {
-                    "baseline_throughput": 1800.0,
-                    "optimized_throughput": 2000.0,
-                    "gain_pct": 11.111,
-                },
-            }
+            "replay_bundle": refresh_bundle_digest(
+                {
+                    "schema_version": 1,
+                    "replayable": True,
+                    "producer_session_id": "prior",
+                    "config": {"argv": ["--x", "1"], "extra_envs": {"A": "1"}},
+                    "source_artifacts": [],
+                    "measurement": {
+                        "baseline_throughput": 1800.0,
+                        "optimized_throughput": 2000.0,
+                        "gain_pct": 11.111,
+                    },
+                }
+            )
         },
     )
     run_t0_anchor(

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -4349,3 +4349,38 @@ class TestBuildTraceAnalyzeCmd:
         assert cmd[cmd.index("--steady-state-mode") + 1] == "median"
         # session-id falls back to the session dir name when payload omits it.
         assert cmd[cmd.index("--session-id") + 1] == session_dir.name
+
+
+def test_snapshot_integrate_keep_source_captures_kernel_patch(tmp_path):
+    repo = tmp_path / "aiter"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    target = repo / "csrc" / "kernel.hip"
+    target.parent.mkdir()
+    target.write_text("int value = 1;\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-qm",
+            "base",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    target.write_text("int value = 2;\n")
+    fields = krh._snapshot_integrate_keep_source(
+        {"kernel_repo": str(repo), "target_file": str(target)},
+        {"status": "ok", "touched": [str(target)]},
+        session_dir=tmp_path / "session",
+        kernel_id="k1",
+    )
+    assert fields["scope"] == "source_patch"
+    assert fields["framework_root"] == str(repo)
+    assert fields["target_files"] == ["csrc/kernel.hip"]
+    assert Path(fields["source_snapshot"]).is_dir()

--- a/src/hyperloom/inference_optimizer/tests/test_knowledge_plane_phase1.py
+++ b/src/hyperloom/inference_optimizer/tests/test_knowledge_plane_phase1.py
@@ -443,10 +443,19 @@ def test_remote_store_champion_merge_is_monotonic_and_paired(tmp_path: Path) -> 
     mcp = _PageMcp()
     store = _remote_store(mcp, tmp_path / "locks")
     cid = "inference:m:h:f:mt:a:v:p"
+    bundle_a = {
+        "schema_version": 1,
+        "replayable": True,
+        "bundle_sha256": "a",
+        "config": {"argv": ["--champion"], "extra_envs": {}},
+        "source_artifacts": [],
+        "measurement": {"optimized_throughput": 100.0},
+    }
     store.put_recipe(
         canonical_id=cid,
         best_config={"extra_server_args": "--champion"},
         best_throughput=100.0,
+        extras={"replay_bundle": bundle_a},
     )
 
     store.put_recipe(
@@ -462,11 +471,19 @@ def test_remote_store_champion_merge_is_monotonic_and_paired(tmp_path: Path) -> 
         canonical_id=cid,
         best_config={"extra_server_args": "--late-lower"},
         best_throughput=90.0,
+        extras={
+            "replay_bundle": {
+                **bundle_a,
+                "bundle_sha256": "lower",
+                "measurement": {"optimized_throughput": 90.0},
+            }
+        },
     )
     row = store.get_recipe(canonical_id=cid)
     assert row is not None
     assert row["best_config"] == {"extra_server_args": "--champion"}
     assert row["best_throughput"] == 100.0
+    assert row["replay_bundle"]["bundle_sha256"] == "a"
     assert lower["write_safety"]["champion"] == "latest_preserved"
 
     store.put_recipe(canonical_id=cid, best_config={}, best_throughput=200.0)
@@ -479,11 +496,20 @@ def test_remote_store_champion_merge_is_monotonic_and_paired(tmp_path: Path) -> 
         canonical_id=cid,
         best_config={"extra_server_args": "--higher"},
         best_throughput=101.0,
+        extras={
+            "replay_bundle": {
+                **bundle_a,
+                "bundle_sha256": "higher",
+                "config": {"argv": ["--higher"], "extra_envs": {}},
+                "measurement": {"optimized_throughput": 101.0},
+            }
+        },
     )
     row = store.get_recipe(canonical_id=cid)
     assert row is not None
     assert row["best_config"] == {"extra_server_args": "--higher"}
     assert row["best_throughput"] == 101.0
+    assert row["replay_bundle"]["bundle_sha256"] == "higher"
     assert higher["write_safety"]["champion"] == "incoming_higher_throughput"
 
     empty_cid = "inference:m:h:f:mt:a:v:fp16"

--- a/src/hyperloom/inference_optimizer/tests/test_knowledge_plane_phase1.py
+++ b/src/hyperloom/inference_optimizer/tests/test_knowledge_plane_phase1.py
@@ -30,6 +30,9 @@ from hyperloom.orchestrator.knowledge.recipe_kb.gbrain_store import (
     GbrainRecipeLockError,
     GbrainRecipeStore,
 )
+from hyperloom.orchestrator.knowledge.recipe_kb.replay_bundle import (
+    refresh_bundle_digest,
+)
 
 
 def _args(**kwargs) -> argparse.Namespace:
@@ -443,14 +446,15 @@ def test_remote_store_champion_merge_is_monotonic_and_paired(tmp_path: Path) -> 
     mcp = _PageMcp()
     store = _remote_store(mcp, tmp_path / "locks")
     cid = "inference:m:h:f:mt:a:v:p"
-    bundle_a = {
-        "schema_version": 1,
-        "replayable": True,
-        "bundle_sha256": "a",
-        "config": {"argv": ["--champion"], "extra_envs": {}},
-        "source_artifacts": [],
-        "measurement": {"optimized_throughput": 100.0},
-    }
+    bundle_a = refresh_bundle_digest(
+        {
+            "schema_version": 1,
+            "replayable": True,
+            "config": {"argv": ["--champion"], "extra_envs": {}},
+            "source_artifacts": [],
+            "measurement": {"optimized_throughput": 100.0},
+        }
+    )
     store.put_recipe(
         canonical_id=cid,
         best_config={"extra_server_args": "--champion"},
@@ -467,23 +471,36 @@ def test_remote_store_champion_merge_is_monotonic_and_paired(tmp_path: Path) -> 
     assert row is not None
     assert row["best_config"] == {"extra_server_args": "--champion"}
 
+    rejected = store.put_recipe(
+        canonical_id=cid,
+        best_config={"extra_server_args": "--unbound-higher"},
+        best_throughput=110.0,
+    )
+    row = store.get_recipe(canonical_id=cid)
+    assert row is not None
+    assert row["best_config"] == {"extra_server_args": "--champion"}
+    assert row["best_throughput"] == 100.0
+    assert row["replay_bundle"]["bundle_sha256"] == bundle_a["bundle_sha256"]
+    assert rejected["write_safety"]["champion"] == "incoming_rejected_unbound_bundle"
+
     lower = store.put_recipe(
         canonical_id=cid,
         best_config={"extra_server_args": "--late-lower"},
         best_throughput=90.0,
         extras={
-            "replay_bundle": {
-                **bundle_a,
-                "bundle_sha256": "lower",
-                "measurement": {"optimized_throughput": 90.0},
-            }
+            "replay_bundle": refresh_bundle_digest(
+                {
+                    **bundle_a,
+                    "measurement": {"optimized_throughput": 90.0},
+                }
+            )
         },
     )
     row = store.get_recipe(canonical_id=cid)
     assert row is not None
     assert row["best_config"] == {"extra_server_args": "--champion"}
     assert row["best_throughput"] == 100.0
-    assert row["replay_bundle"]["bundle_sha256"] == "a"
+    assert row["replay_bundle"]["bundle_sha256"] == bundle_a["bundle_sha256"]
     assert lower["write_safety"]["champion"] == "latest_preserved"
 
     store.put_recipe(canonical_id=cid, best_config={}, best_throughput=200.0)
@@ -497,19 +514,20 @@ def test_remote_store_champion_merge_is_monotonic_and_paired(tmp_path: Path) -> 
         best_config={"extra_server_args": "--higher"},
         best_throughput=101.0,
         extras={
-            "replay_bundle": {
-                **bundle_a,
-                "bundle_sha256": "higher",
-                "config": {"argv": ["--higher"], "extra_envs": {}},
-                "measurement": {"optimized_throughput": 101.0},
-            }
+            "replay_bundle": refresh_bundle_digest(
+                {
+                    **bundle_a,
+                    "config": {"argv": ["--higher"], "extra_envs": {}},
+                    "measurement": {"optimized_throughput": 101.0},
+                }
+            )
         },
     )
     row = store.get_recipe(canonical_id=cid)
     assert row is not None
     assert row["best_config"] == {"extra_server_args": "--higher"}
     assert row["best_throughput"] == 101.0
-    assert row["replay_bundle"]["bundle_sha256"] == "higher"
+    assert row["replay_bundle"]["bundle_sha256"] != bundle_a["bundle_sha256"]
     assert higher["write_safety"]["champion"] == "incoming_higher_throughput"
 
     empty_cid = "inference:m:h:f:mt:a:v:fp16"
@@ -524,6 +542,38 @@ def test_remote_store_champion_merge_is_monotonic_and_paired(tmp_path: Path) -> 
     assert row["best_config"] == {"extra_server_args": "--first-real-config"}
     assert row["best_throughput"] == 5.0
     assert filled["write_safety"]["champion"] == "incoming_filled_empty"
+
+
+def test_local_store_rejects_champion_advance_with_stale_bundle(tmp_path: Path) -> None:
+    store = LocalRecipeStore(tmp_path / "local")
+    cid = "inference:m:h:f:mt:a:v:p"
+    bundle = refresh_bundle_digest(
+        {
+            "schema_version": 1,
+            "replayable": True,
+            "config": {"argv": ["--old"], "extra_envs": {}},
+            "source_artifacts": [],
+            "measurement": {"optimized_throughput": 100.0},
+        }
+    )
+    store.put_recipe(
+        canonical_id=cid,
+        best_config={"extra_server_args": "--old"},
+        best_throughput=100.0,
+        extras={"replay_bundle": bundle},
+    )
+    store.put_recipe(
+        canonical_id=cid,
+        best_config={"extra_server_args": "--new"},
+        best_throughput=200.0,
+        # This is the exact stale-extras shape produced by a mid-session amend.
+        extras={"replay_bundle": bundle},
+    )
+    row = store.get_recipe(canonical_id=cid)
+    assert row is not None
+    assert row["best_config"] == {"extra_server_args": "--old"}
+    assert row["best_throughput"] == 100.0
+    assert row["replay_bundle"]["bundle_sha256"] == bundle["bundle_sha256"]
 
 
 def test_remote_store_stale_collections_sessions_and_mappings_merge(tmp_path: Path) -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_promote_shared_state_lock.py
+++ b/src/hyperloom/inference_optimizer/tests/test_promote_shared_state_lock.py
@@ -992,11 +992,26 @@ async def test_integrate_keep_carries_the_stack_env_layer(session_dir):
     }
 
     await coord.writeback._record_integrate_keep(
-        {"new_tput": 1200.0, "kernel_id": "k001", "integration_id": "i1"},
+        {
+            "new_tput": 1200.0,
+            "kernel_id": "k001",
+            "integration_id": "i1",
+            "scope": "source_patch",
+            "source_snapshot": "/session/src/kernel-k001",
+            "source_manifest": "/session/src/kernel-k001/manifest.json",
+            "target_files": ["aiter/csrc/kernel.hip"],
+            "framework_root": "/opt/aiter",
+            "base_sha": "abc123",
+        },
     )
 
     assert s.current_best["extra_envs"] == {"VLLM_ROCM_USE_AITER": "1"}
     assert s.current_best["extra_server_args"] == "--kv-cache-dtype fp8_e4m3"
+    top = s.optimization_stack[-1]
+    assert top["scope"] == "source_patch"
+    assert top["source_snapshot"] == "/session/src/kernel-k001"
+    assert top["target_files"] == ["aiter/csrc/kernel.hip"]
+    assert top["base_sha"] == "abc123"
 
 
 async def test_integrate_keep_lets_a_tuning_env_delta_win(session_dir):

--- a/src/hyperloom/inference_optimizer/tests/test_replay_bundle.py
+++ b/src/hyperloom/inference_optimizer/tests/test_replay_bundle.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from hyperloom.orchestrator.knowledge.recipe_kb.replay_bundle import (
+    argv_to_env_string,
+    build_replay_bundle,
+    canonical_server_argv,
+    externalize_large_artifacts,
+    hydrate_replay_bundle,
+    replay_patches,
+)
+from hyperloom.orchestrator.source_snapshot import snapshot_source_layer
+
+
+def test_server_argv_removes_shell_quotes_but_preserves_json() -> None:
+    raw = """--compilation-config '{"cudagraph_mode":"FULL"}' --max-num-seqs 64"""
+    argv = canonical_server_argv(raw)
+    assert argv == [
+        "--compilation-config",
+        '{"cudagraph_mode":"FULL"}',
+        "--max-num-seqs",
+        "64",
+    ]
+    assert argv_to_env_string(argv) == (
+        '--compilation-config {"cudagraph_mode":"FULL"} --max-num-seqs 64'
+    )
+
+
+def test_config_only_bundle_is_atomic_and_replayable() -> None:
+    bundle = build_replay_bundle(
+        env_spec={
+            "config": {
+                "extra_server_args": "--kv-cache-dtype fp8",
+                "extra_envs": {"USE_AITER": "1"},
+            },
+            "source_snapshots": [],
+        },
+        producer_session_id="session-a",
+        baseline_throughput=100.0,
+        optimized_throughput=120.0,
+        workload={"conc": 64},
+    )
+    assert bundle["replayable"] is True
+    assert bundle["config"]["argv"] == ["--kv-cache-dtype", "fp8"]
+    assert bundle["measurement"]["gain_pct"] == 20.0
+    assert bundle["source_artifacts"] == []
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.name=Test", "-c", "user.email=test@example.com", *args],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+
+
+def test_source_snapshot_becomes_squashed_unified_diff(tmp_path: Path) -> None:
+    repo = tmp_path / "aiter"
+    repo.mkdir()
+    _git(repo, "init")
+    target = repo / "configs" / "qwen.csv"
+    target.parent.mkdir()
+    target.write_text("M,N,K\n32,1,2\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    base_sha = (
+        subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        .stdout.strip()
+    )
+    target.write_text("M,N,K\n32,1,2\n64,1,2\n", encoding="utf-8")
+    snapshot = snapshot_source_layer(
+        framework_root=repo,
+        base_sha=base_sha,
+        rel_paths=["configs/qwen.csv"],
+        dest_dir=tmp_path / "snapshot",
+        provenance="layer-a",
+    )
+    assert snapshot is not None
+
+    bundle = build_replay_bundle(
+        env_spec={
+            "config": {"extra_server_args": "", "extra_envs": {}},
+            "source_snapshots": [
+                {
+                    "id": "layer-a",
+                    "snapshot_dir": snapshot["snapshot_dir"],
+                    "base_sha": base_sha,
+                }
+            ],
+        },
+        producer_session_id="session-a",
+        baseline_throughput=100.0,
+        optimized_throughput=130.0,
+    )
+    assert bundle["replayable"] is True
+    artifact = bundle["source_artifacts"][0]
+    assert artifact["repo"] == "aiter"
+    assert "+64,1,2" in artifact["patch_content"]
+    assert replay_patches(bundle)[0]["target_repo"] == "aiter"
+    _git(repo, "reset", "--hard", base_sha)
+    patch_path = tmp_path / "bundle.diff"
+    patch_path.write_text(artifact["patch_content"], encoding="utf-8")
+    subprocess.run(
+        ["git", "apply", "--check", str(patch_path)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "apply", str(patch_path)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    assert "+64,1,2" not in target.read_text(encoding="utf-8")
+    assert "64,1,2" in target.read_text(encoding="utf-8")
+
+
+class _FakeMcp:
+    def __init__(self) -> None:
+        self.pages: dict[str, str] = {}
+
+    def call(self, tool: str, args: dict):
+        if tool == "put_page":
+            self.pages[args["slug"]] = args["content"]
+            return {"ok": True}
+        if tool == "get_page":
+            content = self.pages.get(args["slug"], "")
+            body = content.split("---\n", 2)[-1].lstrip("\n") if content else ""
+            return {"compiled_truth": body} if content else None
+        raise AssertionError(tool)
+
+
+def test_large_artifact_round_trips_through_gbrain_page() -> None:
+    patch = (
+        "diff --git a/a.py b/a.py\n"
+        "--- a/a.py\n"
+        "+++ b/a.py\n"
+        "@@ -1 +1 @@\n"
+        "-old\n"
+        "+new\n"
+    )
+    import hashlib
+
+    bundle = {
+        "schema_version": 1,
+        "replayable": True,
+        "source_artifacts": [
+            {
+                "storage": "inline",
+                "sha256": hashlib.sha256(patch.encode()).hexdigest(),
+                "bytes": len(patch),
+                "patch_content": patch,
+            }
+        ],
+    }
+    mcp = _FakeMcp()
+    external = externalize_large_artifacts(
+        mcp,
+        canonical_id="inference:test",
+        bundle=bundle,
+        inline_max_bytes=1,
+    )
+    artifact = external["source_artifacts"][0]
+    assert artifact["storage"] == "gbrain_page"
+    assert "patch_content" not in artifact
+    hydrated = hydrate_replay_bundle(mcp, external)
+    assert hydrated["replayable"] is True
+    assert hydrated["source_artifacts"][0]["patch_content"] == patch
+
+
+def test_hydration_fails_closed_when_artifact_is_missing() -> None:
+    hydrated = hydrate_replay_bundle(
+        _FakeMcp(),
+        {
+            "schema_version": 1,
+            "replayable": True,
+            "source_artifacts": [
+                {
+                    "storage": "gbrain_page",
+                    "artifact_slug": "missing",
+                    "sha256": "deadbeef",
+                }
+            ],
+        },
+    )
+    assert hydrated["replayable"] is False
+    assert hydrated["reason"] == "artifact_missing"

--- a/src/hyperloom/inference_optimizer/tests/test_replay_bundle.py
+++ b/src/hyperloom/inference_optimizer/tests/test_replay_bundle.py
@@ -10,6 +10,7 @@ from hyperloom.orchestrator.knowledge.recipe_kb.replay_bundle import (
     externalize_large_artifacts,
     hydrate_replay_bundle,
     replay_patches,
+    validate_replay_bundle,
 )
 from hyperloom.orchestrator.source_snapshot import snapshot_source_layer
 
@@ -23,9 +24,7 @@ def test_server_argv_removes_shell_quotes_but_preserves_json() -> None:
         "--max-num-seqs",
         "64",
     ]
-    assert argv_to_env_string(argv) == (
-        '--compilation-config {"cudagraph_mode":"FULL"} --max-num-seqs 64'
-    )
+    assert argv_to_env_string(argv) == ('--compilation-config {"cudagraph_mode":"FULL"} --max-num-seqs 64')
 
 
 def test_config_only_bundle_is_atomic_and_replayable() -> None:
@@ -48,6 +47,42 @@ def test_config_only_bundle_is_atomic_and_replayable() -> None:
     assert bundle["source_artifacts"] == []
 
 
+def test_overlay_that_was_not_flattened_fails_closed() -> None:
+    bundle = build_replay_bundle(
+        env_spec={
+            "config": {
+                "extra_server_args": "--kv-cache-dtype fp8",
+                "extra_envs": {},
+            },
+            "source_snapshots": [],
+            "overlay_pythonpath": "/tmp/authored-kernel-overlay",
+        },
+        producer_session_id="session-a",
+        baseline_throughput=100.0,
+        optimized_throughput=120.0,
+    )
+    assert bundle["replayable"] is False
+    assert bundle["reason"] == "overlay_not_flattened_to_patch"
+    assert bundle["measurement"]["measured_with_complete_bundle"] is False
+
+
+def test_uncaptured_absolute_env_path_fails_closed() -> None:
+    bundle = build_replay_bundle(
+        env_spec={
+            "config": {
+                "extra_server_args": "--x",
+                "extra_envs": {"AITER_CONFIG": "/tmp/ephemeral.csv"},
+            },
+            "source_snapshots": [],
+        },
+        producer_session_id="session-a",
+        baseline_throughput=100.0,
+        optimized_throughput=120.0,
+    )
+    assert bundle["replayable"] is False
+    assert bundle["reason"] == "unportable_env_path:AITER_CONFIG"
+
+
 def _git(root: Path, *args: str) -> None:
     subprocess.run(
         ["git", "-c", "user.name=Test", "-c", "user.email=test@example.com", *args],
@@ -66,16 +101,13 @@ def test_source_snapshot_becomes_squashed_unified_diff(tmp_path: Path) -> None:
     target.write_text("M,N,K\n32,1,2\n", encoding="utf-8")
     _git(repo, "add", ".")
     _git(repo, "commit", "-m", "base")
-    base_sha = (
-        subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=repo,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        .stdout.strip()
-    )
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
     target.write_text("M,N,K\n32,1,2\n64,1,2\n", encoding="utf-8")
     snapshot = snapshot_source_layer(
         framework_root=repo,
@@ -88,7 +120,10 @@ def test_source_snapshot_becomes_squashed_unified_diff(tmp_path: Path) -> None:
 
     bundle = build_replay_bundle(
         env_spec={
-            "config": {"extra_server_args": "", "extra_envs": {}},
+            "config": {
+                "extra_server_args": "",
+                "extra_envs": {"AITER_CONFIG": str(target)},
+            },
             "source_snapshots": [
                 {
                     "id": "layer-a",
@@ -105,6 +140,13 @@ def test_source_snapshot_becomes_squashed_unified_diff(tmp_path: Path) -> None:
     artifact = bundle["source_artifacts"][0]
     assert artifact["repo"] == "aiter"
     assert "+64,1,2" in artifact["patch_content"]
+    assert bundle["config"]["extra_envs"] == {}
+    assert bundle["config"]["env_path_refs"] == {
+        "AITER_CONFIG": {
+            "repo": "aiter",
+            "path": "configs/qwen.csv",
+        }
+    }
     assert replay_patches(bundle)[0]["target_repo"] == "aiter"
     _git(repo, "reset", "--hard", base_sha)
     patch_path = tmp_path / "bundle.diff"
@@ -125,6 +167,39 @@ def test_source_snapshot_becomes_squashed_unified_diff(tmp_path: Path) -> None:
     assert "64,1,2" in target.read_text(encoding="utf-8")
 
 
+def test_non_git_source_root_fails_closed(tmp_path: Path) -> None:
+    root = tmp_path / "not-a-repo"
+    root.mkdir()
+    target = root / "kernel.py"
+    target.write_text("optimized = True\n", encoding="utf-8")
+    snapshot = snapshot_source_layer(
+        framework_root=root,
+        base_sha="deadbeef",
+        rel_paths=["kernel.py"],
+        dest_dir=tmp_path / "snapshot-non-git",
+        provenance="kernel",
+    )
+    assert snapshot is not None
+    bundle = build_replay_bundle(
+        env_spec={
+            "config": {"extra_server_args": "", "extra_envs": {}},
+            "source_snapshots": [
+                {
+                    "id": "kernel",
+                    "snapshot_dir": snapshot["snapshot_dir"],
+                    "base_sha": "deadbeef",
+                }
+            ],
+        },
+        producer_session_id="session-a",
+        baseline_throughput=100.0,
+        optimized_throughput=130.0,
+    )
+    assert bundle["replayable"] is False
+    assert bundle["reason"] == "source_snapshot_base_read_failed"
+    assert bundle["source_artifacts"] == []
+
+
 class _FakeMcp:
     def __init__(self) -> None:
         self.pages: dict[str, str] = {}
@@ -141,14 +216,7 @@ class _FakeMcp:
 
 
 def test_large_artifact_round_trips_through_gbrain_page() -> None:
-    patch = (
-        "diff --git a/a.py b/a.py\n"
-        "--- a/a.py\n"
-        "+++ b/a.py\n"
-        "@@ -1 +1 @@\n"
-        "-old\n"
-        "+new\n"
-    )
+    patch = "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -1 +1 @@\n-old\n+new\n"
     import hashlib
 
     bundle = {
@@ -195,3 +263,37 @@ def test_hydration_fails_closed_when_artifact_is_missing() -> None:
     )
     assert hydrated["replayable"] is False
     assert hydrated["reason"] == "artifact_missing"
+
+
+def test_inline_patch_tampering_fails_local_validation() -> None:
+    patch = "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -1 +1 @@\n-old\n+new\n"
+    import hashlib
+
+    bundle = {
+        "schema_version": 1,
+        "replayable": True,
+        "source_artifacts": [
+            {
+                "storage": "inline",
+                "sha256": hashlib.sha256(patch.encode()).hexdigest(),
+                "patch_content": patch + "# tampered\n",
+            }
+        ],
+    }
+    checked = validate_replay_bundle(bundle)
+    assert checked["replayable"] is False
+    assert checked["reason"] == "artifact_sha_mismatch"
+    assert replay_patches(bundle) == []
+
+
+def test_replayable_bundle_without_digest_fails_closed() -> None:
+    checked = validate_replay_bundle(
+        {
+            "schema_version": 1,
+            "replayable": True,
+            "config": {"argv": ["--x"], "extra_envs": {}},
+            "source_artifacts": [],
+        }
+    )
+    assert checked["replayable"] is False
+    assert checked["reason"] == "bundle_sha_missing"

--- a/src/hyperloom/inference_optimizer/tests/test_warm_patch_apply.py
+++ b/src/hyperloom/inference_optimizer/tests/test_warm_patch_apply.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import subprocess
+import sys
+import types
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from hyperloom.orchestrator.actions.executors.baseline import (
     _apply_warm_patches,
+    _materialize_warm_env_path_refs,
+    _prepare_warm_kernel_rebuild,
+    _revert_applied_patch,
 )
 
 
@@ -82,6 +88,176 @@ def test_apply_single_patch(fake_repo, output_dir):
     # Verify file was patched
     content = (fake_repo / "vllm" / "fp8.py").read_text()
     assert "patched = True" in content
+
+
+def test_reverse_patch_preserves_unrelated_dirty_and_untracked_files(
+    fake_repo,
+    output_dir,
+):
+    unrelated = fake_repo / "unrelated.txt"
+    unrelated.write_text("committed\n")
+    subprocess.run(["git", "add", "unrelated.txt"], cwd=fake_repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "add unrelated"],
+        cwd=fake_repo,
+        check=True,
+        capture_output=True,
+    )
+    unrelated.write_text("operator change\n")
+    untracked = fake_repo / "jit-cache.bin"
+    untracked.write_text("cache")
+    result = _apply_warm_patches(
+        {
+            "patches": [
+                {
+                    "patch_file": "vllm/fp8.py",
+                    "patch_content": VALID_PATCH,
+                }
+            ]
+        },
+        str(fake_repo),
+        output_dir,
+    )
+    assert len(result) == 1
+    _revert_applied_patch(
+        result[0]["target_repo"],
+        result[0]["patch_path"],
+    )
+    assert "patched = True" not in (fake_repo / "vllm" / "fp8.py").read_text()
+    assert unrelated.read_text() == "operator change\n"
+    assert untracked.read_text() == "cache"
+
+
+def test_bundle_patch_with_wrong_base_sha_is_skipped(fake_repo, output_dir):
+    result = _apply_warm_patches(
+        {
+            "patches": [
+                {
+                    "patch_file": "vllm/fp8.py",
+                    "patch_content": VALID_PATCH,
+                    "target_repo": "inferencex",
+                    "base_sha": "deadbeef",
+                }
+            ]
+        },
+        str(fake_repo),
+        output_dir,
+    )
+    assert result == []
+    assert "patched = True" not in (fake_repo / "vllm" / "fp8.py").read_text()
+
+
+def test_bundle_patch_resolves_aiter_meta_repo(
+    tmp_path,
+    output_dir,
+    monkeypatch,
+):
+    repo = tmp_path / "aiter_meta"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    target = repo / "kernel.py"
+    target.write_text("value = 1\n")
+    subprocess.run(["git", "add", "kernel.py"], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=test@test.com",
+            "-c",
+            "user.name=Test",
+            "commit",
+            "-m",
+            "base",
+        ],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    base_sha = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        text=True,
+    ).strip()
+    patch_content = """\
+diff --git a/kernel.py b/kernel.py
+--- a/kernel.py
++++ b/kernel.py
+@@ -1 +1 @@
+-value = 1
++value = 2
+"""
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.framework.paths.resolve_patch_target_roots",
+        lambda: [f"{repo}/"],
+    )
+    result = _apply_warm_patches(
+        {
+            "patches": [
+                {
+                    "patch_file": "aiter-kernel.diff",
+                    "patch_content": patch_content,
+                    "target_repo": "aiter",
+                    "base_sha": base_sha,
+                }
+            ]
+        },
+        "",
+        output_dir,
+    )
+    assert len(result) == 1
+    assert Path(result[0]["target_repo"]) == repo
+    assert target.read_text() == "value = 2\n"
+
+
+def test_aiter_cpp_patch_prepares_kernelforge_jit(monkeypatch, tmp_path):
+    calls: list[list[str]] = []
+    package = types.ModuleType("kernel_agents")
+    package.__path__ = []
+    loop = types.ModuleType("kernel_agents.loop")
+    loop.__path__ = []
+    module = types.ModuleType("kernel_agents.loop.jit_rebuild")
+    module.force_jit_rebuild = lambda paths: calls.append(list(paths))
+    monkeypatch.setitem(sys.modules, "kernel_agents", package)
+    monkeypatch.setitem(sys.modules, "kernel_agents.loop", loop)
+    monkeypatch.setitem(sys.modules, "kernel_agents.loop.jit_rebuild", module)
+    repo = tmp_path / "aiter_meta"
+    ok, reason = _prepare_warm_kernel_rebuild(
+        [
+            {
+                "target_repo": str(repo),
+                "changed_files": ["csrc/kernels/tuned_kernel.hip"],
+            }
+        ]
+    )
+    assert ok is True
+    assert reason == ""
+    assert calls == [[str(repo / "csrc/kernels/tuned_kernel.hip")]]
+
+
+def test_portable_env_path_materializes_from_applied_repo(tmp_path):
+    repo = tmp_path / "aiter_meta"
+    tuned = repo / "configs" / "tuned.csv"
+    tuned.parent.mkdir(parents=True)
+    tuned.write_text("M,N,K\n")
+    params = {
+        "extra_envs": {"STATIC": "1"},
+        "env_path_refs": {
+            "AITER_CONFIG": {
+                "repo": "aiter",
+                "path": "configs/tuned.csv",
+            }
+        },
+    }
+    ok, reason = _materialize_warm_env_path_refs(
+        params,
+        [{"logical_repo": "aiter", "target_repo": str(repo)}],
+    )
+    assert ok is True
+    assert reason == ""
+    assert params["extra_envs"] == {
+        "STATIC": "1",
+        "AITER_CONFIG": str(tuned),
+    }
 
 
 def test_blocked_patch_skipped(fake_repo, output_dir):

--- a/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
+++ b/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
@@ -11,6 +11,9 @@ from pathlib import Path
 import pytest
 
 from hyperloom.orchestrator.loop.coordinator import Coordinator
+from hyperloom.orchestrator.knowledge.recipe_kb.replay_bundle import (
+    refresh_bundle_digest,
+)
 
 
 @dataclass
@@ -135,22 +138,23 @@ def _warm_recipe_t1(
             "extra_envs": dict(extra_envs or {}),
         },
         "sessions": recipe_sessions,
-        "replay_bundle": {
-            "schema_version": 1,
-            "replayable": True,
-            "bundle_sha256": "test-bundle",
-            "producer_session_id": "prior-session-A",
-            "config": {
-                "argv": extra_server_args.split(),
-                "extra_envs": dict(extra_envs or {}),
-            },
-            "source_artifacts": [],
-            "measurement": {
-                "baseline_throughput": 100.0,
-                "optimized_throughput": 125.0,
-                "gain_pct": expected_gain_pct,
-            },
-        },
+        "replay_bundle": refresh_bundle_digest(
+            {
+                "schema_version": 1,
+                "replayable": True,
+                "producer_session_id": "prior-session-A",
+                "config": {
+                    "argv": extra_server_args.split(),
+                    "extra_envs": dict(extra_envs or {}),
+                },
+                "source_artifacts": [],
+                "measurement": {
+                    "baseline_throughput": 100.0,
+                    "optimized_throughput": 125.0,
+                    "gain_pct": expected_gain_pct,
+                },
+            }
+        ),
     }
     if what_failed is not None:
         attrs["what_failed"] = what_failed
@@ -190,22 +194,23 @@ def _warm_recipe_v2_arbor(
             "sessions": [
                 {"session_id": "prior-A", "gain_pct": expected_gain_pct, "stack_len": 1},
             ],
-            "replay_bundle": {
-                "schema_version": 1,
-                "replayable": True,
-                "bundle_sha256": "test-bundle-v2",
-                "producer_session_id": "prior-A",
-                "config": {
-                    "argv": extra_server_args.split(),
-                    "extra_envs": dict(extra_envs or {}),
-                },
-                "source_artifacts": [],
-                "measurement": {
-                    "baseline_throughput": 100.0,
-                    "optimized_throughput": 125.0,
-                    "gain_pct": expected_gain_pct,
-                },
-            },
+            "replay_bundle": refresh_bundle_digest(
+                {
+                    "schema_version": 1,
+                    "replayable": True,
+                    "producer_session_id": "prior-A",
+                    "config": {
+                        "argv": extra_server_args.split(),
+                        "extra_envs": dict(extra_envs or {}),
+                    },
+                    "source_artifacts": [],
+                    "measurement": {
+                        "baseline_throughput": 100.0,
+                        "optimized_throughput": 125.0,
+                        "gain_pct": expected_gain_pct,
+                    },
+                }
+            ),
         },
     }
 
@@ -971,7 +976,7 @@ async def test_legacy_recipe_without_bundle_is_reference_only(tmp_path):
     }
     await coord._maybe_enqueue_warm_replay(baseline_tput=600.0)
     assert coord.tasks.calls == []
-    assert coord.shared_state.warm_replay_outcome["reason"] == "best_config_empty"
+    assert coord.shared_state.warm_replay_outcome["reason"] == "legacy_recipe_without_bundle"
 
 
 def test_promote_warm_replay_cumulative_gain_uses_tput_ratio(tmp_path):

--- a/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
+++ b/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
@@ -135,6 +135,22 @@ def _warm_recipe_t1(
             "extra_envs": dict(extra_envs or {}),
         },
         "sessions": recipe_sessions,
+        "replay_bundle": {
+            "schema_version": 1,
+            "replayable": True,
+            "bundle_sha256": "test-bundle",
+            "producer_session_id": "prior-session-A",
+            "config": {
+                "argv": extra_server_args.split(),
+                "extra_envs": dict(extra_envs or {}),
+            },
+            "source_artifacts": [],
+            "measurement": {
+                "baseline_throughput": 100.0,
+                "optimized_throughput": 125.0,
+                "gain_pct": expected_gain_pct,
+            },
+        },
     }
     if what_failed is not None:
         attrs["what_failed"] = what_failed
@@ -174,6 +190,22 @@ def _warm_recipe_v2_arbor(
             "sessions": [
                 {"session_id": "prior-A", "gain_pct": expected_gain_pct, "stack_len": 1},
             ],
+            "replay_bundle": {
+                "schema_version": 1,
+                "replayable": True,
+                "bundle_sha256": "test-bundle-v2",
+                "producer_session_id": "prior-A",
+                "config": {
+                    "argv": extra_server_args.split(),
+                    "extra_envs": dict(extra_envs or {}),
+                },
+                "source_artifacts": [],
+                "measurement": {
+                    "baseline_throughput": 100.0,
+                    "optimized_throughput": 125.0,
+                    "gain_pct": expected_gain_pct,
+                },
+            },
         },
     }
 
@@ -902,8 +934,8 @@ def test_inject_warm_recipe_history_skips_empty_rows(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_warm_replay_pulls_expected_gain_from_sessions_max(tmp_path):
-    """The historical gain anchor is the MAX of ``attrs.sessions[].gain_pct``."""
+async def test_warm_replay_uses_bundle_gain_not_unbound_session_max(tmp_path):
+    """The gain anchor is atomically bound to the replay bundle."""
     recipe = _warm_recipe_t1(
         sessions=[
             {"session_id": "older", "gain_pct": 12.0, "stack_len": 1},
@@ -913,21 +945,19 @@ async def test_warm_replay_pulls_expected_gain_from_sessions_max(tmp_path):
     )
     coord = _make_coord(tmp_path, warm_start_recipe=recipe)
     await coord._maybe_enqueue_warm_replay(baseline_tput=600.0)
-    assert coord.tasks.calls[0]["params"]["warm_expected_gain_pct"] == 28.0
+    assert coord.tasks.calls[0]["params"]["warm_expected_gain_pct"] == 25.0
 
 
 @pytest.mark.asyncio
-async def test_warm_replay_zero_expected_when_no_sessions(tmp_path):
-    """Recipes without sessions[] → expected_gain falls to 0 (``_promote`` accepts any positive measurement)."""
+async def test_warm_replay_bundle_gain_does_not_require_sessions(tmp_path):
     recipe = _warm_recipe_t1(sessions=[])
     coord = _make_coord(tmp_path, warm_start_recipe=recipe)
     await coord._maybe_enqueue_warm_replay(baseline_tput=600.0)
-    assert coord.tasks.calls[0]["params"]["warm_expected_gain_pct"] == 0.0
+    assert coord.tasks.calls[0]["params"]["warm_expected_gain_pct"] == 25.0
 
 
 @pytest.mark.asyncio
-async def test_warm_replay_falls_back_to_flat_gain_pct_for_arbor_seed(tmp_path):
-    """Arbor seeds with a flat ``gain_pct`` attr (no sessions[]) are still read as the expected anchor."""
+async def test_legacy_recipe_without_bundle_is_reference_only(tmp_path):
     coord = _make_coord(tmp_path)
     coord.shared_state.warm_start_recipe = {
         "tier": "relative",
@@ -940,7 +970,8 @@ async def test_warm_replay_falls_back_to_flat_gain_pct_for_arbor_seed(tmp_path):
         },
     }
     await coord._maybe_enqueue_warm_replay(baseline_tput=600.0)
-    assert coord.tasks.calls[0]["params"]["warm_expected_gain_pct"] == 18.0
+    assert coord.tasks.calls == []
+    assert coord.shared_state.warm_replay_outcome["reason"] == "best_config_empty"
 
 
 def test_promote_warm_replay_cumulative_gain_uses_tput_ratio(tmp_path):

--- a/src/hyperloom/inference_optimizer/tests/test_warm_replay_donor_gate.py
+++ b/src/hyperloom/inference_optimizer/tests/test_warm_replay_donor_gate.py
@@ -17,6 +17,9 @@ from hyperloom.orchestrator.knowledge.recipe_kb_t0 import (
     _donor_is_trustworthy,
     _find_config_donor,
 )
+from hyperloom.orchestrator.knowledge.recipe_kb.replay_bundle import (
+    refresh_bundle_digest,
+)
 
 
 def _donor(
@@ -41,19 +44,20 @@ def _donor(
     }
     if with_config:
         row["best_config"] = {"extra_server_args": "--enable-foo", "extra_envs": {"X": "1"}}
-        row["replay_bundle"] = {
-            "schema_version": 1,
-            "replayable": True,
-            "bundle_sha256": "donor-bundle",
-            "producer_session_id": "donor-session",
-            "config": {"argv": ["--enable-foo"], "extra_envs": {"X": "1"}},
-            "source_artifacts": [],
-            "measurement": {
-                "baseline_throughput": 100.0,
-                "optimized_throughput": 100.0 + gain,
-                "gain_pct": gain,
-            },
-        }
+        row["replay_bundle"] = refresh_bundle_digest(
+            {
+                "schema_version": 1,
+                "replayable": True,
+                "producer_session_id": "donor-session",
+                "config": {"argv": ["--enable-foo"], "extra_envs": {"X": "1"}},
+                "source_artifacts": [],
+                "measurement": {
+                    "baseline_throughput": 100.0,
+                    "optimized_throughput": 100.0 + gain,
+                    "gain_pct": gain,
+                },
+            }
+        )
     return row
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_warm_replay_donor_gate.py
+++ b/src/hyperloom/inference_optimizer/tests/test_warm_replay_donor_gate.py
@@ -41,6 +41,19 @@ def _donor(
     }
     if with_config:
         row["best_config"] = {"extra_server_args": "--enable-foo", "extra_envs": {"X": "1"}}
+        row["replay_bundle"] = {
+            "schema_version": 1,
+            "replayable": True,
+            "bundle_sha256": "donor-bundle",
+            "producer_session_id": "donor-session",
+            "config": {"argv": ["--enable-foo"], "extra_envs": {"X": "1"}},
+            "source_artifacts": [],
+            "measurement": {
+                "baseline_throughput": 100.0,
+                "optimized_throughput": 100.0 + gain,
+                "gain_pct": gain,
+            },
+        }
     return row
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_warm_replay_patches.py
+++ b/src/hyperloom/inference_optimizer/tests/test_warm_replay_patches.py
@@ -6,6 +6,9 @@ from hyperloom.orchestrator.knowledge.recipe_kb_t0 import (
     _build_warm_start_context,
     _extract_patches_from_prs_tested,
 )
+from hyperloom.orchestrator.knowledge.recipe_kb.replay_bundle import (
+    refresh_bundle_digest,
+)
 
 
 def _recipe_with_prs(prs_tested):
@@ -156,22 +159,23 @@ def test_build_warm_start_context_includes_patches():
         "canonical_id": "inference:test:mi300x:sglang:llama:llamaforcausallm:0.5.11:fp8",
         "best_config": {"extra_server_args": "--disable-radix-cache"},
         "best_throughput": 5000.0,
-        "replay_bundle": {
-            "schema_version": 1,
-            "replayable": True,
-            "bundle_sha256": "bundle",
-            "producer_session_id": "prior",
-            "config": {
-                "argv": ["--disable-radix-cache"],
-                "extra_envs": {},
-            },
-            "source_artifacts": [],
-            "measurement": {
-                "baseline_throughput": 4000.0,
-                "optimized_throughput": 5000.0,
-                "gain_pct": 25.0,
-            },
-        },
+        "replay_bundle": refresh_bundle_digest(
+            {
+                "schema_version": 1,
+                "replayable": True,
+                "producer_session_id": "prior",
+                "config": {
+                    "argv": ["--disable-radix-cache"],
+                    "extra_envs": {},
+                },
+                "source_artifacts": [],
+                "measurement": {
+                    "baseline_throughput": 4000.0,
+                    "optimized_throughput": 5000.0,
+                    "gain_pct": 25.0,
+                },
+            }
+        ),
         "prs_tested": [
             {
                 "outcome": "KEEP",

--- a/src/hyperloom/inference_optimizer/tests/test_warm_replay_patches.py
+++ b/src/hyperloom/inference_optimizer/tests/test_warm_replay_patches.py
@@ -156,6 +156,22 @@ def test_build_warm_start_context_includes_patches():
         "canonical_id": "inference:test:mi300x:sglang:llama:llamaforcausallm:0.5.11:fp8",
         "best_config": {"extra_server_args": "--disable-radix-cache"},
         "best_throughput": 5000.0,
+        "replay_bundle": {
+            "schema_version": 1,
+            "replayable": True,
+            "bundle_sha256": "bundle",
+            "producer_session_id": "prior",
+            "config": {
+                "argv": ["--disable-radix-cache"],
+                "extra_envs": {},
+            },
+            "source_artifacts": [],
+            "measurement": {
+                "baseline_throughput": 4000.0,
+                "optimized_throughput": 5000.0,
+                "gain_pct": 25.0,
+            },
+        },
         "prs_tested": [
             {
                 "outcome": "KEEP",

--- a/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
@@ -41,10 +41,74 @@ def validate_server_args_shell_safe(server_args: str | None) -> str:
         return ""
     if _UNSAFE_SERVER_ARG_CHARS_RE.search(args):
         raise ValueError("extra_server_args contains shell control characters")
+    # Protect balanced JSON blobs before shell tokenization. ``shlex`` correctly
+    # removes their *outer* syntax quotes but would also strip the JSON's inner
+    # double quotes. Placeholders let us obtain the actual argv while restoring
+    # byte-valid JSON afterwards.
+    compact = _reserialize_json_blobs(args)
+    placeholders: dict[str, str] = {}
+    protected: list[str] = []
+    index = 0
+    cursor = 0
+    while cursor < len(compact):
+        if compact[cursor] not in "{[":
+            protected.append(compact[cursor])
+            cursor += 1
+            continue
+        start = cursor
+        depth = 0
+        in_string = False
+        escaped = False
+        while cursor < len(compact):
+            char = compact[cursor]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+            elif char == '"':
+                in_string = True
+            elif char in "{[":
+                depth += 1
+            elif char in "}]":
+                depth -= 1
+                if depth == 0:
+                    cursor += 1
+                    break
+            cursor += 1
+        blob = compact[start:cursor]
+        marker = f"__HYPERLOOM_JSON_{index}__"
+        placeholders[marker] = blob
+        protected.append(marker)
+        index += 1
+    protected_args = "".join(protected)
     try:
-        tokens = shlex.split(args)
+        tokens = shlex.split(protected_args)
     except ValueError as exc:
         raise ValueError(f"extra_server_args is not shell-tokenizable: {exc}") from exc
+    tokens = [
+        next(
+            (
+                token.replace(marker, blob)
+                for marker, blob in placeholders.items()
+                if marker in token
+            ),
+            token,
+        )
+        for token in tokens
+    ]
+    # Magpie expands ``$EXTRA_*_ARGS`` unquoted. Quotes embedded in the env
+    # value are therefore literal bytes, not shell syntax; returning the
+    # original string would pass outer quotes around JSON to vLLM. Parse once
+    # here and persist the actual argv tokens. A token containing whitespace
+    # cannot survive Magpie's current env transport and must fail closed rather
+    # than silently becoming several arguments.
+    if any(any(ch.isspace() for ch in token) for token in tokens):
+        raise ValueError(
+            "extra_server_args contains a whitespace-bearing value unsupported by Magpie env expansion"
+        )
     expect_value = False
     for token in tokens:
         if token.startswith("-"):
@@ -54,7 +118,7 @@ def validate_server_args_shell_safe(server_args: str | None) -> str:
             expect_value = False
             continue
         raise ValueError("extra_server_args must be argv-like flags, not bare positional arguments")
-    return args
+    return " ".join(tokens)
 
 
 def server_args_env_name(framework: str | None) -> str:

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -738,17 +738,19 @@ def _apply_warm_patches(
     target_repo: str,
     output_dir: Path,
 ) -> list[dict[str, str]]:
-    """Apply warm-replay code patches to the InferenceX checkout.
+    """Apply warm-replay code patches to their recorded source checkouts.
 
     Reads ``params["patches"]`` (list of dicts with patch_file/patch_content/
     patch_ref) and ``params["blocked_patches"]`` (blocklist). Applies each patch
-    via ``git apply`` in the target repo. Skips patches that appear in the
-    blocklist. Returns list of successfully applied patch metadata dicts.
+    via ``git apply``. Legacy patches use ``target_repo`` (InferenceX); replay
+    bundle patches resolve their ``target_repo`` name against installed
+    framework roots and require an exact base SHA. Skips patches that appear in
+    the blocklist. Returns list of successfully applied patch metadata dicts.
 
     If target_repo is empty or no patches are present, returns [].
     """
     patches = params.get("patches") or []
-    if not patches or not target_repo:
+    if not patches:
         return []
 
     blocked = {p.get("patch_file", "") for p in (params.get("blocked_patches") or [])}
@@ -757,15 +759,52 @@ def _apply_warm_patches(
     patch_log_dir = output_dir / "warm_patches"
     patch_log_dir.mkdir(parents=True, exist_ok=True)
 
+    def resolve_target(patch: dict[str, Any]) -> str:
+        requested = str(patch.get("target_repo") or "").strip().lower()
+        if not requested or requested in {"inferencex", "default"}:
+            return target_repo
+        from ...framework.paths import resolve_patch_target_roots
+
+        candidates = [Path(root.rstrip("/")) for root in resolve_patch_target_roots()]
+        matches: list[Path] = []
+        for candidate in candidates:
+            name = candidate.name.lower().replace("_meta", "")
+            if candidate.is_dir() and name == requested:
+                matches.append(candidate)
+        expected_base = str(patch.get("base_sha") or "")
+        if expected_base:
+            for candidate in matches:
+                if _git_head_sha(str(candidate)) == expected_base:
+                    return str(candidate)
+        return str(matches[0]) if matches else ""
+
     for idx, patch in enumerate(patches):
         patch_file = patch.get("patch_file") or ""
         patch_content = patch.get("patch_content") or ""
         patch_ref = patch.get("patch_ref") or ""
+        patch_target = resolve_target(patch)
 
         if patch_file in blocked:
             log.info(
                 "baseline_executor: skipping blocked patch %s",
                 patch_file,
+            )
+            continue
+        if not patch_target:
+            log.warning(
+                "baseline_executor: no installed source root for warm patch %s target_repo=%s",
+                patch_file,
+                patch.get("target_repo"),
+            )
+            continue
+        pre_sha = _git_head_sha(patch_target)
+        expected_base = str(patch.get("base_sha") or "")
+        if expected_base and pre_sha != expected_base:
+            log.warning(
+                "baseline_executor: warm patch %s base mismatch (need %s, have %s)",
+                patch_file,
+                expected_base[:12],
+                pre_sha[:12] if pre_sha else "<non-git>",
             )
             continue
 
@@ -825,14 +864,14 @@ def _apply_warm_patches(
         try:
             subprocess.run(
                 ["git", "apply", "--stat", "--check", str(patch_path)],
-                cwd=target_repo,
+                cwd=patch_target,
                 capture_output=True,
                 timeout=30,
                 check=True,
             )
             subprocess.run(
                 ["git", "apply", str(patch_path)],
-                cwd=target_repo,
+                cwd=patch_target,
                 capture_output=True,
                 timeout=30,
                 check=True,
@@ -852,7 +891,14 @@ def _apply_warm_patches(
             )
             continue
 
-        applied.append({"patch_file": patch_file, "idx": str(idx)})
+        applied.append(
+            {
+                "patch_file": patch_file,
+                "idx": str(idx),
+                "target_repo": patch_target,
+                "pre_sha": pre_sha,
+            }
+        )
 
     return applied
 
@@ -1930,13 +1976,11 @@ class BaselineExecutor:
         # Record pre-apply HEAD so patches are reverted after the benchmark
         # completes (or fails), preventing residue in the shared checkout.
         patch_target = effective_inferencex_path or ix_env
-        _pre_patch_sha = _git_head_sha(patch_target)
         applied_patches = _apply_warm_patches(params, patch_target, output_dir)
         if applied_patches:
             log.info(
-                "baseline_executor: applied %d warm-replay code patches (pre_sha=%s): %s",
+                "baseline_executor: applied %d warm-replay code patches: %s",
                 len(applied_patches),
-                _pre_patch_sha[:8],
                 [p["patch_file"] for p in applied_patches],
             )
 
@@ -2307,8 +2351,14 @@ class BaselineExecutor:
             )
             # Revert warm-replay patches to prevent state leakage into
             # subsequent tasks that reuse the same InferenceX checkout.
-            if applied_patches and _pre_patch_sha:
-                _revert_patches(patch_target, _pre_patch_sha)
+            reverted: set[tuple[str, str]] = set()
+            for patch in applied_patches:
+                target = str(patch.get("target_repo") or "")
+                pre_sha = str(patch.get("pre_sha") or "")
+                key = (target, pre_sha)
+                if target and pre_sha and key not in reverted:
+                    _revert_patches(target, pre_sha)
+                    reverted.add(key)
             if bench_lease is not None:
                 bench_lease.close()
 

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -974,6 +974,7 @@ def _apply_warm_patches(
                 .lower(),
                 "pre_sha": pre_sha,
                 "patch_path": str(patch_path),
+                "sha256": str(patch.get("sha256") or ""),
                 "changed_files": [str(path) for path in (patch.get("changed_files") or []) if str(path)],
             }
         )
@@ -2055,6 +2056,36 @@ class BaselineExecutor:
         # completes (or fails), preventing residue in the shared checkout.
         patch_target = effective_inferencex_path or ix_env
         applied_patches = _apply_warm_patches(params, patch_target, output_dir)
+        required_bundle_patches = [
+            patch
+            for patch in (params.get("patches") or [])
+            if isinstance(patch, dict) and patch.get("sha256")
+        ]
+        applied_bundle_hashes = {
+            str(patch.get("sha256") or "")
+            for patch in applied_patches
+            if patch.get("sha256")
+        }
+        missing_bundle_hashes = [
+            str(patch.get("sha256") or "")
+            for patch in required_bundle_patches
+            if str(patch.get("sha256") or "") not in applied_bundle_hashes
+        ]
+        if missing_bundle_hashes:
+            for patch in reversed(applied_patches):
+                _revert_applied_patch(
+                    str(patch.get("target_repo") or ""),
+                    str(patch.get("patch_path") or ""),
+                )
+            return {
+                "status": "failed",
+                "error_class": "warm_patch_incomplete",
+                "error": (
+                    "one or more replay-bundle patches could not be applied "
+                    "at their recorded repository/base SHA"
+                ),
+                "missing_patch_sha256": missing_bundle_hashes,
+            }
         if applied_patches:
             log.info(
                 "baseline_executor: applied %d warm-replay code patches: %s",

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -328,9 +328,7 @@ def _set_materialized_run_eval(config_path: Path, *, enabled: bool) -> None:
     """Set the effective eval mode after lifecycle eligibility is known."""
     cfg = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
     benchmark = cfg.setdefault("benchmark", {})
-    benchmark.setdefault("envs", {})["RUN_EVAL"] = (
-        "true" if enabled else "false"
-    )
+    benchmark.setdefault("envs", {})["RUN_EVAL"] = "true" if enabled else "false"
     config_path.write_text(
         yaml.safe_dump(cfg, sort_keys=False),
         encoding="utf-8",
@@ -706,38 +704,113 @@ def _git_head_sha(repo_path: str) -> str:
         return ""
 
 
-def _revert_patches(repo_path: str, pre_sha: str) -> None:
-    """Revert the repo to pre_sha after warm-replay patches were applied.
-
-    Prevents patch residue from leaking into subsequent tasks that reuse
-    the same InferenceX checkout mirror.
-    """
-    if not repo_path or not pre_sha:
+def _revert_applied_patch(repo_path: str, patch_path: str) -> None:
+    """Reverse only one warm patch, preserving unrelated checkout state."""
+    if not repo_path or not patch_path:
         return
     try:
         subprocess.run(
-            ["git", "reset", "--hard", pre_sha],
+            ["git", "apply", "-R", "--check", patch_path],
             cwd=repo_path,
             capture_output=True,
             timeout=15,
             check=True,
         )
         subprocess.run(
-            ["git", "clean", "-fd"],
+            ["git", "apply", "-R", patch_path],
             cwd=repo_path,
             capture_output=True,
             timeout=15,
-            check=False,
+            check=True,
         )
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
-        log.warning("baseline_executor: patch revert failed: %s", exc)
+        log.warning(
+            "baseline_executor: reverse warm patch failed for %s: %s",
+            patch_path,
+            exc,
+        )
+
+
+_KERNEL_CPP_SUFFIXES = {
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cu",
+    ".cuh",
+    ".cxx",
+    ".h",
+    ".hip",
+    ".hpp",
+}
+
+
+def _prepare_warm_kernel_rebuild(
+    applied_patches: list[dict[str, Any]],
+) -> tuple[bool, str]:
+    """Activate KernelForge's source-keyed JIT cache for replayed AITER code."""
+    kernel_sources: list[str] = []
+    for patch in applied_patches:
+        root = Path(str(patch.get("target_repo") or ""))
+        if "aiter" not in root.name.lower():
+            continue
+        for rel in patch.get("changed_files") or []:
+            path = root / str(rel)
+            if path.suffix.lower() in _KERNEL_CPP_SUFFIXES:
+                kernel_sources.append(str(path))
+    if not kernel_sources:
+        return True, ""
+    try:
+        from kernel_agents.loop.jit_rebuild import force_jit_rebuild
+    except ImportError:
+        return False, "kernelforge_jit_rebuild_unavailable"
+    try:
+        force_jit_rebuild(kernel_sources)
+    except Exception as exc:  # noqa: BLE001 - fail closed before benchmark
+        log.warning("baseline_executor: KernelForge JIT preparation failed: %s", exc)
+        return False, "kernelforge_jit_rebuild_failed"
+    return True, ""
+
+
+def _materialize_warm_env_path_refs(
+    params: dict[str, Any],
+    applied_patches: list[dict[str, Any]],
+) -> tuple[bool, str]:
+    """Resolve portable repo-relative env values after their patches apply."""
+    refs = params.get("env_path_refs") or {}
+    if not isinstance(refs, dict) or not refs:
+        return True, ""
+    roots: dict[str, Path] = {}
+    for patch in applied_patches:
+        logical_repo = str(patch.get("logical_repo") or "").strip().lower()
+        target = Path(str(patch.get("target_repo") or ""))
+        if logical_repo and target.is_dir():
+            roots[logical_repo] = target.resolve()
+    resolved_envs = dict(params.get("extra_envs") or {})
+    for raw_key, raw_ref in refs.items():
+        if not isinstance(raw_ref, dict):
+            return False, f"invalid_env_path_ref:{raw_key}"
+        repo = str(raw_ref.get("repo") or "").strip().lower()
+        rel = str(raw_ref.get("path") or "").strip().lstrip("/")
+        root = roots.get(repo)
+        if root is None or not rel or ".." in Path(rel).parts:
+            return False, f"unresolved_env_path_ref:{raw_key}"
+        value = (root / rel).resolve(strict=False)
+        try:
+            value.relative_to(root)
+        except ValueError:
+            return False, f"unsafe_env_path_ref:{raw_key}"
+        if not value.is_file():
+            return False, f"missing_env_path_ref:{raw_key}"
+        resolved_envs[str(raw_key)] = str(value)
+    params["extra_envs"] = resolved_envs
+    return True, ""
 
 
 def _apply_warm_patches(
     params: dict[str, Any],
     target_repo: str,
     output_dir: Path,
-) -> list[dict[str, str]]:
+) -> list[dict[str, Any]]:
     """Apply warm-replay code patches to their recorded source checkouts.
 
     Reads ``params["patches"]`` (list of dicts with patch_file/patch_content/
@@ -755,7 +828,7 @@ def _apply_warm_patches(
 
     blocked = {p.get("patch_file", "") for p in (params.get("blocked_patches") or [])}
 
-    applied: list[dict[str, str]] = []
+    applied: list[dict[str, Any]] = []
     patch_log_dir = output_dir / "warm_patches"
     patch_log_dir.mkdir(parents=True, exist_ok=True)
 
@@ -896,7 +969,12 @@ def _apply_warm_patches(
                 "patch_file": patch_file,
                 "idx": str(idx),
                 "target_repo": patch_target,
+                "logical_repo": str(patch.get("target_repo") or "inferencex")
+                .strip()
+                .lower(),
                 "pre_sha": pre_sha,
+                "patch_path": str(patch_path),
+                "changed_files": [str(path) for path in (patch.get("changed_files") or []) if str(path)],
             }
         )
 
@@ -1983,6 +2061,36 @@ class BaselineExecutor:
                 len(applied_patches),
                 [p["patch_file"] for p in applied_patches],
             )
+            env_ready, env_reason = _materialize_warm_env_path_refs(
+                params,
+                applied_patches,
+            )
+            if not env_ready:
+                for patch in reversed(applied_patches):
+                    _revert_applied_patch(
+                        str(patch.get("target_repo") or ""),
+                        str(patch.get("patch_path") or ""),
+                    )
+                return {
+                    "status": "failed",
+                    "error_class": env_reason,
+                    "error": (
+                        "portable environment path could not be materialized "
+                        "from its replayed source artifact"
+                    ),
+                }
+            jit_ready, jit_reason = _prepare_warm_kernel_rebuild(applied_patches)
+            if not jit_ready:
+                for patch in reversed(applied_patches):
+                    _revert_applied_patch(
+                        str(patch.get("target_repo") or ""),
+                        str(patch.get("patch_path") or ""),
+                    )
+                return {
+                    "status": "failed",
+                    "error_class": jit_reason,
+                    "error": ("kernel source patch was applied but its JIT rebuild could not be prepared"),
+                }
 
         timeout_sec = self._resolve_timeout(params)
         # Model path: task.params['model_path'] > $MODEL_PATH > SharedState;
@@ -2022,9 +2130,7 @@ class BaselineExecutor:
         # Accuracy eval (GSM8K) opt-out: the ``disable_run_eval`` param and the
         # in-executor eval-failure fallback both force ``RUN_EVAL=false``.
         base_extra_envs = dict(params.get("extra_envs") or {})
-        defer_accuracy_until_after_measure = is_truthy(
-            params.get("defer_accuracy_until_after_measure")
-        )
+        defer_accuracy_until_after_measure = is_truthy(params.get("defer_accuracy_until_after_measure"))
         if force_disable_eval or is_truthy(params.get("disable_run_eval")):
             base_extra_envs["RUN_EVAL"] = "false"
         try:
@@ -2126,9 +2232,7 @@ class BaselineExecutor:
                 materialized_config_path,
                 enabled=False,
             )
-        run_eval_disabled = _materialized_run_eval_disabled(
-            materialized_config_path
-        )
+        run_eval_disabled = _materialized_run_eval_disabled(materialized_config_path)
 
         # Ray-managed GPU execution (§12 T1): one held Ray lease (``num_gpus=TP``)
         # spans this baseline's benchmark rounds — a double-run's warmup +
@@ -2293,10 +2397,7 @@ class BaselineExecutor:
                             run_eval=True,
                         )
                         try:
-                            accuracy_timeout_sec = int(
-                                params.get("accuracy_timeout_sec")
-                                or timeout_sec
-                            )
+                            accuracy_timeout_sec = int(params.get("accuracy_timeout_sec") or timeout_sec)
                         except (TypeError, ValueError):
                             accuracy_timeout_sec = timeout_sec
                         accuracy_result = await self._run_single_benchmark(
@@ -2313,9 +2414,7 @@ class BaselineExecutor:
                         )
                         result["accuracy_stage"] = {
                             "status": accuracy_result.get("status"),
-                            "error_class": accuracy_result.get(
-                                "error_class"
-                            ),
+                            "error_class": accuracy_result.get("error_class"),
                             "workspace": accuracy_result.get("workspace"),
                         }
                         if accuracy_result.get("status") == "succeeded":
@@ -2329,9 +2428,7 @@ class BaselineExecutor:
                                     result[key] = accuracy_result[key]
                         else:
                             result.setdefault("nonfatal_warnings", [])
-                            result["nonfatal_warnings"].append(
-                                "post_measure_accuracy_failed"
-                            )
+                            result["nonfatal_warnings"].append("post_measure_accuracy_failed")
                     else:
                         result["accuracy_stage"] = {
                             "status": "skipped",
@@ -2351,14 +2448,22 @@ class BaselineExecutor:
             )
             # Revert warm-replay patches to prevent state leakage into
             # subsequent tasks that reuse the same InferenceX checkout.
-            reverted: set[tuple[str, str]] = set()
-            for patch in applied_patches:
+            # Reverse in LIFO order so overlapping patches unwind exactly in
+            # the inverse order they were applied. Never reset/clean a shared
+            # framework checkout: it may contain unrelated operator changes,
+            # instrumentation, caches, or build outputs.
+            for patch in reversed(applied_patches):
                 target = str(patch.get("target_repo") or "")
-                pre_sha = str(patch.get("pre_sha") or "")
-                key = (target, pre_sha)
-                if target and pre_sha and key not in reverted:
-                    _revert_patches(target, pre_sha)
-                    reverted.add(key)
+                patch_path = str(patch.get("patch_path") or "")
+                if target and patch_path:
+                    _revert_applied_patch(target, patch_path)
+            if applied_patches:
+                restored_jit, restored_reason = _prepare_warm_kernel_rebuild(applied_patches)
+                if not restored_jit:
+                    log.warning(
+                        "baseline_executor: could not restore post-replay JIT cache identity: %s",
+                        restored_reason,
+                    )
             if bench_lease is not None:
                 bench_lease.close()
 
@@ -2454,9 +2559,7 @@ class BaselineExecutor:
             port=port,
         )
         if run_eval is not None:
-            bench.setdefault("envs", {})["RUN_EVAL"] = (
-                "true" if run_eval else "false"
-            )
+            bench.setdefault("envs", {})["RUN_EVAL"] = "true" if run_eval else "false"
         dest_dir.mkdir(parents=True, exist_ok=True)
         out = Path(dest_dir) / "baseline_lifecycle.yaml"
         with out.open("w", encoding="utf-8") as f:

--- a/src/hyperloom/orchestrator/actions/executors/framework_agent.py
+++ b/src/hyperloom/orchestrator/actions/executors/framework_agent.py
@@ -965,6 +965,67 @@ class FrameworkAgentExecutor:
                     },
                 )
 
+        source_snapshot: dict[str, Any] = {}
+        if git_tree and pre_apply_sha and keep_sha:
+            try:
+                changed = subprocess.run(
+                    [
+                        "git",
+                        "diff",
+                        "--name-only",
+                        pre_apply_sha,
+                        keep_sha,
+                        "--",
+                    ],
+                    cwd=framework_root,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    check=False,
+                )
+                rel_paths = [
+                    line.strip()
+                    for line in changed.stdout.splitlines()
+                    if line.strip()
+                ]
+                if changed.returncode == 0 and rel_paths:
+                    from ...source_snapshot import (
+                        MANIFEST_NAME,
+                        snapshot_source_layer,
+                    )
+
+                    snapshot = snapshot_source_layer(
+                        framework_root=framework_root,
+                        base_sha=pre_apply_sha,
+                        rel_paths=rel_paths,
+                        dest_dir=(
+                            self.session_dir
+                            / "optimization_stack"
+                            / "src"
+                            / f"framework_{slug}"
+                        ),
+                        provenance="framework_agent",
+                        extra={"candidate_id": slug},
+                    )
+                    if snapshot:
+                        snapshot_dir = str(
+                            snapshot.get("snapshot_dir") or ""
+                        )
+                        source_snapshot = {
+                            "scope": "source_patch",
+                            "source_snapshot": snapshot_dir,
+                            "source_manifest": (
+                                str(Path(snapshot_dir) / MANIFEST_NAME)
+                                if snapshot_dir
+                                else ""
+                            ),
+                            "target_files": rel_paths,
+                            "framework_root": str(framework_root),
+                            "base_sha": pre_apply_sha,
+                        }
+            except Exception:  # noqa: BLE001 - KEEP remains valid; bundle fails closed
+                log.exception("framework KEEP source snapshot failed")
+
         await self._write_kb_record(
             candidate=candidate,
             outcome=OUTCOME_INTEGRATED,
@@ -993,6 +1054,7 @@ class FrameworkAgentExecutor:
                 "reason": (f"throughput delta {delta_pct:+.2f}% >= {keep_threshold_pct:.2f}%"),
                 "bench_result": bench_result,
                 "workspace": str(output_root),
+                **source_snapshot,
             },
         )
 

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -6041,6 +6041,93 @@ def _integrate_rebaseline_timeout_sec(
     return max(1, int(default_timeout_sec))
 
 
+def _snapshot_integrate_keep_source(
+    payload: dict[str, Any],
+    apply_result: dict[str, Any],
+    *,
+    session_dir: Path,
+    kernel_id: Any,
+) -> dict[str, Any]:
+    """Capture the final source files retained by a kernel integrate KEEP."""
+    if str(apply_result.get("reason") or "") == "env_only_validation":
+        return {}
+    raw_paths: list[str] = [
+        str(path) for path in (apply_result.get("touched") or []) if str(path).strip()
+    ]
+    for backup in apply_result.get("source_backups") or []:
+        if isinstance(backup, dict) and backup.get("path"):
+            raw_paths.append(str(backup["path"]))
+    target = str(payload.get("target_file") or payload.get("source_file") or "").strip()
+    if target:
+        raw_paths.append(target)
+    raw_paths = list(dict.fromkeys(raw_paths))
+    if not raw_paths:
+        return {}
+
+    root_text = str(payload.get("kernel_repo") or payload.get("repo") or "").strip()
+    root = Path(root_text) if root_text else None
+    if root is None or not root.is_dir():
+        probe = subprocess.run(
+            ["git", "-C", str(Path(raw_paths[0]).parent), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        root = Path(probe.stdout.strip()) if probe.returncode == 0 and probe.stdout.strip() else None
+    if root is None or not root.is_dir():
+        return {}
+    base = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    base_sha = base.stdout.strip() if base.returncode == 0 else ""
+    if not base_sha:
+        return {}
+
+    rel_paths: list[str] = []
+    resolved_root = root.resolve()
+    for raw in raw_paths:
+        try:
+            rel = Path(raw).resolve().relative_to(resolved_root)
+        except (OSError, ValueError):
+            continue
+        if str(rel) and ".." not in rel.parts:
+            rel_paths.append(str(rel))
+    rel_paths = list(dict.fromkeys(rel_paths))
+    if not rel_paths:
+        return {}
+    try:
+        from ..source_snapshot import MANIFEST_NAME, snapshot_source_layer
+
+        safe_id = re.sub(r"[^A-Za-z0-9._-]+", "_", str(kernel_id or "kernel"))
+        snapshot = snapshot_source_layer(
+            framework_root=root,
+            base_sha=base_sha,
+            rel_paths=rel_paths,
+            dest_dir=session_dir / "optimization_stack" / "src" / f"kernel_integrate_{safe_id}",
+            provenance="kernel_integrate",
+            extra={"kernel_id": str(kernel_id or "")},
+        )
+        if not snapshot:
+            return {}
+        snapshot_dir = str(snapshot.get("snapshot_dir") or "")
+        return {
+            "scope": "source_patch",
+            "source_snapshot": snapshot_dir,
+            "source_manifest": str(Path(snapshot_dir) / MANIFEST_NAME) if snapshot_dir else "",
+            "target_files": rel_paths,
+            "framework_root": str(root),
+            "base_sha": base_sha,
+        }
+    except Exception:  # noqa: BLE001 - KEEP remains valid but bundle fails closed
+        log.exception("kernel integrate KEEP source snapshot failed")
+        return {}
+
+
 async def integrate_handler(
     payload: dict,
     *,
@@ -6503,6 +6590,15 @@ async def integrate_handler(
         "identity_route": str(payload.get("identity_route") or ""),
         "integration_id": str(payload.get("integration_id") or ""),
     }
+    if decision == "KEEP":
+        result.update(
+            _snapshot_integrate_keep_source(
+                payload,
+                apply_result,
+                session_dir=session_dir,
+                kernel_id=kernel_id,
+            )
+        )
     if stack_positive_keep and gain_pct <= keep_threshold_pct:
         result["decision_reason"] = "stack_positive_increment"
         result["stack_incremental_gain_pct"] = stack_incremental_gain_pct

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -29,6 +29,9 @@ from typing import Any, Awaitable, Callable
 
 from hyperloom.common.env import env_bool, is_truthy
 from hyperloom.common.io import append_jsonl
+from hyperloom.common.kernel_shape_contract import (
+    ALLOWED_SHAPE_PROVENANCE as _ALLOWED_SHAPE_PROVENANCE,
+)
 
 from ..trace.llm_trace import LLMCallRecord, append_llm_call
 from ..trace.parse_usage import (
@@ -187,8 +190,6 @@ _COMPILE_GENERATED_NAME_MARKERS = (
     "torchinductor",
     "inductor",
 )
-from hyperloom.common.env import is_truthy
-from hyperloom.common.kernel_shape_contract import ALLOWED_SHAPE_PROVENANCE as _ALLOWED_SHAPE_PROVENANCE
 
 
 def _reusable_source_roots() -> tuple[str, ...]:
@@ -1050,9 +1051,7 @@ def _maybe_apply_kernel_patch(
         dry_run=bool(payload.get("dry_run_patch", False)),
         snapshot_dir=snapshot_dir,
         repo_root=repo_root,
-        producer_manifest=(
-            str(payload.get("producer_manifest") or "").strip() or None
-        ),
+        producer_manifest=(str(payload.get("producer_manifest") or "").strip() or None),
     )
 
 
@@ -1088,9 +1087,7 @@ def materialize_unified_patch_snapshot(
     # normalization and the create/modify disposition), which avoids a second,
     # drift-prone parse of the raw patch text.
     _new_file_paths = {
-        str(desc.get("path") or "")
-        for desc in descriptors
-        if desc.get("op") == "write" and desc.get("is_new")
+        str(desc.get("path") or "") for desc in descriptors if desc.get("op") == "write" and desc.get("is_new")
     }
 
     snap = Path(snapshot_dir) if snapshot_dir is not None else patch.parent / "fusion_snapshot"
@@ -1126,8 +1123,7 @@ def materialize_unified_patch_snapshot(
                 # a precise error here instead of the opaque ``git apply`` "No
                 # such file or directory" that would otherwise follow.
                 raise FileNotFoundError(
-                    f"patch base missing for {rel.as_posix()}: not in git HEAD "
-                    f"and not on disk under {root}"
+                    f"patch base missing for {rel.as_posix()}: not in git HEAD and not on disk under {root}"
                 )
             dst.parent.mkdir(parents=True, exist_ok=True)
             dst.write_bytes(src.read_bytes())
@@ -1171,14 +1167,9 @@ def _maybe_finalize_kernel_patch(
     apply_result: HandlerResult,
 ) -> HandlerResult:
     """Delete backups once a KEEP becomes the accepted baseline."""
-    if (
-        apply_result.get("status") != "ok"
-        or not apply_result.get("manifest_path")
-    ):
+    if apply_result.get("status") != "ok" or not apply_result.get("manifest_path"):
         return {"status": "skipped", "reason": "no applied patch manifest"}
-    return _load_apply_tool().finalize_kernel_patch(
-        apply_result["manifest_path"]
-    )
+    return _load_apply_tool().finalize_kernel_patch(apply_result["manifest_path"])
 
 
 def _find_selected_kernel_source(state: Any, kernel_id: str) -> str:
@@ -1234,11 +1225,7 @@ def _fill_integrate_defaults_from_state(
     integration_id = str(resolved.get("integration_id") or "")
     pending_records = state.pending_kernel_integration_records()
     pending_record = next(
-        (
-            record
-            for record in pending_records
-            if str(record.get("integration_id") or "") == integration_id
-        ),
+        (record for record in pending_records if str(record.get("integration_id") or "") == integration_id),
         None,
     )
     if pending_record is None and resolved.get("kernel_id"):
@@ -1249,11 +1236,7 @@ def _fill_integrate_defaults_from_state(
                 record
                 for record in pending_records
                 if str(record.get("kernel_id") or "") == requested_kernel_id
-                and (
-                    not requested_task_key
-                    or str(record.get("task_group_key") or "")
-                    == requested_task_key
-                )
+                and (not requested_task_key or str(record.get("task_group_key") or "") == requested_task_key)
             ),
             None,
         )
@@ -1295,17 +1278,9 @@ def _fill_integrate_defaults_from_state(
             resolved["extra_server_args"] = cb_args
     if isinstance(current_best, dict):
         current_envs = current_best.get("extra_envs")
-        current_envs = (
-            dict(current_envs)
-            if isinstance(current_envs, dict)
-            else {}
-        )
+        current_envs = dict(current_envs) if isinstance(current_envs, dict) else {}
         requested_envs = resolved.get("extra_envs")
-        requested_envs = (
-            dict(requested_envs)
-            if isinstance(requested_envs, dict)
-            else {}
-        )
+        requested_envs = dict(requested_envs) if isinstance(requested_envs, dict) else {}
         if current_envs or requested_envs:
             # The candidate stacks onto current_best. Candidate-specific
             # overrides win, but omitting an env must not silently drop the
@@ -1335,13 +1310,8 @@ def _fill_integrate_snapshot_from_bundle(resolved: dict, bundle: Any) -> None:
         resolved["patch_path"] = str(bundle["patch_path"])
     if not resolved.get("kernel_repo") and bundle.get("repo_root"):
         resolved["kernel_repo"] = str(bundle["repo_root"])
-    if (
-        not resolved.get("producer_manifest")
-        and bundle.get("producer_manifest")
-    ):
-        resolved["producer_manifest"] = str(
-            bundle["producer_manifest"]
-        )
+    if not resolved.get("producer_manifest") and bundle.get("producer_manifest"):
+        resolved["producer_manifest"] = str(bundle["producer_manifest"])
 
 
 def _resolve_integrate_payload(payload: dict, *, session_dir: Path) -> tuple[dict, HandlerResult | None]:
@@ -1374,9 +1344,7 @@ def _resolve_integrate_payload(payload: dict, *, session_dir: Path) -> tuple[dic
     if pending_record is not None:
         kernel_id = str(pending_record.get("kernel_id") or kernel_id)
         resolved["kernel_id"] = kernel_id
-        resolved["integration_id"] = str(
-            pending_record.get("integration_id") or integration_id
-        )
+        resolved["integration_id"] = str(pending_record.get("integration_id") or integration_id)
         resolved.setdefault(
             "task_group_key",
             str(pending_record.get("task_group_key") or ""),
@@ -1393,13 +1361,9 @@ def _resolve_integrate_payload(payload: dict, *, session_dir: Path) -> tuple[dic
             resolved["snapshot_dir"] = str(pending_record["snapshot_dir"])
         if not resolved.get("patch_path"):
             resolved["patch_path"] = str(
-                pending_record.get("deploy_patch_path")
-                or pending_record.get("artifact_path")
-                or ""
+                pending_record.get("deploy_patch_path") or pending_record.get("artifact_path") or ""
             )
-        if not resolved.get("kernel_repo") and pending_record.get(
-            "deploy_repo_root"
-        ):
+        if not resolved.get("kernel_repo") and pending_record.get("deploy_repo_root"):
             resolved["kernel_repo"] = str(pending_record["deploy_repo_root"])
         if not resolved.get("source_file") and pending_record.get("source_file"):
             resolved["source_file"] = str(pending_record["source_file"])
@@ -1835,6 +1799,7 @@ def _resolve_forge_server_log(state, session_dir: Path) -> str:
     check sibling ``warmup_round/`` dirs and walk up to the parent run
     directory.
     """
+
     def _find_server_log_near(workspace_str: str) -> str | None:
         if not workspace_str:
             return None
@@ -2034,9 +1999,7 @@ def _canonical_dtype(raw: str) -> str:
     return ""
 
 
-def _extract_gemm_shapes_from_candidates(
-    candidates_path_str: str, session_dir: Path, *, precision: str = ""
-) -> str:
+def _extract_gemm_shapes_from_candidates(candidates_path_str: str, session_dir: Path, *, precision: str = "") -> str:
     """Extract M,N,K from kernel_candidates.json hot_kernels input_shapes.
 
     Derives the GEMM dimensions actually observed during serving and writes a
@@ -2334,7 +2297,11 @@ def _is_gfx950_rocminfo() -> bool:
     """Cached rocminfo probe for gfx950 arch."""
     try:
         out = subprocess.run(
-            ["rocminfo"], capture_output=True, text=True, timeout=15, check=False,
+            ["rocminfo"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
         ).stdout
         return "gfx950" in out.lower()
     except (OSError, subprocess.SubprocessError):
@@ -2380,8 +2347,7 @@ def _resolve_forge_untuned_csv(session_dir: Path, precision: str, quant_type: st
     fname = _FORGE_UNTUNED_CSV_BY_QUANT.get(quant_type)
     if fname is None:
         log.warning(
-            "Forge GEMM shapes: unknown quant_type=%r for precision=%r; "
-            "not guessing an untuned CSV",
+            "Forge GEMM shapes: unknown quant_type=%r for precision=%r; not guessing an untuned CSV",
             quant_type,
             precision,
         )
@@ -2684,8 +2650,7 @@ def _reuse_vllm_block_fp8_roofline_shapes(
             if recorded_workload.get(key) != expected_workload.get(key)
         )
         log.info(
-            "vLLM block-FP8 shape capture: Roofline workload mismatch (%s); "
-            "running a standard Roofline fallback",
+            "vLLM block-FP8 shape capture: Roofline workload mismatch (%s); running a standard Roofline fallback",
             ", ".join(mismatches) or "missing profile workload metadata",
         )
         return None
@@ -2861,8 +2826,7 @@ async def _capture_vllm_tunableop_shapes(
     capture_envs = {
         str(key): str(value)
         for key, value in inherited_envs.items()
-        if profile_mode
-        or not str(key).startswith(("PYTORCH_TUNABLEOP_", "HL_TUNABLEOP_"))
+        if profile_mode or not str(key).startswith(("PYTORCH_TUNABLEOP_", "HL_TUNABLEOP_"))
     }
     if not profile_mode:
         try:
@@ -3212,13 +3176,16 @@ async def _run_forge_gemm_tuning(
             shapes_json = str(shape_capture["shapes_json"])
             untuned_csv = ""
             block_fp8_profile_capture = False
-    tunableop_capture = _vllm_dense_shape_capture_required(
-        framework=framework,
-        model_path=model_path,
-        shapes_json=shapes_json,
-        tunableop_input=tunableop_input,
-        dry_run=bool(payload.get("dry_run")),
-    ) and not block_fp8_profile_capture
+    tunableop_capture = (
+        _vllm_dense_shape_capture_required(
+            framework=framework,
+            model_path=model_path,
+            shapes_json=shapes_json,
+            tunableop_input=tunableop_input,
+            dry_run=bool(payload.get("dry_run")),
+        )
+        and not block_fp8_profile_capture
+    )
     if block_fp8_profile_capture or tunableop_capture:
         capture_payload = dict(payload)
         if block_fp8_profile_capture:
@@ -3366,9 +3333,7 @@ async def _run_forge_gemm_tuning(
     return result
 
 
-def _persist_forge_gemm_csv_durably(
-    extra_envs: dict, *, model_path: str, session_dir: Path
-) -> tuple[dict, str]:
+def _persist_forge_gemm_csv_durably(extra_envs: dict, *, model_path: str, session_dir: Path) -> tuple[dict, str]:
     """Make a forge GEMM tuned CSV durable + recipe-portable.
 
     The forge KEEP references the tuned CSV by its ephemeral tuner-workspace path,
@@ -3402,9 +3367,7 @@ def _persist_forge_gemm_csv_durably(
             return extra_envs, ""
         aiter_pkg = Path(spec.origin).resolve().parent
         slug = (
-            "".join(c if (c.isalnum() or c in "._-") else "_" for c in Path(model_path).name)
-            .strip("_")
-            .lower()
+            "".join(c if (c.isalnum() or c in "._-") else "_" for c in Path(model_path).name).strip("_").lower()
             or "model"
         )
         rel = f"configs/model_configs/a8w8_blockscale_tuned_gemm_{slug}.csv"
@@ -3425,9 +3388,17 @@ def _persist_forge_gemm_csv_durably(
     try:
         from ..source_snapshot import snapshot_source_layer
 
+        base_proc = subprocess.run(
+            ["git", "-C", str(aiter_pkg), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        base_sha = base_proc.stdout.strip() if base_proc.returncode == 0 else ""
         snap = snapshot_source_layer(
             framework_root=aiter_pkg,
-            base_sha=None,
+            base_sha=base_sha,
             rel_paths=[rel],
             # Durable, run-cleanup-surviving location (mirrors integrate_patch),
             # NOT the ephemeral runs/gemm_tuning workspace.
@@ -4759,11 +4730,7 @@ def _batch_kernel_candidates(
     # front so both the grouped and legacy passes agree: they resolve a source
     # yet fail the kernel-opt gate on untrusted shape provenance. Absent field
     # (TraceLens path) stays dispatchable to avoid regressing it.
-    kernels = [
-        k
-        for k in kernels
-        if not (isinstance(k, dict) and k.get("shape_dispatchable") is False)
-    ]
+    kernels = [k for k in kernels if not (isinstance(k, dict) and k.get("shape_dispatchable") is False)]
     reusable_ids = data.get("reusable_native_kernel_ids") or []
     reusable_id_set = {str(item) for item in reusable_ids if item}
 
@@ -4843,23 +4810,11 @@ def _batch_kernel_candidates(
             return False
         entry = attempts_by_kid.get(kid) or {}
         recorded_group_key = str(entry.get("task_group_key") or "")
-        if (
-            current_task_group_key
-            and recorded_group_key
-            and recorded_group_key != current_task_group_key
-        ):
+        if current_task_group_key and recorded_group_key and recorded_group_key != current_task_group_key:
             return True
         recorded_source = str(entry.get("last_source_file") or "")
-        same_source = (
-            not current_source
-            or not recorded_source
-            or recorded_source == current_source
-        )
-        if (
-            kid in rejected_kernel_ids
-            and same_source
-            and not (current_task_group_key and not recorded_group_key)
-        ):
+        same_source = not current_source or not recorded_source or recorded_source == current_source
+        if kid in rejected_kernel_ids and same_source and not (current_task_group_key and not recorded_group_key):
             return False
         if not _entry_allows_dispatch(entry, current_source):
             return False
@@ -4888,11 +4843,7 @@ def _batch_kernel_candidates(
         group_key = str(group.get("task_group_key") or "")
         group_key_aliases = {
             group_key,
-            *[
-                str(alias)
-                for alias in (group.get("legacy_task_group_keys") or [])
-                if str(alias)
-            ],
+            *[str(alias) for alias in (group.get("legacy_task_group_keys") or []) if str(alias)],
         }
         group_key_aliases.discard("")
         primary = str(group.get("primary_kernel_id") or "")
@@ -4915,14 +4866,10 @@ def _batch_kernel_candidates(
                     (
                         group_key
                         and (
-                            str(entry.get("stable_task_key") or "")
-                            == group_key
-                            or str(entry.get("task_group_key") or "")
-                            == group_key
-                            or str(entry.get("stable_task_key") or "")
-                            in group_key_aliases
-                            or str(entry.get("task_group_key") or "")
-                            in group_key_aliases
+                            str(entry.get("stable_task_key") or "") == group_key
+                            or str(entry.get("task_group_key") or "") == group_key
+                            or str(entry.get("stable_task_key") or "") in group_key_aliases
+                            or str(entry.get("task_group_key") or "") in group_key_aliases
                         )
                     )
                     or (
@@ -4942,8 +4889,7 @@ def _batch_kernel_candidates(
                     kernel_by_id[member_id]
                     for member_id in member_ids
                     if member_id in kernel_by_id
-                    and kernel_by_id[member_id].get("reusable_native_kernel")
-                    is True
+                    and kernel_by_id[member_id].get("reusable_native_kernel") is True
                     and kernel_by_id[member_id].get("source_file")
                 ),
                 None,
@@ -5217,11 +5163,7 @@ def _stamp_task_group_result(
     )
     stamped.setdefault(
         "legacy_task_group_keys",
-        [
-            str(item)
-            for item in (task_group.get("legacy_task_group_keys") or [])
-            if str(item)
-        ],
+        [str(item) for item in (task_group.get("legacy_task_group_keys") or []) if str(item)],
     )
     stamped.setdefault(
         "task_group_kernel_ids",
@@ -5505,11 +5447,7 @@ async def _run_optimization_single(
     candidate_payload = payload.get("candidate")
     if isinstance(candidate_payload, dict):
         task_group = candidate_payload.get("task_group")
-        group_id = (
-            str(task_group.get("task_group_id") or "")
-            if isinstance(task_group, dict)
-            else ""
-        )
+        group_id = str(task_group.get("task_group_id") or "") if isinstance(task_group, dict) else ""
         identity = group_id or str(candidate_payload.get("kernel_id") or kernel_id)
         safe_identity = re.sub(r"[^A-Za-z0-9._-]+", "_", identity).strip("._-") or "candidate"
         candidate_json_path = (
@@ -5523,8 +5461,7 @@ async def _run_optimization_single(
         try:
             candidate_json_path.parent.mkdir(parents=True, exist_ok=True)
             candidate_json_path.write_text(
-                json.dumps(candidate_payload, indent=2, sort_keys=True, ensure_ascii=False)
-                + "\n",
+                json.dumps(candidate_payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
                 encoding="utf-8",
             )
             cmd += ["--candidate-json", str(candidate_json_path)]
@@ -5934,9 +5871,7 @@ async def _run_integrate_rebaseline_with_lock_retry(
     # unknown, a fresh skipped lock is also not safe to remove. Retry only after
     # at least one deletion or after confirming the lock disappeared.
     cleanup_safe = not cleanup.get("skipped_live") and not cleanup.get("errors")
-    lock_removed = bool(cleanup.get("deleted")) or (
-        cleanup.get("scanned", 0) == 0 and not cleanup.get("skipped_fresh")
-    )
+    lock_removed = bool(cleanup.get("deleted")) or (cleanup.get("scanned", 0) == 0 and not cleanup.get("skipped_fresh"))
     if not (cleanup_safe and lock_removed):
         return result
 
@@ -6092,12 +6027,7 @@ def _integrate_rebaseline_timeout_sec(
         try:
             import yaml  # type: ignore[import-untyped]
 
-            config = (
-                yaml.safe_load(
-                    Path(config_path).read_text(encoding="utf-8")
-                )
-                or {}
-            )
+            config = yaml.safe_load(Path(config_path).read_text(encoding="utf-8")) or {}
             benchmark = config.get("benchmark")
             if isinstance(benchmark, dict):
                 value = int(benchmark.get("timeout_seconds") or 0)
@@ -6197,8 +6127,7 @@ async def integrate_handler(
             "apply_result": apply_result,
             "kernel_id": kernel_id,
             "patch_path": patch_path,
-            "target_file": payload.get("target_file")
-            or payload.get("source_file"),
+            "target_file": payload.get("target_file") or payload.get("source_file"),
         }
     if apply_result.get("status") != "ok":
         return {
@@ -6241,8 +6170,7 @@ async def integrate_handler(
             "extra_server_args": extra_args,
             "extra_envs": dict(payload.get("extra_envs") or {}),
             "defer_accuracy_until_after_measure": True,
-            "post_measure_accuracy_min_tput": base_tput
-            * (1.0 + keep_threshold_pct / 100.0),
+            "post_measure_accuracy_min_tput": base_tput * (1.0 + keep_threshold_pct / 100.0),
             "accuracy_timeout_sec": rebaseline_timeout_sec,
             # Synthetic kind="baseline": candidate A/B validation against the
             # already-anchored reference. It runs eval for the kernel accuracy
@@ -6329,8 +6257,7 @@ async def integrate_handler(
             "error": repr(exc),
             "kernel_id": kernel_id,
             "patch_path": patch_path,
-            "target_file": payload.get("target_file")
-            or payload.get("source_file"),
+            "target_file": payload.get("target_file") or payload.get("source_file"),
             "apply_result": apply_result,
             "revert_result": revert_result,
         }
@@ -6356,8 +6283,7 @@ async def integrate_handler(
             "rebaseline_detail": bench_result,
             "kernel_id": kernel_id,
             "patch_path": patch_path,
-            "target_file": payload.get("target_file")
-            or payload.get("source_file"),
+            "target_file": payload.get("target_file") or payload.get("source_file"),
             "apply_result": apply_result,
             "revert_result": revert_result,
         }

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_ingest.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_ingest.py
@@ -25,7 +25,12 @@ import re
 import shlex
 from typing import Any, Mapping
 
-from .replay_bundle import argv_to_env_string, canonical_server_argv
+from .replay_bundle import (
+    REPLAY_BUNDLE_KEY,
+    argv_to_env_string,
+    canonical_server_argv,
+    refresh_bundle_digest,
+)
 
 # A scalar safe to emit bare (unquoted) in YAML: letter-leading, otherwise
 # alnum/._- only. Anything reinterpretable (digit-leading versions, tokens with
@@ -129,8 +134,10 @@ def _is_secret_option(value: str) -> bool:
         return True
     if not parts or "token" not in parts:
         return False
-    return len(parts) == 1 or parts[-1] == "token" or bool(
-        {"api", "auth", "bearer", "access", "refresh", "hf", "gbrain"} & set(parts)
+    return (
+        len(parts) == 1
+        or parts[-1] == "token"
+        or bool({"api", "auth", "bearer", "access", "refresh", "hf", "gbrain"} & set(parts))
     )
 
 
@@ -173,6 +180,30 @@ def _sanitize_server_args(value: str, *, drop_paths: bool) -> str:
         return ""
 
 
+def _sanitize_server_argv(value: Any, *, drop_paths: bool) -> list[str]:
+    """Remove credential operands and host-local paths from structured argv."""
+    tokens = canonical_server_argv(value)
+    safe: list[str] = []
+    skip_value = False
+    for token in tokens:
+        if skip_value:
+            skip_value = False
+            continue
+        option, separator, operand = token.partition("=")
+        normalized_option = option.lstrip("-")
+        if _is_secret_option(normalized_option):
+            skip_value = not separator
+            continue
+        if drop_paths and _is_absolute_path_text(token):
+            if safe and safe[-1].startswith("-") and "=" not in safe[-1]:
+                safe.pop()
+            continue
+        if drop_paths and separator and _is_absolute_path_text(operand):
+            continue
+        safe.append(token)
+    return safe
+
+
 def _sanitize_gbrain_value(
     value: Any,
     *,
@@ -183,6 +214,8 @@ def _sanitize_gbrain_value(
 
     if _is_secret_key(key):
         return _DROP_VALUE
+    if key == "argv" and isinstance(value, (list, tuple, str)):
+        return _sanitize_server_argv(value, drop_paths=True)
     if isinstance(value, Mapping):
         sanitized: dict[str, Any] = {}
         for nested_key, nested_value in value.items():
@@ -232,8 +265,10 @@ def _sanitize_recipe_for_gbrain(recipe: Mapping[str, Any]) -> dict[str, Any]:
         # replay fields retain path-valued knobs/artifacts but still lose any
         # nested secret-bearing keys.
         drop_paths = key not in _CORE_RECIPE_KEYS or key in {
+            "best_config",
             "provenance",
             "evidence_refs",
+            REPLAY_BUNDLE_KEY,
         }
         cleaned = _sanitize_gbrain_value(
             raw_value,
@@ -242,6 +277,23 @@ def _sanitize_recipe_for_gbrain(recipe: Mapping[str, Any]) -> dict[str, Any]:
         )
         if cleaned is not _DROP_VALUE:
             sanitized[key] = cleaned
+    original_bundle = recipe.get(REPLAY_BUNDLE_KEY)
+    cleaned_bundle = sanitized.get(REPLAY_BUNDLE_KEY)
+    if isinstance(original_bundle, Mapping) and isinstance(cleaned_bundle, Mapping):
+        original_without_digest = dict(original_bundle)
+        cleaned_without_digest = dict(cleaned_bundle)
+        original_without_digest.pop("bundle_sha256", None)
+        cleaned_without_digest.pop("bundle_sha256", None)
+        if original_without_digest != cleaned_without_digest:
+            cleaned_without_digest["replayable"] = False
+            cleaned_without_digest["reason"] = "gbrain_replay_data_sanitized"
+            measurement = cleaned_without_digest.get("measurement")
+            if isinstance(measurement, Mapping):
+                cleaned_without_digest["measurement"] = {
+                    **measurement,
+                    "measured_with_complete_bundle": False,
+                }
+        sanitized[REPLAY_BUNDLE_KEY] = refresh_bundle_digest(cleaned_without_digest)
     return sanitized
 
 
@@ -380,9 +432,7 @@ def _best_config_split(best_config: Mapping[str, Any]) -> tuple[str, dict[str, s
         A tuple of the launch-args string and the env-var dict.
     """
     argv = canonical_server_argv(
-        best_config.get("argv")
-        if best_config.get("argv") is not None
-        else best_config.get(_EXTRA_SERVER_ARGS_KEY)
+        best_config.get("argv") if best_config.get("argv") is not None else best_config.get(_EXTRA_SERVER_ARGS_KEY)
     )
     try:
         args = argv_to_env_string(argv)
@@ -422,11 +472,7 @@ def recipe_to_page(recipe: Mapping[str, Any]) -> tuple[str, str] | None:
     if not canonical:
         return None
     args, envs = _best_config_split(best_config)
-    argv = canonical_server_argv(
-        best_config.get("argv")
-        if best_config.get("argv") is not None
-        else args
-    )
+    argv = canonical_server_argv(best_config.get("argv") if best_config.get("argv") is not None else args)
     model = str(recipe.get("model") or "")
     hardware = str(recipe.get("hardware") or "")
     # Back-compat: rows predating the framework_name rename use ``framework``.

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_ingest.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_ingest.py
@@ -25,6 +25,8 @@ import re
 import shlex
 from typing import Any, Mapping
 
+from .replay_bundle import argv_to_env_string, canonical_server_argv
+
 # A scalar safe to emit bare (unquoted) in YAML: letter-leading, otherwise
 # alnum/._- only. Anything reinterpretable (digit-leading versions, tokens with
 # ``:`` / spaces / YAML keywords) is JSON-quoted instead.
@@ -69,6 +71,7 @@ _CORE_RECIPE_KEYS = frozenset(
         "architectures",
         "best_config",
         "best_throughput",
+        "replay_bundle",
         "validated_gain_pct",
         "what_worked",
         "what_failed",
@@ -161,7 +164,13 @@ def _sanitize_server_args(value: str, *, drop_paths: bool) -> str:
         if drop_paths and separator and _is_absolute_path_text(operand):
             continue
         safe.append(token)
-    return shlex.join(safe)
+    try:
+        return argv_to_env_string(safe)
+    except ValueError:
+        # Magpie cannot represent whitespace-bearing argv tokens through its
+        # unquoted EXTRA_*_ARGS environment expansion. Do not publish a string
+        # that will be interpreted differently when replayed.
+        return ""
 
 
 def _sanitize_gbrain_value(
@@ -329,6 +338,7 @@ _NON_ENV_BEST_CONFIG_KEYS = frozenset(
         "name",
         "tput",
         "accuracy",
+        "argv",
     }
 )
 
@@ -369,7 +379,17 @@ def _best_config_split(best_config: Mapping[str, Any]) -> tuple[str, dict[str, s
     Returns:
         A tuple of the launch-args string and the env-var dict.
     """
-    args = _coerce_server_args(best_config.get(_EXTRA_SERVER_ARGS_KEY)).strip()
+    argv = canonical_server_argv(
+        best_config.get("argv")
+        if best_config.get("argv") is not None
+        else best_config.get(_EXTRA_SERVER_ARGS_KEY)
+    )
+    try:
+        args = argv_to_env_string(argv)
+    except ValueError:
+        # Keep the legacy string for reference-only rows. Replay-bundle
+        # eligibility will fail closed when the argv transport is unsafe.
+        args = _coerce_server_args(best_config.get(_EXTRA_SERVER_ARGS_KEY)).strip()
     nested = best_config.get("extra_envs")
     if isinstance(nested, Mapping):
         envs = {str(k): str(v) for k, v in nested.items()}
@@ -402,6 +422,11 @@ def recipe_to_page(recipe: Mapping[str, Any]) -> tuple[str, str] | None:
     if not canonical:
         return None
     args, envs = _best_config_split(best_config)
+    argv = canonical_server_argv(
+        best_config.get("argv")
+        if best_config.get("argv") is not None
+        else args
+    )
     model = str(recipe.get("model") or "")
     hardware = str(recipe.get("hardware") or "")
     # Back-compat: rows predating the framework_name rename use ``framework``.
@@ -415,6 +440,7 @@ def recipe_to_page(recipe: Mapping[str, Any]) -> tuple[str, str] | None:
         "model_type": str(recipe.get("model_type") or ""),
         "architectures": list(recipe.get("architectures") or []),
         "best_config_args": args,
+        "best_config_argv": argv,
         "best_config_envs": envs,
         "best_throughput": float(recipe.get("best_throughput") or 0.0),
         "validated_gain_pct": float(recipe.get("validated_gain_pct") or 0.0),

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_remote_client.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_remote_client.py
@@ -39,6 +39,12 @@ from hyperloom.common.jsonio import iter_sse_objects
 from hyperloom.inference_optimizer import recipe_snapshot_constants as C
 from . import RemoteRecipeClientError
 from .canonical_id import recipe_canonical_id
+from .replay_bundle import (
+    REPLAY_BUNDLE_KEY,
+    argv_to_env_string,
+    canonical_server_argv,
+    hydrate_replay_bundle,
+)
 
 log = logging.getLogger(__name__)
 
@@ -351,7 +357,15 @@ def _best_config_from_attrs(attrs: Mapping[str, Any]) -> dict[str, Any]:
         canonical key and the env map nested under ``extra_envs``.
     """
     out: dict[str, Any] = {}
-    args = str(attrs.get("best_config_args") or "").strip()
+    argv = canonical_server_argv(
+        attrs.get("best_config_argv")
+        if attrs.get("best_config_argv") is not None
+        else attrs.get("best_config_args")
+    )
+    try:
+        args = argv_to_env_string(argv) if argv else ""
+    except ValueError:
+        args = str(attrs.get("best_config_args") or "").strip()
     if args:
         out[_EXTRA_SERVER_ARGS_KEY] = args
     envs = attrs.get("best_config_envs")
@@ -718,7 +732,13 @@ class GbrainRemoteRecipeClient:
         fm = page.get("frontmatter") if isinstance(page, dict) else None
         if not isinstance(fm, Mapping):
             return None
-        return _page_to_recipe(fm)
+        row = _page_to_recipe(fm)
+        if isinstance(row, dict) and isinstance(row.get(REPLAY_BUNDLE_KEY), Mapping):
+            row[REPLAY_BUNDLE_KEY] = hydrate_replay_bundle(
+                self._mcp,
+                row[REPLAY_BUNDLE_KEY],
+            )
+        return row
 
     def _search_recipe_candidates(self, label_match: Mapping[str, Any], *, limit: int) -> list[dict[str, Any]]:
         """Use gbrain page search to preselect recipe candidates by labels.

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_store.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_store.py
@@ -13,7 +13,7 @@ import threading
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from hyperloom.common.timeutil import now_iso
 
@@ -32,6 +32,7 @@ from .local_store import (
     _normalise_str_dicts,
 )
 from .replay_bundle import REPLAY_BUNDLE_KEY, externalize_large_artifacts
+from .replay_bundle import bundle_matches_champion
 from .schema import Recipe
 
 try:
@@ -344,6 +345,26 @@ class GbrainRecipeStore:
                 "incoming_filled_empty",
                 "incoming_higher_throughput",
             }
+            if (
+                incoming_won
+                and latest
+                and isinstance(latest_bundle, Mapping)
+                and not bundle_matches_champion(
+                    incoming_bundle if isinstance(incoming_bundle, Mapping) else None,
+                    best_config=incoming_config,
+                    best_throughput=incoming_throughput,
+                )
+            ):
+                # Never advance only part of the champion. Mid-session metadata
+                # amendments historically carried the previous bundle forward
+                # while replacing config/throughput, producing a plausible but
+                # false replay contract. Preserve the last atomic champion.
+                merged_config = latest_config
+                merged_throughput = latest_throughput
+                champion = "incoming_rejected_unbound_bundle"
+                incoming_won = False
+                payload["best_config"] = merged_config
+                payload["best_throughput"] = merged_throughput
             selected_bundle = incoming_bundle if incoming_won else latest_bundle
             if isinstance(selected_bundle, dict):
                 selected_bundle = externalize_large_artifacts(

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_store.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_store.py
@@ -31,6 +31,7 @@ from .local_store import (
     _normalise_sessions,
     _normalise_str_dicts,
 )
+from .replay_bundle import REPLAY_BUNDLE_KEY, externalize_large_artifacts
 from .schema import Recipe
 
 try:
@@ -332,7 +333,27 @@ class GbrainRecipeStore:
                 ),
                 "provenance": dict(provenance or {}),
             }
-            merged_extras = _merge_nonempty_mapping(latest_extras, dict(extras or {}))
+            incoming_extras = dict(extras or {})
+            latest_bundle = latest_extras.get(REPLAY_BUNDLE_KEY)
+            incoming_bundle = incoming_extras.pop(REPLAY_BUNDLE_KEY, None)
+            # The champion's config, throughput and replay bundle are one value.
+            # Metadata-only writes must never replace just the bundle, and a
+            # losing candidate must not displace the live champion's artifacts.
+            incoming_won = champion in {
+                "incoming_new",
+                "incoming_filled_empty",
+                "incoming_higher_throughput",
+            }
+            selected_bundle = incoming_bundle if incoming_won else latest_bundle
+            if isinstance(selected_bundle, dict):
+                selected_bundle = externalize_large_artifacts(
+                    self.mcp,
+                    canonical_id=canonical_id,
+                    bundle=selected_bundle,
+                )
+            merged_extras = _merge_nonempty_mapping(latest_extras, incoming_extras)
+            if isinstance(selected_bundle, dict):
+                merged_extras[REPLAY_BUNDLE_KEY] = selected_bundle
             for key, value in merged_extras.items():
                 payload.setdefault(key, value)
             written = Recipe.from_dict(payload).to_dict()

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/local_store.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/local_store.py
@@ -45,7 +45,7 @@ import os
 import threading
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
 from hyperloom.common.io import atomic_write_json
 from hyperloom.common.jsonio import read_json
@@ -57,6 +57,7 @@ from .canonical_id import (
     cid_to_path_components,
 )
 from .schema import Attempt, Recipe
+from .replay_bundle import REPLAY_BUNDLE_KEY, bundle_matches_champion
 
 
 log = logging.getLogger(__name__)
@@ -408,6 +409,30 @@ class LocalRecipeStore:
             prior_counts = _collection_counts(live)
             prior_version = int(live.get("version", 0)) if isinstance(live, dict) else 0
             new_version = prior_version + 1 if not created else 1
+            effective_best_config = dict(best_config or {})
+            effective_best_throughput = float(best_throughput)
+            effective_extras = dict(extras or {})
+            if isinstance(live, dict):
+                live_config = dict(live.get("best_config") or {})
+                live_throughput = float(live.get("best_throughput") or 0.0)
+                champion_changed = (
+                    effective_best_config != live_config or abs(effective_best_throughput - live_throughput) > 1e-9
+                )
+                incoming_bundle = effective_extras.get(REPLAY_BUNDLE_KEY)
+                if (
+                    champion_changed
+                    and isinstance(live.get(REPLAY_BUNDLE_KEY), Mapping)
+                    and not bundle_matches_champion(
+                        incoming_bundle if isinstance(incoming_bundle, Mapping) else None,
+                        best_config=effective_best_config,
+                        best_throughput=effective_best_throughput,
+                    )
+                ):
+                    # Metadata/lesson amendments must not pair a new config and
+                    # throughput with the previous champion's replay bundle.
+                    effective_best_config = live_config
+                    effective_best_throughput = live_throughput
+                    effective_extras[REPLAY_BUNDLE_KEY] = live[REPLAY_BUNDLE_KEY]
 
             if not created:
                 # Archive prior live before overwrite; ``replaced_by`` carries
@@ -444,8 +469,8 @@ class LocalRecipeStore:
                 "framework_name": framework_name,
                 "framework_version": framework_version,
                 "precision": precision,
-                "best_config": dict(best_config or {}),
-                "best_throughput": float(best_throughput),
+                "best_config": effective_best_config,
+                "best_throughput": effective_best_throughput,
                 "what_worked": _normalise_str_dicts(what_worked, ("description", "measured_impact")),
                 "what_failed": _normalise_str_dicts(what_failed, ("description", "reason")),
                 "remaining_gaps": _normalise_str_dicts(remaining_gaps, ("description", "metrics")),
@@ -461,9 +486,9 @@ class LocalRecipeStore:
                 "evidence_refs": list(evidence_refs or []),
                 "provenance": dict(provenance or {}),
             }
-            if extras:
+            if effective_extras:
                 # Splat extras at the top level (no nested ``extras`` key on disk).
-                for key, val in extras.items():
+                for key, val in effective_extras.items():
                     payload_dict.setdefault(key, val)
 
             recipe = Recipe.from_dict(payload_dict)

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/replay_bundle.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/replay_bundle.py
@@ -83,13 +83,119 @@ def _bundle_digest(bundle: Mapping[str, Any]) -> str:
         artifact.pop("patch_content", None)
         artifact.pop("storage", None)
         artifact.pop("artifact_slug", None)
-    return _sha256(
-        json.dumps(digest_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return _sha256(json.dumps(digest_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")))
+
+
+def refresh_bundle_digest(bundle: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a copy whose digest describes its current replay semantics."""
+    out = copy.deepcopy(dict(bundle))
+    out["bundle_sha256"] = _bundle_digest(out)
+    return out
+
+
+def validate_replay_bundle(bundle: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate an already-inline bundle without consulting a remote store."""
+    out = copy.deepcopy(dict(bundle))
+    if int(out.get("schema_version") or 0) != SCHEMA_VERSION:
+        out["replayable"] = False
+        out["reason"] = "unsupported_replay_bundle_schema"
+        return refresh_bundle_digest(out)
+    for artifact in out.get("source_artifacts") or []:
+        if not isinstance(artifact, dict):
+            out["replayable"] = False
+            out["reason"] = "artifact_manifest_invalid"
+            return refresh_bundle_digest(out)
+        patch = str(artifact.get("patch_content") or "")
+        if not patch:
+            out["replayable"] = False
+            out["reason"] = (
+                "artifact_missing" if artifact.get("storage") == "gbrain_page" else "artifact_content_missing"
+            )
+            return refresh_bundle_digest(out)
+        if _sha256(patch) != str(artifact.get("sha256") or ""):
+            out["replayable"] = False
+            out["reason"] = "artifact_sha_mismatch"
+            return refresh_bundle_digest(out)
+    expected_bundle_sha = str(out.get("bundle_sha256") or "")
+    if not expected_bundle_sha:
+        out["replayable"] = False
+        out["reason"] = "bundle_sha_missing"
+        return refresh_bundle_digest(out)
+    if _bundle_digest(out) != expected_bundle_sha:
+        out["replayable"] = False
+        out["reason"] = "bundle_sha_mismatch"
+        return refresh_bundle_digest(out)
+    return out
+
+
+def bundle_matches_champion(
+    bundle: Mapping[str, Any] | None,
+    *,
+    best_config: Mapping[str, Any] | None,
+    best_throughput: float,
+) -> bool:
+    """Return whether a bundle is bound to the supplied champion fields."""
+    if not isinstance(bundle, Mapping):
+        return False
+    config = bundle.get("config") if isinstance(bundle.get("config"), Mapping) else {}
+    expected_argv = canonical_server_argv(
+        (best_config or {}).get("argv")
+        if (best_config or {}).get("argv") is not None
+        else (best_config or {}).get("extra_server_args")
+    )
+    bundle_argv = canonical_server_argv(config.get("argv") or [])
+    expected_envs = (best_config or {}).get("extra_envs") or {}
+    if not isinstance(expected_envs, Mapping):
+        expected_envs = {}
+    bundle_envs = config.get("extra_envs") or {}
+    if not isinstance(bundle_envs, Mapping):
+        bundle_envs = {}
+    expected_refs = (best_config or {}).get("env_path_refs") or {}
+    if not isinstance(expected_refs, Mapping):
+        expected_refs = {}
+    bundle_refs = config.get("env_path_refs") or {}
+    if not isinstance(bundle_refs, Mapping):
+        bundle_refs = {}
+    measurement = bundle.get("measurement") if isinstance(bundle.get("measurement"), Mapping) else {}
+    try:
+        bundle_throughput = float(measurement.get("optimized_throughput") or 0.0)
+        champion_throughput = float(best_throughput or 0.0)
+    except (TypeError, ValueError):
+        return False
+    return (
+        bundle_argv == expected_argv
+        and {str(k): str(v) for k, v in bundle_envs.items()} == {str(k): str(v) for k, v in expected_envs.items()}
+        and bundle_refs == expected_refs
+        and abs(bundle_throughput - champion_throughput) <= 1e-9
     )
 
 
 def _git_show(root: Path, revision: str, rel: str) -> tuple[bool, str]:
     if not revision:
+        raise ValueError("source snapshot has no base revision")
+    inside = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "--is-inside-work-tree"],
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    if inside.returncode != 0 or inside.stdout.strip() != b"true":
+        raise ValueError(f"source root is not a git worktree: {root}")
+    commit = subprocess.run(
+        ["git", "-C", str(root), "cat-file", "-e", f"{revision}^{{commit}}"],
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    if commit.returncode != 0:
+        raise ValueError(f"source base revision is unavailable: {revision}")
+    exists = subprocess.run(
+        ["git", "-C", str(root), "cat-file", "-e", f"{revision}:{rel}"],
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    if exists.returncode != 0:
         return False, ""
     proc = subprocess.run(
         ["git", "-C", str(root), "show", f"{revision}:{rel}"],
@@ -98,7 +204,7 @@ def _git_show(root: Path, revision: str, rel: str) -> tuple[bool, str]:
         timeout=30,
     )
     if proc.returncode != 0:
-        return False, ""
+        raise ValueError(f"could not read {rel!r} from source base {revision}")
     try:
         return True, proc.stdout.decode("utf-8")
     except UnicodeDecodeError as exc:
@@ -214,6 +320,47 @@ def _snapshot_groups(source_snapshots: list[Mapping[str, Any]]) -> tuple[list[di
     return artifacts, ""
 
 
+def _portable_envs(
+    envs: Mapping[str, Any],
+    source_snapshots: list[Mapping[str, Any]],
+) -> tuple[dict[str, str], dict[str, dict[str, str]], str]:
+    """Replace env paths to captured files with repo-relative references."""
+    captured_paths: dict[Path, dict[str, str]] = {}
+    for raw in source_snapshots:
+        snapshot_dir = Path(str(raw.get("snapshot_dir") or ""))
+        try:
+            manifest = json.loads((snapshot_dir / MANIFEST_NAME).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, TypeError):
+            continue
+        root = Path(str(manifest.get("framework_root") or ""))
+        repo = root.name.lower().replace("_meta", "")
+        if not root.is_absolute() or not repo:
+            continue
+        for item in manifest.get("files") or []:
+            if not isinstance(item, Mapping):
+                continue
+            rel = str(item.get("rel") or "").strip().lstrip("/")
+            if not rel or ".." in Path(rel).parts:
+                continue
+            captured_paths[(root / rel).resolve(strict=False)] = {
+                "repo": repo,
+                "path": rel,
+            }
+    literal: dict[str, str] = {}
+    refs: dict[str, dict[str, str]] = {}
+    for raw_key, raw_value in envs.items():
+        key = str(raw_key)
+        value = str(raw_value)
+        if not Path(value).is_absolute():
+            literal[key] = value
+            continue
+        ref = captured_paths.get(Path(value).resolve(strict=False))
+        if ref is None:
+            return {}, {}, f"unportable_env_path:{key}"
+        refs[key] = ref
+    return literal, refs, ""
+
+
 def build_replay_bundle(
     *,
     env_spec: Mapping[str, Any],
@@ -224,14 +371,21 @@ def build_replay_bundle(
 ) -> dict[str, Any]:
     """Build the atomic replay value for the measured champion."""
     config = env_spec.get("config") if isinstance(env_spec.get("config"), Mapping) else {}
-    raw_args = config.get("extra_server_args") or ""
+    raw_args = config.get("effective_server_args") or config.get("extra_server_args") or ""
     argv = canonical_server_argv(raw_args)
     envs = config.get("extra_envs") if isinstance(config.get("extra_envs"), Mapping) else {}
-    snapshots = [
-        item for item in (env_spec.get("source_snapshots") or []) if isinstance(item, Mapping)
-    ]
+    snapshots = [item for item in (env_spec.get("source_snapshots") or []) if isinstance(item, Mapping)]
     artifacts, reason = _snapshot_groups(snapshots)
-    replayable = not reason and bool(argv or envs or artifacts)
+    literal_envs, env_path_refs, env_reason = _portable_envs(envs, snapshots)
+    if env_reason and not reason:
+        reason = env_reason
+    overlay = str(env_spec.get("overlay_pythonpath") or "").strip()
+    if overlay and not reason:
+        # A host-local authored-kernel overlay is not a durable replay input.
+        # It must first be flattened to a source patch (or handled by a future
+        # KernelForge artifact resolver) before this champion can be replayed.
+        reason = "overlay_not_flattened_to_patch"
+    replayable = not reason and bool(argv or literal_envs or env_path_refs or artifacts)
     baseline = float(baseline_throughput or 0.0)
     optimized = float(optimized_throughput or 0.0)
     gain_pct = ((optimized - baseline) / baseline * 100.0) if baseline > 0.0 else 0.0
@@ -242,7 +396,8 @@ def build_replay_bundle(
         "producer_session_id": str(producer_session_id or ""),
         "config": {
             "argv": argv,
-            "extra_envs": {str(k): str(v) for k, v in envs.items()},
+            "extra_envs": literal_envs,
+            "env_path_refs": env_path_refs,
             "server_launch_flags": str(config.get("server_launch_flags") or ""),
         },
         "source_artifacts": artifacts,
@@ -254,8 +409,7 @@ def build_replay_bundle(
             "measured_with_complete_bundle": replayable,
         },
     }
-    bundle["bundle_sha256"] = _bundle_digest(bundle)
-    return bundle
+    return refresh_bundle_digest(bundle)
 
 
 def _artifact_slug(sha256: str) -> str:
@@ -329,7 +483,7 @@ def externalize_large_artifacts(
         artifact["storage"] = "gbrain_page"
         artifact["artifact_slug"] = slug
         artifact.pop("patch_content", None)
-    return out
+    return refresh_bundle_digest(out)
 
 
 def _extract_artifact_page(page: Any) -> str:
@@ -346,38 +500,30 @@ def hydrate_replay_bundle(mcp: Any, bundle: Mapping[str, Any]) -> dict[str, Any]
     if int(out.get("schema_version") or 0) != SCHEMA_VERSION:
         out["replayable"] = False
         out["reason"] = "unsupported_replay_bundle_schema"
-        return out
+        return refresh_bundle_digest(out)
     for artifact in out.get("source_artifacts") or []:
         if not isinstance(artifact, dict):
             out["replayable"] = False
             out["reason"] = "artifact_manifest_invalid"
-            return out
+            return refresh_bundle_digest(out)
         if artifact.get("storage") == "gbrain_page":
             slug = str(artifact.get("artifact_slug") or "")
             patch = _extract_artifact_page(mcp.call("get_page", {"slug": slug})) if slug else ""
             if not patch:
                 out["replayable"] = False
                 out["reason"] = "artifact_missing"
-                return out
+                return refresh_bundle_digest(out)
             artifact["patch_content"] = patch
-        patch = str(artifact.get("patch_content") or "")
-        if not patch or _sha256(patch) != str(artifact.get("sha256") or ""):
-            out["replayable"] = False
-            out["reason"] = "artifact_sha_mismatch"
-            return out
-    expected_bundle_sha = str(out.get("bundle_sha256") or "")
-    if expected_bundle_sha and _bundle_digest(out) != expected_bundle_sha:
-        out["replayable"] = False
-        out["reason"] = "bundle_sha_mismatch"
-    return out
+    return validate_replay_bundle(out)
 
 
 def replay_patches(bundle: Mapping[str, Any]) -> list[dict[str, Any]]:
     """Project a hydrated bundle into the baseline executor's patch contract."""
-    if not bundle.get("replayable"):
+    validated = validate_replay_bundle(bundle)
+    if not validated.get("replayable"):
         return []
     out: list[dict[str, Any]] = []
-    for artifact in bundle.get("source_artifacts") or []:
+    for artifact in validated.get("source_artifacts") or []:
         if not isinstance(artifact, Mapping):
             continue
         patch = str(artifact.get("patch_content") or "")
@@ -390,6 +536,7 @@ def replay_patches(bundle: Mapping[str, Any]) -> list[dict[str, Any]]:
                 "target_repo": str(artifact.get("repo") or ""),
                 "base_sha": str(artifact.get("base_sha") or ""),
                 "sha256": str(artifact.get("sha256") or ""),
+                "changed_files": [str(path) for path in (artifact.get("changed_files") or []) if str(path)],
             }
         )
     return out
@@ -400,8 +547,11 @@ __all__ = [
     "SCHEMA_VERSION",
     "argv_to_env_string",
     "build_replay_bundle",
+    "bundle_matches_champion",
     "canonical_server_argv",
     "externalize_large_artifacts",
     "hydrate_replay_bundle",
+    "refresh_bundle_digest",
     "replay_patches",
+    "validate_replay_bundle",
 ]

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/replay_bundle.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/replay_bundle.py
@@ -239,7 +239,10 @@ def _snapshot_groups(source_snapshots: list[Mapping[str, Any]]) -> tuple[list[di
     groups: dict[tuple[str, str], dict[str, Any]] = {}
     repo_bases: dict[str, str] = {}
     for raw in source_snapshots:
-        snapshot_dir = Path(str(raw.get("snapshot_dir") or ""))
+        snapshot_text = str(raw.get("snapshot_dir") or "").strip()
+        if not snapshot_text:
+            return [], "source_snapshot_missing"
+        snapshot_dir = Path(snapshot_text)
         if not snapshot_dir.is_dir():
             return [], "source_snapshot_missing"
         try:

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/replay_bundle.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/replay_bundle.py
@@ -1,0 +1,407 @@
+"""Replay-bundle codec shared by Recipe writers and warm-start readers.
+
+A throughput number is reusable only when it is bound to the exact state that
+produced it: server argv, environment variables, workload, and every source
+layer.  This module builds that atomic value and provides a GBrain-native
+artifact transport.  Small diffs remain inline; larger diffs are written as
+content-addressed GBrain pages and are hydrated through the same MCP credentials
+as the recipe itself.
+"""
+
+from __future__ import annotations
+
+import copy
+import difflib
+import hashlib
+import json
+import os
+import re
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping
+
+from ...source_snapshot import MANIFEST_NAME
+
+SCHEMA_VERSION = 1
+REPLAY_BUNDLE_KEY = "replay_bundle"
+ARTIFACT_PREFIX_ENV = "GBRAIN_REPLAY_ARTIFACT_PREFIX"
+DEFAULT_ARTIFACT_PREFIX = "hyperloom-replay-artifacts"
+INLINE_MAX_BYTES_ENV = "GBRAIN_REPLAY_INLINE_MAX_BYTES"
+DEFAULT_INLINE_MAX_BYTES = 64 * 1024
+
+_ARTIFACT_MARKER = '<!-- replay-artifact: patch file="bundle.diff" -->'
+_FENCE_RE = re.compile(
+    r'<!--\s*replay-artifact:\s*patch\s+file="bundle\.diff"\s*-->\s*'
+    r"```diff\s*\n(?P<payload>.*?)\n```",
+    re.DOTALL,
+)
+
+
+def canonical_server_argv(value: Any) -> list[str]:
+    """Return the launch argv represented by ``value``.
+
+    Legacy recipes store a shell-like string.  ``shlex.split`` is used exactly
+    once to remove syntax quotes; the resulting tokens are the durable shape.
+    """
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value if str(item)]
+    text = str(value or "").strip()
+    if not text:
+        return []
+    try:
+        return shlex.split(text)
+    except ValueError:
+        return []
+
+
+def argv_to_env_string(argv: Any) -> str:
+    """Encode argv for Magpie's unquoted ``$EXTRA_*_ARGS`` expansion.
+
+    Quote characters stored inside an environment variable are data, not shell
+    syntax.  Joining the already-parsed tokens without ``shlex.join`` therefore
+    removes harmful outer quotes while retaining JSON's inner double quotes.
+    Tokens containing whitespace cannot survive this transport and are refused.
+    """
+    tokens = canonical_server_argv(argv)
+    if any(any(ch.isspace() for ch in token) for token in tokens):
+        raise ValueError("server argv contains a whitespace-bearing token unsupported by Magpie env expansion")
+    return " ".join(tokens)
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _bundle_digest(bundle: Mapping[str, Any]) -> str:
+    """Hash replay semantics while ignoring artifact transport details."""
+    digest_payload = copy.deepcopy(dict(bundle))
+    digest_payload.pop("bundle_sha256", None)
+    for artifact in digest_payload.get("source_artifacts") or []:
+        if not isinstance(artifact, dict):
+            continue
+        artifact.pop("patch_content", None)
+        artifact.pop("storage", None)
+        artifact.pop("artifact_slug", None)
+    return _sha256(
+        json.dumps(digest_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    )
+
+
+def _git_show(root: Path, revision: str, rel: str) -> tuple[bool, str]:
+    if not revision:
+        return False, ""
+    proc = subprocess.run(
+        ["git", "-C", str(root), "show", f"{revision}:{rel}"],
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        return False, ""
+    try:
+        return True, proc.stdout.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"source artifact {rel!r} is binary and cannot be represented as a unified diff") from exc
+
+
+def _diff_file(rel: str, old_exists: bool, old: str, new_exists: bool, new: str) -> str:
+    if old_exists == new_exists and old == new:
+        return ""
+    lines = [f"diff --git a/{rel} b/{rel}\n"]
+    if not old_exists:
+        lines.append("new file mode 100644\n")
+    elif not new_exists:
+        lines.append("deleted file mode 100644\n")
+    old_name = f"a/{rel}" if old_exists else "/dev/null"
+    new_name = f"b/{rel}" if new_exists else "/dev/null"
+    lines.extend(
+        difflib.unified_diff(
+            old.splitlines(keepends=True) if old_exists else [],
+            new.splitlines(keepends=True) if new_exists else [],
+            fromfile=old_name,
+            tofile=new_name,
+            lineterm="\n",
+        )
+    )
+    rendered = "".join(lines)
+    return rendered if rendered.endswith("\n") else rendered + "\n"
+
+
+def _snapshot_groups(source_snapshots: list[Mapping[str, Any]]) -> tuple[list[dict[str, Any]], str]:
+    """Squash ordered source snapshots into one final diff per repo/base SHA."""
+    groups: dict[tuple[str, str], dict[str, Any]] = {}
+    repo_bases: dict[str, str] = {}
+    for raw in source_snapshots:
+        snapshot_dir = Path(str(raw.get("snapshot_dir") or ""))
+        if not snapshot_dir.is_dir():
+            return [], "source_snapshot_missing"
+        try:
+            manifest = json.loads((snapshot_dir / MANIFEST_NAME).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, TypeError):
+            return [], "source_snapshot_manifest_invalid"
+        root = Path(str(manifest.get("framework_root") or ""))
+        base_sha = str(manifest.get("base_sha") or raw.get("base_sha") or "")
+        if not root.is_dir() or not base_sha:
+            return [], "source_snapshot_base_unavailable"
+        repo = root.name.lower().replace("_meta", "")
+        previous_base = repo_bases.setdefault(repo, base_sha)
+        if previous_base != base_sha:
+            return [], "source_snapshot_base_changed"
+        key = (str(root), base_sha)
+        group = groups.setdefault(
+            key,
+            {
+                "repo": repo,
+                "root": root,
+                "base_sha": base_sha,
+                "files": {},
+                "provenance_layers": [],
+            },
+        )
+        layer_id = str(raw.get("id") or manifest.get("provenance") or "")
+        if layer_id:
+            group["provenance_layers"].append(layer_id)
+        for item in manifest.get("files") or []:
+            if not isinstance(item, Mapping):
+                continue
+            rel = str(item.get("rel") or "").strip().lstrip("/")
+            if not rel or ".." in Path(rel).parts:
+                return [], "source_snapshot_path_unsafe"
+            op = str(item.get("op") or "upsert")
+            if op == "delete":
+                group["files"][rel] = (False, "")
+                continue
+            try:
+                content = (snapshot_dir / "files" / rel).read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                return [], "source_snapshot_binary"
+            except OSError:
+                return [], "source_snapshot_file_missing"
+            group["files"][rel] = (True, content)
+
+    artifacts: list[dict[str, Any]] = []
+    for group in groups.values():
+        patch_parts: list[str] = []
+        changed_files: list[str] = []
+        for rel, (new_exists, new) in sorted(group["files"].items()):
+            try:
+                old_exists, old = _git_show(group["root"], group["base_sha"], rel)
+            except (OSError, subprocess.SubprocessError, ValueError):
+                return [], "source_snapshot_base_read_failed"
+            patch = _diff_file(rel, old_exists, old, new_exists, new)
+            if patch:
+                patch_parts.append(patch)
+                changed_files.append(rel)
+        patch_text = "".join(patch_parts)
+        if not patch_text:
+            continue
+        artifacts.append(
+            {
+                "repo": group["repo"],
+                "base_sha": group["base_sha"],
+                "format": "unified-diff",
+                "storage": "inline",
+                "sha256": _sha256(patch_text),
+                "bytes": len(patch_text.encode("utf-8")),
+                "changed_files": changed_files,
+                "provenance_layers": list(group["provenance_layers"]),
+                "patch_content": patch_text,
+            }
+        )
+    if source_snapshots and not artifacts:
+        return [], "source_snapshot_empty"
+    return artifacts, ""
+
+
+def build_replay_bundle(
+    *,
+    env_spec: Mapping[str, Any],
+    producer_session_id: str,
+    baseline_throughput: float,
+    optimized_throughput: float,
+    workload: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the atomic replay value for the measured champion."""
+    config = env_spec.get("config") if isinstance(env_spec.get("config"), Mapping) else {}
+    raw_args = config.get("extra_server_args") or ""
+    argv = canonical_server_argv(raw_args)
+    envs = config.get("extra_envs") if isinstance(config.get("extra_envs"), Mapping) else {}
+    snapshots = [
+        item for item in (env_spec.get("source_snapshots") or []) if isinstance(item, Mapping)
+    ]
+    artifacts, reason = _snapshot_groups(snapshots)
+    replayable = not reason and bool(argv or envs or artifacts)
+    baseline = float(baseline_throughput or 0.0)
+    optimized = float(optimized_throughput or 0.0)
+    gain_pct = ((optimized - baseline) / baseline * 100.0) if baseline > 0.0 else 0.0
+    bundle: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "replayable": replayable,
+        "reason": reason or ("" if replayable else "empty_replay_bundle"),
+        "producer_session_id": str(producer_session_id or ""),
+        "config": {
+            "argv": argv,
+            "extra_envs": {str(k): str(v) for k, v in envs.items()},
+            "server_launch_flags": str(config.get("server_launch_flags") or ""),
+        },
+        "source_artifacts": artifacts,
+        "workload": dict(workload or {}),
+        "measurement": {
+            "baseline_throughput": baseline,
+            "optimized_throughput": optimized,
+            "gain_pct": gain_pct,
+            "measured_with_complete_bundle": replayable,
+        },
+    }
+    bundle["bundle_sha256"] = _bundle_digest(bundle)
+    return bundle
+
+
+def _artifact_slug(sha256: str) -> str:
+    prefix = os.environ.get(ARTIFACT_PREFIX_ENV, "").strip().strip("/") or DEFAULT_ARTIFACT_PREFIX
+    return f"{prefix}/{sha256[:2]}/{sha256}"
+
+
+def _artifact_page(artifact: Mapping[str, Any], canonical_id: str) -> str:
+    patch = str(artifact.get("patch_content") or "")
+    attrs = {
+        "canonical_id": canonical_id,
+        "sha256": str(artifact.get("sha256") or ""),
+        "bytes": int(artifact.get("bytes") or len(patch.encode("utf-8"))),
+        "format": "unified-diff",
+    }
+    return (
+        "---\n"
+        'type: "replay_artifact"\n'
+        'title: "Hyperloom replay source artifact"\n'
+        'tags: ["kind:replay_artifact"]\n'
+        f"attrs: {json.dumps(attrs, ensure_ascii=False, sort_keys=True)}\n"
+        "---\n\n"
+        f"{_ARTIFACT_MARKER}\n```diff\n{patch.rstrip()}\n```\n"
+    )
+
+
+def externalize_large_artifacts(
+    mcp: Any,
+    *,
+    canonical_id: str,
+    bundle: Mapping[str, Any],
+    inline_max_bytes: int | None = None,
+) -> dict[str, Any]:
+    """Write oversized inline artifacts as immutable GBrain pages."""
+    out = copy.deepcopy(dict(bundle))
+    try:
+        threshold = int(
+            inline_max_bytes
+            if inline_max_bytes is not None
+            else os.environ.get(INLINE_MAX_BYTES_ENV, "") or DEFAULT_INLINE_MAX_BYTES
+        )
+    except (TypeError, ValueError):
+        threshold = DEFAULT_INLINE_MAX_BYTES
+    for artifact in out.get("source_artifacts") or []:
+        if not isinstance(artifact, dict):
+            continue
+        if artifact.get("storage") == "gbrain_page":
+            # Readers hydrate the bytes for execution; writers keep only the
+            # immutable reference so metadata-only updates do not inline it.
+            artifact.pop("patch_content", None)
+            continue
+        if artifact.get("storage") != "inline":
+            continue
+        patch = str(artifact.get("patch_content") or "")
+        if len(patch.encode("utf-8")) <= threshold:
+            continue
+        slug = _artifact_slug(str(artifact.get("sha256") or _sha256(patch)))
+        try:
+            mcp.call(
+                "put_page",
+                {"slug": slug, "content": _artifact_page(artifact, canonical_id)},
+            )
+        except Exception:
+            # Preserve the Recipe write as reference material, but never claim
+            # the champion can be replayed when its source bytes were not
+            # durably published.
+            out["replayable"] = False
+            out["reason"] = "artifact_publish_failed"
+            artifact.pop("patch_content", None)
+            continue
+        artifact["storage"] = "gbrain_page"
+        artifact["artifact_slug"] = slug
+        artifact.pop("patch_content", None)
+    return out
+
+
+def _extract_artifact_page(page: Any) -> str:
+    if not isinstance(page, Mapping):
+        return ""
+    body = str(page.get("compiled_truth") or page.get("body") or page.get("content") or "")
+    match = _FENCE_RE.search(body)
+    return match.group("payload") + "\n" if match else ""
+
+
+def hydrate_replay_bundle(mcp: Any, bundle: Mapping[str, Any]) -> dict[str, Any]:
+    """Hydrate artifact-page references and fail closed on integrity errors."""
+    out = copy.deepcopy(dict(bundle))
+    if int(out.get("schema_version") or 0) != SCHEMA_VERSION:
+        out["replayable"] = False
+        out["reason"] = "unsupported_replay_bundle_schema"
+        return out
+    for artifact in out.get("source_artifacts") or []:
+        if not isinstance(artifact, dict):
+            out["replayable"] = False
+            out["reason"] = "artifact_manifest_invalid"
+            return out
+        if artifact.get("storage") == "gbrain_page":
+            slug = str(artifact.get("artifact_slug") or "")
+            patch = _extract_artifact_page(mcp.call("get_page", {"slug": slug})) if slug else ""
+            if not patch:
+                out["replayable"] = False
+                out["reason"] = "artifact_missing"
+                return out
+            artifact["patch_content"] = patch
+        patch = str(artifact.get("patch_content") or "")
+        if not patch or _sha256(patch) != str(artifact.get("sha256") or ""):
+            out["replayable"] = False
+            out["reason"] = "artifact_sha_mismatch"
+            return out
+    expected_bundle_sha = str(out.get("bundle_sha256") or "")
+    if expected_bundle_sha and _bundle_digest(out) != expected_bundle_sha:
+        out["replayable"] = False
+        out["reason"] = "bundle_sha_mismatch"
+    return out
+
+
+def replay_patches(bundle: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Project a hydrated bundle into the baseline executor's patch contract."""
+    if not bundle.get("replayable"):
+        return []
+    out: list[dict[str, Any]] = []
+    for artifact in bundle.get("source_artifacts") or []:
+        if not isinstance(artifact, Mapping):
+            continue
+        patch = str(artifact.get("patch_content") or "")
+        if not patch:
+            continue
+        out.append(
+            {
+                "patch_file": f"{artifact.get('repo') or 'framework'}-{str(artifact.get('sha256') or '')[:12]}.diff",
+                "patch_content": patch,
+                "target_repo": str(artifact.get("repo") or ""),
+                "base_sha": str(artifact.get("base_sha") or ""),
+                "sha256": str(artifact.get("sha256") or ""),
+            }
+        )
+    return out
+
+
+__all__ = [
+    "REPLAY_BUNDLE_KEY",
+    "SCHEMA_VERSION",
+    "argv_to_env_string",
+    "build_replay_bundle",
+    "canonical_server_argv",
+    "externalize_large_artifacts",
+    "hydrate_replay_bundle",
+    "replay_patches",
+]

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/schema.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/schema.py
@@ -316,7 +316,10 @@ class Recipe:
     precision: str = ""
 
     # ----- arbor payload (verbatim shape) -----
-    best_config: dict[str, str] = field(default_factory=dict)
+    # ``argv`` is intentionally a list: shell quoting is not a durable argv
+    # transport. Legacy ``extra_server_args`` remains alongside it for readers
+    # predating replay bundles.
+    best_config: dict[str, Any] = field(default_factory=dict)
     best_throughput: float = 0.0
     what_worked: list[Finding] = field(default_factory=list)
     what_failed: list[Failure] = field(default_factory=list)

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb_t0.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb_t0.py
@@ -17,6 +17,7 @@ from hyperloom.orchestrator.knowledge.recipe_kb.replay_bundle import (
     REPLAY_BUNDLE_KEY,
     argv_to_env_string,
     replay_patches,
+    validate_replay_bundle,
 )
 from hyperloom.inference_optimizer.recipe_snapshot_constants import detect_framework_version, kb_hardware_slug
 from hyperloom.inference_optimizer.session.session_paths import (
@@ -158,9 +159,12 @@ def _config_replay_args_envs(row: Mapping[str, Any]) -> tuple[str, dict[str, str
     replayable is present.
     """
     bundle = row.get(REPLAY_BUNDLE_KEY)
-    if not isinstance(bundle, Mapping) or not bundle.get("replayable"):
+    if not isinstance(bundle, Mapping):
         # Legacy config+throughput pairs are not known to describe the same
         # state. Keep them as priors, never as executable warm replay.
+        return "", {}
+    bundle = validate_replay_bundle(bundle)
+    if not bundle.get("replayable"):
         return "", {}
     config = bundle.get("config") if isinstance(bundle.get("config"), Mapping) else {}
     try:
@@ -180,7 +184,10 @@ def _has_replayable_config(row: Mapping[str, Any]) -> bool:
     args, envs = _config_replay_args_envs(row)
     bundle = row.get(REPLAY_BUNDLE_KEY)
     patches = replay_patches(bundle) if isinstance(bundle, Mapping) else []
-    return bool(args or envs or patches)
+    checked = validate_replay_bundle(bundle) if isinstance(bundle, Mapping) else {}
+    config = checked.get("config") if isinstance(checked.get("config"), Mapping) else {}
+    env_path_refs = config.get("env_path_refs") if isinstance(config.get("env_path_refs"), Mapping) else {}
+    return bool(args or envs or env_path_refs or patches)
 
 
 def _max_session_gain(row: Mapping[str, Any]) -> float:
@@ -483,30 +490,28 @@ def _build_warm_start_context(
         config_donor_tier = config_donor_tier or "self"
         config_donor_confidence = config_donor_confidence or confidence
     if donor is not None:
+        donor = dict(donor)
+        raw_bundle = donor.get(REPLAY_BUNDLE_KEY)
+        if isinstance(raw_bundle, Mapping):
+            donor[REPLAY_BUNDLE_KEY] = validate_replay_bundle(raw_bundle)
         args, envs = _config_replay_args_envs(donor)
         bundle = donor.get(REPLAY_BUNDLE_KEY)
         bundle = bundle if isinstance(bundle, Mapping) else {}
         patches = replay_patches(bundle)
-        if args or envs or patches:
-            measurement = (
-                bundle.get("measurement")
-                if isinstance(bundle.get("measurement"), Mapping)
-                else {}
-            )
+        bundle_config = bundle.get("config") if isinstance(bundle.get("config"), Mapping) else {}
+        env_path_refs = (
+            bundle_config.get("env_path_refs")
+            if isinstance(bundle_config.get("env_path_refs"), Mapping)
+            else {}
+        )
+        if args or envs or env_path_refs or patches:
+            measurement = bundle.get("measurement") if isinstance(bundle.get("measurement"), Mapping) else {}
             try:
-                best_tput = float(
-                    measurement.get("optimized_throughput")
-                    or donor.get("best_throughput")
-                    or 0.0
-                )
+                best_tput = float(measurement.get("optimized_throughput") or donor.get("best_throughput") or 0.0)
             except (TypeError, ValueError):
                 best_tput = 0.0
             try:
-                expected_gain = float(
-                    measurement.get("gain_pct")
-                    or donor.get("validated_gain_pct")
-                    or 0.0
-                )
+                expected_gain = float(measurement.get("gain_pct") or donor.get("validated_gain_pct") or 0.0)
             except (TypeError, ValueError):
                 expected_gain = 0.0
             if expected_gain <= 0:
@@ -526,6 +531,11 @@ def _build_warm_start_context(
             recommended_replay: dict[str, Any] = {
                 "extra_server_args": args,
                 "extra_envs": envs,
+                "env_path_refs": {
+                    str(key): dict(value)
+                    for key, value in env_path_refs.items()
+                    if isinstance(value, Mapping)
+                },
                 "expected_gain_pct": expected_gain,
                 "best_throughput": best_tput,
                 "config_source": str(donor.get("canonical_id") or ""),
@@ -540,30 +550,34 @@ def _build_warm_start_context(
             breakdown_link = str(donor.get("breakdown_link") or "")
             if donor_session is not None:
                 breakdown_link = str(
-                    donor_session.get("breakdown_link")
-                    or donor_session.get("session_breakdown_url")
-                    or breakdown_link
+                    donor_session.get("breakdown_link") or donor_session.get("session_breakdown_url") or breakdown_link
                 )
             recommended_replay.update(
                 {
                     "donor_canonical_id": donor_canonical_id,
                     "donor_model": donor_model,
                     "donor_session_id": str(bundle.get("producer_session_id") or "")
-                    or (
-                        str(donor_session.get("session_id") or "")
-                        if donor_session is not None
-                        else ""
-                    ),
+                    or (str(donor_session.get("session_id") or "") if donor_session is not None else ""),
                     "donor_family_tags": (
-                        [str(tag) for tag in family_tags]
-                        if isinstance(family_tags, (list, tuple, set))
-                        else []
+                        [str(tag) for tag in family_tags] if isinstance(family_tags, (list, tuple, set)) else []
                     ),
                     "donor_gain_pct": expected_gain,
                     "donor_breakdown_link": breakdown_link,
                 }
             )
             ctx["recommended_replay"] = recommended_replay
+        elif bundle:
+            ctx["replay_unavailable_reason"] = str(bundle.get("reason") or "replay_bundle_not_replayable")
+        elif donor.get("best_config"):
+            ctx["replay_unavailable_reason"] = "legacy_recipe_without_bundle"
+    elif isinstance(recipe, Mapping):
+        raw_bundle = recipe.get(REPLAY_BUNDLE_KEY)
+        if isinstance(raw_bundle, Mapping):
+            checked = validate_replay_bundle(raw_bundle)
+            if not checked.get("replayable"):
+                ctx["replay_unavailable_reason"] = str(checked.get("reason") or "replay_bundle_not_replayable")
+        elif recipe.get("best_config"):
+            ctx["replay_unavailable_reason"] = "legacy_recipe_without_bundle"
     # Extract replayable code patches from prs_tested (positive + negative).
     _extract_patches_from_prs_tested(ctx, recipe, model_architectures)
     # KG enhancement (best-effort, degradable).
@@ -870,9 +884,7 @@ def _extract_patches_from_prs_tested(
         replay = ctx.setdefault("recommended_replay", {})
         replay.setdefault("extra_server_args", "")
         replay.setdefault("extra_envs", {})
-        existing = [
-            item for item in (replay.get("patches") or []) if isinstance(item, dict)
-        ]
+        existing = [item for item in (replay.get("patches") or []) if isinstance(item, dict)]
         replay["patches"] = existing + patches
     if blocked:
         ctx["blocked_patches"] = blocked

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb_t0.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb_t0.py
@@ -13,6 +13,11 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 
 from hyperloom.orchestrator.knowledge.recipe_kb import RecipeKB, recipe_canonical_id
+from hyperloom.orchestrator.knowledge.recipe_kb.replay_bundle import (
+    REPLAY_BUNDLE_KEY,
+    argv_to_env_string,
+    replay_patches,
+)
 from hyperloom.inference_optimizer.recipe_snapshot_constants import detect_framework_version, kb_hardware_slug
 from hyperloom.inference_optimizer.session.session_paths import (
     recipe_kb_lessons_json,
@@ -152,9 +157,17 @@ def _config_replay_args_envs(row: Mapping[str, Any]) -> tuple[str, dict[str, str
     under ``extra_envs`` / ``envs``. Returns empty values when nothing
     replayable is present.
     """
-    best_config = row.get("best_config") if isinstance(row.get("best_config"), Mapping) else {}
-    args = str(best_config.get("extra_server_args") or "").strip()
-    envs = best_config.get("extra_envs") or {}
+    bundle = row.get(REPLAY_BUNDLE_KEY)
+    if not isinstance(bundle, Mapping) or not bundle.get("replayable"):
+        # Legacy config+throughput pairs are not known to describe the same
+        # state. Keep them as priors, never as executable warm replay.
+        return "", {}
+    config = bundle.get("config") if isinstance(bundle.get("config"), Mapping) else {}
+    try:
+        args = argv_to_env_string(config.get("argv") or [])
+    except ValueError:
+        return "", {}
+    envs = config.get("extra_envs") or {}
     if not isinstance(envs, Mapping):
         envs = {}
     return args, {str(k): str(v) for k, v in envs.items()}
@@ -165,11 +178,23 @@ def _has_replayable_config(row: Mapping[str, Any]) -> bool:
     if not isinstance(row, Mapping):
         return False
     args, envs = _config_replay_args_envs(row)
-    return bool(args or envs)
+    bundle = row.get(REPLAY_BUNDLE_KEY)
+    patches = replay_patches(bundle) if isinstance(bundle, Mapping) else []
+    return bool(args or envs or patches)
 
 
 def _max_session_gain(row: Mapping[str, Any]) -> float:
     """Return the MAX ``gain_pct`` across a row's sessions (fallback flat gain_pct)."""
+    bundle = row.get(REPLAY_BUNDLE_KEY)
+    if isinstance(bundle, Mapping):
+        measurement = bundle.get("measurement")
+        if isinstance(measurement, Mapping):
+            try:
+                bundle_gain = float(measurement.get("gain_pct") or 0.0)
+            except (TypeError, ValueError):
+                bundle_gain = 0.0
+            if bundle_gain > 0.0:
+                return bundle_gain
     best = 0.0
     sessions = row.get("sessions")
     if isinstance(sessions, list):
@@ -227,6 +252,11 @@ def _donor_is_trustworthy(
     if not isinstance(donor, Mapping):
         return False
     if not _has_replayable_config(donor):
+        return False
+    bundle = donor.get(REPLAY_BUNDLE_KEY)
+    if isinstance(bundle, Mapping) and bundle.get("source_artifacts"):
+        # Source layers are model/repository specific. They may only be replayed
+        # by the exact identity row, never by a cross-model config donor.
         return False
     # Require evidence of a real positive gain.
     if _max_session_gain(donor) <= 0:
@@ -454,13 +484,29 @@ def _build_warm_start_context(
         config_donor_confidence = config_donor_confidence or confidence
     if donor is not None:
         args, envs = _config_replay_args_envs(donor)
-        if args or envs:
+        bundle = donor.get(REPLAY_BUNDLE_KEY)
+        bundle = bundle if isinstance(bundle, Mapping) else {}
+        patches = replay_patches(bundle)
+        if args or envs or patches:
+            measurement = (
+                bundle.get("measurement")
+                if isinstance(bundle.get("measurement"), Mapping)
+                else {}
+            )
             try:
-                best_tput = float(donor.get("best_throughput") or 0.0)
+                best_tput = float(
+                    measurement.get("optimized_throughput")
+                    or donor.get("best_throughput")
+                    or 0.0
+                )
             except (TypeError, ValueError):
                 best_tput = 0.0
             try:
-                expected_gain = float(donor.get("validated_gain_pct") or 0.0)
+                expected_gain = float(
+                    measurement.get("gain_pct")
+                    or donor.get("validated_gain_pct")
+                    or 0.0
+                )
             except (TypeError, ValueError):
                 expected_gain = 0.0
             if expected_gain <= 0:
@@ -485,6 +531,8 @@ def _build_warm_start_context(
                 "config_source": str(donor.get("canonical_id") or ""),
                 "config_tier": config_donor_tier or "self",
                 "config_confidence": float(config_donor_confidence or confidence),
+                "patches": patches,
+                "bundle_sha256": str(bundle.get("bundle_sha256") or ""),
             }
             donor_canonical_id = str(donor.get("canonical_id") or "")
             donor_model = str(donor.get("model") or "")
@@ -500,7 +548,8 @@ def _build_warm_start_context(
                 {
                     "donor_canonical_id": donor_canonical_id,
                     "donor_model": donor_model,
-                    "donor_session_id": (
+                    "donor_session_id": str(bundle.get("producer_session_id") or "")
+                    or (
                         str(donor_session.get("session_id") or "")
                         if donor_session is not None
                         else ""
@@ -821,7 +870,10 @@ def _extract_patches_from_prs_tested(
         replay = ctx.setdefault("recommended_replay", {})
         replay.setdefault("extra_server_args", "")
         replay.setdefault("extra_envs", {})
-        replay["patches"] = patches
+        existing = [
+            item for item in (replay.get("patches") or []) if isinstance(item, dict)
+        ]
+        replay["patches"] = existing + patches
     if blocked:
         ctx["blocked_patches"] = blocked
 

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -23,7 +23,10 @@ from ..state.optimization_journal import (
     summarize_change,
 )
 from ..actions.executors._accuracy_gate import ENABLEMENT_REVALIDATION_REASON
-from ..knowledge.recipe_kb.replay_bundle import build_replay_bundle
+from ..knowledge.recipe_kb.replay_bundle import (
+    argv_to_env_string,
+    build_replay_bundle,
+)
 from ..state.shared_state import SharedState, resolve_grading_anchor_tput
 from hyperloom.inference_optimizer.protocol.intent import Intent
 from ..bus.message_bus import Message
@@ -678,8 +681,7 @@ class WritebackCollaborator:
                 if launch_log:
                     self.shared_state.enablement.launch_log = launch_log
                 log.warning(
-                    "enablement revalidation task %s failed (error_class=%s); "
-                    "stall_streak=%d rearm=%s",
+                    "enablement revalidation task %s failed (error_class=%s); stall_streak=%d rearm=%s",
                     task.task_id,
                     err_class,
                     self.shared_state.enablement.stall_streak,
@@ -694,9 +696,7 @@ class WritebackCollaborator:
             # baseline_failed budget yet. Multi-node keeps the strict backstop,
             # and so does a session that never admitted the eval lane — nothing
             # would re-run the eval, so holding the budget just stalls the run.
-            eval_pending_suppress = (
-                eval_failed and not is_multi_node() and eval_enablement_allowed(self.shared_state)
-            )
+            eval_pending_suppress = eval_failed and not is_multi_node() and eval_enablement_allowed(self.shared_state)
             if eval_failed:
                 self._persist_eval_failure(result_payload)
             if err_class == "fast_exit_arg_error":
@@ -706,7 +706,11 @@ class WritebackCollaborator:
             else:
                 self.shared_state.baseline_failure_streak += 1
                 self.shared_state.baseline_arg_error_streak = 0
-                if self.shared_state.baseline_failure_streak >= 3 and not enablement_engaged and not eval_pending_suppress:
+                if (
+                    self.shared_state.baseline_failure_streak >= 3
+                    and not enablement_engaged
+                    and not eval_pending_suppress
+                ):
                     self.shared_state.set_stop_reason("baseline_failed")
             # Combined backstop: count ALL baseline failures so mixed
             # error_classes that split the per-class streaks still fast-fail.
@@ -1344,11 +1348,7 @@ class WritebackCollaborator:
             joined with its E2E integrate verdict where available.
         """
         ss = self.shared_state
-        opt_attempts = (
-            getattr(ss, "kernel_opt_task_attempts", {})
-            or getattr(ss, "kernel_opt_attempts", {})
-            or {}
-        )
+        opt_attempts = getattr(ss, "kernel_opt_task_attempts", {}) or getattr(ss, "kernel_opt_attempts", {}) or {}
         integ_attempts = getattr(ss, "kernel_integrate_attempts", {}) or {}
         if not isinstance(opt_attempts, dict):
             return []
@@ -1377,17 +1377,9 @@ class WritebackCollaborator:
                 micro = float(e.get("last_micro_speedup") or 0.0)
             except (TypeError, ValueError):
                 micro = 0.0
-            kid = str(
-                e.get("current_kernel_id")
-                or e.get("kernel_id")
-                or ledger_id
-            )
+            kid = str(e.get("current_kernel_id") or e.get("kernel_id") or ledger_id)
             task_group_key = str(e.get("task_group_key") or "")
-            integ = (
-                integ_by_task.get(task_group_key)
-                if task_group_key
-                else integ_by_kid.get(kid)
-            )
+            integ = integ_by_task.get(task_group_key) if task_group_key else integ_by_kid.get(kid)
             e2e_gain = 0.0
             e2e_tput = 0.0
             e2e_decision = ""
@@ -1503,14 +1495,10 @@ class WritebackCollaborator:
         # the authoritative replay contract: config argv + every source layer.
         env_spec = self.build_env_spec()
         workload_tags = self._coord._collect_workload_tags()
-        optimized_tput = (
-            float(current_best.get("tput", 0.0)) if isinstance(current_best, dict) else 0.0
-        )
+        optimized_tput = float(current_best.get("tput", 0.0)) if isinstance(current_best, dict) else 0.0
         replay_bundle = build_replay_bundle(
             env_spec=env_spec,
-            producer_session_id=str(
-                getattr(ss, "recipe_kb_session_id", "") or self.session_dir.name
-            ),
+            producer_session_id=str(getattr(ss, "recipe_kb_session_id", "") or self.session_dir.name),
             baseline_throughput=float(getattr(ss, "baseline_tput", 0.0) or 0.0),
             optimized_throughput=optimized_tput,
             workload=workload_tags,
@@ -1518,6 +1506,17 @@ class WritebackCollaborator:
         bundle_argv = list((replay_bundle.get("config") or {}).get("argv") or [])
         if bundle_argv:
             best_config["argv"] = bundle_argv
+            best_config["extra_server_args"] = argv_to_env_string(bundle_argv)
+        bundle_envs = (replay_bundle.get("config") or {}).get("extra_envs") or {}
+        if isinstance(bundle_envs, Mapping):
+            best_config["extra_envs"] = {str(key): str(value) for key, value in bundle_envs.items()}
+        bundle_env_refs = (replay_bundle.get("config") or {}).get("env_path_refs") or {}
+        if isinstance(bundle_env_refs, Mapping) and bundle_env_refs:
+            best_config["env_path_refs"] = {
+                str(key): dict(value)
+                for key, value in bundle_env_refs.items()
+                if isinstance(value, Mapping)
+            }
         sediment_on = bool(getattr(ss, "recipe_sediment_enabled", True))
         kept_sources, kept_by_gap, reverted_rows = self._collect_attempt_provenance() if sediment_on else ({}, {}, [])
         what_worked: list[dict[str, Any]] = []
@@ -1922,9 +1921,7 @@ class WritebackCollaborator:
                 "specialist bookkeeping: _refresh_gaps failed for task=%s",
                 task.task_id,
             )
-        if bool((task.params or {}).get("enablement")) and isinstance(
-            done_payload.get("needs_targeted_build"), dict
-        ):
+        if bool((task.params or {}).get("enablement")) and isinstance(done_payload.get("needs_targeted_build"), dict):
             try:
                 await self._maybe_enqueue_specialist_requested_build(
                     task_id=str(task.task_id or ""),
@@ -2144,11 +2141,7 @@ class WritebackCollaborator:
             if not already_stacked:
                 source_phase = str(
                     (bv.get("source_phase") if isinstance(bv, dict) else "")
-                    or (
-                        getattr(self.shared_state, "phase", "")
-                        if task_kind != "integrate_patch"
-                        else ""
-                    )
+                    or (getattr(self.shared_state, "phase", "") if task_kind != "integrate_patch" else "")
                     or ""
                 ).strip()
                 stack_entry: dict[str, Any] = {
@@ -2221,20 +2214,14 @@ class WritebackCollaborator:
                         val = bv.get(_src_key)
                         if val:
                             stack_entry[_src_key] = str(val)
-                    target_files = [
-                        str(path)
-                        for path in (bv.get("target_files") or [])
-                        if str(path).strip()
-                    ]
+                    target_files = [str(path) for path in (bv.get("target_files") or []) if str(path).strip()]
                     if target_files:
                         stack_entry["target_files"] = target_files
                     for _attr_key in ("baseline_enablement", "attribution_eligible"):
                         if _attr_key in bv:
                             stack_entry[_attr_key] = bool(bv.get(_attr_key))
                     if "framework_agent_authoring" in bv:
-                        stack_entry["framework_agent_authoring"] = bool(
-                            bv.get("framework_agent_authoring")
-                        )
+                        stack_entry["framework_agent_authoring"] = bool(bv.get("framework_agent_authoring"))
                     for _origin_key in ("domain", "gap_layer"):
                         if bv.get(_origin_key):
                             stack_entry[_origin_key] = str(bv.get(_origin_key))
@@ -2434,8 +2421,7 @@ class WritebackCollaborator:
                 self.shared_state.baseline_tput = float(tput)
             else:
                 log.info(
-                    "baseline anchor: keeping %.1f; re-baseline measured %.1f "
-                    "(task=%s)",
+                    "baseline anchor: keeping %.1f; re-baseline measured %.1f (task=%s)",
                     prior_anchor,
                     float(tput),
                     promoting_tid,
@@ -2472,7 +2458,10 @@ class WritebackCollaborator:
                                 from ..phases.framework import _ENABLEMENT_MAX_STALL as _max_stall
                             except ImportError:
                                 _max_stall = 5
-                        if self.shared_state.enablement.stall_streak >= _max_stall and not self.shared_state.stop_reason:
+                        if (
+                            self.shared_state.enablement.stall_streak >= _max_stall
+                            and not self.shared_state.stop_reason
+                        ):
                             self.shared_state.set_stop_reason("enablement_stalled")
                         else:
                             self.shared_state.enablement.inflight_task_id = ""
@@ -2538,9 +2527,7 @@ class WritebackCollaborator:
             anchor_tput = float(self.shared_state.baseline_tput or 0.0)
             self.shared_state.current_best = {
                 "action": "baseline",
-                "tput": (
-                    anchor_tput if anchor_tput > 0 else (float(tput) if isinstance(tput, (int, float)) else None)
-                ),
+                "tput": (anchor_tput if anchor_tput > 0 else (float(tput) if isinstance(tput, (int, float)) else None)),
                 "hot_tput": (float(tput) if isinstance(tput, (int, float)) else None),
                 "cold_tput": (
                     float(warmup_anchor) if isinstance(warmup_anchor, (int, float)) and warmup_anchor > 0 else None
@@ -2743,15 +2730,12 @@ class WritebackCollaborator:
                     arm=("baseline" if str(task_params.get("reason") or "") == "prelude_initial" else ""),
                 )
             else:
-                self.shared_state.last_profile_workload = (
-                    self.shared_state.current_profile_workload_context()
-                )
+                self.shared_state.last_profile_workload = self.shared_state.current_profile_workload_context()
                 self.shared_state.last_profile_workload_action = str(
                     (self.shared_state.current_best or {}).get("action") or ""
                 )
             self.shared_state.last_profile_args = str(
-                self.shared_state.last_profile_workload.get("server_args")
-                or profile_args
+                self.shared_state.last_profile_workload.get("server_args") or profile_args
             )
             # New trace invalidates the stale trace_analyze cache.
             self.shared_state.last_trace_analyze = {}
@@ -2767,12 +2751,7 @@ class WritebackCollaborator:
             if isinstance(cb_tput, (int, float)) and cb_tput > 0
             else float(self.shared_state.baseline_tput or 0.0)
         )
-        if (
-            isinstance(tput, (int, float))
-            and tput > 0
-            and cur_best > 0
-            and (tput - cur_best) / cur_best * 100.0 >= 1.0
-        ):
+        if isinstance(tput, (int, float)) and tput > 0 and cur_best > 0 and (tput - cur_best) / cur_best * 100.0 >= 1.0:
             promoted = dict(cb) if isinstance(cb, dict) else {}
             promoted.update(
                 {
@@ -2939,9 +2918,7 @@ class WritebackCollaborator:
                     got_hash = str(best_winner.get("fingerprint") or "")
                 if not got_hash and isinstance(winners, list) and winners and isinstance(winners[0], dict):
                     got_hash = str(winners[0].get("fingerprint") or "")
-                cb_now = (
-                    self.shared_state.current_best if isinstance(self.shared_state.current_best, dict) else {}
-                )
+                cb_now = self.shared_state.current_best if isinstance(self.shared_state.current_best, dict) else {}
                 cb_tput = cb_now.get("tput")
                 decision = _geak_revalidation_decision(
                     measured=measured,
@@ -2966,9 +2943,7 @@ class WritebackCollaborator:
                 # (let it through); otherwise there is no material to validate.
                 if decision == "validated":
                     stack_now = self.shared_state.optimization_stack or []
-                    has_prior_geak_e2e = any(
-                        isinstance(e, dict) and e.get("action") == "geak_e2e" for e in stack_now
-                    )
+                    has_prior_geak_e2e = any(isinstance(e, dict) and e.get("action") == "geak_e2e" for e in stack_now)
                     # Escape hatch first: a pre-existing geak_e2e stack entry is
                     # an already-proven win, so this is a resume revalidation.
                     # It must short-circuit the material check regardless of
@@ -3014,9 +2989,7 @@ class WritebackCollaborator:
                             {
                                 "kind": "geak_no_material",
                                 "measured_tput": float(measured),
-                                "current_best_tput": (
-                                    float(cb_tput) if isinstance(cb_tput, (int, float)) else None
-                                ),
+                                "current_best_tput": (float(cb_tput) if isinstance(cb_tput, (int, float)) else None),
                                 "baseline_tput": float(self.shared_state.baseline_tput or 0.0),
                             },
                         )
@@ -3036,9 +3009,7 @@ class WritebackCollaborator:
                         self.phase_kernel._reject_geak_kernel_journey(
                             ps_stamped,
                             measured_tput=float(measured),
-                            current_best_tput=(
-                                float(cb_tput) if isinstance(cb_tput, (int, float)) else 0.0
-                            ),
+                            current_best_tput=(float(cb_tput) if isinstance(cb_tput, (int, float)) else 0.0),
                             provenance="geak_no_material",
                             rejection_reason="geak_no_material_product",
                         )
@@ -3052,8 +3023,7 @@ class WritebackCollaborator:
                     # do not replay via the GEAK harness (2a); clear the pending
                     # candidate without touching the headline / stack / gain.
                     log.info(
-                        "geak 2b rebench did not beat current_best "
-                        "(measured=%r current_best=%r) -> no_promote",
+                        "geak 2b rebench did not beat current_best (measured=%r current_best=%r) -> no_promote",
                         measured,
                         cb_tput,
                     )
@@ -3064,9 +3034,7 @@ class WritebackCollaborator:
                             {
                                 "kind": "geak_no_promote",
                                 "measured_tput": float(measured),
-                                "current_best_tput": (
-                                    float(cb_tput) if isinstance(cb_tput, (int, float)) else None
-                                ),
+                                "current_best_tput": (float(cb_tput) if isinstance(cb_tput, (int, float)) else None),
                                 "baseline_tput": float(self.shared_state.baseline_tput or 0.0),
                             },
                         )
@@ -3089,9 +3057,7 @@ class WritebackCollaborator:
                         # Routed via ``_coord`` so a test / caller that overrides
                         # ``coordinator._validate_geak_via_geak_harness`` still wins
                         # (bare-name delegation resolves it back onto this class).
-                        fallback_result = await self._coord._validate_geak_via_geak_harness(
-                            reason="2b_inconclusive"
-                        )
+                        fallback_result = await self._coord._validate_geak_via_geak_harness(reason="2b_inconclusive")
                     except Exception as exc:  # noqa: BLE001 - defensive
                         log.exception("geak 2a GEAK-harness fallback failed")
                         fallback_result = {
@@ -3139,9 +3105,7 @@ class WritebackCollaborator:
             else:
                 if measured_ok and self.shared_state.baseline_tput > 0:
                     self._update_cumulative_gain_validated(measured)
-                    cb_rec = (
-                        self.shared_state.current_best if isinstance(self.shared_state.current_best, dict) else {}
-                    )
+                    cb_rec = self.shared_state.current_best if isinstance(self.shared_state.current_best, dict) else {}
                     recorded = cb_rec.get("tput")
                     floor = _DEFAULT_RESUME_DRIFT_FLOOR_PCT
                     if (
@@ -3254,51 +3218,24 @@ class WritebackCollaborator:
         prebaseline_enablement = bool(
             kept_flag
             and float(getattr(self.shared_state, "baseline_tput", 0.0) or 0.0) <= 0.0
-            and (
-                result.get("enablement")
-                or task_params.get("enablement")
-                or task_params.get("enablement_landing")
-            )
+            and (result.get("enablement") or task_params.get("enablement") or task_params.get("enablement_landing"))
         )
         lifted = False
         if kept_flag:
-            specialist_task_id = str(
-                result.get("specialist_task_id")
-                or task_params.get("specialist_task_id")
-                or ""
-            )
+            specialist_task_id = str(result.get("specialist_task_id") or task_params.get("specialist_task_id") or "")
             origin_domain = str(
-                task_params.get("domain")
-                or task_params.get("source_domain")
-                or result.get("domain")
-                or ""
+                task_params.get("domain") or task_params.get("source_domain") or result.get("domain") or ""
             ).strip()
-            origin_provenance = str(
-                task_params.get("provenance")
-                or result.get("provenance")
-                or ""
-            ).strip()
+            origin_provenance = str(task_params.get("provenance") or result.get("provenance") or "").strip()
             if origin_domain and not origin_provenance.startswith("specialist:"):
                 origin_provenance = f"specialist:{origin_domain}"
-            source_phase = str(
-                task_params.get("source_phase")
-                or result.get("source_phase")
-                or ""
-            ).strip()
-            gap_canonical_id = str(
-                task_params.get("gap_canonical_id")
-                or result.get("gap_canonical_id")
-                or ""
-            ).strip()
+            source_phase = str(task_params.get("source_phase") or result.get("source_phase") or "").strip()
+            gap_canonical_id = str(task_params.get("gap_canonical_id") or result.get("gap_canonical_id") or "").strip()
             lift = {
                 "name": specialist_task_id or "integrate_patch_keep",
                 "task_id": getattr(task, "task_id", "") if task is not None else "",
                 "candidate_extra_server_args": str(result.get("extra_server_args_applied") or ""),
-                "extra_envs": dict(
-                    result.get("extra_envs_applied")
-                    or result.get("config_changes_applied")
-                    or {}
-                ),
+                "extra_envs": dict(result.get("extra_envs_applied") or result.get("config_changes_applied") or {}),
                 "tput": float(new_tput),
                 "workspace": result.get("workspace"),
                 "provenance": origin_provenance or "integrate_patch",
@@ -3307,11 +3244,7 @@ class WritebackCollaborator:
                 # and reproducible in the GEAK baseline.
                 "source_snapshot": result.get("source_snapshot") or "",
                 "source_manifest": result.get("source_manifest") or "",
-                "target_files": [
-                    str(path)
-                    for path in (result.get("target_files") or [])
-                    if str(path).strip()
-                ],
+                "target_files": [str(path) for path in (result.get("target_files") or []) if str(path).strip()],
                 "framework_root": result.get("framework_root") or "",
                 "base_sha": result.get("base_sha") or "",
             }
@@ -3764,11 +3697,17 @@ class WritebackCollaborator:
             )
         except Exception:  # noqa: BLE001 — additive; never block env_spec
             server_launch_flags = ""
+        effective_server_args = _merge_cumulative_extra_server_args(
+            server_launch_flags,
+            str(materialized.get("extra_server_args") or ""),
+            "",
+        )
         return {
             "schema_version": 1,
             "config": {
                 "extra_server_args": materialized.get("extra_server_args") or "",
                 "extra_envs": dict(materialized.get("extra_envs") or {}),
+                "effective_server_args": effective_server_args,
                 # Authoritative, COMPLETE engine flags (run-specific stripped);
                 # empty => consumer keeps its own adapter defaults (prior behavior).
                 "server_launch_flags": server_launch_flags,
@@ -3913,20 +3852,14 @@ class WritebackCollaborator:
             sid = str(result.get("specialist_task_id") or "")
             if not sid:
                 return False
-            domain = str(
-                result.get("domain") or result.get("source_domain") or ""
-            ).strip()
+            domain = str(result.get("domain") or result.get("source_domain") or "").strip()
             provenance = str(result.get("provenance") or "").strip()
             if domain and not provenance.startswith("specialist:"):
                 provenance = f"specialist:{domain}"
             bv = {
                 "name": sid,
                 "candidate_extra_server_args": str(result.get("extra_server_args_applied") or ""),
-                "extra_envs": dict(
-                    result.get("extra_envs_applied")
-                    or result.get("config_changes_applied")
-                    or {}
-                ),
+                "extra_envs": dict(result.get("extra_envs_applied") or result.get("config_changes_applied") or {}),
                 "tput": float(tput),
                 "workspace": result.get("workspace"),
                 "provenance": provenance or "integrate_patch",
@@ -3936,11 +3869,7 @@ class WritebackCollaborator:
                 # the GEAK baseline (no path is left snapshot-less).
                 "source_snapshot": result.get("source_snapshot") or "",
                 "source_manifest": result.get("source_manifest") or "",
-                "target_files": [
-                    str(path)
-                    for path in (result.get("target_files") or [])
-                    if str(path).strip()
-                ],
+                "target_files": [str(path) for path in (result.get("target_files") or []) if str(path).strip()],
                 "framework_root": result.get("framework_root") or "",
                 "base_sha": result.get("base_sha") or "",
             }
@@ -4129,9 +4058,7 @@ class WritebackCollaborator:
             try:
                 task = await self.tasks.get(task_id)
                 if getattr(task, "state", "") == "running":
-                    await self.tasks.transition(
-                        task_id, "failed", evidence={"failure_class": "resume_interrupted"}
-                    )
+                    await self.tasks.transition(task_id, "failed", evidence={"failure_class": "resume_interrupted"})
                     summary["failed_row"] = True
             except Exception:  # noqa: BLE001 — reclaim backstop still applies
                 log.debug("resume: targeted-build row fail raced for %s", task_id, exc_info=True)
@@ -4164,13 +4091,9 @@ class WritebackCollaborator:
             if is_terminal:
                 state.enablement.validation_pending = False
                 state.enablement.revalidation_task_id = ""
-                state.enablement.stall_streak = (
-                    int(state.enablement.stall_streak or 0) + 1
-                )
+                state.enablement.stall_streak = int(state.enablement.stall_streak or 0) + 1
                 state.enablement.inflight_task_id = ""
-                report["fixes"].append(
-                    {"kind": "cleared_orphaned_revalidation_pending", "task_id": tracked_tid}
-                )
+                report["fixes"].append({"kind": "cleared_orphaned_revalidation_pending", "task_id": tracked_tid})
                 log.info(
                     "resume: cleared stale enablement_validation_pending for terminal revalidation task %s",
                     tracked_tid,

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -23,6 +23,7 @@ from ..state.optimization_journal import (
     summarize_change,
 )
 from ..actions.executors._accuracy_gate import ENABLEMENT_REVALIDATION_REASON
+from ..knowledge.recipe_kb.replay_bundle import build_replay_bundle
 from ..state.shared_state import SharedState, resolve_grading_anchor_tput
 from hyperloom.inference_optimizer.protocol.intent import Intent
 from ..bus.message_bus import Message
@@ -1497,6 +1498,26 @@ class WritebackCollaborator:
                 ).strip()
                 if stack_args:
                     best_config["extra_server_args"] = stack_args
+        # Bind the champion's throughput to the complete state that produced it.
+        # ``best_config`` remains for legacy readers, while ``replay_bundle`` is
+        # the authoritative replay contract: config argv + every source layer.
+        env_spec = self.build_env_spec()
+        workload_tags = self._coord._collect_workload_tags()
+        optimized_tput = (
+            float(current_best.get("tput", 0.0)) if isinstance(current_best, dict) else 0.0
+        )
+        replay_bundle = build_replay_bundle(
+            env_spec=env_spec,
+            producer_session_id=str(
+                getattr(ss, "recipe_kb_session_id", "") or self.session_dir.name
+            ),
+            baseline_throughput=float(getattr(ss, "baseline_tput", 0.0) or 0.0),
+            optimized_throughput=optimized_tput,
+            workload=workload_tags,
+        )
+        bundle_argv = list((replay_bundle.get("config") or {}).get("argv") or [])
+        if bundle_argv:
+            best_config["argv"] = bundle_argv
         sediment_on = bool(getattr(ss, "recipe_sediment_enabled", True))
         kept_sources, kept_by_gap, reverted_rows = self._collect_attempt_provenance() if sediment_on else ({}, {}, [])
         what_worked: list[dict[str, Any]] = []
@@ -1539,12 +1560,11 @@ class WritebackCollaborator:
         cumulative_total = float(getattr(ss, "cumulative_gain", 0.0) or 0.0)
         validated_stack_len = int(getattr(ss, "cumulative_gain_validated_stack_len", 0) or 0)
         stack_fingerprint = getattr(ss, "stack_fingerprint", "") or ""
-        # Workload-shape tags for shape-filtered warm-start queries (shared via _collect_workload_tags).
-        workload_tags = self._coord._collect_workload_tags()
         # framework_version left unset here (manifest-derived); the T0 backfill writes it.
         return {
             "best_config": best_config,
-            "best_throughput": float(current_best.get("tput", 0.0)) if isinstance(current_best, dict) else 0.0,
+            "best_throughput": optimized_tput,
+            "replay_bundle": replay_bundle,
             "what_worked": what_worked,
             "what_failed": what_failed,
             "kernel_optimizations": kernel_optimizations,
@@ -1675,6 +1695,9 @@ class WritebackCollaborator:
             if has_validated_win and my_tput > live_tput:
                 overrides["best_config"] = attrs["best_config"]
                 overrides["best_throughput"] = my_tput
+                # Champion state is atomic: never advance throughput/config
+                # without the bundle that was actually measured.
+                extras_payload["replay_bundle"] = attrs["replay_bundle"]
             # Merge stack_fingerprint rather than replace (CLOSE only has the sha; T0 stamps version keys).
             merged_fp = dict(existing_row.get("stack_fingerprint") or {})
             for fp_key, fp_val in (attrs.get("stack_fingerprint") or {}).items():

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -303,6 +303,25 @@ class WritebackCollaborator:
             "workspace": result.get("workspace"),
             "ts": datetime.now(timezone.utc).isoformat(),
         }
+        if result.get("source_snapshot"):
+            entry.update(
+                {
+                    "scope": "source_patch",
+                    "source_snapshot": str(result.get("source_snapshot") or ""),
+                    "source_manifest": str(result.get("source_manifest") or ""),
+                    "target_files": [
+                        str(path)
+                        for path in (result.get("target_files") or [])
+                        if str(path).strip()
+                    ],
+                    "framework_root": str(result.get("framework_root") or ""),
+                    "base_sha": str(result.get("base_sha") or ""),
+                }
+            )
+        elif result.get("patch_path") or result.get("target_file"):
+            # Surface an uncaptured source mutation so bundle construction
+            # fails closed instead of silently replaying only its config/env.
+            entry["scope"] = "source_patch"
         stack_kernel_ids = result.get("stack_kernel_ids")
         if isinstance(stack_kernel_ids, list) and stack_kernel_ids:
             entry["stack_kernel_ids"] = [str(kid) for kid in stack_kernel_ids if str(kid)]
@@ -3414,7 +3433,29 @@ class WritebackCollaborator:
                 # if writeback runs after the state machine has advanced.
                 "source_phase": "FRAMEWORK_AGENT",
                 "provenance": "framework_agent",
+                "scope": "source_patch",
             }
+            if result.get("source_snapshot"):
+                lift.update(
+                    {
+                        "scope": "source_patch",
+                        "source_snapshot": str(
+                            result.get("source_snapshot") or ""
+                        ),
+                        "source_manifest": str(
+                            result.get("source_manifest") or ""
+                        ),
+                        "target_files": [
+                            str(path)
+                            for path in (result.get("target_files") or [])
+                            if str(path).strip()
+                        ],
+                        "framework_root": str(
+                            result.get("framework_root") or ""
+                        ),
+                        "base_sha": str(result.get("base_sha") or ""),
+                    }
+                )
             lifted = self._lift_to_current_best("framework", float(new_tput), lift)
             if lifted and self.shared_state.baseline_tput > 0:
                 self._update_cumulative_gain_validated(new_tput)

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -43,6 +43,36 @@ log = _logging.getLogger(__name__)
 _CONTAINER_AITER_CONFIG_DIR = Path("/sgl-workspace/aiter/aiter/configs")
 
 
+def _source_snapshot_stack_fields(snapshot_dir: Any) -> dict[str, Any]:
+    """Project a durable source snapshot into optimization-stack metadata."""
+    directory = Path(str(snapshot_dir or ""))
+    if not directory.is_dir():
+        return {}
+    try:
+        from ..source_snapshot import MANIFEST_NAME
+
+        manifest = json.loads((directory / MANIFEST_NAME).read_text(encoding="utf-8"))
+    except (OSError, TypeError, ValueError):
+        return {}
+    files = [
+        str(item.get("rel") or "")
+        for item in (manifest.get("files") or [])
+        if isinstance(item, dict) and str(item.get("rel") or "").strip()
+    ]
+    root = str(manifest.get("framework_root") or "")
+    base_sha = str(manifest.get("base_sha") or "")
+    if not root or not base_sha or not files:
+        return {}
+    return {
+        "scope": "source_patch",
+        "source_snapshot": str(directory),
+        "source_manifest": str(directory / MANIFEST_NAME),
+        "target_files": files,
+        "framework_root": root,
+        "base_sha": base_sha,
+    }
+
+
 class KernelPhase(PhaseHandler):
     """Extracted phase handler; delegates unknown attrs to its Coordinator."""
 
@@ -2004,6 +2034,9 @@ class KernelPhase(PhaseHandler):
             "source": "kernel_entry_auto",
             "ts": ts,
         }
+        entry.update(
+            _source_snapshot_stack_fields(result.get("source_snapshot"))
+        )
         if tuned_file not in existing:
             self.shared_state.optimization_stack.append(entry)
             self.shared_state.append_stack_gain_entry(
@@ -2267,6 +2300,11 @@ class KernelPhase(PhaseHandler):
                     "source": "kernel_entry_auto",
                     "ts": ts,
                 }
+                entry.update(
+                    _source_snapshot_stack_fields(
+                        result.get("source_snapshot")
+                    )
+                )
                 self.shared_state.optimization_stack.append(entry)
                 self.shared_state.append_stack_gain_entry(
                     action="gemm_tuning",
@@ -2617,6 +2655,31 @@ class KernelPhase(PhaseHandler):
             "best_pattern": fusion_result.get("best_pattern"),
             "ts": ts,
         }
+        if patch:
+            entry["scope"] = "source_patch"
+        if integrate_result.get("source_snapshot"):
+            entry.update(
+                {
+                    "scope": "source_patch",
+                    "source_snapshot": str(
+                        integrate_result.get("source_snapshot") or ""
+                    ),
+                    "source_manifest": str(
+                        integrate_result.get("source_manifest") or ""
+                    ),
+                    "target_files": [
+                        str(path)
+                        for path in (
+                            integrate_result.get("target_files") or []
+                        )
+                        if str(path).strip()
+                    ],
+                    "framework_root": str(
+                        integrate_result.get("framework_root") or ""
+                    ),
+                    "base_sha": str(integrate_result.get("base_sha") or ""),
+                }
+            )
         if patch not in existing:
             self.shared_state.optimization_stack.append(entry)
             self.shared_state.append_stack_gain_entry(

--- a/src/hyperloom/orchestrator/phases/prelude.py
+++ b/src/hyperloom/orchestrator/phases/prelude.py
@@ -12,6 +12,11 @@ from . import machine_state as _phase_state
 from ..state.optimization_journal import (
     JournalEntry,
 )
+from ..knowledge.recipe_kb.replay_bundle import (
+    REPLAY_BUNDLE_KEY,
+    argv_to_env_string,
+    replay_patches,
+)
 from ..state.shared_state import inject_stack_base_params
 from ..state.task_registry import Task
 from ..loop.coordinator import (
@@ -268,6 +273,7 @@ class PreludePhase(PhaseHandler):
         wsc = getattr(state, "warm_start_context", None) or {}
         replay = wsc.get("recommended_replay") if isinstance(wsc, dict) else {}
         replay = replay if isinstance(replay, dict) else {}
+        bundle: dict[str, Any] = {}
         rep_args = str(replay.get("extra_server_args") or "").strip()
         rep_envs = replay.get("extra_envs") if isinstance(replay.get("extra_envs"), dict) else {}
         if rep_args or rep_envs:
@@ -279,17 +285,32 @@ class PreludePhase(PhaseHandler):
             config_tier = str(replay.get("config_tier") or "self")
             donor_expected_gain = float(replay.get("expected_gain_pct") or 0.0)
         else:
-            best_config = recipe_attrs.get("best_config") or {}
-            if not isinstance(best_config, dict):
-                best_config = {}
-            bc_args = str(best_config.get("extra_server_args") or "").strip()
-            bc_envs = best_config.get("extra_envs") or {}
-            if not isinstance(bc_envs, dict):
-                bc_envs = {}
+            raw_bundle = recipe_attrs.get(REPLAY_BUNDLE_KEY)
+            bundle = raw_bundle if isinstance(raw_bundle, dict) else {}
+            bundle_config = (
+                bundle.get("config") if isinstance(bundle.get("config"), dict) else {}
+            )
+            if bundle.get("replayable"):
+                try:
+                    bc_args = argv_to_env_string(bundle_config.get("argv") or [])
+                except ValueError:
+                    bc_args = ""
+                bc_envs = bundle_config.get("extra_envs") or {}
+                if not isinstance(bc_envs, dict):
+                    bc_envs = {}
+            else:
+                # Old recipes do not atomically bind config, source layers and
+                # throughput. They remain useful as history, but are not run.
+                bc_args, bc_envs = "", {}
             replay_conf = float(conf or 0.0)
             config_source = str(recipe.get("canonical_id") or "")
             config_tier = "self"
-            donor_expected_gain = 0.0
+            measurement = (
+                bundle.get("measurement")
+                if isinstance(bundle.get("measurement"), dict)
+                else {}
+            )
+            donor_expected_gain = float(measurement.get("gain_pct") or 0.0)
         donor_metadata = {
             field: replay.get(field)
             for field in (
@@ -317,6 +338,8 @@ class PreludePhase(PhaseHandler):
             return None
         # Extract code patches from warm_start_context (populated by T0).
         wsc_patches = (wsc.get("recommended_replay") or {}).get("patches") or [] if isinstance(wsc, dict) else []
+        if not wsc_patches and bundle:
+            wsc_patches = replay_patches(bundle)
         wsc_blocked = wsc.get("blocked_patches") or [] if isinstance(wsc, dict) else []
         wsc_advisory = wsc.get("advisory_blocked_patches") or [] if isinstance(wsc, dict) else []
         # KG-driven filtering (best-effort; unfiltered on any KG failure).

--- a/src/hyperloom/orchestrator/phases/prelude.py
+++ b/src/hyperloom/orchestrator/phases/prelude.py
@@ -16,6 +16,7 @@ from ..knowledge.recipe_kb.replay_bundle import (
     REPLAY_BUNDLE_KEY,
     argv_to_env_string,
     replay_patches,
+    validate_replay_bundle,
 )
 from ..state.shared_state import inject_stack_base_params
 from ..state.task_registry import Task
@@ -274,11 +275,15 @@ class PreludePhase(PhaseHandler):
         replay = wsc.get("recommended_replay") if isinstance(wsc, dict) else {}
         replay = replay if isinstance(replay, dict) else {}
         bundle: dict[str, Any] = {}
+        env_path_refs: dict[str, Any] = {}
+        replay_unavailable_reason = str(wsc.get("replay_unavailable_reason") or "")
         rep_args = str(replay.get("extra_server_args") or "").strip()
         rep_envs = replay.get("extra_envs") if isinstance(replay.get("extra_envs"), dict) else {}
-        if rep_args or rep_envs:
+        rep_env_path_refs = replay.get("env_path_refs") if isinstance(replay.get("env_path_refs"), dict) else {}
+        if rep_args or rep_envs or rep_env_path_refs:
             bc_args = rep_args
             bc_envs = dict(rep_envs)
+            env_path_refs = dict(rep_env_path_refs)
             # Donor transfer confidence (self-donor == identity confidence).
             replay_conf = float(replay.get("config_confidence") or conf or 0.0)
             config_source = str(replay.get("config_source") or "")
@@ -286,10 +291,12 @@ class PreludePhase(PhaseHandler):
             donor_expected_gain = float(replay.get("expected_gain_pct") or 0.0)
         else:
             raw_bundle = recipe_attrs.get(REPLAY_BUNDLE_KEY)
-            bundle = raw_bundle if isinstance(raw_bundle, dict) else {}
-            bundle_config = (
-                bundle.get("config") if isinstance(bundle.get("config"), dict) else {}
-            )
+            bundle = validate_replay_bundle(raw_bundle) if isinstance(raw_bundle, dict) else {}
+            if not bundle and recipe_attrs.get("best_config"):
+                replay_unavailable_reason = "legacy_recipe_without_bundle"
+            elif bundle and not bundle.get("replayable"):
+                replay_unavailable_reason = str(bundle.get("reason") or "replay_bundle_not_replayable")
+            bundle_config = bundle.get("config") if isinstance(bundle.get("config"), dict) else {}
             if bundle.get("replayable"):
                 try:
                     bc_args = argv_to_env_string(bundle_config.get("argv") or [])
@@ -298,18 +305,20 @@ class PreludePhase(PhaseHandler):
                 bc_envs = bundle_config.get("extra_envs") or {}
                 if not isinstance(bc_envs, dict):
                     bc_envs = {}
+                env_path_refs = (
+                    dict(bundle_config.get("env_path_refs") or {})
+                    if isinstance(bundle_config.get("env_path_refs"), dict)
+                    else {}
+                )
             else:
                 # Old recipes do not atomically bind config, source layers and
                 # throughput. They remain useful as history, but are not run.
                 bc_args, bc_envs = "", {}
+                env_path_refs = {}
             replay_conf = float(conf or 0.0)
             config_source = str(recipe.get("canonical_id") or "")
             config_tier = "self"
-            measurement = (
-                bundle.get("measurement")
-                if isinstance(bundle.get("measurement"), dict)
-                else {}
-            )
+            measurement = bundle.get("measurement") if isinstance(bundle.get("measurement"), dict) else {}
             donor_expected_gain = float(measurement.get("gain_pct") or 0.0)
         donor_metadata = {
             field: replay.get(field)
@@ -344,10 +353,10 @@ class PreludePhase(PhaseHandler):
         wsc_advisory = wsc.get("advisory_blocked_patches") or [] if isinstance(wsc, dict) else []
         # KG-driven filtering (best-effort; unfiltered on any KG failure).
         wsc_patches = self._filter_warm_patches_with_kg(wsc_patches, wsc_advisory, state)
-        if not bc_args and not bc_envs and not wsc_patches:
+        if not bc_args and not bc_envs and not env_path_refs and not wsc_patches:
             state.warm_replay_outcome = {
                 "status": "skipped",
-                "reason": "best_config_empty",
+                "reason": str(replay_unavailable_reason or "best_config_empty"),
                 "warm_recipe_tier": tier,
                 "warm_recipe_conf": conf,
                 **donor_metadata,
@@ -383,6 +392,7 @@ class PreludePhase(PhaseHandler):
             "reason": "warm_replay_prelude",
             "extra_server_args": bc_args,
             "extra_envs": dict(bc_envs),
+            "env_path_refs": dict(env_path_refs),
             # Reuse the baseline's workload contract (else YAML smoke defaults).
             "config_path": str(state.baseline_config_path or ""),
             # Historical-gain anchor for the promote path's reproduce ratio.


### PR DESCRIPTION
## Summary
- persist one flattened replay state: full effective argv, environment, workload metadata, measured throughput, and every retained source patch from kernel integrate, framework-agent, fusion, GEMM, and integrate-patch KEEPs
- enforce atomic champion pairing across local JSON and GBrain stores; stale or missing bundles can no longer advance config/throughput
- validate bundle and artifact integrity for both local and remote reads, externalize large GBrain patches, and materialize captured absolute env paths as portable repo-relative references
- fail closed for unflattened overlays, uncaptured source mutations, unavailable Git bases, sanitized secrets/paths, legacy rows, missing artifacts, partial patch application, and unavailable KernelForge JIT preparation
- apply multi-repo patches with exact base-SHA checks and reverse only those patches after benchmarking, preserving unrelated dirty and untracked checkout state
- normalize replayed server arguments for Magpie's unquoted environment expansion

## Test plan
- [x] Source-patch producer integration suite (`432 passed`)
- [x] Broader affected-area regression suite (`400 passed`)
- [x] Ruff lint and IDE diagnostics
- [x] Live in-cluster GBrain smoke: write Recipe + externalized artifact, read/hydrate, recover config/env, apply patch, and clean isolated test pages
- [x] Full-suite diagnostic (`8989 passed`, `11 skipped`; 18 unrelated environment/existing failures outside changed paths)
- [x] Prior PR CI and GPU E2E passed on the initial commit; checks will rerun for this update