### PR TITLE
Fix warm replay JSON argument quoting

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_helpers_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_helpers_unit.py
@@ -196,6 +196,15 @@ def test_dedupe_leaves_json_arg_untouched():
     assert ch._dedupe_extra_server_args(args) == args
 
 
+def test_dedupe_leaves_warm_replay_json_flags_untouched():
+    args = (
+        """--speculative-config '{"method":"ngram","num_speculative_tokens":7}' """
+        """--compilation-config '{"pass_config":{"enable_sp":true}}' """
+        "--max-num-seqs 512 --max-num-seqs 1024"
+    )
+    assert ch._dedupe_extra_server_args(args) == args
+
+
 # ---- _merge_cumulative_extra_server_args ----
 
 _merge = ch._merge_cumulative_extra_server_args

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_helpers_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_helpers_unit.py
@@ -188,21 +188,29 @@ def test_dedupe_normalizes_equals_form():
     assert out == "--attention-backend ROCM_AITER_FA"
 
 
-def test_dedupe_leaves_json_arg_untouched():
+def test_dedupe_preserves_json_and_collapses_other_flags():
     args = (
         '--json-model-override-args {"rope_scaling":null} '
         "--attention-backend ROCM_ATTN --attention-backend ROCM_AITER_FA"
     )
-    assert ch._dedupe_extra_server_args(args) == args
+    assert ch._dedupe_extra_server_args(args) == (
+        '--json-model-override-args {"rope_scaling":null} '
+        "--attention-backend ROCM_AITER_FA"
+    )
 
 
-def test_dedupe_leaves_warm_replay_json_flags_untouched():
+def test_dedupe_warm_replay_json_flags_without_skipping_other_dedup():
     args = (
         """--speculative-config '{"method":"ngram","num_speculative_tokens":7}' """
         """--compilation-config '{"pass_config":{"enable_sp":true}}' """
         "--max-num-seqs 512 --max-num-seqs 1024"
     )
-    assert ch._dedupe_extra_server_args(args) == args
+    out = ch._dedupe_extra_server_args(args)
+    assert out == (
+        '--speculative-config {"method":"ngram","num_speculative_tokens":7} '
+        '--compilation-config {"pass_config":{"enable_sp":true}} '
+        "--max-num-seqs 1024"
+    )
 
 
 # ---- _merge_cumulative_extra_server_args ----
@@ -237,12 +245,15 @@ def test_merge_dedupes_attention_backend_equals_space_mix():
     assert out == "--attention-backend ROCM_AITER_FA"
 
 
-def test_merge_leaves_json_arg_untouched():
+def test_merge_preserves_json_while_deduping_other_flags():
     args = (
         '--json-model-override-args {"rope_scaling":null} '
         "--attention-backend ROCM_ATTN --attention-backend ROCM_AITER_FA"
     )
-    assert _merge("", args, "") == args
+    assert _merge("", args, "") == (
+        '--json-model-override-args {"rope_scaling":null} '
+        "--attention-backend ROCM_AITER_FA"
+    )
 
 
 # ---- serialize_verdict_advisory ----

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_selection_audit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_selection_audit.py
@@ -73,7 +73,7 @@ def test_config_levers_preserve_envs_and_args() -> None:
         }
     )
     assert levers == {
-        "extra_server_args": extra_args,
+        "extra_server_args": '--enable-x --compilation-config {"mode":"max-autotune"} --bare',
         "extra_envs": {"VLLM_FOO": "1"},
     }
 
@@ -81,8 +81,25 @@ def test_config_levers_preserve_envs_and_args() -> None:
 def test_config_levers_args_as_list() -> None:
     f = coord_mod._framework_config_levers_from_done
     levers = f({"proposal_set": [{"extra_args": ["--flag", "value with space"]}]})
+    assert levers == {}
+
+
+def test_config_levers_json_args_as_list_stay_unquoted() -> None:
+    f = coord_mod._framework_config_levers_from_done
+    levers = f(
+        {
+            "proposal_set": [
+                {
+                    "extra_args": [
+                        "--json-model-override-args",
+                        '{"rope_scaling":null}',
+                    ],
+                }
+            ]
+        }
+    )
     assert levers == {
-        "extra_server_args": "--flag 'value with space'",
+        "extra_server_args": '--json-model-override-args {"rope_scaling":null}',
         "extra_envs": {},
     }
 

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_selection_audit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_selection_audit.py
@@ -84,6 +84,24 @@ def test_config_levers_args_as_list() -> None:
     assert levers == {}
 
 
+def test_invalid_config_args_preserve_independent_env_overrides() -> None:
+    f = coord_mod._framework_config_levers_from_done
+    levers = f(
+        {
+            "proposal_set": [
+                {
+                    "extra_args": ["--flag", "value with space"],
+                    "extra_envs": {"SAFE_ENV": "1"},
+                }
+            ]
+        }
+    )
+    assert levers == {
+        "extra_server_args": "",
+        "extra_envs": {"SAFE_ENV": "1"},
+    }
+
+
 def test_config_levers_json_args_as_list_stay_unquoted() -> None:
     f = coord_mod._framework_config_levers_from_done
     levers = f(

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_selection_audit_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_selection_audit_coverage_unit.py
@@ -73,7 +73,7 @@ def test_config_levers_preserve_envs_and_args() -> None:
         }
     )
     assert levers == {
-        "extra_server_args": extra_args,
+        "extra_server_args": '--enable-x --compilation-config {"mode":"max-autotune"} --bare',
         "extra_envs": {"VLLM_FOO": "1"},
     }
 
