### PR TITLE
fix(kernel): preserve cumulative gain after fusion

### DIFF
--- a/src/hyperloom/inference_optimizer/breakdown/collectors/attribution.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/attribution.py
@@ -49,7 +49,10 @@ def _normalize_specialist_key(provenance: str) -> str:
 # order is load-bearing (e.g. the ``kernel_opt`` prefix must precede the exact
 # ``==`` checks below it). Falls through to ``"other"`` when nothing matches.
 _ACTION_FAMILY_TABLE: tuple[tuple[Callable[[str], bool], str], ...] = (
-    (lambda s: s.startswith("kernel_opt") or s == "integrate", "kernel_agent"),
+    (
+        lambda s: s.startswith("kernel_opt") or s in {"integrate", "fusion"},
+        "kernel_agent",
+    ),
     # Legacy stack-entry action labels from archived sessions.
     (lambda s: s == "backends", "backends"),
     (lambda s: s == "params", "params"),

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_gemm_promote_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_gemm_promote_units.py
@@ -336,10 +336,21 @@ class TestPromoteGemmTuningKeep:
 
 
 class TestPromoteFusionIntegrateKeep:
-    def test_records_patch_envs_and_current_best(self, tmp_path):
+    def test_records_incremental_gain_but_preserves_baseline_total(self, tmp_path):
         coord = _coord(
             tmp_path,
             baseline_tput=100.0,
+            cumulative_gain=20.0,
+            cumulative_gain_validated=20.0,
+            cumulative_gain_validated_stack_len=1,
+            optimization_stack=[
+                {
+                    "action": "replay_warm_recipe",
+                    "tput": 120.0,
+                    "gain_pct": 20.0,
+                }
+            ],
+            gain_per_stack_entry=[20.0],
             current_best={
                 "action": "replay_warm_recipe",
                 "tput": 120.0,
@@ -359,7 +370,9 @@ class TestPromoteFusionIntegrateKeep:
                 "status": "ok",
                 "decision": "KEEP",
                 "new_tput": 180.0,
-                "gain_pct": 80.0,
+                # integrate's gain is relative to current_best=120, not the
+                # original baseline=100.
+                "gain_pct": 50.0,
                 "workspace": "/tmp/run",
                 "extra_server_args": "--moe-runner-backend aiter",
             },
@@ -367,20 +380,22 @@ class TestPromoteFusionIntegrateKeep:
         )
 
         stack = coord.shared_state.optimization_stack
-        assert len(stack) == 1
-        assert stack[0]["action"] == "fusion"
-        assert stack[0]["backend"] == "forge"
-        assert stack[0]["engine"] == "forge_fusion"
-        assert stack[0]["patch_path"] == "/tmp/fusion.patch"
-        assert stack[0]["extra_envs"]["SGLANG_USE_AITER"] == "1"
-        assert stack[0]["extra_envs"]["ZAYA_FUSED_HYBRID_RESIDUAL"] == "1"
-        assert stack[0]["kernel_speedup"] == 3.05
+        assert len(stack) == 2
+        assert stack[1]["action"] == "fusion"
+        assert stack[1]["backend"] == "forge"
+        assert stack[1]["engine"] == "forge_fusion"
+        assert stack[1]["patch_path"] == "/tmp/fusion.patch"
+        assert stack[1]["gain_pct"] == pytest.approx(50.0)
+        assert stack[1]["extra_envs"]["SGLANG_USE_AITER"] == "1"
+        assert stack[1]["extra_envs"]["ZAYA_FUSED_HYBRID_RESIDUAL"] == "1"
+        assert stack[1]["kernel_speedup"] == 3.05
         assert coord.shared_state.current_best["action"] == "fusion"
         assert coord.shared_state.current_best["backend"] == "forge"
         assert coord.shared_state.current_best["engine"] == "forge_fusion"
         assert coord.shared_state.current_best["tput"] == 180.0
         assert coord.shared_state.cumulative_gain_validated == 80.0
-        assert coord.shared_state.cumulative_gain_validated_stack_len == 1
+        assert coord.shared_state.gain_per_stack_entry == [20.0, 80.0]
+        assert coord.shared_state.cumulative_gain_validated_stack_len == 2
 
     def test_guard_paths_do_not_promote(self, tmp_path):
         coord = _coord(tmp_path, baseline_tput=100.0)

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py
@@ -78,6 +78,57 @@ def test_collect_optimizations_unifies_warm_framework_and_explore():
     assert source_breakdown["unattributed_pct_of_total"] == 0.0
 
 
+def test_fusion_after_warm_replay_is_attributed_to_kernel_agent():
+    state = {
+        "session_id": "warm-then-fusion",
+        "baseline_tput": 100.0,
+        "cumulative_gain_validated": 80.0,
+        "cumulative_gain_validated_stack_len": 2,
+        "optimization_stack": [
+            {
+                "action": "replay_warm_recipe",
+                "source_phase": "PRELUDE",
+                "variant_name": "warm",
+                "tput": 120.0,
+                "gain_pct": 20.0,
+                "ts": "1970-01-01T00:00:10+00:00",
+            },
+            {
+                "action": "fusion",
+                "source_phase": "KERNEL_AGENT",
+                "variant_name": "forge_fusion",
+                "backend": "forge",
+                "tput": 180.0,
+                # The stack entry retains integrate's increment relative to
+                # warm=120; the authoritative ledger remains baseline-relative.
+                "gain_pct": 50.0,
+                "ts": "1970-01-01T00:00:20+00:00",
+            },
+        ],
+        "gain_per_stack_entry": [20.0, 80.0],
+        "phase_history": [
+            {"to_phase": "PRELUDE", "ts_unix": 0.0},
+            {"to_phase": "KERNEL_AGENT", "ts_unix": 15.0},
+        ],
+    }
+    warnings: list[str] = []
+
+    attribution = collect_attribution(state, [], [], warnings)
+    result = collect_optimizations(state, attribution, [], [], warnings)
+
+    source_breakdown = attribution["source_breakdown"]
+    assert source_breakdown["replay_warm_recipe_pct_of_total"] == 20.0
+    assert source_breakdown["kernel_unattributed_pct_of_total"] == 60.0
+    assert source_breakdown["unattributed_pct_of_total"] == 0.0
+    assert attribution["phase_breakdown"]["kernel_agent"]["total_gain_pct"] == 60.0
+    assert not any("actions: fusion" in warning for warning in warnings)
+    assert [entry["source"] for entry in result["entries"]] == [
+        "warm_replay",
+        "kernel_agent",
+    ]
+    assert result["entries"][1]["optimization_kind"] == "kernel_fusion"
+
+
 def test_prebaseline_enablement_is_not_framework_gain_before_warm_replay():
     """A runnable-baseline patch is config provenance, not a Framework gain."""
     state = {

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -2583,7 +2583,7 @@ class KernelPhase(PhaseHandler):
             return
         try:
             new_tput = float(integrate_result.get("new_tput") or 0.0)
-            gain = float(integrate_result.get("gain_pct") or 0.0)
+            incremental_gain = float(integrate_result.get("gain_pct") or 0.0)
         except (TypeError, ValueError):
             return
         if new_tput <= 0:
@@ -2607,7 +2607,10 @@ class KernelPhase(PhaseHandler):
             "provenance": "forge_fusion",
             "source": "kernel_entry_auto",
             "tput": new_tput,
-            "gain_pct": gain,
+            # integrate reports the increment against its own base_tput (the
+            # currently active stack). Keep that local meaning on the entry;
+            # the session headline below must use the original baseline.
+            "gain_pct": incremental_gain,
             "workspace": integrate_result.get("workspace"),
             "patch_path": patch,
             "target_file": fusion_result.get("source_file") or integrate_result.get("target_file"),
@@ -2638,10 +2641,18 @@ class KernelPhase(PhaseHandler):
             "extra_envs": envs,
             "extra_server_args": extra_args,
         }
-        self.shared_state.cumulative_gain = gain
-        self.shared_state.cumulative_gain_validated = gain
-        self.shared_state.cumulative_gain_validated_ts = ts
-        self.shared_state.cumulative_gain_validated_stack_len = len(self.shared_state.optimization_stack or [])
+        try:
+            baseline_tput = float(self.shared_state.baseline_tput or 0.0)
+        except (TypeError, ValueError):
+            baseline_tput = 0.0
+        if baseline_tput > 0:
+            total_gain = (new_tput - baseline_tput) / baseline_tput * 100.0
+            self.shared_state.cumulative_gain = total_gain
+            self.shared_state.cumulative_gain_validated = total_gain
+            self.shared_state.cumulative_gain_validated_ts = ts
+            self.shared_state.cumulative_gain_validated_stack_len = len(
+                self.shared_state.optimization_stack or []
+            )
 
     def _current_tput_from_validated_gain(self) -> float:
         """Project current tput from ``baseline_tput * (1 + cumulative_gain_validated/100)``; 0.0 when baseline unknown (watermark not-yet-armed).


### PR DESCRIPTION
## Summary
- keep fusion's stack-entry gain relative to the active stack while recomputing the validated session headline against the original baseline
- classify fusion attribution as `kernel_agent` so its validated delta no longer falls into `other/unattributed`
- cover warm-replay-to-fusion multi-step gain semantics and reporting

## Test plan
- [x] `uv run pytest -q src/hyperloom/inference_optimizer/tests/test_coordinator_gemm_promote_units.py -k fusion` (9 passed)
- [x] `uv run pytest -q src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py` (17 passed)
- [x] compile all modified Python modules with `py_compile`