### PR TITLE
feat(kernel): add the Wan 3D/video frame axis to the diffusion FLOP model

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_diffusion_flops.py
+++ b/src/hyperloom/agents/kernel/tests/test_diffusion_flops.py
@@ -47,6 +47,7 @@ def test_family_routing_for_each_class(tmp_path):
         "ZImageTransformer2DModel": "single",
         "SanaTransformer2DModel": "sana",
         "UNet2DConditionModel": "unet",
+        "Flux2Transformer2DModel": "flux",
     }
     for cls, fam in cases.items():
         d = _write_denoiser(
@@ -349,3 +350,118 @@ def test_main_text_and_json_and_failure(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["diffusion_flops", "--model-dir", str(bad)])
     assert df.main() == 1
     assert "could not resolve" in capsys.readouterr().out
+
+
+# ---- FLUX.2 --------------------------------------------------------------
+_FLUX2_CFG = {
+    "_class_name": "Flux2Transformer2DModel",
+    "num_layers": 8,
+    "num_single_layers": 48,
+    "num_attention_heads": 48,
+    "attention_head_dim": 128,
+    "in_channels": 128,
+    "patch_size": 1,
+    "joint_attention_dim": 15360,
+    "axes_dims_rope": [32, 32, 32, 32],
+}
+
+
+def test_flux2_geometry_and_defaults(tmp_path):
+    """Real geometry from the shipped black-forest-labs/FLUX.2-dev config."""
+    g = df.resolve_geometry(_write_denoiser(tmp_path / "flux2", _FLUX2_CFG))
+    assert g is not None
+    assert (g.family, g.model_class) == ("flux", "Flux2Transformer2DModel")
+    assert g.hidden == 6144  # 48 heads x 128
+    assert (g.num_double_layers, g.num_single_layers) == (8, 48)
+    # patch_size=1 in the config, but FLUX packs 2x2 for the token count.
+    assert g.patch == 2
+    # FLUX.2-dev is guidance-distilled: one forward per step.
+    assert (g.default_cfg_batch, g.default_steps) == (1, 50)
+
+    est = df.estimate_image_flops(_write_denoiser(tmp_path / "flux2b", _FLUX2_CFG))
+    assert est["image_tokens"] == 4096  # (1024/8/2)^2
+    assert est["layers"] == 56
+    assert est["total_flops"] > 0
+
+
+def test_flux1_is_unaffected_by_the_flux2_entry(tmp_path):
+    cfg = {
+        "_class_name": "FluxTransformer2DModel",
+        "num_layers": 19,
+        "num_single_layers": 38,
+        "num_attention_heads": 24,
+        "attention_head_dim": 128,
+    }
+    g = df.resolve_geometry(_write_denoiser(tmp_path / "flux1", cfg))
+    assert g.hidden == 3072
+    assert (g.num_double_layers, g.num_single_layers) == (19, 38)
+    assert (g.default_cfg_batch, g.default_steps) == (1, 28)
+
+
+# ---- cross-attention completeness ----------------------------------------
+def _cross_geom(**kw):
+    base = dict(
+        model_class="x",
+        family="sana",
+        hidden=5120,
+        num_double_layers=1,
+        num_single_layers=0,
+        head_dim=128,
+        intermediate=13824,
+        gated_ffn=False,
+    )
+    base.update(kw)
+    return df.DenoiserGeometry(**base)
+
+
+def test_cross_attention_counts_q_and_o_projections():
+    """All four projections, not just K and V.
+
+    The query stream needs its own Q and O matmuls, charged to the query token
+    count. They were previously omitted, understating a cross-attending block.
+    """
+    g = _cross_geom()
+    q_tokens, tt = 75_600, 512
+    total = df._cross_attention_block_flops(g, q_tokens, tt)
+
+    attn = df._cross_attention_flops(q_tokens, tt, g.hidden)
+    kv = tt * df._linear_flops(1.0, g.hidden, g.hidden) * 2
+    qo = q_tokens * df._linear_flops(1.0, g.hidden, g.hidden) * 2
+    assert total == pytest.approx(attn + kv + qo)
+    # Q/O scale with the query tokens, so they dominate the K/V term here.
+    assert qo > kv * 100
+
+
+def test_cross_attention_qo_scales_with_query_tokens():
+    """Q/O scale with the queries; K/V does not, so growth is sub-linear."""
+    g, tt = _cross_geom(), 512
+    small = df._cross_attention_block_flops(g, 1_000, tt)
+    large = df._cross_attention_block_flops(g, 2_000, tt)
+
+    # The K/V projection is charged to the text length and is invariant in q,
+    # so the delta is exactly the q-proportional attention + Q/O terms.
+    attn_delta = df._cross_attention_flops(2_000, tt, g.hidden) - df._cross_attention_flops(1_000, tt, g.hidden)
+    qo_delta = 1_000 * df._linear_flops(1.0, g.hidden, g.hidden) * 2
+    assert large - small == pytest.approx(attn_delta + qo_delta)
+    # Sub-linear overall precisely because K/V stays put.
+    assert 1.0 < large / small < 2.0
+
+
+def test_sana_layer_includes_cross_attention_projections(tmp_path):
+    cfg = {
+        "_class_name": "SanaTransformer2DModel",
+        "num_layers": 2,
+        "num_attention_heads": 8,
+        "attention_head_dim": 32,
+    }
+    g = df.resolve_geometry(_write_denoiser(tmp_path / "sana", cfg))
+    ffn_pt = df._ffn_per_token(g)
+    ti, tt = 1024, g.text_tokens
+    layer = df._sana_layer(g, ti, tt, ffn_pt)
+    # The layer must contain the full cross-attention block, Q/O included.
+    assert layer == pytest.approx(
+        ti * df._qkvo_flops(1.0, g.hidden)
+        + ti * ffn_pt
+        + df._linear_attention_flops(ti, g.hidden, g.head_dim or 32)
+        + df._cross_attention_block_flops(g, ti, tt)
+    )

--- a/src/hyperloom/agents/kernel/tests/test_diffusion_flops.py
+++ b/src/hyperloom/agents/kernel/tests/test_diffusion_flops.py
@@ -48,6 +48,7 @@ def test_family_routing_for_each_class(tmp_path):
         "SanaTransformer2DModel": "sana",
         "UNet2DConditionModel": "unet",
         "Flux2Transformer2DModel": "flux",
+        "WanTransformer3DModel": "wan",
     }
     for cls, fam in cases.items():
         d = _write_denoiser(
@@ -465,3 +466,125 @@ def test_sana_layer_includes_cross_attention_projections(tmp_path):
         + df._linear_attention_flops(ti, g.hidden, g.head_dim or 32)
         + df._cross_attention_block_flops(g, ti, tt)
     )