@@ -81,8 +81,25 @@ def test_config_levers_preserve_envs_and_args() -> None:
 def test_config_levers_args_as_list() -> None:
     f = coord_mod._framework_config_levers_from_done
     levers = f({"proposal_set": [{"extra_args": ["--flag", "value with space"]}]})
+    assert levers == {}
+
+
+def test_config_levers_json_args_as_list_stay_unquoted() -> None:
+    f = coord_mod._framework_config_levers_from_done
+    levers = f(
+        {
+            "proposal_set": [
+                {
+                    "extra_args": [
+                        "--json-model-override-args",
+                        '{"rope_scaling":null}',
+                    ],
+                }
+            ]
+        }
+    )
     assert levers == {
-        "extra_server_args": "--flag 'value with space'",
+        "extra_server_args": '--json-model-override-args {"rope_scaling":null}',
         "extra_envs": {},
     }
 

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_selection_audit_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_selection_audit_coverage_unit.py
@@ -84,6 +84,24 @@ def test_config_levers_args_as_list() -> None:
     assert levers == {}
 
 
+def test_invalid_config_args_preserve_independent_env_overrides() -> None:
+    f = coord_mod._framework_config_levers_from_done
+    levers = f(
+        {
+            "proposal_set": [
+                {
+                    "extra_args": ["--flag", "value with space"],
+                    "extra_envs": {"SAFE_ENV": "1"},
+                }
+            ]
+        }
+    )
+    assert levers == {
+        "extra_server_args": "",
+        "extra_envs": {"SAFE_ENV": "1"},
+    }
+
+
 def test_config_levers_json_args_as_list_stay_unquoted() -> None:
     f = coord_mod._framework_config_levers_from_done
     levers = f(

--- a/src/hyperloom/inference_optimizer/tests/test_gbrain_ingest_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_gbrain_ingest_unit.py
@@ -115,3 +115,26 @@ def test_recipe_json_strips_secrets_and_internal_paths_but_keeps_safe_replay_fie
         "/tmp/session/",
     ):
         assert secret_or_path not in content
+
+
+def test_sanitize_server_args_preserves_json_without_shell_wrappers() -> None:
+    raw = (
+        "--speculative-config "
+        """'{"method":"ngram","num_speculative_tokens":16}' """
+        "--compilation-config "
+        """'{"pass_config":{"enable_sp":true}}'"""
+    )
+
+    sanitized = gi._sanitize_server_args(raw, drop_paths=False)
+    tokens = sanitized.split()
+
+    assert tokens == [
+        "--speculative-config",
+        '{"method":"ngram","num_speculative_tokens":16}',
+        "--compilation-config",
+        '{"pass_config":{"enable_sp":true}}',
+    ]
+    json.loads(tokens[1])
+    json.loads(tokens[3])
+    assert "'{" not in sanitized
+    assert "}'" not in sanitized

--- a/src/hyperloom/inference_optimizer/tests/test_gbrain_ingest_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_gbrain_ingest_unit.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 
+import pytest
 import yaml
 
 from hyperloom.orchestrator.knowledge.recipe_kb import gbrain_ingest as gi
@@ -138,3 +139,19 @@ def test_sanitize_server_args_preserves_json_without_shell_wrappers() -> None:
     json.loads(tokens[3])
     assert "'{" not in sanitized
     assert "}'" not in sanitized
+
+
+def test_sanitize_server_args_rejects_whitespace_bearing_token() -> None:
+    with pytest.raises(ValueError, match="whitespace-bearing"):
+        gi._sanitize_server_args(
+            '--tool-call-parser "my parser"',
+            drop_paths=False,
+        )
+
+
+def test_sanitize_server_args_rejects_unbalanced_shell_input() -> None:
+    with pytest.raises(ValueError, match="not shell-tokenizable"):
+        gi._sanitize_server_args(
+            "--speculative-config 'unterminated",
+            drop_paths=False,
+        )

--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner.py
@@ -1127,9 +1127,8 @@ class TestDedupVllmServerArgs:
         # STRIPPED the inner double quotes of a compact --compilation-config
         # JSON value (``{"cudagraph_mode":"PIECEWISE"}`` -> ``{cudagraph_mode:
         # PIECEWISE}``) and crashed every explore/kernel/integrate variant
