### PR TITLE
fix(kernel): honor graph under-recording in the TraceLens idle gate

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -940,3 +940,63 @@ def test_fully_recorded_idle_graph_still_suppressed_by_idle_gate(tmp_path, capsy
     assert "high_gpu_idle_pct" in codes
     assert "bypass_graph_under_recorded" not in codes
     assert not result["hot_kernels"]
+
+
+def test_finalize_graph_coverage_is_whole_trace_scoped_under_steady_window():
+    """Regression: recorded-launch coverage must be computed over the FULL event
+    stream, not the steady window. A fully-recorded 4-launch trace whose steady
+    window happens to clip to a single replay must NOT read as 1/4 under-recorded
+    (the denominator graph_launch_count is whole-trace, so the numerator must be
+    too). Guards the steady-state bypass path (xDiT / HYPERLOOM_BYPASS_STEADY_STATE)."""
+    # One recorded kernel per graph launch (coverage 1.0 on the full trace),
+    # spread far apart in time so a narrow window contains only the first replay.
+    k_events = [
+        ("graph_k0", 100.0, 5, 1000.0, 1100.0),
+        ("graph_k1", 100.0, 6, 3_000_000.0, 3_000_100.0),
+        ("graph_k2", 100.0, 7, 6_000_000.0, 6_000_100.0),
+        ("graph_k3", 100.0, 8, 9_000_000.0, 9_000_100.0),
+    ]
+    out = bta._reader._finalize(
+        k_events,
+        [],
+        {},
+        {},
+        {},
+        window=(0.0, 2_000_000.0),  # clips to only the corr-5 replay
+        top_k=0,
+        graph_launch_corrs=frozenset({5, 6, 7, 8}),
+        graph_launch_count=4,
+    )
+    cov = out["graph_coverage"]
+    assert cov["graph_launch_count"] == 4
+    # whole-trace scope: all four launches recorded a kernel, not just the one in
+    # the window -> coverage 1.0 -> NOT under-recorded.
+    assert cov["graph_launches_with_kernels"] == 4
+    assert cov["graph_under_recorded"] is False
+
+
+def _graph_launch_stripped_events():
+    """The graph-under-recorded kernels WITHOUT the hipGraphLaunch runtime events
+    -- i.e. what a steady-state chunk can look like after the splitter drops the
+    launch records. Detection must see this as non-graph (so probing the chunk
+    instead of the raw trace would miss the artifact)."""
+    return [
+        {"cat": "kernel", "ph": "X", "name": "graph_fused_attn", "ts": 1100, "dur": 100, "args": {"correlation": 5}},
+        {"cat": "kernel", "ph": "X", "name": "graph_fused_mlp", "ts": 10_000_000, "dur": 100, "args": {"correlation": 5}},
+    ]
+
+
+def test_graph_launch_events_required_for_detection(tmp_path):
+    # Raw trace (with hipGraphLaunch events) -> detected as graph, under-recorded.
+    raw = tmp_path / "raw.trace.json"
+    raw.write_bytes(json.dumps({"traceEvents": _graph_under_recorded_events()}).encode("utf-8"))
+    raw_cov = bta._reader.analyze_trace(str(raw), top_k=0)["graph_coverage"]
+    assert raw_cov["graph_mode"] is True
+    assert raw_cov["graph_under_recorded"] is True
+    # Chunk with the launch runtime events stripped -> looks non-graph, so the
+    # artifact would be missed. This is why the guard must probe the RAW trace.
+    chunk = tmp_path / "chunk.trace.json"
+    chunk.write_bytes(json.dumps({"traceEvents": _graph_launch_stripped_events()}).encode("utf-8"))
+    chunk_cov = bta._reader.analyze_trace(str(chunk), top_k=0)["graph_coverage"]
+    assert chunk_cov["graph_mode"] is False
+    assert chunk_cov["graph_under_recorded"] is False

--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -896,3 +896,47 @@ def test_single_graph_launch_low_busy_not_under_recorded(tmp_path):
     cov = bta._reader.analyze_trace(str(trace), top_k=0)["graph_coverage"]
     assert cov["graph_launch_count"] == 1
     assert cov["graph_under_recorded"] is False
+
+
+def _graph_fully_recorded_idle_events():
+    """Four graph launches that EACH recorded a kernel (coverage 1.0) but spread
+    over a long wall so busy% ~0 / idle% ~100%. This is a genuinely idle graph
+    workload, NOT an under-recorded capture: recorded-launch coverage is full, so
+    the idle gate must still suppress candidates (regression for the P1 review)."""
+    events = []
+    for corr in (5, 6, 7, 8):
+        events.append(
+            {"cat": "cuda_runtime", "name": "hipGraphLaunch", "args": {"correlation": corr, "External id": None}}
+        )
+    for i, corr in enumerate((5, 6, 7, 8)):
+        events.append(
+            {"cat": "kernel", "ph": "X", "name": f"graph_k{i}", "ts": 1000 + i * 3_000_000, "dur": 100, "args": {"correlation": corr}}
+        )
+    return events
+
+
+def test_graph_fully_recorded_low_busy_not_under_recorded(tmp_path):
+    trace = tmp_path / "idle.trace.json"
+    trace.write_bytes(json.dumps({"traceEvents": _graph_fully_recorded_idle_events()}).encode("utf-8"))
+    cov = bta._reader.analyze_trace(str(trace), top_k=0)["graph_coverage"]
+    assert cov["graph_launch_count"] == 4
+    assert cov["graph_launches_with_kernels"] == 4
+    assert cov["busy_fraction"] < 0.5
+    # Full recorded-launch coverage => NOT under-recorded even though busy is low.
+    assert cov["graph_under_recorded"] is False
+
+
+def test_fully_recorded_idle_graph_still_suppressed_by_idle_gate(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("HYPERLOOM_BYPASS_STEADY_STATE", raising=False)
+    monkeypatch.delenv("HYPERLOOM_TRACELENS_IDLE_PCT_THRESHOLD", raising=False)
+    trace = tmp_path / "idle.trace.json"
+    trace.write_bytes(json.dumps({"traceEvents": _graph_fully_recorded_idle_events()}).encode("utf-8"))
+    rc, result, _ = _run(_base_argv(tmp_path, str(trace)), capsys)
+    assert rc == 0
+    assert result["timeline"]["idle_pct"] > 80.0
+    assert result["graph_coverage"]["graph_under_recorded"] is False
+    codes = {w["code"] for w in result["trace_health_warnings"]}
+    # Genuinely idle (fully recorded) graph workload: idle gate MUST still fire.
+    assert "high_gpu_idle_pct" in codes
+    assert "bypass_graph_under_recorded" not in codes
+    assert not result["hot_kernels"]

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -4741,3 +4741,54 @@ def test_deterministic_extract_tolerates_null_efficiency_and_impact(tmp_path):
     # member impact_score is null -> falls back to the finding-level score.
     assert result[0]["impact_score"] == 12.5
     assert result[0]["duration_us"] == 520223.0
+
+
+# --- idle gate must honor cuda/HIP-graph under-recording (regression) ---
+# A graph-mode capture under-records replays (profiler activity-buffer overflow),
+# so idle% is inflated. The bypass route already skips its idle gate in that
+# case; the TraceLens route must do the same instead of suppressing every hot
+# kernel on a workload that is actually compute-bound.
+
+def test_idle_gate_graph_guard_skips_suppression_when_under_recorded(monkeypatch):
+    monkeypatch.setattr(
+        tla,
+        "_graph_coverage_from_raw_trace",
+        lambda _tp: {"graph_under_recorded": True, "graph_launch_count": 8},
+    )
+    threshold, high_idle, graph_warn = tla._evaluate_idle_gate_with_graph_guard(
+        95.0, Path("analysis.md"), "raw.trace.json"
+    )
+    assert threshold == 80.0
+    assert high_idle is None  # NOT suppressed
+    assert graph_warn is not None
+    assert graph_warn["code"] == "bypass_graph_under_recorded"
+    assert graph_warn["graph_launch_count"] == 8
+
+
+def test_idle_gate_graph_guard_applies_gate_when_not_under_recorded(monkeypatch):
+    monkeypatch.setattr(tla, "_graph_coverage_from_raw_trace", lambda _tp: {})
+    threshold, high_idle, graph_warn = tla._evaluate_idle_gate_with_graph_guard(
+        95.0, Path("analysis.md"), "raw.trace.json"
+    )
+    assert threshold == 80.0
+    assert graph_warn is None
+    assert high_idle is not None  # genuinely idle -> suppress
+    assert high_idle["code"] == "high_gpu_idle_pct"
+
+
+def test_idle_gate_graph_guard_noop_below_threshold(monkeypatch):
+    # Below the threshold the guard must not even probe the trace.
+    def _boom(_tp):  # pragma: no cover - must not be called
+        raise AssertionError("graph coverage probed below threshold")
+
+    monkeypatch.setattr(tla, "_graph_coverage_from_raw_trace", _boom)
+    threshold, high_idle, graph_warn = tla._evaluate_idle_gate_with_graph_guard(
+        10.0, Path("analysis.md"), "raw.trace.json"
+    )
+    assert (high_idle, graph_warn) == (None, None)
+
+
+def test_graph_coverage_from_raw_trace_never_raises():
+    # Missing/unreadable trace must degrade to {} (fall back to the plain gate).
+    assert tla._graph_coverage_from_raw_trace(None) == {}
+    assert tla._graph_coverage_from_raw_trace("/no/such/trace.json") == {}

--- a/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
+++ b/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
@@ -62,26 +62,34 @@ def _backfill_shape_signature(meta: dict[str, Any]) -> tuple[tuple[tuple[int, ..
     return (tuple(norm_shapes), norm_dtypes)
 
 
+# A graph trace is judged under-recorded when fewer than this fraction of its
+# graph-launch correlations actually recorded any kernel: activity-buffer
+# overflow drops whole replays, so recorded-launch coverage collapses toward
+# ~1/launch_count, whereas a fully-recorded (merely idle) workload keeps kernels
+# on essentially every launch.
+_GRAPH_RECORDED_LAUNCH_COVERAGE_MAX = 0.5
+
+
 def _graph_under_recorded(
     *,
     graph_mode: bool,
     graph_launch_count: int,
+    graph_launches_with_kernels: int,
     graph_kernels: int,
-    busy_fraction: float,
 ) -> bool:
-    """Return whether a graph-mode trace likely under-recorded replays."""
-    if not graph_mode or graph_launch_count < 2:
+    """Return whether a graph-mode trace likely under-recorded replays.
+
+    Keyed on *recorded-launch coverage* — the share of graph-launch correlations
+    that recorded at least one kernel — NOT on busy%. A low busy fraction alone
+    is ambiguous: a genuinely idle / sparse / host-bound workload whose replays
+    are all fully recorded also looks idle, and must still be gated by the
+    high-idle suppression. Only when the profiler dropped whole replays (coverage
+    far below 1.0) is idle% an unreliable capture artifact.
+    """
+    if not graph_mode or graph_launch_count < 2 or graph_kernels <= 0:
         return False
-    if busy_fraction < 0.5:
-        return True
-    if graph_launch_count >= 4 and graph_kernels > 0 and busy_fraction < 0.9:
-        return True
-    # Few graph-kernel events per launch suggests only ~1 replay was captured.
-    if graph_kernels > 0:
-        events_per_launch = graph_kernels / graph_launch_count
-        if events_per_launch < 2.0 and busy_fraction < 0.9:
-            return True
-    return False
+    coverage = graph_launches_with_kernels / graph_launch_count
+    return coverage < _GRAPH_RECORDED_LAUNCH_COVERAGE_MAX
 
 
 def _file_size(fp: Path) -> int:
@@ -470,6 +478,12 @@ def _finalize(
     graph_corrs = graph_launch_corrs or frozenset()
     graph_kernels = 0
     graph_gpu_us = 0.0
+    # Distinct graph-launch correlations that actually recorded >=1 kernel. Under
+    # activity-buffer overflow the profiler drops whole replays, so most launch
+    # correlations record nothing and this count falls far below
+    # graph_launch_count; a genuinely idle (but fully recorded) graph workload
+    # keeps kernels on every launch, so the two counts stay close.
+    graph_launch_corrs_with_kernels: set[int] = set()
     geom = corr_to_launch_geom or {}
     # Name-keyed shape backfill: accumulate GPU time per (kernel, shape) so the
     # majority capture-time shape wins; multiple distinct shapes mark ambiguous.
@@ -488,6 +502,7 @@ def _finalize(
             op_name = "(graph)"
             graph_kernels += 1
             graph_gpu_us += dur
+            graph_launch_corrs_with_kernels.add(corr)
         else:
             op_name = "(unlinked)"
             unlinked_us += dur
@@ -555,11 +570,12 @@ def _finalize(
     # many launches map to a single recorded replay's worth of kernels.
     graph_mode = graph_launch_count > 0
     busy_fraction = round(busy_ms / total_ms, 4) if total_ms > 0 else 0.0
+    graph_launches_with_kernels = len(graph_launch_corrs_with_kernels)
     graph_under_recorded = _graph_under_recorded(
         graph_mode=graph_mode,
         graph_launch_count=graph_launch_count,
+        graph_launches_with_kernels=graph_launches_with_kernels,
         graph_kernels=graph_kernels,
-        busy_fraction=busy_fraction,
     )
     kern_name_backfill_meta: dict[str, dict[str, Any]] = {}
     kern_name_backfill_ambiguous: set[str] = set()
@@ -662,6 +678,7 @@ def _finalize(
         "graph_coverage": {
             "graph_mode": graph_mode,
             "graph_launch_count": graph_launch_count,
+            "graph_launches_with_kernels": graph_launches_with_kernels,
             "graph_attributed_kernels": graph_kernels,
             "busy_fraction": busy_fraction,
             "graph_under_recorded": graph_under_recorded,

--- a/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
+++ b/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
@@ -416,6 +416,17 @@ def _finalize(
         A dict with ``kernel_launches`` (when ``emit_launches``) / ``timeline`` /
         ``ops`` / ``kernels`` / ``attribution`` / ``graph_coverage``.
     """
+    # Graph capture health is a WHOLE-TRACE property (activity-buffer overflow
+    # drops replays across the run), so the recorded-launch coverage must be
+    # computed over the full event stream -- BEFORE any steady-window filter --
+    # to stay scope-consistent with ``graph_launch_count`` (also whole-trace).
+    # Otherwise a window holding one replay of a fully-recorded N-launch trace
+    # would read as 1/N and be misflagged as under-recorded.
+    _graph_corrs_full = graph_launch_corrs or frozenset()
+    graph_launch_corrs_with_kernels: set[int] = {
+        e[2] for e in k_events if e[2] is not None and e[2] in _graph_corrs_full
+    }
+
     ws = we = None
     if window is not None:
         ws, we = window
@@ -478,12 +489,6 @@ def _finalize(
     graph_corrs = graph_launch_corrs or frozenset()
     graph_kernels = 0
     graph_gpu_us = 0.0
-    # Distinct graph-launch correlations that actually recorded >=1 kernel. Under
-    # activity-buffer overflow the profiler drops whole replays, so most launch
-    # correlations record nothing and this count falls far below
-    # graph_launch_count; a genuinely idle (but fully recorded) graph workload
-    # keeps kernels on every launch, so the two counts stay close.
-    graph_launch_corrs_with_kernels: set[int] = set()
     geom = corr_to_launch_geom or {}
     # Name-keyed shape backfill: accumulate GPU time per (kernel, shape) so the
     # majority capture-time shape wins; multiple distinct shapes mark ambiguous.
@@ -502,7 +507,6 @@ def _finalize(
             op_name = "(graph)"
             graph_kernels += 1
             graph_gpu_us += dur
-            graph_launch_corrs_with_kernels.add(corr)
         else:
             op_name = "(unlinked)"
             unlinked_us += dur

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -64,6 +64,7 @@ from _paths import workspace_root
 # Idle-gate threshold + high-idle warning: shared single source of truth so the
 # TraceLens and bypass routes gate on identical semantics.
 from _idle_gate import (
+    build_graph_under_recorded_warning as _build_graph_under_recorded_warning,
     build_high_idle_warning as _build_high_idle_warning,
     resolve_idle_pct_threshold,
 )
@@ -758,6 +759,64 @@ def _evaluate_high_idle_gate(idle_pct: float | None, report_path: Path) -> tuple
         threshold_pct=threshold,
         report_path=report_path,
     )
+
+
+def _graph_coverage_from_raw_trace(trace_path: str | Path | None) -> dict[str, Any]:
+    """Return the bypass reader's ``graph_coverage`` for the raw trace, or ``{}``.
+
+    Reuses the tested ``_bypass_trace_reader.analyze_trace`` graph-launch
+    detection so the TraceLens route can tell a cuda/HIP-graph under-recorded
+    capture (profiler activity-buffer overflow → only ~1 of N replays recorded →
+    inflated idle%) apart from a genuinely idle/launch-bound workload. Best
+    effort: any failure returns ``{}`` so the caller falls back to the plain
+    idle gate (never worse than today).
+    """
+    if not trace_path:
+        return {}
+    try:
+        import _bypass_trace_reader as _reader
+
+        analyze = _reader.analyze_trace(str(trace_path), top_k=0, emit_launches=True)
+        cov = analyze.get("graph_coverage") if isinstance(analyze, dict) else None
+        return cov if isinstance(cov, dict) else {}
+    except Exception:  # noqa: BLE001 - guard is advisory; never block on it
+        return {}
+
+
+def _evaluate_idle_gate_with_graph_guard(
+    idle_pct: float | None,
+    report_path: Path,
+    trace_path: str | Path | None,
+) -> tuple[float, dict[str, Any] | None, dict[str, Any] | None]:
+    """Idle gate that first honors graph under-recording.
+
+    A cuda/HIP-graph trace that under-records replays reports an unreliable
+    (inflated) idle%, so gating candidates on it wrongly suppresses the whole
+    hot-kernel list on a workload that is actually compute-bound (the exact
+    failure the bypass route already guards against via
+    ``bypass_graph_under_recorded``). When under-recording is detected we skip
+    the high-idle suppression and surface the graph-under-recorded warning
+    instead; otherwise the plain idle gate applies unchanged.
+
+    Returns:
+        ``(threshold, high_idle_warning, graph_under_recorded_warning)`` where at
+        most one of the two warnings is non-``None``.
+    """
+    threshold = resolve_idle_pct_threshold()
+    if idle_pct is None or idle_pct <= threshold:
+        return threshold, None, None
+    cov = _graph_coverage_from_raw_trace(trace_path)
+    if cov.get("graph_under_recorded"):
+        return (
+            threshold,
+            None,
+            _build_graph_under_recorded_warning(
+                graph_launch_count=int(cov.get("graph_launch_count", 0) or 0),
+                idle_pct=float(idle_pct),
+            ),
+        )
+    _, high_idle_warning = _evaluate_high_idle_gate(idle_pct, report_path)
+    return threshold, high_idle_warning, None
 
 
 def _build_trace_split_warning(
@@ -6354,10 +6413,21 @@ def main() -> int:
                 idle_pct_value = _extract_idle_pct_from_gpu_timeline(
                     tracelens_dir,
                 )
-                idle_pct_threshold, high_idle_warning = _evaluate_high_idle_gate(
-                    idle_pct_value,
-                    tracelens_dir / "analysis.md",
+                idle_pct_threshold, high_idle_warning, graph_under_recorded_warning = (
+                    _evaluate_idle_gate_with_graph_guard(
+                        idle_pct_value,
+                        tracelens_dir / "analysis.md",
+                        cli_trace_path,
+                    )
                 )
+                if graph_under_recorded_warning is not None:
+                    trace_health_warnings.append(graph_under_recorded_warning)
+                    append_log(
+                        log_path,
+                        "deterministic: high idle% is a graph under-recording "
+                        "artifact (profiler captured ~1 of N graph replays); "
+                        "skipping the idle gate and keeping hot_kernels[].",
+                    )
                 if high_idle_warning is not None:
                     assert idle_pct_value is not None
                     agent_candidates = []
@@ -6453,10 +6523,21 @@ def main() -> int:
                     idle_pct_value = extract_idle_pct_from_analysis_md(
                         skill_result.report_path,
                     )
-                    idle_pct_threshold, high_idle_warning = _evaluate_high_idle_gate(
-                        idle_pct_value,
-                        skill_result.report_path,
+                    idle_pct_threshold, high_idle_warning, graph_under_recorded_warning = (
+                        _evaluate_idle_gate_with_graph_guard(
+                            idle_pct_value,
+                            skill_result.report_path,
+                            cli_trace_path,
+                        )
                     )
+                    if graph_under_recorded_warning is not None:
+                        trace_health_warnings.append(graph_under_recorded_warning)
+                        append_log(
+                            log_path,
+                            "TraceLens high idle% is a graph under-recording "
+                            "artifact (profiler captured ~1 of N graph replays); "
+                            "skipping the idle gate and keeping hot_kernels[].",
+                        )
                     if high_idle_warning is not None:
                         assert idle_pct_value is not None
                         agent_candidates = []

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -6153,6 +6153,11 @@ def main() -> int:
             # TraceLens's own splitter, since the perf report expects a single
             # steady-state chunk.
             cli_trace_path = trace_files[0]
+            # The un-split source trace: analysis runs on the steady-state chunk
+            # (cli_trace_path is reassigned below), but graph-capture health is a
+            # whole-run property and must be read from the original trace -- the
+            # chunk may drop the graph-launch runtime events the detector needs.
+            raw_trace_path = trace_files[0]
             trace_split_blocked = False
             if not args.skip_split:
                 update_status(
@@ -6422,7 +6427,7 @@ def main() -> int:
                     _evaluate_idle_gate_with_graph_guard(
                         idle_pct_value,
                         tracelens_dir / "analysis.md",
-                        cli_trace_path,
+                        raw_trace_path,
                     )
                 )
                 if graph_under_recorded_warning is not None:
@@ -6532,7 +6537,7 @@ def main() -> int:
                         _evaluate_idle_gate_with_graph_guard(
                             idle_pct_value,
                             skill_result.report_path,
-                            cli_trace_path,
+                            raw_trace_path,
                         )
                     )
                     if graph_under_recorded_warning is not None:

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -770,13 +770,18 @@ def _graph_coverage_from_raw_trace(trace_path: str | Path | None) -> dict[str, A
     inflated idle%) apart from a genuinely idle/launch-bound workload. Best
     effort: any failure returns ``{}`` so the caller falls back to the plain
     idle gate (never worse than today).
+
+    ``graph_coverage`` is derived from the launch/kernel correlation scan and is
+    independent of the returned aggregation lists, so we pass ``emit_launches=
+    False`` and ``top_k=1`` to avoid materializing the per-launch rows and full
+    top-N lists on large ``--skip-split`` raw traces.
     """
     if not trace_path:
         return {}
     try:
         import _bypass_trace_reader as _reader
 
-        analyze = _reader.analyze_trace(str(trace_path), top_k=0, emit_launches=True)
+        analyze = _reader.analyze_trace(str(trace_path), top_k=1, emit_launches=False)
         cov = analyze.get("graph_coverage") if isinstance(analyze, dict) else None
         return cov if isinstance(cov, dict) else {}
     except Exception:  # noqa: BLE001 - guard is advisory; never block on it
@@ -6440,7 +6445,7 @@ def main() -> int:
                         "suppressing hot_kernels[]",
                     )
                 else:
-                    if idle_pct_value is not None:
+                    if idle_pct_value is not None and graph_under_recorded_warning is None:
                         append_log(
                             log_path,
                             f"deterministic: GPU Idle % = "
@@ -6556,7 +6561,7 @@ def main() -> int:
                             "parameter optimization.",
                         )
                     else:
-                        if idle_pct_value is not None:
+                        if idle_pct_value is not None and graph_under_recorded_warning is None:
                             append_log(
                                 log_path,
                                 f"TraceLens Executive Summary: "


### PR DESCRIPTION
## Summary

The high-idle gate suppresses the hot-kernel candidate list (skipping the forge kernel lane entirely) whenever GPU idle % exceeds the threshold (default 80%). The **bypass** trace route already skips that gate when the trace is a cuda/HIP-graph **under-recorded** capture — under continuous graph replay the profiler activity buffer overflows and only ~1 of N replays is recorded, so idle% is inflated (`bypass_graph_under_recorded`). The **TraceLens** route (deterministic + LLM-orchestrator) applied the idle gate with **no such guard**.

Result: a graph-mode workload that is actually compute/GEMM-bound (rocm-smi shows full saturation) gets reported as ~87% idle from the roofline capture, every hot kernel is suppressed, and forge-loop is wrongly skipped as "host/scheduling-bound".

Observed on Qwen3-8B sglang (`.../safe-opt-claw-top-models-forge-qwen-sgla-b0c92b15-a1/.../20260806T082051Z`): `busy_of_wall=0.093` roofline artifact → `report_source=skipped:high_gpu_idle_pct`, while the session's own scouts flagged the 87% idle as a "cuda-graph capture artifact" and the real workload as GEMM-bound.

## Changes

- `tracelens_analysis.py`:
  - `_graph_coverage_from_raw_trace()` — reuse the tested `_bypass_trace_reader.analyze_trace(..., emit_launches=True)` graph-coverage detection; fail-open to `{}`.
  - `_evaluate_idle_gate_with_graph_guard()` — when idle exceeds the threshold, first check graph under-recording; if under-recorded, skip suppression and return the `bypass_graph_under_recorded` warning instead of `high_gpu_idle_pct`.
  - Wire both TraceLens idle-gate sites (deterministic + LLM-orchestrator) through the guard.
- Aligns the TraceLens route with the semantics the bypass route already enforces; no new mechanism.

## Test plan

- New unit tests in `test_tracelens_csv.py`: under-recorded → skip suppression; not-under-recorded → plain gate applies; below-threshold → no probe; bad trace path → never raises.
- `pytest test_tracelens_csv.py test_idle_gate.py test_bypass_trace_analysis.py` — 273 passed, no regressions.