### PR TITLE
docs: update recommended images to rocm/hyperloom (SGLang 0.5.16 / vLLM 0.24.0)

### DIFF
--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -135,7 +135,7 @@ Container images
 ----------------
 
 Pick the image that matches your environment. Public Docker Hub refs
-(``primussafe/sglang:<tag>``) are used on your own GPU machine. If your
+(``rocm/hyperloom:<tag>``) are used on your own GPU machine. If your
 deployment uses a private registry mirror, set the registry prefix
 accordingly.
 
@@ -145,15 +145,15 @@ accordingly.
 
    * - Image
      - GPU
-   * - ``primussafe/sglang:v0.5.12-rocm720-mi30x-profilerfix``
+   * - ``rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x``
      - MI300X / MI325X
-   * - ``primussafe/sglang:v0.5.12-rocm720-mi35x-profilerfix``
+   * - ``rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi350x``
      - MI355X
-   * - ``primussafe/vllm-openai-rocm:v0.21.0-rocm720-profilerfix``
+   * - ``rocm/hyperloom:vllm-v0.24.0-rocm7.2.0``
      - MI300X / MI325X / MI355X
 
-Browse all available SGLang tags at
-`hub.docker.com/r/primussafe/sglang/tags <https://hub.docker.com/r/primussafe/sglang/tags>`_.
+Browse all available tags at
+`hub.docker.com/r/rocm/hyperloom/tags <https://hub.docker.com/r/rocm/hyperloom/tags>`_.
 
 Bare-metal recommended environment
 -----------------------------------
@@ -178,20 +178,20 @@ Hyperloom does not install ROCm or torch itself.
      - ROCm build matching the host ROCm
      - Preinstalled by the operator; not managed by Hyperloom.
    * - SGLang
-     - v0.5.12 (rocm720)
+     - v0.5.16 (rocm720)
      - Installed in ``shared`` mode (reuses the host torch). Uses the ROCm 7.2.0 AMD wheel index (``SGLANG_ROCM_EXTRA=rocm720``), so the SGLang ROCm layer is 7.2.0.
    * - vLLM
-     - v0.21.0 (rocm722), isolated venv
-     - Installs ``vllm==0.21.0+rocm722`` from the wheels.vllm.ai pip index. vLLM's ROCm wheel pins its own torch, so it installs into a dedicated venv (``--framework-env isolated``, the default for vLLM) and never touches the host torch.
+     - v0.24.0 (rocm722), isolated venv
+     - Installs ``vllm==0.24.0+rocm722`` from the wheels.vllm.ai pip index. vLLM's ROCm wheel pins its own torch, so it installs into a dedicated venv (``--framework-env isolated``, the default for vLLM) and never touches the host torch.
 
 Bare-metal ROCm patch levels differ per framework. The vLLM version matches the
-``v0.21.0`` Docker image, but the pip index only publishes the ``rocm722``
+``v0.24.0`` Docker image, but the pip index only publishes the ``rocm722``
 variant (ROCm 7.2.2), so the bare-metal vLLM ROCm layer is 7.2.2 rather than the
 image's rocm720. The SGLang stack installs from the ROCm 7.2.0 AMD wheel index,
 so its ROCm layer is 7.2.0. In ``docker`` mode both frameworks use ROCm 7.2.0
 (the ``-rocm720-`` images). For a fully validated, pre-aligned vLLM stack with
 rocm720, prefer ``docker`` mode with