-        # server with ``Invalid JSON``. Listing --compilation-config (and the
-        # other JSON-object flags) in _SPACE_VALUE_FLAGS makes dedup leave the
-        # whole string untouched so the JSON round-trips.
+        # server with ``Invalid JSON``. JSON-aware tokenization must preserve
+        # that value while still collapsing unrelated duplicate flags.
         raw = (
             '--compilation-config {"cudagraph_mode":"PIECEWISE"} '
             "--block-size 128 --block-size 128 --gpu-memory-utilization 0.95"
@@ -1137,11 +1136,13 @@ class TestDedupVllmServerArgs:
         out = _grid_runner.dedup_vllm_server_args(raw, "vllm")
         assert '{"cudagraph_mode":"PIECEWISE"}' in out
         assert "{cudagraph_mode:PIECEWISE}" not in out
+        assert out.count("--block-size") == 1
 
     def test_speculative_config_quotes_survive_dedup(self):
         raw = '--speculative-config {"method":"eagle"} --max-num-seqs 256 --max-num-seqs 256'
         out = _grid_runner.dedup_vllm_server_args(raw, "vllm")
         assert '{"method":"eagle"}' in out
+        assert out.count("--max-num-seqs") == 1
 
     def test_equals_form_is_deduped(self):
         out = _grid_runner.dedup_vllm_server_args(
@@ -1202,10 +1203,13 @@ class TestDedupVllmServerArgs:
         )
         assert out == "--attention-backend C"
 
-    def test_json_space_value_flag_left_untouched(self):
-        # A flag carrying a JSON/space value must not be tokenized and re-joined;
-        # leave the whole string verbatim even with a duplicate flag present.
+    def test_json_flag_does_not_disable_other_flag_dedup(self):
         raw = "--attention-backend A --attention-backend B --override-generation-config '{\"temperature\": 0.7}'"
+        out = _grid_runner.dedup_vllm_server_args(raw, "vllm")
+        assert out == '--attention-backend B --override-generation-config {"temperature":0.7}'
+
+    def test_json_string_with_internal_space_fails_closed(self):
+        raw = '--attention-backend A --attention-backend B --speculative-config \'{"model":"draft model"}\''
         assert _grid_runner.dedup_vllm_server_args(raw, "vllm") == raw
 
     def test_multi_value_flag_left_untouched(self):
@@ -1401,9 +1405,17 @@ class TestCompactJsonServerArgs:
         out = _grid_runner.compact_json_server_args('--kv-cache-dtype fp8 --compilation-config {"level": 3}', "vllm")
         assert out == '--kv-cache-dtype fp8 --compilation-config {"level":3}'
 
-    def test_sglang_is_noop(self):
+    def test_sglang_json_is_normalized_for_unquoted_transport(self):
         raw = '--speculative-config {"method": "eagle"}'
-        assert _grid_runner.compact_json_server_args(raw, "sglang") == raw
+        assert _grid_runner.compact_json_server_args(raw, "sglang") == (
+            '--speculative-config {"method":"eagle"}'
+        )
+
+    def test_sglang_and_missing_framework_remove_legacy_shell_wrappers(self):
+        raw = """--json-model-override-args '{"rope_scaling":null}'"""
+        expected = '--json-model-override-args {"rope_scaling":null}'
+        assert _grid_runner.compact_json_server_args(raw, "sglang") == expected
+        assert _grid_runner.compact_json_server_args(raw, None) == expected
 
     def test_no_json_is_noop(self):
         raw = "--block-size 128 --no-enable-prefix-caching"
@@ -1411,6 +1423,10 @@ class TestCompactJsonServerArgs:
 
     def test_malformed_json_left_verbatim(self):
         raw = "--compilation-config {not json}"
+        assert _grid_runner.compact_json_server_args(raw, "vllm") == raw
+
+    def test_malformed_wrapped_json_keeps_both_shell_wrappers(self):
+        raw = "--compilation-config '{not json}'"
         assert _grid_runner.compact_json_server_args(raw, "vllm") == raw
 
     def test_empty_is_noop(self):

--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner.py
@@ -1379,6 +1379,17 @@ class TestCompactJsonServerArgs:
             "nested": {"a": 1},
         }
 
+    def test_shell_single_quote_wrappers_are_removed(self):
+        out = _grid_runner.compact_json_server_args(
+            """--speculative-config '{"method":"ngram","num_speculative_tokens":7}' """,
+            "vllm",
+        )
+        assert out.strip() == (
+            "--speculative-config "
+            '{"method":"ngram","num_speculative_tokens":7}'
+        )
+        json.loads(out.split(" ", 1)[1].strip())
+
     def test_unrepairable_json_left_verbatim(self):
         # Genuinely broken blobs that cannot be repaired to valid JSON are left
         # verbatim (no worse than before), never raising.

--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner.py
@@ -1212,6 +1212,10 @@ class TestDedupVllmServerArgs:
         raw = '--attention-backend A --attention-backend B --speculative-config \'{"model":"draft model"}\''
         assert _grid_runner.dedup_vllm_server_args(raw, "vllm") == raw
 
+    def test_quoted_non_json_operand_fragments_fail_closed(self):
+        raw = '--tool-call-parser "my parser" --max-num-seqs 512 --max-num-seqs 1024'
+        assert _grid_runner.dedup_vllm_server_args(raw, "vllm") == raw
+
     def test_multi_value_flag_left_untouched(self):
         # cuda-graph-bs takes a list; never collapse a string that carries one.
         raw = "--attention-backend A --cuda-graph-bs 1 2 4 8 --attention-backend B"

--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner_helpers_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner_helpers_coverage_unit.py
@@ -364,13 +364,14 @@ def test_build_variant_yaml_drops_unsafe_overlay(tmp_path: Path) -> None:
         assert "PYTHONPATH" not in envs or bad not in envs.get("PYTHONPATH", ""), bad
 
 