+
+
+# ---- Wan (3D video) ------------------------------------------------------
+_WAN_CFG = {
+    "_class_name": "WanTransformer3DModel",
+    "num_layers": 40,
+    "num_attention_heads": 40,
+    "attention_head_dim": 128,
+    "in_channels": 16,
+    "out_channels": 16,
+    "patch_size": [1, 2, 2],
+    "text_dim": 4096,
+    "ffn_dim": 13824,
+    "freq_dim": 256,
+    "cross_attn_norm": True,
+    "qk_norm": "rms_norm_across_heads",
+}
+
+
+def test_wan_geometry_from_real_config(tmp_path):
+    g = df.resolve_geometry(_write_denoiser(tmp_path / "wan", _WAN_CFG))
+    assert (g.family, g.model_class) == ("wan", "WanTransformer3DModel")
+    assert g.hidden == 5120 and g.num_double_layers == 40
+    # patch_size is (t, h, w); the spatial patch is 2, NOT the leading 1.
+    assert (g.patch, g.patch_t) == (2, 1)
+    # ffn_dim must win over the 4*hidden fallback (which would be 20480).
+    assert g.intermediate == 13824
+    assert (g.vae_spatial, g.vae_temporal, g.default_frames) == (8, 4, 81)
+
+
+def test_wan_latent_frames_causal_vae(tmp_path):
+    g = df.resolve_geometry(_write_denoiser(tmp_path / "wan", _WAN_CFG))
+    assert df._latent_frames(g, 81) == 21  # causal: (81-1)//4 + 1
+    assert df._latent_frames(g, 1) == 1
+    assert df._latent_frames(g, 4) == 1
+    assert df._latent_frames(g, 5) == 2
+    assert df._latent_frames(g, 0) == 1
+
+
+def test_wan_video_tokens_match_observed_trace_shape(tmp_path):
+    """720p x 81 frames must give 75600 tokens.
+
+    That is the operand shape a real Wan2.2 trace carries under Ulysses-8
+    ((1, 75600, 5, 128)), so it pins the whole token model at once.
+    """
+    g = df.resolve_geometry(_write_denoiser(tmp_path / "wan", _WAN_CFG))
+    assert df._video_tokens(g, 720, 1280, 81) == 75600  # 21 * 45 * 80
+    fwd = df.forward_flops(g, 720, 1280, 81)
+    assert fwd["image_tokens"] == 75600 and fwd["latent_frames"] == 21
+
+
+def test_forward_flops_frames_defaults_to_the_family_not_one(tmp_path):
+    """A bare ``frames=1`` default silently undercut Wan by the frame count.
+
+    ``forward_flops`` is public, so omitting ``frames`` must mean "this model's
+    own default", exactly as ``estimate_image_flops`` already behaved.
+    """
+    g = df.resolve_geometry(_write_denoiser(tmp_path / "wan", _WAN_CFG))
+    implicit = df.forward_flops(g, 720, 1280)["forward_flops"]
+    explicit = df.forward_flops(g, 720, 1280, 81)["forward_flops"]
+    single = df.forward_flops(g, 720, 1280, 1)["forward_flops"]
+    assert implicit == explicit
+    assert explicit / single > 50  # the magnitude of the old silent undercount
+
+
+def test_image_families_ignore_frames(tmp_path):
+    cfg = {"_class_name": "FluxTransformer2DModel", "num_layers": 2, "num_attention_heads": 8, "attention_head_dim": 64}
+    d = _write_denoiser(tmp_path / "flux", cfg)
+    assert df.estimate_image_flops(d, num_frames=1)["total_flops"] == (
+        df.estimate_image_flops(d, num_frames=97)["total_flops"]
+    )
+    assert "num_frames" not in df.estimate_image_flops(d)
+    g = df.resolve_geometry(d)
+    assert df._latent_frames(g, 81) == 1
+
+
+def test_wan_estimate_and_ceiling_thread_num_frames(tmp_path):
+    d = _write_denoiser(tmp_path / "wan", _WAN_CFG)
+    est = df.estimate_image_flops(d, height=720, width=1280, num_frames=81, num_steps=8)
+    assert est["image_tokens"] == 75600
+    assert (est["num_frames"], est["latent_frames"]) == (81, 21)
+    assert est["cfg_batch"] == 2  # WanPipeline uses CFG
+    assert df.estimate_image_flops(d, height=720, width=1280)["num_frames"] == 81
+    fewer = df.estimate_image_flops(d, height=720, width=1280, num_frames=41, num_steps=8)
+    assert fewer["total_flops"] < est["total_flops"]
+
+    ceil = df.analytic_ceiling(d, height=720, width=1280, num_frames=81, num_steps=8)
+    assert ceil["ideal_ms"] > 0
+    line = df._fmt(ceil)
+    assert "TFLOP/clip" in line and "f=81(21lat)" in line
+
+
+def test_wan_keeps_text_out_of_self_attention(tmp_path):
+    """Wan cross-attends to text rather than concatenating it."""
+    g = df.resolve_geometry(_write_denoiser(tmp_path / "wan", _WAN_CFG))
+    ffn_pt = df._ffn_per_token(g)
+    base = df._wan_layer(g, 10_000, 512, ffn_pt)
+    more_text = df._wan_layer(g, 10_000, 1024, ffn_pt)
+    assert base < more_text < 1.10 * base
+
+
+def test_main_frames_flag(tmp_path, monkeypatch, capsys):
+    d = _write_denoiser(tmp_path / "wan", _WAN_CFG)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["diffusion_flops", "--model-dir", str(d), "--height", "720", "--width", "1280", "--frames", "81", "--json"],
+    )
+    assert df.main() == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["image_tokens"] == 75600 and out["latent_frames"] == 21
+
+
+def test_cross_attention_kv_reads_the_context_width(tmp_path):
+    """K/V project from the text-encoder width, not from ``hidden``."""
+    g = df.resolve_geometry(_write_denoiser(tmp_path / "wan", _WAN_CFG))
+    assert g.context_dim == 4096  # Wan text_dim, vs hidden 5120
+    tt = 512
+    kv = tt * df._linear_flops(1.0, g.context_dim, g.hidden) * 2
+    qo = 1_000 * df._linear_flops(1.0, g.hidden, g.hidden) * 2
+    attn = df._cross_attention_flops(1_000, tt, g.hidden)
+    assert df._cross_attention_block_flops(g, 1_000, tt) == pytest.approx(attn + qo + kv)