-``primussafe/vllm-openai-rocm:v0.21.0-rocm720-profilerfix``.
+``rocm/hyperloom:vllm-v0.24.0-rocm7.2.0``.
 
 These are recommended defaults, not hard pins. Framework and ROCm versions are
 overridable via env (``SGLANG_REF``, ``SGLANG_ROCM_EXTRA``, ``VLLM_VERSION``,

--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -170,7 +170,7 @@ Hyperloom does not install ROCm or torch itself.
      - Notes
    * - ROCm
      - 7.2.x
-     - Bare-metal patch level differs per framework: the vLLM stack uses ROCm 7.2.2 and the SGLang stack uses ROCm 7.2.0 (see the note below). ``docker`` mode uses ROCm 7.2.0 for both frameworks (the ``-rocm720-`` images).
+     - Bare-metal patch level differs per framework: the vLLM stack uses ROCm 7.2.3 and the SGLang stack uses ROCm 7.2.0 (see the note below). ``docker`` mode uses the ``rocm/hyperloom`` images (ROCm 7.2.x) for both frameworks.
    * - Python
      - 3.12
      - Required by the vLLM ROCm wheel.
@@ -179,19 +179,18 @@ Hyperloom does not install ROCm or torch itself.
      - Preinstalled by the operator; not managed by Hyperloom.
    * - SGLang
      - v0.5.16 (rocm720)
-     - Installed in ``shared`` mode (reuses the host torch). Uses the ROCm 7.2.0 AMD wheel index (``SGLANG_ROCM_EXTRA=rocm720``), so the SGLang ROCm layer is 7.2.0.
+     - Installed in ``shared`` mode (reuses the host torch). Uses the ROCm 7.2.0 AMD wheel index (``SGLANG_ROCM_EXTRA=rocm720``), so the SGLang ROCm layer is 7.2.0. Note: ``SGLANG_REF`` (v0.5.16) only pins the version on the source-install branch (non-3.10 Python); on Python 3.10 the AMD wheel index installs ``amd-sglang`` unpinned, which may resolve to a different patch release.
    * - vLLM
-     - v0.24.0 (rocm722), isolated venv
-     - Installs ``vllm==0.24.0+rocm722`` from the wheels.vllm.ai pip index. vLLM's ROCm wheel pins its own torch, so it installs into a dedicated venv (``--framework-env isolated``, the default for vLLM) and never touches the host torch.
+     - v0.24.0 (rocm723), isolated venv
+     - Installs ``vllm==0.24.0+rocm723`` from the wheels.vllm.ai pip index. vLLM's ROCm wheel pins its own torch, so it installs into a dedicated venv (``--framework-env isolated``, the default for vLLM) and never touches the host torch.
 
 Bare-metal ROCm patch levels differ per framework. The vLLM version matches the
-``v0.24.0`` Docker image, but the pip index only publishes the ``rocm722``
-variant (ROCm 7.2.2), so the bare-metal vLLM ROCm layer is 7.2.2 rather than the
-image's rocm720. The SGLang stack installs from the ROCm 7.2.0 AMD wheel index,
-so its ROCm layer is 7.2.0. In ``docker`` mode both frameworks use ROCm 7.2.0
-(the ``-rocm720-`` images). For a fully validated, pre-aligned vLLM stack with
-rocm720, prefer ``docker`` mode with
-``rocm/hyperloom:vllm-v0.24.0-rocm7.2.0``.
+``v0.24.0`` Docker image; the pip index publishes 0.24.0 only as the ``rocm723``
+variant (ROCm 7.2.3), so the bare-metal vLLM ROCm layer is 7.2.3. The SGLang
+stack installs from the ROCm 7.2.0 AMD wheel index, so its ROCm layer is 7.2.0.
+In ``docker`` mode both frameworks use the ``rocm/hyperloom`` images (ROCm
+7.2.x). For a fully validated, pre-aligned vLLM stack, prefer ``docker`` mode
+with ``rocm/hyperloom:vllm-v0.24.0-rocm7.2.0``.
 
 These are recommended defaults, not hard pins. Framework and ROCm versions are
 overridable via env (``SGLANG_REF``, ``SGLANG_ROCM_EXTRA``, ``VLLM_VERSION``,

--- a/docs/how-to/multi-node/hyperloom-remote-demo.md
+++ b/docs/how-to/multi-node/hyperloom-remote-demo.md
@@ -91,8 +91,7 @@ KubeRay cluster and Hyperloom drives them through the Ray Dashboard:
 
 Example: `…/custom/hyperloom-sglang:v0.5.16-rocm7.2.0-mi300x-ray2.44.1` adds
 `ray 2.44.1` to the `rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x` base, which
-does not ship Ray. The image already ships `click`, so pin it below 8.2
-(e.g. `click==8.1.8`) as explained below, since Ray's CLI breaks on click 8.2. Keep click below 8.2 whatever the Ray version claims:
+does not ship it. Keep click below 8.2 whatever the Ray version claims:
 ray 2.44.1 declares only `click>=7.0`, but click 8.2 changed `Sentinel` and ray's
 CLI then dies on import, so KubeRay's `ray start` never runs.
 

--- a/docs/how-to/multi-node/hyperloom-remote-demo.md
+++ b/docs/how-to/multi-node/hyperloom-remote-demo.md
@@ -89,8 +89,8 @@ KubeRay cluster and Hyperloom drives them through the Ray Dashboard:
   its entrypoint to `tail -f /dev/null` so the cluster stays up instead of
   finishing a job and tearing itself down.
 
-Example: `…/custom/primussafe/sglang:v0.5.15-rocm720-mi30x-ray2.44.1` adds
-`ray 2.44.1` and `click 8.1.8` to the `lmsysorg/sglang-rocm:v0.5.15-rocm720-mi30x`
+Example: `…/custom/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x-ray2.44.1` adds
+`ray 2.44.1` and `click 8.1.8` to the `rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x`
 base, which ships neither. Keep click below 8.2 whatever the Ray version claims:
 ray 2.44.1 declares only `click>=7.0`, but click 8.2 changed `Sentinel` and ray's
 CLI then dies on import, so KubeRay's `ray start` never runs.

--- a/docs/how-to/multi-node/hyperloom-remote-demo.md
+++ b/docs/how-to/multi-node/hyperloom-remote-demo.md
@@ -89,9 +89,10 @@ KubeRay cluster and Hyperloom drives them through the Ray Dashboard:
   its entrypoint to `tail -f /dev/null` so the cluster stays up instead of
   finishing a job and tearing itself down.
 
-Example: `…/custom/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x-ray2.44.1` adds
-`ray 2.44.1` and `click 8.1.8` to the `rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x`
-base, which ships neither. Keep click below 8.2 whatever the Ray version claims:
+Example: `…/custom/hyperloom-sglang:v0.5.16-rocm7.2.0-mi300x-ray2.44.1` adds
+`ray 2.44.1` to the `rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x` base, which
+does not ship Ray. The image already ships `click`, so pin it below 8.2
+(e.g. `click==8.1.8`) as explained below, since Ray's CLI breaks on click 8.2. Keep click below 8.2 whatever the Ray version claims:
 ray 2.44.1 declares only `click>=7.0`, but click 8.2 changed `Sentinel` and ray's
 CLI then dies on import, so KubeRay's `ray start` never runs.
 

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -335,15 +335,15 @@ It is recommended that you use a ROCm image that already ships the serving
 framework, so nothing needs to be installed inside the container beyond
 Hyperloom's runtime deps. The following images are recommended:
 
-- `vllm`: `docker.io/primussafe/vllm-openai-rocm:v0.21.0-rocm720-profilerfix`
-- `sglang` MI300X: `docker.io/primussafe/sglang:v0.5.12-rocm720-mi30x-profilerfix`
-- `sglang` MI355X: `docker.io/primussafe/sglang:v0.5.12-rocm720-mi35x-profilerfix`
+- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.24.0-rocm7.2.0`
+- `sglang` MI300X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x`
+- `sglang` MI355X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi350x`
 
 Start a long-running container from the repo root, mounting it at the same path
 so `.env`, logs, and session artifacts stay valid:
 
 ```bash
-export HYPERLOOM_IMAGE=docker.io/primussafe/vllm-openai-rocm:v0.21.0-rocm720-profilerfix
+export HYPERLOOM_IMAGE=docker.io/rocm/hyperloom:vllm-v0.24.0-rocm7.2.0
 export REPO_ROOT="$(pwd -P)"
 docker run -d \
   --name "${HYPERLOOM_CONTAINER_NAME:-hyperloom-local}" \

--- a/docs/reference/session-breakdown.md
+++ b/docs/reference/session-breakdown.md
@@ -588,7 +588,7 @@ The following example shows a complete `session_breakdown.json` for a finished G
     "pid": 12345,
     "session_dir": "/workspace/hyperloom/GLM-5-FP8/20260517T113000Z",
     "tick_count": 89,
-    "image": "lmsysorg/sglang:v0.5.11-rocm720-mi30x-profilerfix"
+    "image": "rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x"
   },
 
   "workload": {

--- a/examples/hyperloom-custom-advanced/SKILL.md
+++ b/examples/hyperloom-custom-advanced/SKILL.md
@@ -37,9 +37,9 @@ In docker mode:
 
 Suggested Docker images:
 
-- `vllm`: `docker.io/primussafe/vllm-openai-rocm:v0.21.0-rocm720-profilerfix`
-- `sglang` MI300X: `docker.io/primussafe/sglang:v0.5.12-rocm720-mi30x-profilerfix`
-- `sglang` MI355X: `docker.io/primussafe/sglang:v0.5.12-rocm720-mi35x-profilerfix`
+- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.24.0-rocm7.2.0`
+- `sglang` MI300X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x`
+- `sglang` MI355X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi350x`
 
 In Docker mode, start a long-running container on `HYPERLOOM_DOCKER_TARGET_HOST`
 (or the current host when it is unset) before running setup or optimize:

--- a/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
+++ b/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
@@ -27,9 +27,9 @@ In docker mode:
 
 Suggested Docker images:
 
-- `vllm`: `docker.io/primussafe/vllm-openai-rocm:v0.21.0-rocm720-profilerfix`
-- `sglang` MI300X: `docker.io/primussafe/sglang:v0.5.12-rocm720-mi30x-profilerfix`
-- `sglang` MI355X: `docker.io/primussafe/sglang:v0.5.12-rocm720-mi35x-profilerfix`
+- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.24.0-rocm7.2.0`
+- `sglang` MI300X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x`
+- `sglang` MI355X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi350x`
 
 In Docker mode, start a long-running container on `HYPERLOOM_DOCKER_TARGET_HOST`
 (or the current host when it is unset) before running setup or optimize:

--- a/examples/hyperloom-qwen3-8b-3h/SKILL.md
+++ b/examples/hyperloom-qwen3-8b-3h/SKILL.md
@@ -27,9 +27,9 @@ In docker mode:
 
 Suggested Docker images:
 
-- `vllm`: `docker.io/primussafe/vllm-openai-rocm:v0.21.0-rocm720-profilerfix`
-- `sglang` MI300X: `docker.io/primussafe/sglang:v0.5.12-rocm720-mi30x-profilerfix`
-- `sglang` MI355X: `docker.io/primussafe/sglang:v0.5.12-rocm720-mi35x-profilerfix`
+- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.24.0-rocm7.2.0`
+- `sglang` MI300X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x`
+- `sglang` MI355X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi350x`
 
 In Docker mode, start a long-running container on `HYPERLOOM_DOCKER_TARGET_HOST`
 (or the current host when it is unset) before running setup or optimize:

--- a/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
+++ b/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
@@ -43,13 +43,13 @@ INSTALL_FRAMEWORK="none"
 _FRAMEWORK_ENV_WAS_SET="${FRAMEWORK_ENV+x}"
 FRAMEWORK_ENV="${FRAMEWORK_ENV:-shared}"
 SGLANG_REPO="${SGLANG_REPO:-https://github.com/sgl-project/sglang.git}"
-# Framework versions track docs/compatibility.rst (SGLang v0.5.12, ROCm 7.2).
-# vLLM installs 0.21.0+rocm722 from the wheels.vllm.ai pip index, matching the
-# v0.21.0 Docker image version. The pip index only publishes the rocm722
+# Framework versions track docs/compatibility.rst (SGLang v0.5.16, ROCm 7.2).
+# vLLM installs 0.24.0+rocm722 from the wheels.vllm.ai pip index, matching the
+# v0.24.0 Docker image version. The pip index only publishes the rocm722
 # variant (no rocm720 wheel exists there), so the ROCm layer is 7.2.2. AITER_REF
 # can pin ROCm/aiter to a released tag; when unset, the installer selects the
 # newest tag compatible with the already-installed ROCm torch/triton stack.
-SGLANG_REF="${SGLANG_REF:-v0.5.12}"
+SGLANG_REF="${SGLANG_REF:-v0.5.16}"
 _SGLANG_ROCM_PYPI_VERSION_WAS_SET="${SGLANG_ROCM_PYPI_VERSION+x}"
 _AITER_REF_WAS_SET="${AITER_REF+x}"
 SGLANG_ROCM_EXTRA="${SGLANG_ROCM_EXTRA:-rocm720}"
@@ -62,7 +62,7 @@ fi
 SGLANG_ROCM_PYPI_VERSION="${SGLANG_ROCM_PYPI_VERSION:-7.2.0}"
 AITER_REPO="${AITER_REPO:-https://github.com/ROCm/aiter.git}"
 AITER_REF="${AITER_REF:-}"
-VLLM_VERSION="${VLLM_VERSION:-0.21.0}"
+VLLM_VERSION="${VLLM_VERSION:-0.24.0}"
 VLLM_ROCM_VARIANT="${VLLM_ROCM_VARIANT:-rocm722}"
 VLLM_ROCM_INDEX="${VLLM_ROCM_INDEX:-https://wheels.vllm.ai/rocm/${VLLM_VERSION}/${VLLM_ROCM_VARIANT}}"
 VLLM_VENV_ROOT="${VLLM_VENV_ROOT:-/opt/hyperloom/vllm-venv}"
@@ -158,7 +158,7 @@ warn() { echo "[install-baremetal WARN] $*" >&2; }
 die() { echo "[install-baremetal ERROR] $*" >&2; exit 1; }
 
 IMAGE_HINT="Provision the ROCm framework base first (run inside an AMD ROCm \
-SGLang/vLLM image such as primussafe/sglang:*-rocm*-mi30x|mi35x-profilerfix, or \
+SGLang/vLLM image such as rocm/hyperloom:sglang-*-rocm7.2.0-mi300x|mi350x, or \
 install an equivalent ROCm torch + framework stack), then re-run."
 
 is_interactive() { [ "$ASSUME_YES" -eq 0 ] && [ -t 0 ] && [ -t 1 ]; }

--- a/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
+++ b/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
@@ -44,9 +44,9 @@ _FRAMEWORK_ENV_WAS_SET="${FRAMEWORK_ENV+x}"
 FRAMEWORK_ENV="${FRAMEWORK_ENV:-shared}"
 SGLANG_REPO="${SGLANG_REPO:-https://github.com/sgl-project/sglang.git}"
 # Framework versions track docs/compatibility.rst (SGLang v0.5.16, ROCm 7.2).
-# vLLM installs 0.24.0+rocm722 from the wheels.vllm.ai pip index, matching the
-# v0.24.0 Docker image version. The pip index only publishes the rocm722
-# variant (no rocm720 wheel exists there), so the ROCm layer is 7.2.2. AITER_REF
+# vLLM installs 0.24.0+rocm723 from the wheels.vllm.ai pip index, matching the
+# v0.24.0 Docker image version. The pip index publishes 0.24.0 only as the
+# rocm723 variant (ROCm 7.2.3), so the ROCm layer is 7.2.3. AITER_REF
 # can pin ROCm/aiter to a released tag; when unset, the installer selects the
 # newest tag compatible with the already-installed ROCm torch/triton stack.
 SGLANG_REF="${SGLANG_REF:-v0.5.16}"
@@ -63,7 +63,7 @@ SGLANG_ROCM_PYPI_VERSION="${SGLANG_ROCM_PYPI_VERSION:-7.2.0}"
 AITER_REPO="${AITER_REPO:-https://github.com/ROCm/aiter.git}"
 AITER_REF="${AITER_REF:-}"
 VLLM_VERSION="${VLLM_VERSION:-0.24.0}"
-VLLM_ROCM_VARIANT="${VLLM_ROCM_VARIANT:-rocm722}"
+VLLM_ROCM_VARIANT="${VLLM_ROCM_VARIANT:-rocm723}"
 VLLM_ROCM_INDEX="${VLLM_ROCM_INDEX:-https://wheels.vllm.ai/rocm/${VLLM_VERSION}/${VLLM_ROCM_VARIANT}}"
 VLLM_VENV_ROOT="${VLLM_VENV_ROOT:-/opt/hyperloom/vllm-venv}"
 REQUIRE_FRAMEWORKS=0
@@ -774,16 +774,22 @@ PY
     # +git<sha>) that PyPI lacks, so an exact pin forces the ROCm build; vLLM then
     # reuses the already-satisfied torch.
     rocm_torch_ver="$("$py" - "$VLLM_ROCM_INDEX" <<'PY'
-import re, sys, urllib.request
+import re, sys, urllib.request, urllib.error
 
 base = sys.argv[1].rstrip("/") + "/torch/"
 try:
     html = urllib.request.urlopen(base, timeout=30).read().decode()
-except Exception:
+except urllib.error.HTTPError as e:
+    print("index unreachable: HTTP %s at %s" % (e.code, base), file=sys.stderr)
+    raise SystemExit(0)
+except Exception as e:
+    print("index unreachable: %s at %s" % (e, base), file=sys.stderr)
     raise SystemExit(0)
 # Match the plain "+local" form (e.g. 2.10.0+git8514f05); URL-encoded %2B
 # anchors are skipped so the pinned spec stays pip-usable.
 matches = re.findall(r"torch-([0-9][0-9A-Za-z.]*\+[0-9A-Za-z.]+)-cp", html)
+if not matches:
+    print("index reachable but no torch wheel matched at %s" % base, file=sys.stderr)
 print(matches[-1] if matches else "")
 PY
 )"

--- a/src/hyperloom/inference_optimizer/assets/quick-start/Dockerfile
+++ b/src/hyperloom/inference_optimizer/assets/quick-start/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM primussafe/sglang:v0.5.12-rocm720-mi30x-profilerfix
+FROM rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x
 
 
 #install AMD self-signed certificate

--- a/src/hyperloom/inference_optimizer/assets/slurm/models.tsv
+++ b/src/hyperloom/inference_optimizer/assets/slurm/models.tsv
@@ -1,6 +1,6 @@
 # key	repo_id	framework	gpu_type	image	tp	prec	isl	osl	conc	model_class	max_hours	target_gain
 # Example registry consumed by submit.sh. Replace repo_id / image / gpu_type
 # with your own published models and container images before running.
-deepseek_r1_sglang	deepseek-ai/DeepSeek-R1	sglang	MI300X	lmsysorg/sglang-rocm:v0.5.15-rocm720	8	fp8	1024	1024	64	moe_mla	6	10
+deepseek_r1_sglang	deepseek-ai/DeepSeek-R1	sglang	MI300X	rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x	8	fp8	1024	1024	64	moe_mla	6	10
 deepseek_r1_vllm	deepseek-ai/DeepSeek-R1	vllm	MI300X	vllm/vllm-openai-rocm:v0.24.0	8	fp8	1024	1024	64	moe_mla	6	10
 gptoss_vllm	openai/gpt-oss-120b	vllm	MI300X	vllm/vllm-openai-rocm:v0.24.0	8	fp4	1024	1024	64	moe_swa	6	10

--- a/src/hyperloom/inference_optimizer/tests/test_baremetal_doc_version_consistency.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baremetal_doc_version_consistency.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""Guard: install_baremetal.sh defaults stay in sync with docs/compatibility.rst.
+
+Cheap, no-network consistency check. It does NOT verify that the
+(version, variant) tuple actually exists on wheels.vllm.ai -- it only ensures
+the script defaults and the documented recommendation do not silently drift
+apart (the failure mode behind the 0.24.0 rocm722->rocm723 regression).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+INSTALLER = REPO_ROOT / "src/hyperloom/inference_optimizer/assets/install_baremetal.sh"
+COMPAT = REPO_ROOT / "docs/compatibility.rst"
+
+
+def _default(var: str, text: str) -> str:
+    m = re.search(r'%s="\$\{%s:-([^}]+)\}"' % (var, var), text)
+    assert m, "could not find default for %s in install_baremetal.sh" % var
+    return m.group(1)
+
+
+def test_baremetal_defaults_match_compat_doc():
+    sh = INSTALLER.read_text(encoding="utf-8")
+    doc = COMPAT.read_text(encoding="utf-8")
+
+    vllm_version = _default("VLLM_VERSION", sh)        # e.g. 0.24.0
+    vllm_variant = _default("VLLM_ROCM_VARIANT", sh)   # e.g. rocm723
+    sglang_ref = _default("SGLANG_REF", sh)            # e.g. v0.5.16
+
+    # compatibility.rst documents e.g. "v0.24.0 (rocm723)" and the pip spec
+    # "vllm==0.24.0+rocm723"; keep both in lockstep with the script defaults.
+    assert "v%s (%s)" % (vllm_version, vllm_variant) in doc, (
+        "docs/compatibility.rst must document vLLM 'v%s (%s)' to match "
+        "install_baremetal.sh defaults" % (vllm_version, vllm_variant)
+    )
+    assert "vllm==%s+%s" % (vllm_version, vllm_variant) in doc, (
+        "docs/compatibility.rst pip spec must be 'vllm==%s+%s'"
+        % (vllm_version, vllm_variant)
+    )
+
+    sglang_version = sglang_ref.lstrip("v")
+    assert "v%s (rocm" % sglang_version in doc, (
+        "docs/compatibility.rst must document SGLang v%s" % sglang_version
+    )


### PR DESCRIPTION
## Problem

Docs, examples, and the quick-start Dockerfile still reference the old
`primussafe/*-profilerfix` (and `lmsysorg/*-profilerfix`) images and recommend
SGLang v0.5.12 / vLLM v0.21.0, which are outdated.

## Fix

- Repoint all image references to the `rocm/hyperloom` images:
  - `rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x` (MI300X/MI325X)
  - `rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi350x` (MI355X)
  - `rocm/hyperloom:vllm-v0.24.0-rocm7.2.0`
- Bump recommended bare-metal pip versions to SGLang 0.5.16 / vLLM 0.24.0
  (`SGLANG_REF`, `VLLM_VERSION` defaults and compatibility table).
- The support-matrix minimum requirement (`>= 0.5.12`, `>= 0.21.0`) is left
  unchanged as it denotes the lowest supported versions, not the recommended ones.