-def test_shell_safe_dedupe_leaves_json_arg_untouched() -> None:
-    """When a space/JSON-valued flag is present, dedupe must leave the whole
-    string untouched (the unquoted $EXTRA_*_ARGS expansion downstream cannot
-    round-trip a quoted value anyway, so mangling it is worse than skipping)."""
+def test_shell_safe_dedupe_preserves_json_and_dedupes_other_flags() -> None:
+    """JSON stays an opaque argv token while unrelated flags dedupe last-wins."""
     args = '--json-model-override-args {"rope_scaling":null} --context-length 8192 --context-length 4096'
     out = gr._shell_safe_dedupe(args)
-    assert out == args, f"JSON-bearing string must be left as-is: {out}"
+    assert out == '--json-model-override-args {"rope_scaling":null} --context-length 4096'
+    assert json.loads(out.split("--json-model-override-args ", 1)[1].split(" ", 1)[0]) == {
+        "rope_scaling": None
+    }
 
 
 def test_shell_safe_dedupe_leaves_multi_value_arg_untouched() -> None:

--- a/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
@@ -270,38 +270,38 @@ def compact_json_server_args(
     server_args: str | None,
     framework: str | None,
 ) -> str:
-    """Strip separator spaces inside JSON-valued vLLM/atom server args.
+    """Normalize JSON-valued server args for unquoted Magpie expansion.
 
-    Magpie's scripts expand ``vllm serve ... $EXTRA_VLLM_ARGS`` UNQUOTED, so any
-    token with an embedded space is word-split by the shell before vLLM sees it.
-    Re-serialising each JSON object/array with compact separators removes the
-    SEPARATOR spaces only — ``json.dumps`` preserves spaces *inside* string
-    values.
+    Magpie's scripts expand ``$EXTRA_*_ARGS`` UNQUOTED, so shell quote wrappers
+    stored by a prior ``shlex.join`` become literal argv bytes and separator
+    spaces inside JSON values are word-split. Re-serialising each valid JSON
+    object/array removes both hazards for every framework, including sglang
+    (the default when ``framework`` is missing).
 
     JSON string values that themselves contain spaces cannot survive unquoted
-    expansion and are left intact rather than corrupted; callers must avoid
-    them for vLLM/atom.
+    expansion and are left intact rather than corrupted; callers must reject
+    those values before launch.
 