--- a/src/hyperloom/agents/kernel/tools/diffusion_flops.py
+++ b/src/hyperloom/agents/kernel/tools/diffusion_flops.py
@@ -155,6 +155,8 @@ _CLASS_FAMILY: dict[str, str] = {
     "ZImageTransformer2DModel": "single",
     "SanaTransformer2DModel": "sana",
     "UNet2DConditionModel": "unet",
+    # FLUX.2 keeps FLUX.1's dual + single stream structure, only wider.
+    "Flux2Transformer2DModel": "flux",
 }
 
 # Per-class overrides for constants the config does not expose (diffusers
@@ -162,6 +164,8 @@ _CLASS_FAMILY: dict[str, str] = {
 _CLASS_DEFAULTS: dict[str, dict[str, Any]] = {
     "SD3Transformer2DModel": {"text_tokens": 333, "default_steps": 28, "default_cfg_batch": 2},
     "FluxTransformer2DModel": {"text_tokens": 512, "default_steps": 28, "default_cfg_batch": 1},
+    # FLUX.2-dev is guidance-distilled like FLUX.1-dev, so one forward per step.
+    "Flux2Transformer2DModel": {"text_tokens": 512, "default_steps": 50, "default_cfg_batch": 1},
     "QwenImageTransformer2DModel": {"text_tokens": 256, "default_steps": 30, "default_cfg_batch": 2},
     "AuraFlowTransformer2DModel": {"text_tokens": 256, "default_steps": 50, "default_cfg_batch": 2},
     "HunyuanImageTransformer2DModel": {"text_tokens": 256, "default_steps": 50, "default_cfg_batch": 2},
@@ -443,12 +447,22 @@ def _single_stream_layer(g: DenoiserGeometry, s: int, ffn_pt: float) -> float:
     return lin + attn
 
 
+def _cross_attention_block_flops(g: DenoiserGeometry, q_tokens: int, tt: int) -> float:
+    """Cross-attention over ``q_tokens`` queries against ``tt`` text tokens.
+
+    Counts all four projections: Q and O scale with the queries, K and V with
+    the text length.
+    """
+    qo = q_tokens * _linear_flops(1.0, g.hidden, g.hidden) * 2
+    kv = tt * _linear_flops(1.0, g.hidden, g.hidden) * 2
+    return _cross_attention_flops(q_tokens, tt, g.hidden) + qo + kv
+
+
 def _sana_layer(g: DenoiserGeometry, ti: int, tt: int, ffn_pt: float) -> float:
     """Sana block: linear self-attention over image tokens + cross-attn to text."""
     lin = ti * _qkvo_flops(1.0, g.hidden) + ti * ffn_pt
     self_attn = _linear_attention_flops(ti, g.hidden, g.head_dim or 32)
-    cross = _cross_attention_flops(ti, tt, g.hidden) + tt * _linear_flops(1.0, g.hidden, g.hidden) * 2
-    return lin + self_attn + cross
+    return lin + self_attn + _cross_attention_block_flops(g, ti, tt)
 
 
 def _unet_forward_flops(g: DenoiserGeometry, height: int, width: int) -> float:

--- a/src/hyperloom/agents/kernel/tools/diffusion_flops.py
+++ b/src/hyperloom/agents/kernel/tools/diffusion_flops.py
@@ -119,7 +119,7 @@ class DenoiserGeometry:
     """Resolved denoiser architecture for the analytic FLOPs estimator."""
 
     model_class: str
-    family: str  # mmdit | flux | single | moe_single | unet | sana
+    family: str  # mmdit | flux | single | moe_single | unet | sana | wan
     hidden: int
     num_double_layers: int
     num_single_layers: int
@@ -136,6 +136,12 @@ class DenoiserGeometry:
     text_tokens: int = 256
     default_steps: int = 28
     default_cfg_batch: int = 2  # classifier-free guidance -> 2 forwards/step
+    # cross-attention context width; 0 falls back to ``hidden``
+    context_dim: int = 0
+    # video (3D) geometry; vae_temporal == 1 marks an image model
+    vae_temporal: int = 1  # causal latent downsample along frames
+    patch_t: int = 1  # transformer patch size on the temporal latent axis
+    default_frames: int = 1
     # UNet-only (SDXL)
     unet: dict[str, Any] = field(default_factory=dict)
     notes: str = ""
@@ -157,6 +163,8 @@ _CLASS_FAMILY: dict[str, str] = {
     "UNet2DConditionModel": "unet",
     # FLUX.2 keeps FLUX.1's dual + single stream structure, only wider.
     "Flux2Transformer2DModel": "flux",
+    # Text-to-video; cross-attends to text rather than concatenating it.
+    "WanTransformer3DModel": "wan",
 }
 
 # Per-class overrides for constants the config does not expose (diffusers
@@ -166,6 +174,15 @@ _CLASS_DEFAULTS: dict[str, dict[str, Any]] = {
     "FluxTransformer2DModel": {"text_tokens": 512, "default_steps": 28, "default_cfg_batch": 1},
     # FLUX.2-dev is guidance-distilled like FLUX.1-dev, so one forward per step.
     "Flux2Transformer2DModel": {"text_tokens": 512, "default_steps": 50, "default_cfg_batch": 1},
+    # Wan 2.x T2V; WanPipeline defaults, VAE 8x spatial / 4x temporal.
+    "WanTransformer3DModel": {
+        "text_tokens": 512,
+        "default_steps": 40,
+        "default_cfg_batch": 2,
+        "vae_spatial": 8,
+        "vae_temporal": 4,
+        "default_frames": 81,
+    },
     "QwenImageTransformer2DModel": {"text_tokens": 256, "default_steps": 30, "default_cfg_batch": 2},
     "AuraFlowTransformer2DModel": {"text_tokens": 256, "default_steps": 50, "default_cfg_batch": 2},
     "HunyuanImageTransformer2DModel": {"text_tokens": 256, "default_steps": 50, "default_cfg_batch": 2},
@@ -222,7 +239,8 @@ def _resolve_head_dim(cfg: dict[str, Any], hidden: int) -> int:
 
 
 def _resolve_intermediate(cfg: dict[str, Any], hidden: int) -> int:
-    for k in ("intermediate_size", "ffn_hidden_size"):
+    # ``ffn_dim`` is the Wan spelling of the FFN width.
+    for k in ("intermediate_size", "ffn_hidden_size", "ffn_dim"):
         if cfg.get(k):
             return int(cfg[k])
     if cfg.get("mlp_ratio"):
@@ -375,9 +393,15 @@ def resolve_geometry(model_dir: str | Path) -> DenoiserGeometry | None:
             defaults.update(hint)
 
     patch = 2
+    patch_t = 1
     ps = cfg.get("patch_size") or cfg.get("all_patch_size")
     if isinstance(ps, list) and ps:
-        patch = int(ps[0])
+        # A 3-element patch is (temporal, height, width); Wan ships (1, 2, 2).
+        if len(ps) >= 3:
+            patch_t = int(ps[0])
+            patch = int(ps[-1])
+        else:
+            patch = int(ps[0])
     elif isinstance(ps, int):
         patch = int(ps)
     # FLUX / ERNIE / Sana declare patch_size=1 but pack 2x2; force patch=2 for
@@ -413,6 +437,10 @@ def resolve_geometry(model_dir: str | Path) -> DenoiserGeometry | None:
         text_tokens=int(defaults.get("text_tokens", 256)),
         default_steps=int(defaults.get("default_steps", 28)),
         default_cfg_batch=int(defaults.get("default_cfg_batch", 2)),
+        context_dim=int(cfg.get("text_dim") or cfg.get("joint_attention_dim") or cfg.get("cross_attention_dim") or 0),
+        vae_temporal=int(defaults.get("vae_temporal", 1)),
+        patch_t=patch_t,
+        default_frames=int(defaults.get("default_frames", 1)),
         unet=unet_geom,
         notes=basename,
     )
@@ -423,6 +451,22 @@ def _image_tokens(g: DenoiserGeometry, height: int, width: int) -> int:
     lat_h = max(height // g.vae_spatial // g.patch, 1)
     lat_w = max(width // g.vae_spatial // g.patch, 1)
     return int(lat_h * lat_w)
+
+
+def _latent_frames(g: DenoiserGeometry, frames: int) -> int:
+    """Latent frames after the causal VAE and temporal patch.
+
+    Causal: ``(frames - 1) // vae_temporal + 1``, so 81 frames at 4x gives 21.
+    """
+    if g.vae_temporal <= 1:
+        return 1
+    lat_t = (max(int(frames), 1) - 1) // g.vae_temporal + 1
+    return max(lat_t // max(g.patch_t, 1), 1)
+
+
+def _video_tokens(g: DenoiserGeometry, height: int, width: int, frames: int) -> int:
+    """Denoiser tokens for a video model: latent frames x spatial tokens."""
+    return int(_latent_frames(g, frames) * _image_tokens(g, height, width))
 
 
 def _ffn_per_token(g: DenoiserGeometry) -> float:
@@ -454,7 +498,7 @@ def _cross_attention_block_flops(g: DenoiserGeometry, q_tokens: int, tt: int) ->
     the text length.
     """
     qo = q_tokens * _linear_flops(1.0, g.hidden, g.hidden) * 2
-    kv = tt * _linear_flops(1.0, g.hidden, g.hidden) * 2
+    kv = tt * _linear_flops(1.0, g.context_dim or g.hidden, g.hidden) * 2
     return _cross_attention_flops(q_tokens, tt, g.hidden) + qo + kv
 
 
@@ -463,6 +507,16 @@ def _sana_layer(g: DenoiserGeometry, ti: int, tt: int, ffn_pt: float) -> float:
     lin = ti * _qkvo_flops(1.0, g.hidden) + ti * ffn_pt
     self_attn = _linear_attention_flops(ti, g.hidden, g.head_dim or 32)
     return lin + self_attn + _cross_attention_block_flops(g, ti, tt)
+
+
+def _wan_layer(g: DenoiserGeometry, tv: int, tt: int, ffn_pt: float) -> float:
+    """One Wan block: self-attention over video tokens, cross-attention to text.
+
+    The quadratic term is over video tokens alone; text is not concatenated.
+    """
+    lin = tv * _qkvo_flops(1.0, g.hidden) + tv * ffn_pt
+    self_attn = _full_attention_flops(tv, g.hidden)
+    return lin + self_attn + _cross_attention_block_flops(g, tv, tt)
 
 
 def _unet_forward_flops(g: DenoiserGeometry, height: int, width: int) -> float:
@@ -506,11 +560,32 @@ def _unet_forward_flops(g: DenoiserGeometry, height: int, width: int) -> float:
     return down_and_mid * 2.5  # down + mid(~small) + up(~1.5x down)
 
 
-def forward_flops(g: DenoiserGeometry, height: int, width: int) -> dict[str, float]:
-    """FLOPs for ONE denoiser forward pass (no CFG, no step scaling)."""
+def forward_flops(
+    g: DenoiserGeometry, height: int, width: int, frames: int | None = None
+) -> dict[str, float]:
+    """FLOPs for ONE denoiser forward pass (no CFG, no step scaling).
+
+    ``frames`` defaults to the family value, not a literal 1, so a video
+    denoiser is not silently undercounted. Image families ignore it.
+    """
+    frames = int(frames if frames is not None else g.default_frames)
     if g.family == "unet":
         total = _unet_forward_flops(g, height, width)
         return {"forward_flops": total, "image_tokens": 0, "text_tokens": g.text_tokens}
+
+    if g.family == "wan":
+        tv = _video_tokens(g, height, width, frames)
+        tt = g.text_tokens
+        ffn_pt = _ffn_per_token(g)
+        total = 0.0
+        for _ in range(g.num_double_layers + g.num_single_layers):
+            total += _wan_layer(g, tv, tt, ffn_pt)
+        return {
+            "forward_flops": total,
+            "image_tokens": tv,
+            "text_tokens": tt,
+            "latent_frames": _latent_frames(g, frames),
+        }
 
     ti = _image_tokens(g, height, width)
     tt = g.text_tokens
@@ -544,8 +619,11 @@ def estimate_image_flops(
     width: int = 1024,
     num_steps: int | None = None,
     cfg_batch: int | None = None,
+    num_frames: int | None = None,
 ) -> dict[str, Any] | None:
-    """Full per-image FLOPs = forward x steps x cfg_batch.
+    """Full per-sample FLOPs = forward x steps x cfg_batch.
+
+    A "sample" is one image for 2D families and one clip for video families.
 
     Args:
         model_dir: Local diffusers model directory.
@@ -562,10 +640,11 @@ def estimate_image_flops(
         return None
     steps = int(num_steps if num_steps is not None else g.default_steps)
     cfgb = int(cfg_batch if cfg_batch is not None else g.default_cfg_batch)
-    fwd = forward_flops(g, height, width)
+    frames = int(num_frames if num_frames is not None else g.default_frames)
+    fwd = forward_flops(g, height, width, frames)
     per_step = fwd["forward_flops"] * cfgb
     total = per_step * steps
-    return {
+    est = {
         "model_class": g.model_class,
         "family": g.family,
         "hidden": g.hidden,
@@ -582,6 +661,10 @@ def estimate_image_flops(
         "per_step_flops": per_step,
         "total_flops": total,
     }
+    if g.vae_temporal > 1:
+        est["num_frames"] = frames
+        est["latent_frames"] = fwd.get("latent_frames", 1)
+    return est
 
 
 def analytic_ceiling(
@@ -593,14 +676,22 @@ def analytic_ceiling(
     width: int = 1024,
     num_steps: int | None = None,
     cfg_batch: int | None = None,
+    num_frames: int | None = None,
 ) -> dict[str, Any] | None:
-    """Analytic compute-bound ceiling (ideal ms) for one image.
+    """Analytic compute-bound ceiling (ideal ms) for one image or video clip.
 
     Returns the FLOPs estimate plus ``peak_tflops`` and ``ideal_ms`` =
     total_flops / (peak * 1e12) * 1e3. ``ideal_ms`` is absent when the
     (gpu, precision) peak is unknown.
     """
-    est = estimate_image_flops(model_dir, height=height, width=width, num_steps=num_steps, cfg_batch=cfg_batch)
+    est = estimate_image_flops(
+        model_dir,
+        height=height,
+        width=width,
+        num_steps=num_steps,
+        cfg_batch=cfg_batch,
+        num_frames=num_frames,
+    )
     if est is None:
         return None
     pk = peak_tflops(gpu_type, precision)
@@ -615,12 +706,14 @@ def analytic_ceiling(
 
 def _fmt(est: dict[str, Any]) -> str:
     tf = est["total_flops"] / 1e12
+    frames = f"f={est['num_frames']}({est['latent_frames']}lat) " if "num_frames" in est else ""
     line = (
         f"{est['model_class']:<34} {est['family']:<10} "
         f"h={est['hidden']:<5} L={est['layers']:<3} "
-        f"tok={est['image_tokens']:<5}+{est['text_tokens']:<4} "
+        f"{frames}"
+        f"tok={est['image_tokens']:<6}+{est['text_tokens']:<4} "
         f"steps={est['num_steps']:<3}x{est['cfg_batch']} "
-        f"{tf:8.1f} TFLOP/img"
+        f"{tf:8.1f} TFLOP/{'clip' if 'num_frames' in est else 'img'}"
     )
     if "ideal_ms" in est:
         line += f"  ideal={est['ideal_ms']:8.1f} ms ({est['peak_tflops']:.0f} TFLOPS)"
@@ -636,6 +729,12 @@ def main() -> int:
     ap.add_argument("--width", type=int, default=1024)
     ap.add_argument("--steps", type=int, default=0, help="Override denoise steps (0 = family default).")
     ap.add_argument("--cfg-batch", type=int, default=0, help="Override forwards/step (0 = family default).")
+    ap.add_argument(
+        "--frames",
+        type=int,
+        default=0,
+        help="Output frames for video models (0 = family default). Ignored by image models.",
+    )
     ap.add_argument("--json", action="store_true")
     args = ap.parse_args()
     est = analytic_ceiling(
@@ -646,6 +745,7 @@ def main() -> int:
         width=args.width,
         num_steps=args.steps or None,
         cfg_batch=args.cfg_batch or None,
+        num_frames=args.frames or None,
     )
     if est is None:
         print(f"could not resolve denoiser geometry for {args.model_dir}")

--- a/src/hyperloom/agents/kernel/tools/diffusion_roofline.py
+++ b/src/hyperloom/agents/kernel/tools/diffusion_roofline.py
@@ -524,6 +524,12 @@ def main() -> int:
     parser.add_argument("--height", type=int, default=1024, help="Output image height (px) for the analytic ceiling.")
     parser.add_argument("--width", type=int, default=1024, help="Output image width (px) for the analytic ceiling.")
     parser.add_argument(
+        "--frames",
+        type=int,
+        default=0,
+        help="Output frames for video denoisers (0 = model default). Ignored by image models.",
+    )
+    parser.add_argument(
         "--precision", default="bf16", help="Runtime precision for the peak-TFLOPS ceiling (bf16 / fp8 / mxfp4)."
     )
     parser.add_argument(
@@ -590,6 +596,7 @@ def main() -> int:
                 width=args.width,
                 num_steps=args.num_denoise_steps or None,
                 cfg_batch=args.cfg_batch or None,
+                num_frames=getattr(args, "frames", 0) or None,
             )
             if est:
                 report["analytic_ceiling"] = est

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -6664,6 +6664,7 @@ def write_reports(
                         _h = int(getattr(args, "height", 0) or 0)
                         _w = int(getattr(args, "width", 0) or 0)
                         _cfg_batch = int(getattr(args, "cfg_batch", 0) or 0)
+                        _frames = int(getattr(args, "frames", 0) or 0)
                         _est = _dflops.analytic_ceiling(
                             _model_dir,
                             gpu_type=_gpu,
@@ -6672,6 +6673,7 @@ def write_reports(
                             width=_w or 1024,
                             num_steps=_num_steps or None,
                             cfg_batch=_cfg_batch or None,
+                            num_frames=_frames or None,
                         )
                         if _est:
                             _diff_report["analytic_ceiling"] = _est
@@ -6845,6 +6847,12 @@ def main() -> int:
         type=int,
         default=0,
         help="Diffusion image width for the analytic ceiling (0 = estimator default).",
+    )
+    parser.add_argument(
+        "--frames",
+        type=int,
+        default=0,
+        help="Diffusion output frames for the analytic ceiling (0 = estimator default).",
     )
     parser.add_argument(
         "--cfg-batch",


### PR DESCRIPTION
**Draft — not proposed for merge.** Split out of #1115 at review request, and parked here rather than dropped.

**Description: what and why**

Adds the 3D/video frame axis to `diffusion_flops.py` and routes `WanTransformer3DModel`. It is a draft because, as noted on #1115, there is currently no way to point Hyperloom at a Wan workload — no SGLang `multimodal_gen` route exists and the xDiT wrapper is image-shaped. Merging a code path the tree cannot exercise is worse than parking one, so this sits here until that changes (see #1114).

It is **not** a parking lot for known-broken code: the defects raised on #1115 are fixed here.

**The model.** The Wan VAE is causal, so `latent_frames = (frames - 1) // vae_temporal + 1` and the denoiser sees `latent_frames * lat_h * lat_w` tokens in one full-attention context. Attention is quadratic in that count, so frames dominate the ceiling. Wan gets its own family rather than reusing `single` because it cross-attends to text instead of concatenating it, so the O(n²) term is over video tokens alone. It reuses `_cross_attention_block_flops` from #1115, so it counts all four projections from the start.

**Review fixes carried here**

- `forward_flops(g, h, w)` defaulted `frames` to a literal `1` — a public entry point silently undercounting a video denoiser by its latent-frame count. Now `frames: int | None = None` falling back to `g.default_frames`, matching `estimate_image_flops`. `test_forward_flops_frames_defaults_to_the_family_not_one` pins it.
- `--frames` never reached the report writers. `num_frames` is threaded through `analytic_ceiling` into both `diffusion_roofline.py` and `tracelens_analysis.py`, each of which gains a `--frames` flag. Without this a session could only ever use the table default, which is what produced the 6.28× you measured.

**Config-reading fixes that fall out of the Wan config**

| | before | after |
|---|---|---|
| `patch_size` `[1,2,2]` | `ps[0]` read the temporal patch as spatial (1), inflating tokens 4× | reads `(t, h, w)` on the right axes |
| `ffn_dim` | unrecognised → `4*hidden` = 20480 | 13824, its real width |
| frames | no concept | `vae_temporal` / `patch_t` / `default_frames` |

`vae_temporal == 1` marks an image model, so every existing family is untouched and byte-identical.

**Validation**

Wan2.2-T2V-A14B at 720p × 81 frames resolves to 21 latent frames and **75600 tokens** — exactly the attention operand shape in a real Wan2.2 trace, `(1, 75600, 5, 128)` under Ulysses-8. That single number pins the temporal compression, the causal off-by-one and the spatial patch simultaneously.

```
WanTransformer3DModel  wan  h=5120 L=40  f=81(21lat) tok=75600+512  steps=8 x2
```

```
pytest src/hyperloom/agents/kernel/tests   ->  1624 passed, 29 skipped
ruff check                                 ->  clean
```

**Deliberately not addressed: `num_gpus`.** You flagged that `analytic_ceiling` is single-GPU, so Ulysses-8 is off another 8×. That is real but not Wan-specific — it already affects xDiT sessions, whose `baseline_xdit.yaml` defaults `TP` to 8, so a FLUX run at TP=8 compares a whole-model FLOP count against one GPU's peak and `analytic_within_pct` inherits it. Fixing it would move numbers on a path you are actively using, and the right shape (divide the ceiling vs. report per-GPU explicitly) is your call, so I have left it alone here.

Stacked on #1115 — the FLUX.2 commit is its parent, so review that one first.