-    No-op for sglang, for empty strings, and for strings with no ``{``/``[``.
-    Any blob that does not parse as JSON is left verbatim.
+    Empty strings and strings with no ``{``/``[`` are returned unchanged. Any
+    blob that does not parse (and cannot be safely repaired) retains its complete
+    original substring, including balanced shell wrappers.
     """
     args = str(server_args or "").strip()
     if not args or ("{" not in args and "[" not in args):
-        return args
-    if server_args_env_name(framework) == "EXTRA_SGLANG_ARGS":
         return args
     return _reserialize_json_blobs(args)
 
 
 def _reserialize_json_blobs(args: str) -> str:
-    """Compact (and, when needed, repair) every JSON object/array in ``args``.
+    """Normalize every JSON object/array while preserving invalid substrings.
 
-    Framework-agnostic core shared by :func:`compact_json_server_args` and
-    :func:`remove_server_args`. Each balanced ``{...}``/``[...]`` blob is
-    re-serialised with compact separators; a blob whose inner double quotes were
-    stripped by an earlier shlex round-trip is repaired via
-    :func:`_repair_unquoted_json`, and anything that still does not parse is left
-    verbatim (never worse than the input).
+    Framework-agnostic core shared by :func:`compact_json_server_args`,
+    :func:`remove_server_args`, and the GBrain recipe sanitizer. Each balanced
+    ``{...}``/``[...]`` blob is re-serialised with compact separators; a blob
+    whose inner double quotes were stripped by an earlier shlex round-trip is
+    repaired via :func:`_repair_unquoted_json`. Directly-adjacent shell single
+    quotes are removed only when parsing or repair succeeds. Otherwise the full
+    original substring is retained byte-for-byte.
     """
     if "{" not in args and "[" not in args:
         return args
@@ -350,29 +350,38 @@ def _reserialize_json_blobs(args: str) -> str:
                 and j < n
                 and args[j] == "'"
             )
-            if single_quote_wrapped:
-                out.pop()
             blob = args[i:j]
+            rendered: str | None = None
             try:
-                out.append(json.dumps(json.loads(blob), separators=(",", ":")))
+                rendered = json.dumps(json.loads(blob), separators=(",", ":"))
             except Exception:
                 # A prior shlex round-trip can strip the JSON double quotes,
                 # leaving an unquoted-bareword object (``{"m":"ngram"}`` ->
                 # ``{m:ngram}``) that vLLM's json.loads rejects at boot. Try to
-                # re-quote bare keys/values; fall back to verbatim if that still
-                # does not parse (never worse than before).
-                repaired = _repair_unquoted_json(blob)
-                out.append(repaired if repaired is not None else blob)
-            i = j + 1 if single_quote_wrapped else j
+                # re-quote bare keys/values.
+                rendered = _repair_unquoted_json(blob)
+            if rendered is None:
+                # Keep both wrappers when the content is not valid/repairable.
+                # The opening quote is already in ``out``; leave the closing
+                # quote for the next loop iteration.
+                out.append(blob)
+                i = j
+            else:
+                if single_quote_wrapped:
+                    out.pop()
+                out.append(rendered)
+                i = j + 1 if single_quote_wrapped else j
         else:
             out.append(ch)
             i += 1
     return "".join(out)
 
 
-# Flags whose value can contain spaces / JSON; never tokenize-dedupe these.
-# If any is present, the dedup helpers leave the whole arg string untouched.
-_SPACE_VALUE_FLAGS = (
+# Flags whose values may be JSON or otherwise space-bearing. Kept public so the
+# coordinator and launch paths share one catalogue; JSON presence must NOT make
+# dedup abandon the entire arg string. Actual whitespace-bearing argv tokens are
+# detected by :func:`tokenize_server_args_preserving_json` and fail closed.
+SPACE_VALUE_FLAGS = (
     "--json-model-override-args",
     "--override-generation-config",
     "--tool-call-parser",
@@ -389,6 +398,8 @@ _SPACE_VALUE_FLAGS = (
     "--hf-overrides",
     "--kv-transfer-config",
 )
+# Compatibility export used by ``_grid_runner`` and out-of-tree tests.
+_SPACE_VALUE_FLAGS = SPACE_VALUE_FLAGS
 
 _MULTI_VALUE_FLAGS = (
     "--cuda-graph-bs",
@@ -416,6 +427,61 @@ _VLLM_SINGLE_VALUE_FLAGS = frozenset(
 )
 
 
+def tokenize_server_args_preserving_json(
+    server_args: str | None,
+) -> tuple[str, list[str]] | None:
+    """Tokenize server args without stripping JSON's inner double quotes.
+
+    Valid JSON blobs are normalized first, then ``shlex``'s non-POSIX mode keeps
+    their quote bytes intact. The unquoted ``EXTRA_*_ARGS`` transport cannot
+    represent an argv token containing whitespace; those inputs (including JSON
+    strings with spaces and quoted non-JSON values) return ``None`` so callers
+    can fail closed rather than silently changing token boundaries.
+
+    Returns:
+        ``(normalized_text, tokens)`` when every token is transport-safe;
+        otherwise ``None``.
+    """
+    normalized = _reserialize_json_blobs(str(server_args or "").strip())
+    if not normalized:
+        return "", []
+    try:
+        tokens = shlex.split(normalized, posix=False)
+    except ValueError:
+        return None
+    for token in tokens:
+        # A balanced JSON value must remain one token. Non-zero depth at a token
+        # boundary means an embedded whitespace split it.
+        depth = 0
+        in_string = False
+        escaped = False
+        for char in token:
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+            elif char == '"':
+                in_string = True
+            elif char in "{[":
+                depth += 1
+            elif char in "}]":
+                depth -= 1
+        if depth != 0:
+            return None
+        if any(ch.isspace() for ch in token):
+            return None
+        if (
+            len(token) >= 2
+            and token[0] == token[-1]
+            and token[0] in {"'", '"'}
+        ):
+            return None
+    return normalized, tokens
+
+
 def dedup_vllm_server_args(
     server_args: str | None,
     framework: str | None,
@@ -428,10 +494,10 @@ def dedup_vllm_server_args(
     token is preserved verbatim and in order. For each affected flag the LAST
     occurrence wins, matching the override intent of :func:`merge_server_args`.
 
-    Returns ``server_args`` unchanged when the framework is sglang, the string
-    is empty, it carries a space/JSON-valued flag (see
-    :data:`_SPACE_VALUE_FLAGS` / :data:`_MULTI_VALUE_FLAGS`), or it cannot be
-    shell-parsed.
+    JSON values are treated as opaque, quote-preserving tokens while unrelated
+    duplicated flags are still collapsed. Returns ``server_args`` unchanged
+    when the framework is sglang, the string is empty, carries a multi-value
+    flag, or cannot be represented by Magpie's unquoted argv transport.
 
     Args:
         server_args (str | None): The server-arg string to dedupe.
@@ -447,13 +513,12 @@ def dedup_vllm_server_args(
         return args
     if server_args_env_name(framework) == "EXTRA_SGLANG_ARGS":
         return args
-    # Never tokenize a string carrying a space/JSON-valued (or multi-value) flag.
-    if any(f in args for f in _SPACE_VALUE_FLAGS + _MULTI_VALUE_FLAGS):
+    if any(f in args for f in _MULTI_VALUE_FLAGS):
         return args
-    try:
-        tokens = shlex.split(args)
-    except ValueError:
+    parsed = tokenize_server_args_preserving_json(args)
+    if parsed is None:
         return args
+    normalized, tokens = parsed
     # Collect the token span of every recognized single-value flag.
     spans: list[tuple[str, int, int]] = []
     i = 0
@@ -482,7 +547,7 @@ def dedup_vllm_server_args(
         for _name, start, end in occurrences[:-1]:
             drop.update(range(start, end + 1))
     if not drop:
-        return args
+        return normalized
     kept = [tok for idx, tok in enumerate(tokens) if idx not in drop]
     return " ".join(kept)
 
@@ -491,21 +556,24 @@ def _shell_safe_dedupe(args: str) -> str:
     """Last-wins dedupe for single-token-valued flags only.
 
     Collapses repeated ``--flag value`` (or ``--flag=value``) pairs whose value
-    is a single whitespace-free token, keeping the last occurrence. Returns the
-    string unchanged when it contains a flag known to carry a space/JSON value.
+    is a single whitespace-free token, keeping the last occurrence. JSON values
+    remain opaque tokens; actual whitespace-bearing argv values fail closed.
 
     Args:
         args (str): The server-arg string to dedupe.
 
     Returns:
-        str: The last-wins deduped string, or the input unchanged when it
-        carries a space/JSON-valued flag.
+        str: The last-wins deduped string, or the input unchanged when it cannot
+        be represented by the unquoted argv transport.
     """
     if not args.strip():
         return ""
-    if any(f in args for f in _SPACE_VALUE_FLAGS + _MULTI_VALUE_FLAGS):
+    if any(f in args for f in _MULTI_VALUE_FLAGS):
         return args
-    tokens = args.split()
+    parsed = tokenize_server_args_preserving_json(args)
+    if parsed is None:
+        return args
+    normalized, tokens = parsed
     pairs: dict[str, list[str]] = {}
     order: list[str] = []
     i = 0
@@ -535,7 +603,8 @@ def _shell_safe_dedupe(args: str) -> str:
     out: list[str] = []
     for k in order:
         out.extend(pairs[k])
-    return " ".join(out)
+    rendered = " ".join(out)
+    return rendered if rendered != normalized else normalized
 
 
 # sglang scheduler watchdog timeout injection: the first request's JIT compile

--- a/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
@@ -473,11 +473,10 @@ def tokenize_server_args_preserving_json(
             return None
         if any(ch.isspace() for ch in token):
             return None
-        if (
-            len(token) >= 2
-            and token[0] == token[-1]
-            and token[0] in {"'", '"'}
-        ):
+        # ``shlex.split(..., posix=False)`` can fracture a quoted operand with
+        # whitespace into edge-quoted pieces (``"my`` / ``parser"``). Reject
+        # any such edge, not only a token carrying both wrappers.
+        if token.startswith(("'", '"')) or token.endswith(("'", '"')):
             return None
     return normalized, tokens
 

--- a/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
@@ -311,6 +311,16 @@ def _reserialize_json_blobs(args: str) -> str:
     while i < n:
         ch = args[i]
         if ch in "{[":
+            # A prior shlex.join can wrap a JSON token in shell single quotes.
+            # These args are later expanded from an environment variable
+            # without eval, so the wrappers become literal argv characters.
+            # Strip only directly-adjacent wrappers around the balanced blob.
+            single_quote_wrapped = (
+                i > 0
+                and args[i - 1] == "'"
+                and out
+                and out[-1] == "'"
+            )
             # Walk to the balanced close, honouring quoted strings.
             depth = 0
             in_str = False
@@ -335,6 +345,13 @@ def _reserialize_json_blobs(args: str) -> str:
                         j += 1
                         break
                 j += 1
+            single_quote_wrapped = bool(
+                single_quote_wrapped
+                and j < n
+                and args[j] == "'"
+            )
+            if single_quote_wrapped:
+                out.pop()
             blob = args[i:j]
             try:
                 out.append(json.dumps(json.loads(blob), separators=(",", ":")))
@@ -346,7 +363,7 @@ def _reserialize_json_blobs(args: str) -> str:
                 # does not parse (never worse than before).
                 repaired = _repair_unquoted_json(blob)
                 out.append(repaired if repaired is not None else blob)
-            i = j
+            i = j + 1 if single_quote_wrapped else j
         else:
             out.append(ch)
             i += 1

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_ingest.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_ingest.py
@@ -137,7 +137,7 @@ def _is_absolute_path_text(value: str) -> bool:
 
 
 def _sanitize_server_args(value: str, *, drop_paths: bool) -> str:
-    """Remove secret options and, for non-replay metadata, local paths."""
+    """Remove unsafe options without adding shell syntax to stored argv text."""
 
     try:
         tokens = shlex.split(value)
@@ -161,7 +161,14 @@ def _sanitize_server_args(value: str, *, drop_paths: bool) -> str:
         if drop_paths and separator and _is_absolute_path_text(operand):
             continue
         safe.append(token)
-    return shlex.join(safe)
+    # These args are later expanded from ``$EXTRA_VLLM_ARGS`` without ``eval``.
+    # Quotes emitted by shlex.join therefore become literal argv characters
+    # rather than shell syntax (breaking JSON-valued flags at vLLM argparse).
+    # Store the plain argv text and repair any JSON quotes stripped by the token
+    # walk. Import locally to keep the recipe codec lightweight at module load.
+    from ...actions.executors._grid_server_args import _reserialize_json_blobs
+
+    return _reserialize_json_blobs(" ".join(safe))
 
 
 def _sanitize_gbrain_value(

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_ingest.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb/gbrain_ingest.py
@@ -137,12 +137,20 @@ def _is_absolute_path_text(value: str) -> bool:
 
 
 def _sanitize_server_args(value: str, *, drop_paths: bool) -> str:
-    """Remove unsafe options without adding shell syntax to stored argv text."""
+    """Remove secrets/paths and emit Magpie-safe, whitespace-free argv text.
+
+    Credential-bearing options are always removed; absolute path operands are
+    also removed when ``drop_paths`` is true. GBrain stores launch args as one
+    string that Magpie later expands without shell ``eval``, so a single argv
+    token containing whitespace cannot be represented safely and is rejected
+    rather than silently split. Valid JSON blobs are compacted and legacy shell
+    quote wrappers are removed.
+    """
 
     try:
         tokens = shlex.split(value)
-    except ValueError:
-        tokens = value.split()
+    except ValueError as exc:
+        raise ValueError(f"extra_server_args is not shell-tokenizable: {exc}") from exc
     safe: list[str] = []
     skip_value = False
     for token in tokens:
@@ -161,11 +169,18 @@ def _sanitize_server_args(value: str, *, drop_paths: bool) -> str:
         if drop_paths and separator and _is_absolute_path_text(operand):
             continue
         safe.append(token)
-    # These args are later expanded from ``$EXTRA_VLLM_ARGS`` without ``eval``.
-    # Quotes emitted by shlex.join therefore become literal argv characters
-    # rather than shell syntax (breaking JSON-valued flags at vLLM argparse).
-    # Store the plain argv text and repair any JSON quotes stripped by the token
-    # walk. Import locally to keep the recipe codec lightweight at module load.
+    # These args are later expanded from ``$EXTRA_*_ARGS`` without ``eval``.
+    # There is no safe string encoding for a whitespace-bearing argv token
+    # under that contract; fail the recipe write instead of persisting a partial
+    # or differently-tokenized champion config.
+    whitespace_tokens = [token for token in safe if any(ch.isspace() for ch in token)]
+    if whitespace_tokens:
+        raise ValueError(
+            "extra_server_args contains a whitespace-bearing value unsupported "
+            "by Magpie's unquoted environment expansion"
+        )
+    # Store plain argv text and repair JSON quotes stripped by the token walk.
+    # Import locally to keep the recipe codec lightweight at module load.
     from ...actions.executors._grid_server_args import _reserialize_json_blobs
 
     return _reserialize_json_blobs(" ".join(safe))

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import shlex
 import signal
 import time
 import traceback
@@ -17,6 +16,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
+from hyperloom.orchestrator.actions.executors._grid_server_args import (
+    tokenize_server_args_preserving_json,
+)
 from hyperloom.orchestrator.knowledge.recipe_kb import RecipeKB
 
 # Recipe snapshot severity tags (schema has no fixed enum).
@@ -241,10 +243,33 @@ def _framework_config_levers_from_done(
         args = entry.get("extra_args")
         extra_server_args = ""
         if isinstance(args, str) and args.strip():
-            extra_server_args = args
+            parsed_args = tokenize_server_args_preserving_json(args)
+            if parsed_args is None:
+                log.warning(
+                    "FRAMEWORK config lever %r has server args unsupported by "
+                    "Magpie's unquoted argv transport; skipping the lever",
+                    entry.get("name"),
+                )
+                continue
+            extra_server_args = parsed_args[0]
         elif isinstance(args, (list, tuple)):
             arg_tokens = [str(a) for a in args if str(a).strip()]
-            extra_server_args = shlex.join(arg_tokens)
+            if any(any(ch.isspace() for ch in token) for token in arg_tokens):
+                log.warning(
+                    "FRAMEWORK config lever %r has a whitespace-bearing argv "
+                    "token; skipping the lever",
+                    entry.get("name"),
+                )
+                continue
+            parsed_args = tokenize_server_args_preserving_json(" ".join(arg_tokens))
+            if parsed_args is None:
+                log.warning(
+                    "FRAMEWORK config lever %r has unparseable server args; "
+                    "skipping the lever",
+                    entry.get("name"),
+                )
+                continue
+            extra_server_args = parsed_args[0]
         if extra_server_args or extra_envs:
             return {
                 "extra_server_args": extra_server_args,

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -247,29 +247,38 @@ def _framework_config_levers_from_done(
             if parsed_args is None:
                 log.warning(
                     "FRAMEWORK config lever %r has server args unsupported by "
-                    "Magpie's unquoted argv transport; skipping the lever",
+                    "Magpie's unquoted argv transport; dropping the args%s",
                     entry.get("name"),
+                    " while preserving its environment overrides" if extra_envs else "",
                 )
-                continue
-            extra_server_args = parsed_args[0]
+                if not extra_envs:
+                    continue
+            else:
+                extra_server_args = parsed_args[0]
         elif isinstance(args, (list, tuple)):
             arg_tokens = [str(a) for a in args if str(a).strip()]
             if any(any(ch.isspace() for ch in token) for token in arg_tokens):
                 log.warning(
                     "FRAMEWORK config lever %r has a whitespace-bearing argv "
-                    "token; skipping the lever",
+                    "token; dropping the args%s",
                     entry.get("name"),
+                    " while preserving its environment overrides" if extra_envs else "",
                 )
-                continue
-            parsed_args = tokenize_server_args_preserving_json(" ".join(arg_tokens))
-            if parsed_args is None:
-                log.warning(
-                    "FRAMEWORK config lever %r has unparseable server args; "
-                    "skipping the lever",
-                    entry.get("name"),
-                )
-                continue
-            extra_server_args = parsed_args[0]
+                if not extra_envs:
+                    continue
+            else:
+                parsed_args = tokenize_server_args_preserving_json(" ".join(arg_tokens))
+                if parsed_args is None:
+                    log.warning(
+                        "FRAMEWORK config lever %r has unparseable server args; "
+                        "dropping the args%s",
+                        entry.get("name"),
+                        " while preserving its environment overrides" if extra_envs else "",
+                    )
+                    if not extra_envs:
+                        continue
+                else:
+                    extra_server_args = parsed_args[0]
         if extra_server_args or extra_envs:
             return {
                 "extra_server_args": extra_server_args,

--- a/src/hyperloom/orchestrator/loop/coordinator_helpers.py
+++ b/src/hyperloom/orchestrator/loop/coordinator_helpers.py
@@ -422,6 +422,10 @@ _SPACE_VALUE_FLAGS = (
     "--json-model-override-args",
     "--override-generation-config",
     "--tool-call-parser",
+    "--compilation-config",
+    "--speculative-config",
+    "--hf-overrides",
+    "--kv-transfer-config",
 )
 
 

--- a/src/hyperloom/orchestrator/loop/coordinator_helpers.py
+++ b/src/hyperloom/orchestrator/loop/coordinator_helpers.py
@@ -18,6 +18,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from ..actions.executors._grid_server_args import (
+    tokenize_server_args_preserving_json,
+)
+
 log = logging.getLogger(__name__)
 
 # Constants below are read from other modules; listed here to mark them as
@@ -418,38 +422,29 @@ def _merge_cumulative_extra_server_args(
     return _dedupe_extra_server_args(merged)
 
 
-_SPACE_VALUE_FLAGS = (
-    "--json-model-override-args",
-    "--override-generation-config",
-    "--tool-call-parser",
-    "--compilation-config",
-    "--speculative-config",
-    "--hf-overrides",
-    "--kv-transfer-config",
-)
-
-
 def _dedupe_extra_server_args(args_str: str) -> str:
     """Collapse repeated ``--flag value`` pairs into a unique launch string.
 
     Keep each flag once with its last value (first-seen order preserved),
     since argparse ``action="store"`` only honors the last value. Flags in
-    ``_MULTI_VALUE_SGLANG_FLAGS`` keep their multi-value runs. Args with
-    JSON/space-valued flags are left untouched because downstream launch
-    scripts expand them unquoted.
+    ``_MULTI_VALUE_SGLANG_FLAGS`` keep their multi-value runs. Valid JSON blobs
+    are treated as opaque tokens, so their inner quotes survive while unrelated
+    duplicated flags are still collapsed. Actual whitespace-bearing argv
+    values fail closed because downstream launch scripts expand them unquoted.
 
     Args:
         args_str: The extra server-args string to dedupe.
 
     Returns:
-        The deduped args string, or the input unchanged when it contains a
-        JSON/space-valued flag; ``""`` for empty input.
+        The deduped args string, or the input unchanged when it cannot be safely
+        tokenized; ``""`` for empty input.
     """
     if not args_str:
         return ""
-    if any(flag in args_str for flag in _SPACE_VALUE_FLAGS):
+    parsed = tokenize_server_args_preserving_json(args_str)
+    if parsed is None:
         return args_str
-    tokens = args_str.split()
+    normalized, tokens = parsed
     pair_by_flag: dict[str, list[str]] = {}
     order: list[str] = []
     i = 0
@@ -484,7 +479,8 @@ def _dedupe_extra_server_args(args_str: str) -> str:
     out: list[str] = []
     for k in order:
         out.extend(pair_by_flag[k])
-    return " ".join(out)
+    rendered = " ".join(out)
+    return rendered if rendered != normalized else normalized
 
 
 # Advisory fields carried on a Critic ``review_verdict`` payload beyond the


### PR DESCRIPTION
## Summary
- stop GBrain recipe sanitization from serializing server arguments with shell-only quote wrappers
- repair existing recipe JSON values that were already stored with literal single quotes before vLLM launch
- protect JSON-valued vLLM flags from cumulative argument deduplication

## Root cause
[#1094](https://github.com/AMD-AGI/Hyperloom/pull/1094) introduced `shlex.join()` in the GBrain recipe sanitizer. Warm replay later expands `EXTRA_VLLM_ARGS` without `eval`, so those quotes become literal argv characters and vLLM rejects `--speculative-config` / `--compilation-config` as invalid JSON.

## Test plan
- [x] `python3 -m pytest -q src/hyperloom/inference_optimizer/tests/test_gbrain_ingest_unit.py src/hyperloom/inference_optimizer/tests/test_grid_runner.py::TestCompactJsonServerArgs src/hyperloom/inference_optimizer/tests/test_coordinator_helpers_unit.py src/hyperloom/inference_optimizer/tests/test_cli_workload_envs.py` (81 passed)
- [x] `python3 -m pytest -q src/hyperloom/inference_optimizer/tests/test_gbrain_ingest.py src/hyperloom/inference_optimizer/tests/test_gbrain_ingest_unit.py src/hyperloom/inference_optimizer/tests/test_gbrain_remote_recipe_client.py src/hyperloom/inference_optimizer/tests/test_gbrain_remote_recipe_client_coverage_unit.py` (63 passed)
- [x] `python3 -m compileall -q src/hyperloom/orchestrator`
- [x] `git diff --check`


Made with [Cursor](https://cursor.com)