### PR TITLE
feat(scripts): audit BIOS-only EPYC knobs over Redfish

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -102,7 +102,11 @@ jobs:
         id: bandit_scan
         continue-on-error: true
         run: |
-          bandit -r src/hyperloom -x "*/tests/*" -q --severity-level medium
+          # scripts/ is included deliberately: platform_audit_bmc.py mints BMC
+          # credentials and runs privileged subprocesses, so it is exactly the
+          # code a security scanner should see, even though it ships outside the
+          # package.
+          bandit -r src/hyperloom scripts -x "*/tests/*" -q --severity-level medium
 
       - name: Advisory notice when Bandit failed
         if: always() && steps.bandit_scan.outcome == 'failure'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -105,7 +105,10 @@ jobs:
           # scripts/ is included deliberately: platform_audit_bmc.py mints BMC
           # credentials and runs privileged subprocesses, so it is exactly the
           # code a security scanner should see, even though it ships outside the
-          # package.
+          # package. This widens the full-tree invocation only -- pre-commit's
+          # Bandit hook is passed explicit filenames and already covered
+          # scripts/ -- and the step stays advisory (continue-on-error), so it
+          # reports rather than gates.
           bandit -r src/hyperloom scripts -x "*/tests/*" -q --severity-level medium
 
       - name: Advisory notice when Bandit failed

--- a/README.md
+++ b/README.md
@@ -84,13 +84,14 @@ feedback on how to improve Hyperloom by completing the
   root — the HWCR MSR; no credentials, nothing written. Exit `0` on target, `1` a
   knob is wrong, `2` unresolved, which CI should treat as missing coverage rather
   than as a failure. The BIOS-only knobs are not reachable this way; see below.
-- BIOS audit over the BMC: `sudo python3 scripts/platform_audit_bmc.py` — covers the
-  three knobs the OS cannot see (High Performance profile, APBDIS, DF C-states),
-  targeted per [58011][58011] §4.2.1, §4.4.3 and §4.4.4. **Mints a temporary
-  ADMINISTRATOR account on the BMC** unless `--bmc-user` names an existing one, so
-  running it is a deliberate choice; exit `3` means such an account was left enabled
-  or could not be confirmed revoked, and should page someone. The script's docstring
-  has the account lifecycle and the rest of the exit codes.
+- BIOS audit over the BMC: `sudo python3 scripts/platform_audit_bmc.py --bmc-user <ro>`
+  — covers the three knobs the OS cannot see (High Performance profile, APBDIS, DF
+  C-states), targeted per [58011][58011] §4.2.1, §4.4.3 and §4.4.4. Without
+  `--bmc-user` it refuses to run unless `--allow-account-creation` is passed, because
+  that path **mints a temporary ADMINISTRATOR account on the BMC**; exit `3` means
+  such an account was left enabled or could not be confirmed revoked, and should page
+  someone. The script's docstring has the account lifecycle and the rest of the exit
+  codes.
 - Documentation source: `docs/`
 
 [58011]: https://docs.amd.com/v/u/en-US/58011-epyc-9004-tg-bios-and-workload

--- a/README.md
+++ b/README.md
@@ -85,18 +85,12 @@ feedback on how to improve Hyperloom by completing the
   knob is wrong, `2` unresolved, which CI should treat as missing coverage rather
   than as a failure. The BIOS-only knobs are not reachable this way; see below.
 - BIOS audit over the BMC: `sudo python3 scripts/platform_audit_bmc.py` — covers the
-  three BIOS-only knobs (High Performance profile, APBDIS, DF C-states), each
-  targeted per [58011][58011] §4.2.1, §4.4.3 and §4.4.4 respectively.
-  **This creates a temporary ADMINISTRATOR account on the BMC** unless you pass
-  `--bmc-user` with an existing account: with no credentials on file it mints a
-  sentinel account over the in-band KCS channel, uses it for a few HTTPS GETs,
-  then revokes it and verifies the revocation. Root on the host already holds
-  full BMC authority through KCS, so this is not an escalation — but many sites
-  prohibit creating service-processor accounts, so it must be a deliberate
-  choice. TLS verification is on by default; most BMCs ship a self-signed
-  certificate, so expect to pass `--ca-cert` or an explicit `--insecure`. Exit
-  `3` means an account was left enabled or its state could not be confirmed, and
-  should page someone rather than scroll past as a generic failure.
+  three knobs the OS cannot see (High Performance profile, APBDIS, DF C-states),
+  targeted per [58011][58011] §4.2.1, §4.4.3 and §4.4.4. **Mints a temporary
+  ADMINISTRATOR account on the BMC** unless `--bmc-user` names an existing one, so
+  running it is a deliberate choice; exit `3` means such an account was left enabled
+  or could not be confirmed revoked, and should page someone. The script's docstring
+  has the account lifecycle and the rest of the exit codes.
 - Documentation source: `docs/`
 
 [58011]: https://docs.amd.com/v/u/en-US/58011-epyc-9004-tg-bios-and-workload

--- a/README.md
+++ b/README.md
@@ -83,7 +83,20 @@ feedback on how to improve Hyperloom by completing the
   by workload or the OS layer can only infer them. Reads `/sys`, `/proc` and — as
   root — the HWCR MSR; no credentials, nothing written. Exit `0` on target, `1` a
   knob is wrong, `2` unresolved, which CI should treat as missing coverage rather
-  than as a failure.
+  than as a failure. The BIOS-only knobs are not reachable this way; see below.
+- BIOS audit over the BMC: `sudo python3 scripts/platform_audit_bmc.py` — covers the
+  three BIOS-only knobs (High Performance profile, APBDIS, DF C-states), each
+  targeted per [58011][58011] §4.2.1, §4.4.3 and §4.4.4 respectively.
+  **This creates a temporary ADMINISTRATOR account on the BMC** unless you pass
+  `--bmc-user` with an existing account: with no credentials on file it mints a
+  sentinel account over the in-band KCS channel, uses it for a few HTTPS GETs,
+  then revokes it and verifies the revocation. Root on the host already holds
+  full BMC authority through KCS, so this is not an escalation — but many sites
+  prohibit creating service-processor accounts, so it must be a deliberate
+  choice. TLS verification is on by default; most BMCs ship a self-signed
+  certificate, so expect to pass `--ca-cert` or an explicit `--insecure`. Exit
+  `3` means an account was left enabled or its state could not be confirmed, and
+  should page someone rather than scroll past as a generic failure.
 - Documentation source: `docs/`
 
 [58011]: https://docs.amd.com/v/u/en-US/58011-epyc-9004-tg-bios-and-workload

--- a/scripts/platform_audit_bmc.py
+++ b/scripts/platform_audit_bmc.py
@@ -11,13 +11,15 @@ measured OS state, which is the only way those answers become meaningful.
 
 .. warning::
 
-   **This tool creates a temporary privileged account on the BMC.** With no
-   ``--bmc-user`` on file it mints a sentinel ADMINISTRATOR account over the
-   in-band KCS channel, uses it for a handful of HTTPS GETs, then revokes it and
-   verifies the revocation. Root on the host already carries full BMC authority
-   through KCS, so this is not an escalation -- but many sites prohibit creating
-   service-processor accounts outright, and it must be a deliberate choice. Pass
-   ``--bmc-user`` with an existing read-only account to avoid it entirely.
+   **This tool can create a temporary privileged account on the BMC.** Given
+   ``--allow-account-creation`` and no ``--bmc-user``, it mints a sentinel
+   ADMINISTRATOR account over the in-band KCS channel, uses it for a handful of
+   HTTPS GETs, then revokes it and verifies the revocation. Root on the host
+   already carries full BMC authority through KCS, so this is not an escalation
+   -- but many sites prohibit creating service-processor accounts outright, so
+   the flag is required rather than assumed: with neither option the audit
+   refuses to start. Pass ``--bmc-user`` with an existing read-only account to
+   avoid minting entirely.
 
 Failure philosophy: every step that grants access is checked, and the read-back
 that confirms revocation distinguishes "read it, disabled" from "could not read
@@ -45,6 +47,7 @@ import subprocess  # nosec B404 - fixed argv, no shell.
 import sys
 import urllib.error
 import urllib.request
+from collections.abc import Sequence
 
 SENTINEL_USER = "hlaudit"
 
@@ -111,11 +114,6 @@ BIOS_KNOBS: dict[str, dict] = {
 #: case-sensitive scope, since under re.I a bare ``[a-z]`` also matches "C".
 NAME_BLOCKLIST = re.compile(r"\bsev(?!(?-i:[a-z]))|snp.?support|encrypt", re.I)
 
-#: Populated when an account could not be verifiably revoked, or was found
-#: already enabled from a previous run. Either way credentials were exposed for
-#: longer than this tool intended, which outranks any knob verdict.
-CREDENTIAL_FAILURES: list[str] = []
-
 
 def run(cmd: list[str], timeout: int = 30, stdin: str | None = None) -> tuple[bool, str, str]:
     """Run a command, returning ``(ok, stdout, stderr)``. Never raises."""
@@ -174,9 +172,9 @@ def account_status(slot: int) -> tuple[str | None, str]:
 
     ``None`` means the state could not be read, which is deliberately *not* the
     same answer as "disabled". This read-back is the trust anchor for the whole
-    revocation; built on a failure-swallowing runner it answered "not enabled"
-    for any BMC that errored, timed out, or formatted the output differently --
-    a false confirmation exactly where confirmation matters most.
+    revocation: collapsing an unreadable state into "not enabled" would hand
+    back a false confirmation for any BMC that errors, times out, or formats the
+    output differently -- exactly where confirmation matters most.
     """
     ok, out, err = sudo_run(["ipmitool", "channel", "getaccess", "1", str(slot)])
     if not ok:
@@ -201,8 +199,8 @@ def set_bmc_password(slot: int, password: str) -> tuple[bool, bool]:
 
     Deliberately returns no text. The secret is on this command's stdin and
     ipmitool echoes its input on some failures, while callers print their
-    failures to the console and store them in ``CREDENTIAL_FAILURES`` -- so
-    handing back stderr from here could publish a live BMC password. Callers
+    failures to the console and store them among the account's credential
+    failures -- so handing back stderr here could publish a live password. Callers
     own the wording. Diagnosing a genuinely broken BMC means running ipmitool by
     hand, which is a fair price for keeping the secret inside the one function
     that handles it.
@@ -228,6 +226,13 @@ class TempBmcAccount:
         self.password = ""
         self.note = ""
         self.mint_errors: list[str] = []
+        #: Filled when the account could not be verifiably revoked, or was found
+        #: already enabled from a run that did not shut down cleanly. Either way
+        #: credentials were exposed for longer than this tool intended, which
+        #: outranks any knob verdict. Kept on the instance rather than in a
+        #: module global so ``main()`` reads it after ``__exit__`` has run --
+        #: which is the only moment the list is complete.
+        self.credential_failures: list[str] = []
         self._secret_len = secret_len
 
     def _slot(self) -> int | None:
@@ -253,9 +258,7 @@ class TempBmcAccount:
         # Claim the slot BEFORE any mutation, so __exit__ always runs the revoke
         # path. Revoking a slot that was never enabled is idempotent and costs
         # nothing; skipping revocation on one that was leaves a live
-        # ADMINISTRATOR account. Previously the slot was claimed only after the
-        # password step, so a password failure on an already-enabled sentinel
-        # returned with nothing recorded and a clean exit code.
+        # ADMINISTRATOR account.
         self.slot = slot
 
         status, detail = account_status(slot)
@@ -272,17 +275,21 @@ class TempBmcAccount:
                 f"earlier run that did not shut down cleanly; it has been reachable over "
                 f"the LAN channel since then"
             )
-            CREDENTIAL_FAILURES.append(msg)
+            self.credential_failures.append(msg)
             print(f"WARNING: {msg}. Re-minting and revoking now.", file=sys.stderr)
 
         pw = secrets.token_urlsafe(24)[: self._secret_len]
-        steps: list[tuple[str, list[str]]] = [
-            ("set account name", ["ipmitool", "user", "set", "name", str(slot), self.user]),
-        ]
-        for what, cmd in steps:
-            ok, _, err = sudo_run(cmd)
-            if not ok:
-                self.mint_errors.append(f"{what}: {err.strip() or 'command failed'}")
+
+        # Abort on a failed name step, exactly as the password step does. Every
+        # step after this one grants access, so running them on a slot whose
+        # name is not ours enables an ADMINISTRATOR account that Redfish then
+        # 401s against -- pointing the operator at authentication when the real
+        # cause is a slot the audit never owned.
+        ok, _, err = sudo_run(["ipmitool", "user", "set", "name", str(slot), self.user])
+        if not ok:
+            self.mint_errors.append(f"set account name: {err.strip() or 'command failed'}")
+            self.note = "; ".join(self.mint_errors)
+            return self
 
         ok, confirmed = set_bmc_password(slot, pw)
         if not ok:
@@ -296,9 +303,9 @@ class TempBmcAccount:
             )
 
         # Every remaining step grants access, so each is checked. A silent
-        # failure here previously produced a 401 from Redfish, pointing the
-        # operator at an authentication or OEM-compatibility problem when the
-        # real cause was an account that was never enabled.
+        # failure here surfaces as a 401 from Redfish, which reads as an
+        # authentication or OEM-compatibility problem when the real cause is an
+        # account that was never enabled.
         for what, cmd in (
             ("grant privilege", ["ipmitool", "user", "priv", str(slot), "4", "1"]),
             ("enable account", ["ipmitool", "user", "enable", str(slot)]),
@@ -358,7 +365,7 @@ class TempBmcAccount:
             failures.append("account still reports Enable Status: enabled after revoke")
 
         if failures:
-            CREDENTIAL_FAILURES.extend(failures)
+            self.credential_failures.extend(failures)
             print(
                 f"\n*** SECURITY: could not verify revocation of BMC account "
                 f"'{self.user}' in slot {self.slot} on this node.\n"
@@ -466,7 +473,7 @@ def resolve(attrs: dict) -> dict:
         hits = {k: v for k, v in attrs.items() if rx.search(k) and not NAME_BLOCKLIST.search(k)}
         if not hits:
             continue
-        # Prefer the shortest name: "SMTControl" over "SMTControlPolicyOverride".
+        # Prefer the shortest name: "ApbDis" over "ApbDisPolicyOverride".
         name = sorted(hits, key=lambda k: (len(k), k))[0]
         found[key] = {
             "attribute": name,
@@ -492,9 +499,13 @@ def verdict(key: str, value: object) -> str:
 EXIT_OK, EXIT_FAIL, EXIT_UNKNOWN, EXIT_CREDENTIAL = 0, 1, 2, 3
 
 
-def exit_code(rows: list[dict]) -> int:
-    """Worst status. A credential problem outranks every knob verdict."""
-    if CREDENTIAL_FAILURES:
+def exit_code(rows: list[dict], credential_failures: Sequence[str] = ()) -> int:
+    """Worst status. A credential problem outranks every knob verdict.
+
+    ``credential_failures`` is passed in rather than read from module state so
+    that callers cannot compute this before the revocation has been attempted.
+    """
+    if credential_failures:
         return EXIT_CREDENTIAL
     if any(r["verdict"] == "FAIL" for r in rows):
         return EXIT_FAIL
@@ -525,14 +536,21 @@ def main() -> int:
     ap = argparse.ArgumentParser(
         description="Audit BIOS-only EPYC knobs over Redfish (creates a temporary BMC account)",
         epilog=(
-            "Exit: 0 on target, 1 a knob is wrong, 2 unresolved, 3 a BMC account was "
-            "left enabled or could not be confirmed revoked. The password for "
+            "Exit: 0 on target, 1 a knob is wrong, 2 unresolved (including no BMC "
+            "access at all), 3 a BMC account was left enabled or could not be "
+            "confirmed revoked. Minting the temporary account needs "
+            "--allow-account-creation; without it, pass --bmc-user. The password for "
             "--bmc-user comes from $BMC_PASSWORD or a prompt, never the command line, "
             "where the process table would expose it to every local user."
         ),
     )
     ap.add_argument("--bmc-host", help="BMC address (discovered over KCS when omitted)")
     ap.add_argument("--bmc-user", help="existing BMC account; avoids minting a temporary one")
+    ap.add_argument(
+        "--allow-account-creation",
+        action="store_true",
+        help="permit minting a temporary ADMINISTRATOR account when --bmc-user is absent",
+    )
     ap.add_argument("--ca-cert", help="CA file (or the BMC's own certificate) to trust")
     ap.add_argument("--insecure", action="store_true", help="skip TLS verification (deliberate)")
     ap.add_argument("--json", action="store_true", help="machine-readable output")
@@ -541,9 +559,24 @@ def main() -> int:
     install_signal_handlers()
     ctx = tls_context(args.ca_cert, args.insecure)
 
-    if not args.bmc_host and not ipmitool_present():
-        print("ipmitool is not on PATH, so the BMC address cannot be discovered. "
-              "Pass --bmc-host explicitly.", file=sys.stderr)
+    # The README calls minting "a deliberate choice"; this is what makes it one.
+    # Refusing before any BMC contact means the default invocation cannot create
+    # a privileged account by omission.
+    mints_account = not args.bmc_user
+    if mints_account and not args.allow_account_creation:
+        print("Auditing without --bmc-user mints a temporary ADMINISTRATOR account on "
+              "the BMC. Pass --bmc-user with an existing (ideally read-only) account, "
+              "or --allow-account-creation to accept that.", file=sys.stderr)
+        return EXIT_UNKNOWN
+
+    # ipmitool is needed to mint an account, not only to discover the address,
+    # so --bmc-host does not excuse it on the minting path.
+    if (mints_account or not args.bmc_host) and not ipmitool_present():
+        print("ipmitool is not on PATH, so "
+              + ("the temporary account cannot be minted. Pass --bmc-user to audit "
+                 "with an existing account." if mints_account
+                 else "the BMC address cannot be discovered. Pass --bmc-host explicitly."),
+              file=sys.stderr)
         return EXIT_UNKNOWN
 
     host = args.bmc_host or bmc_ip()
@@ -557,34 +590,62 @@ def main() -> int:
         print(f"BMC {host} is not usable: {err}", file=sys.stderr)
         return EXIT_UNKNOWN
 
-    if args.bmc_user:
-        password = os.environ.get("BMC_PASSWORD") or getpass.getpass(
-            f"Password for {args.bmc_user}@{host}: "
-        )
-        attrs, _, err = redfish_bios(host, args.bmc_user, password, ctx)
-    else:
-        if args.insecure:
-            print(
-                "WARNING: --insecure with a minted account sends freshly created "
-                "ADMINISTRATOR credentials to a peer whose certificate was not "
-                "verified. Prefer --ca-cert, or --bmc-user with a read-only account.",
-                file=sys.stderr,
-            )
-        with TempBmcAccount() as acct:
-            if acct.slot is None or not acct.password:
-                print(f"Could not obtain BMC access: {acct.note or 'no slot'}", file=sys.stderr)
-                return exit_code([])
-            if acct.mint_errors:
-                print(f"Note: {'; '.join(acct.mint_errors)}", file=sys.stderr)
-            attrs, _, err = redfish_bios(host, acct.user, acct.password, ctx)
+    acct: TempBmcAccount | None = None
+    attrs: dict = {}
+    err = ""
+    no_access = ""
+    interrupted = False
 
+    try:
+        if args.bmc_user:
+            password = os.environ.get("BMC_PASSWORD") or getpass.getpass(
+                f"Password for {args.bmc_user}@{host}: "
+            )
+            attrs, _, err = redfish_bios(host, args.bmc_user, password, ctx)
+        else:
+            if args.insecure:
+                print(
+                    "WARNING: --insecure with a minted account sends freshly created "
+                    "ADMINISTRATOR credentials to a peer whose certificate was not "
+                    "verified. Prefer --ca-cert, or --bmc-user with a read-only account.",
+                    file=sys.stderr,
+                )
+            # Bound outside the `with` on purpose. Nothing here may compute the
+            # exit code: __exit__ is what discovers a failed revocation, and it
+            # has not run yet, so a `return` from inside this block would report
+            # a clean audit on the path most likely to have left an
+            # ADMINISTRATOR account enabled.
+            acct = TempBmcAccount()
+            with acct:
+                if acct.slot is None or not acct.password:
+                    no_access = acct.note or "no slot"
+                else:
+                    if acct.mint_errors:
+                        print(f"Note: {'; '.join(acct.mint_errors)}", file=sys.stderr)
+                    attrs, _, err = redfish_bios(host, acct.user, acct.password, ctx)
+    except KeyboardInterrupt:
+        # SIGTERM and SIGINT arrive here as an exception precisely so the `with`
+        # above unwinds and revokes. Letting it escape would end the run in a
+        # traceback and exit 130, discarding the revocation verdict that the
+        # signal handler exists to produce.
+        interrupted = True
+        print("\nInterrupted; see the credential report below.", file=sys.stderr)
+
+    credential_failures = list(acct.credential_failures) if acct else []
     rows = build_rows(resolve(attrs))
-    code = exit_code(rows)
+    code = exit_code(rows, credential_failures)
+
+    if no_access:
+        print(f"Could not obtain BMC access: {no_access}", file=sys.stderr)
+    # Never reaching a knob is unresolved, not "every checked knob is on
+    # target". A credential problem still outranks it.
+    if (no_access or interrupted) and code != EXIT_CREDENTIAL:
+        code = EXIT_UNKNOWN
 
     if args.json:
         print(json.dumps(
             {"host": host, "rows": rows, "error": err,
-             "credential_failures": CREDENTIAL_FAILURES, "exit_code": code},
+             "credential_failures": credential_failures, "exit_code": code},
             indent=2, sort_keys=True,
         ))
     else:
@@ -594,9 +655,9 @@ def main() -> int:
         for r in rows:
             want = f"  (want {r['target']})" if r["verdict"] != "PASS" else ""
             print(f"  {r['verdict']:<7} {r['knob']:<{width}}  {r['value']}{want}")
-        if CREDENTIAL_FAILURES:
+        if credential_failures:
             print("\nCredential problems (exit 3):", file=sys.stderr)
-            for f in CREDENTIAL_FAILURES:
+            for f in credential_failures:
                 print(f"    {f}", file=sys.stderr)
     return code
 

--- a/scripts/platform_audit_bmc.py
+++ b/scripts/platform_audit_bmc.py
@@ -187,26 +187,31 @@ def account_status(slot: int) -> tuple[str | None, str]:
     return m.group(1).lower(), ""
 
 
-def set_bmc_password(slot: int, password: str) -> tuple[bool, str]:
+def set_bmc_password(slot: int, password: str) -> tuple[bool, bool]:
     """Set a BMC account password without exposing it in the process table.
 
     Passing the password in argv would make it readable through
     ``/proc/<pid>/cmdline`` to any local user. Omitting it makes ipmitool prompt
     on stdin instead (twice, for confirmation), keeping it out of argv entirely.
 
-    The return code is the primary signal. The "successful" string is only
-    corroboration: its exact wording varies across ipmitool versions and is not
+    Returns ``(ok, confirmed)``. The return code is ``ok`` and the primary
+    signal; ``confirmed`` adds whether ipmitool printed its success string,
+    which is corroboration only -- the wording varies across versions and is not
     stable under a non-English locale, so it is never the sole criterion.
+
+    Deliberately returns no text. The secret is on this command's stdin and
+    ipmitool echoes its input on some failures, while callers print their
+    failures to the console and store them in ``CREDENTIAL_FAILURES`` -- so
+    handing back stderr from here could publish a live BMC password. Callers
+    own the wording. Diagnosing a genuinely broken BMC means running ipmitool by
+    hand, which is a fair price for keeping the secret inside the one function
+    that handles it.
     """
     ok, out, err = sudo_run(
         ["ipmitool", "user", "set", "password", str(slot)],
         stdin=f"{password}\n{password}\n",
     )
-    if not ok:
-        return False, err.strip() or "command failed"
-    if "successful" not in (out + err).lower():
-        return True, "return code says success but the confirmation string was absent"
-    return True, ""
+    return ok, ok and "successful" in (out + err).lower()
 
 
 class TempBmcAccount:
@@ -279,13 +284,16 @@ class TempBmcAccount:
             if not ok:
                 self.mint_errors.append(f"{what}: {err.strip() or 'command failed'}")
 
-        ok, detail = set_bmc_password(slot, pw)
+        ok, confirmed = set_bmc_password(slot, pw)
         if not ok:
-            self.mint_errors.append(f"set password: {detail}")
+            self.mint_errors.append("set password: ipmitool rejected the password set")
             self.note = "; ".join(self.mint_errors)
             return self
-        if detail:
-            self.mint_errors.append(f"set password: {detail}")
+        if not confirmed:
+            self.mint_errors.append(
+                "set password: return code reported success but ipmitool printed "
+                "no confirmation"
+            )
 
         # Every remaining step grants access, so each is checked. A silent
         # failure here previously produced a 401 from Redfish, pointing the
@@ -338,9 +346,9 @@ class TempBmcAccount:
             failures.append(f"disable account: {err.strip() or 'command failed'}")
 
         # Leave the password unguessable rather than merely disabled.
-        ok, detail = set_bmc_password(self.slot, secrets.token_urlsafe(24)[: self._secret_len])
+        ok, _ = set_bmc_password(self.slot, secrets.token_urlsafe(24)[: self._secret_len])
         if not ok:
-            failures.append(f"randomize password: {detail}")
+            failures.append("randomize password: ipmitool rejected the new password")
         self.password = ""
 
         status, detail = account_status(self.slot)

--- a/scripts/platform_audit_bmc.py
+++ b/scripts/platform_audit_bmc.py
@@ -1,0 +1,597 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Audit the BIOS-only EPYC tuning knobs over Redfish on the BMC.
+
+Extends ``platform_audit.py`` to the three knobs the operating system cannot
+see on kernels without ``amd_hsmp``: the platform High Performance profile,
+APBDIS, and DF C-states. It also reconciles a BIOS answer of "Auto" against the
+measured OS state, which is the only way those answers become meaningful.
+
+.. warning::
+
+   **This tool creates a temporary privileged account on the BMC.** With no
+   ``--bmc-user`` on file it mints a sentinel ADMINISTRATOR account over the
+   in-band KCS channel, uses it for a handful of HTTPS GETs, then revokes it and
+   verifies the revocation. Root on the host already carries full BMC authority
+   through KCS, so this is not an escalation -- but many sites prohibit creating
+   service-processor accounts outright, and it must be a deliberate choice. Pass
+   ``--bmc-user`` with an existing read-only account to avoid it entirely.
+
+Failure philosophy: every step that grants access is checked, and the read-back
+that confirms revocation distinguishes "read it, disabled" from "could not read
+it". A tool that cannot verify it cleaned up must say so, not report success.
+
+Exit codes:
+
+    0  every checked knob is on target
+    1  a knob is definitively wrong
+    2  a knob could not be resolved
+    3  a BMC account was left enabled, or its state could not be confirmed
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import getpass
+import json
+import os
+import re
+import signal
+import ssl
+import subprocess  # nosec B404 - fixed argv, no shell.
+import sys
+import urllib.error
+import urllib.request
+
+SENTINEL_USER = "hlaudit"
+
+#: AMD, "BIOS & Workload Tuning Guide for AMD EPYC 9004 Series Processors",
+#: publication 58011 rev 1.0 (2025-05-09).
+#: https://docs.amd.com/v/u/en-US/58011-epyc-9004-tg-bios-and-workload
+#:
+#: Unlike the OS-layer knobs, all three of these survive contact with chapter 5:
+#: each is either the documented default or is the value chapter 5 selects for
+#: its latency-sensitive columns, which is the closest published analogue to an
+#: inference serving host. The guide covers 9004 (Genoa); the knobs and their
+#: semantics carry forward to 9005 (Turin).
+SOURCE = (
+    "AMD BIOS & Workload Tuning Guide for EPYC 9004 (pub. 58011 rev 1.0), ch. 5"
+)
+
+#: BIOS knobs, matched by vendor attribute name. Names differ per OEM, so each
+#: is a synonym pattern rather than a per-vendor table.
+BIOS_KNOBS: dict[str, dict] = {
+    "power_profile": {
+        "label": "High Performance mode",
+        "pattern": r"power.?profile|system.?profile|perf.*profile.?sel",
+        "target": ("high performance mode", "high performance", "max performance"),
+        "basis": (
+            "58011 §4.2.1: High Performance mode is option 0 and the documented "
+            "default; chapter 5 selects it for the CPU-intensive, Java throughput "
+            "and Java latency profiles, and departs from it only for the explicit "
+            "Power Efficiency column."
+        ),
+    },
+    "apbdis": {
+        "label": "APBDIS",
+        "pattern": r"\bapbdis\b|apb.?dis",
+        "target": ("1",),
+        "basis": (
+            "58011 §4.4.3: setting APBDIS to 1 with a fixed Infinity Fabric "
+            "P-state 'forces the AMD Infinity Fabric and memory controllers into "
+            "full-power mode and significantly reduces latency jitters'. Chapter 5 "
+            "selects 1 for the NIC-latency, database and HPC columns. Serving is "
+            "latency-sensitive with bursty arrivals, so it matches those."
+        ),
+    },
+    "df_cstates": {
+        "label": "DF C-states",
+        "pattern": r"df.?c.?states?|data.?fabric.?c.?state",
+        "target": ("disabled",),
+        "basis": (
+            "58011 §4.4.4: the fabric takes a delay returning to full power that "
+            "'causes some latency jitter', and disabling it 'for workloads "
+            "requiring low latency and/or bursty I/O will increase performance' "
+            "at the cost of power. Chapter 5 disables it for the EDA column."
+        ),
+    },
+}
+
+#: Attribute names that collide with a knob pattern but mean something else.
+#:
+#: ``sev`` needs care in both directions. Unanchored it matched any name merely
+#: containing those letters, so "SeverityLevel" was dropped. A plain ``\bsev\b``
+#: over-corrects the other way: BIOS attributes are CamelCase, so "SevControl"
+#: has no trailing word boundary and would stop being blocked. Matching "sev"
+#: not followed by a lower-case letter keeps the CamelCase and SCREAMING_CASE
+#: forms while letting "Severity" through. The lookahead needs its own
+#: case-sensitive scope, since under re.I a bare ``[a-z]`` also matches "C".
+NAME_BLOCKLIST = re.compile(r"\bsev(?!(?-i:[a-z]))|snp.?support|encrypt", re.I)
+
+#: Populated when an account could not be verifiably revoked, or was found
+#: already enabled from a previous run. Either way credentials were exposed for
+#: longer than this tool intended, which outranks any knob verdict.
+CREDENTIAL_FAILURES: list[str] = []
+
+
+def run(cmd: list[str], timeout: int = 30, stdin: str | None = None) -> tuple[bool, str, str]:
+    """Run a command, returning ``(ok, stdout, stderr)``. Never raises."""
+    try:
+        r = subprocess.run(  # nosec B603 - fixed argv, no shell.
+            cmd, capture_output=True, text=True, timeout=timeout, input=stdin
+        )
+        return r.returncode == 0, r.stdout, r.stderr
+    except Exception as exc:  # noqa: BLE001 - surfaced to the caller as stderr
+        return False, "", str(exc)
+
+
+def sudo_run(cmd: list[str], **kw) -> tuple[bool, str, str]:
+    """Checked privileged run. Every access-granting step uses this."""
+    return run(cmd if os.geteuid() == 0 else ["sudo", "-n", *cmd], **kw)
+
+
+def ipmitool_present() -> bool:
+    """Whether ipmitool is callable, so a missing tool is not read as a missing BMC."""
+    return run(["ipmitool", "-V"], timeout=10)[0]
+
+
+def bmc_ip() -> str:
+    """Discover the BMC address over the local KCS interface."""
+    for ch in ("1", "8", "2"):
+        ok, out, _ = sudo_run(["ipmitool", "lan", "print", ch])
+        if not ok:
+            continue
+        m = re.search(r"^IP Address\s+:\s+([0-9.]+)", out, re.M)
+        # nosec B104 - not a bind address; this rejects the unconfigured-LAN
+        # sentinel that ipmitool reports for a channel with no IP assigned.
+        if m and m.group(1) != "0.0.0.0":  # nosec B104
+            return m.group(1)
+    return ""
+
+
+def bmc_users() -> dict[int, str]:
+    """Parse ``ipmitool user list`` into ``{slot: name}``; empty name means free."""
+    users: dict[int, str] = {}
+    ok, out, _ = sudo_run(["ipmitool", "user", "list", "1"])
+    if not ok:
+        return users
+    for line in out.splitlines():
+        f = line.split()
+        if not f or not f[0].isdigit():
+            continue
+        # An unnamed slot runs straight from the ID into the boolean columns,
+        # so a boolean in field 1 means the name is blank.
+        name = "" if len(f) < 2 or f[1] in ("true", "false") else f[1]
+        users[int(f[0])] = name
+    return users
+
+
+def account_status(slot: int) -> tuple[str | None, str]:
+    """Return ``(status, detail)`` where status is ``"enabled"``/``"disabled"``/``None``.
+
+    ``None`` means the state could not be read, which is deliberately *not* the
+    same answer as "disabled". This read-back is the trust anchor for the whole
+    revocation; built on a failure-swallowing runner it answered "not enabled"
+    for any BMC that errored, timed out, or formatted the output differently --
+    a false confirmation exactly where confirmation matters most.
+    """
+    ok, out, err = sudo_run(["ipmitool", "channel", "getaccess", "1", str(slot)])
+    if not ok:
+        return None, err.strip() or "getaccess failed"
+    m = re.search(r"Enable Status\s*:\s*(\w+)", out)
+    if not m:
+        return None, "could not parse 'Enable Status' from getaccess output"
+    return m.group(1).lower(), ""
+
+
+def set_bmc_password(slot: int, password: str) -> tuple[bool, str]:
+    """Set a BMC account password without exposing it in the process table.
+
+    Passing the password in argv would make it readable through
+    ``/proc/<pid>/cmdline`` to any local user. Omitting it makes ipmitool prompt
+    on stdin instead (twice, for confirmation), keeping it out of argv entirely.
+
+    The return code is the primary signal. The "successful" string is only
+    corroboration: its exact wording varies across ipmitool versions and is not
+    stable under a non-English locale, so it is never the sole criterion.
+    """
+    ok, out, err = sudo_run(
+        ["ipmitool", "user", "set", "password", str(slot)],
+        stdin=f"{password}\n{password}\n",
+    )
+    if not ok:
+        return False, err.strip() or "command failed"
+    if "successful" not in (out + err).lower():
+        return True, "return code says success but the confirmation string was absent"
+    return True, ""
+
+
+class TempBmcAccount:
+    """Mint a sentinel BMC account over KCS for one audit, then revoke it.
+
+    The same sentinel slot is reused across runs: Supermicro and others refuse
+    to blank a user name once set, so a fresh slot per run would slowly fill the
+    user table with dead accounts.
+    """
+
+    def __init__(self, secret_len: int = 16):
+        self.slot: int | None = None
+        self.user = SENTINEL_USER
+        self.password = ""
+        self.note = ""
+        self.mint_errors: list[str] = []
+        self._secret_len = secret_len
+
+    def _slot(self) -> int | None:
+        users = bmc_users()
+        if not users:
+            return None
+        for slot, name in sorted(users.items()):
+            if name == SENTINEL_USER:
+                return slot
+        for slot, name in sorted(users.items()):
+            if slot > 2 and not name:
+                return slot
+        return None
+
+    def __enter__(self):
+        import secrets
+
+        slot = self._slot()
+        if slot is None:
+            self.note = "no reusable BMC user slot"
+            return self
+
+        # Claim the slot BEFORE any mutation, so __exit__ always runs the revoke
+        # path. Revoking a slot that was never enabled is idempotent and costs
+        # nothing; skipping revocation on one that was leaves a live
+        # ADMINISTRATOR account. Previously the slot was claimed only after the
+        # password step, so a password failure on an already-enabled sentinel
+        # returned with nothing recorded and a clean exit code.
+        self.slot = slot
+
+        status, detail = account_status(slot)
+        if status is None:
+            self.mint_errors.append(f"could not read initial account state ({detail})")
+        elif status == "enabled":
+            # __exit__ cannot run if a previous invocation was SIGKILLed or the
+            # box rebooted mid-audit, so a sentinel found enabled is the
+            # fingerprint of exactly that: the account has been reachable over
+            # LAN since then. That is a credential exposure in its own right and
+            # is recorded, not merely printed.
+            msg = (
+                f"BMC account '{SENTINEL_USER}' (slot {slot}) was already enabled from an "
+                f"earlier run that did not shut down cleanly; it has been reachable over "
+                f"the LAN channel since then"
+            )
+            CREDENTIAL_FAILURES.append(msg)
+            print(f"WARNING: {msg}. Re-minting and revoking now.", file=sys.stderr)
+
+        pw = secrets.token_urlsafe(24)[: self._secret_len]
+        steps: list[tuple[str, list[str]]] = [
+            ("set account name", ["ipmitool", "user", "set", "name", str(slot), self.user]),
+        ]
+        for what, cmd in steps:
+            ok, _, err = sudo_run(cmd)
+            if not ok:
+                self.mint_errors.append(f"{what}: {err.strip() or 'command failed'}")
+
+        ok, detail = set_bmc_password(slot, pw)
+        if not ok:
+            self.mint_errors.append(f"set password: {detail}")
+            self.note = "; ".join(self.mint_errors)
+            return self
+        if detail:
+            self.mint_errors.append(f"set password: {detail}")
+
+        # Every remaining step grants access, so each is checked. A silent
+        # failure here previously produced a 401 from Redfish, pointing the
+        # operator at an authentication or OEM-compatibility problem when the
+        # real cause was an account that was never enabled.
+        for what, cmd in (
+            ("grant privilege", ["ipmitool", "user", "priv", str(slot), "4", "1"]),
+            ("enable account", ["ipmitool", "user", "enable", str(slot)]),
+            (
+                "grant channel access",
+                ["ipmitool", "channel", "setaccess", "1", str(slot),
+                 "callin=on", "ipmi=on", "link=on", "privilege=4"],
+            ),
+        ):
+            ok, _, err = sudo_run(cmd)
+            if not ok:
+                self.mint_errors.append(f"{what}: {err.strip() or 'command failed'}")
+
+        self.password = pw
+        self.note = "; ".join(self.mint_errors)
+        return self
+
+    def __exit__(self, *exc):
+        import secrets
+
+        if self.slot is None:
+            return False
+        s = str(self.slot)
+        failures: list[str] = []
+
+        # Channel access must be revoked while the user is still enabled; BMCs
+        # reject setaccess on a disabled account ("not supported in present
+        # state"), which would leave ADMINISTRATOR rights in place.
+        # privilege=15 ("no access") is the right end state, but Supermicro
+        # among others rejects it; CALLBACK is the lowest they accept and still
+        # drops ADMINISTRATOR, so try the strict value first and fall back.
+        revoked, last_err = False, ""
+        for priv in ("15", "1"):
+            revoked, _, last_err = sudo_run(
+                ["ipmitool", "channel", "setaccess", "1", s,
+                 "callin=off", "ipmi=off", "link=off", f"privilege={priv}"]
+            )
+            if revoked:
+                break
+        if not revoked:
+            failures.append(f"revoke channel access: {last_err.strip() or 'command failed'}")
+
+        ok, _, err = sudo_run(["ipmitool", "user", "disable", s])
+        if not ok:
+            failures.append(f"disable account: {err.strip() or 'command failed'}")
+
+        # Leave the password unguessable rather than merely disabled.
+        ok, detail = set_bmc_password(self.slot, secrets.token_urlsafe(24)[: self._secret_len])
+        if not ok:
+            failures.append(f"randomize password: {detail}")
+        self.password = ""
+
+        status, detail = account_status(self.slot)
+        if status is None:
+            failures.append(f"could not confirm final account state ({detail})")
+        elif status == "enabled":
+            failures.append("account still reports Enable Status: enabled after revoke")
+
+        if failures:
+            CREDENTIAL_FAILURES.extend(failures)
+            print(
+                f"\n*** SECURITY: could not verify revocation of BMC account "
+                f"'{self.user}' in slot {self.slot} on this node.\n"
+                f"*** It may remain enabled with ADMINISTRATOR privilege and be "
+                f"reachable over the LAN channel. Revoke it by hand:\n"
+                f"***   sudo ipmitool channel setaccess 1 {self.slot} callin=off "
+                f"ipmi=off link=off privilege=15\n"
+                f"***   sudo ipmitool user disable {self.slot}\n"
+                + "".join(f"***   - {f}\n" for f in failures),
+                file=sys.stderr,
+            )
+        return False
+
+
+def install_signal_handlers() -> None:
+    """Turn SIGTERM/SIGINT into an exception so ``with`` blocks still unwind.
+
+    Without this the account outlives the process on the most ordinary
+    termination there is. SIGKILL and a power cut remain uncoverable -- which is
+    why a sentinel found already enabled is treated as evidence of exposure --
+    but SIGTERM is what a CI timeout, a job scheduler, or an orchestration layer
+    actually sends, and it is recoverable.
+    """
+
+    def _raise(signum, _frame):
+        raise KeyboardInterrupt(f"received signal {signum}")
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            signal.signal(sig, _raise)
+        except (ValueError, OSError):  # not on the main thread
+            pass
+
+
+def tls_context(ca_cert: str | None, insecure: bool) -> ssl.SSLContext:
+    """Build the TLS context used for Redfish. Verification is on by default."""
+    if insecure:
+        return ssl._create_unverified_context()  # nosec B323 - operator opt-in
+    return ssl.create_default_context(cafile=ca_cert) if ca_cert else ssl.create_default_context()
+
+
+def rf_get(host: str, path: str, user: str, password: str, ctx: ssl.SSLContext,
+           timeout: int = 30) -> tuple[dict | None, str]:
+    """GET a Redfish resource, returning ``(document, error)``."""
+    req = urllib.request.Request(f"https://{host}{path}")
+    if user:
+        token = base64.b64encode(f"{user}:{password}".encode()).decode()
+        req.add_header("Authorization", f"Basic {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as r:  # nosec B310
+            return json.loads(r.read().decode()), ""
+    except urllib.error.HTTPError as exc:
+        return None, f"HTTP {exc.code}"
+    except Exception as exc:  # noqa: BLE001 - reported, never swallowed
+        # urlopen wraps a verification failure in URLError, so the useful error
+        # is one level down; without unwrapping, the operator sees a raw OpenSSL
+        # string and no indication of which flag fixes it.
+        cause = getattr(exc, "reason", exc)
+        if isinstance(cause, ssl.SSLCertVerificationError):
+            detail = getattr(cause, "verify_message", None) or cause
+            return None, (
+                f"TLS verification failed ({detail}). BMCs usually ship self-signed "
+                f"certificates: pass --ca-cert <file> to trust this one, or --insecure "
+                f"to skip verification deliberately"
+            )
+        return None, str(exc)
+
+
+def probe_reachable(host: str, ctx: ssl.SSLContext) -> str:
+    """Check the service root before minting anything; ``""`` when reachable.
+
+    ``/redfish/v1`` is unauthenticated by specification, so reachability and TLS
+    can both be settled with no credentials at all. Without this the tool minted
+    an ADMINISTRATOR account, opened the LAN channel, failed certificate
+    verification, and revoked -- exposing an admin account on the management
+    network for a request that was never going to succeed.
+    """
+    doc, err = rf_get(host, "/redfish/v1", "", "", ctx, timeout=15)
+    if doc is not None:
+        return ""
+    return err or "service root unreachable"
+
+
+def redfish_bios(host: str, user: str, password: str,
+                 ctx: ssl.SSLContext) -> tuple[dict, str, str]:
+    """Fetch BIOS attributes, discovering the system path (varies by OEM)."""
+    systems, err = rf_get(host, "/redfish/v1/Systems", user, password, ctx)
+    if systems is None and err:
+        return {}, "", err
+    members = [m.get("@odata.id") for m in (systems or {}).get("Members", [])]
+    last = ""
+    for base in members or ["/redfish/v1/Systems/1", "/redfish/v1/Systems/System.Embedded.1"]:
+        doc, err = rf_get(host, f"{base}/Bios", user, password, ctx)
+        last = err or last
+        if doc and doc.get("Attributes"):
+            return doc["Attributes"], f"{base}/Bios", ""
+    return {}, "", last or "no BIOS attributes exposed"
+
+
+def resolve(attrs: dict) -> dict:
+    """Map vendor attribute names onto canonical knobs."""
+    found = {}
+    for key, spec in BIOS_KNOBS.items():
+        rx = re.compile(spec["pattern"], re.I)
+        hits = {k: v for k, v in attrs.items() if rx.search(k) and not NAME_BLOCKLIST.search(k)}
+        if not hits:
+            continue
+        # Prefer the shortest name: "SMTControl" over "SMTControlPolicyOverride".
+        name = sorted(hits, key=lambda k: (len(k), k))[0]
+        found[key] = {
+            "attribute": name,
+            "value": str(hits[name]),
+            "all_matches": {k: str(v) for k, v in hits.items()},
+        }
+    return found
+
+
+def normalize(value: object) -> str:
+    """Lower-case, whitespace-collapsed form used for every comparison."""
+    return re.sub(r"\s+", " ", str(value if value is not None else "")).strip().lower()
+
+
+def verdict(key: str, value: object) -> str:
+    """PASS/FAIL/UNKNOWN for a BIOS knob. Exact match after normalization."""
+    v = normalize(value)
+    if v in ("", "unknown", "auto", "n/a", "none"):
+        return "UNKNOWN"
+    return "PASS" if any(normalize(t) == v for t in BIOS_KNOBS[key]["target"]) else "FAIL"
+
+
+EXIT_OK, EXIT_FAIL, EXIT_UNKNOWN, EXIT_CREDENTIAL = 0, 1, 2, 3
+
+
+def exit_code(rows: list[dict]) -> int:
+    """Worst status. A credential problem outranks every knob verdict."""
+    if CREDENTIAL_FAILURES:
+        return EXIT_CREDENTIAL
+    if any(r["verdict"] == "FAIL" for r in rows):
+        return EXIT_FAIL
+    if any(r["verdict"] == "UNKNOWN" for r in rows):
+        return EXIT_UNKNOWN
+    return EXIT_OK
+
+
+def build_rows(bios: dict) -> list[dict]:
+    rows = []
+    for key, spec in BIOS_KNOBS.items():
+        hit = bios.get(key)
+        value = hit["value"] if hit else "unknown"
+        rows.append(
+            {
+                "knob": spec["label"],
+                "key": key,
+                "value": str(value),
+                "attribute": hit["attribute"] if hit else "",
+                "target": "/".join(spec["target"]),
+                "verdict": verdict(key, value),
+            }
+        )
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Audit BIOS-only EPYC knobs over Redfish (creates a temporary BMC account)",
+        epilog=(
+            "Exit: 0 on target, 1 a knob is wrong, 2 unresolved, 3 a BMC account was "
+            "left enabled or could not be confirmed revoked. The password for "
+            "--bmc-user comes from $BMC_PASSWORD or a prompt, never the command line, "
+            "where the process table would expose it to every local user."
+        ),
+    )
+    ap.add_argument("--bmc-host", help="BMC address (discovered over KCS when omitted)")
+    ap.add_argument("--bmc-user", help="existing BMC account; avoids minting a temporary one")
+    ap.add_argument("--ca-cert", help="CA file (or the BMC's own certificate) to trust")
+    ap.add_argument("--insecure", action="store_true", help="skip TLS verification (deliberate)")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args()
+
+    install_signal_handlers()
+    ctx = tls_context(args.ca_cert, args.insecure)
+
+    if not args.bmc_host and not ipmitool_present():
+        print("ipmitool is not on PATH, so the BMC address cannot be discovered. "
+              "Pass --bmc-host explicitly.", file=sys.stderr)
+        return EXIT_UNKNOWN
+
+    host = args.bmc_host or bmc_ip()
+    if not host:
+        print("No BMC address found over KCS. Pass --bmc-host.", file=sys.stderr)
+        return EXIT_UNKNOWN
+
+    # Settle reachability and TLS before creating any credential.
+    err = probe_reachable(host, ctx)
+    if err:
+        print(f"BMC {host} is not usable: {err}", file=sys.stderr)
+        return EXIT_UNKNOWN
+
+    if args.bmc_user:
+        password = os.environ.get("BMC_PASSWORD") or getpass.getpass(
+            f"Password for {args.bmc_user}@{host}: "
+        )
+        attrs, _, err = redfish_bios(host, args.bmc_user, password, ctx)
+    else:
+        if args.insecure:
+            print(
+                "WARNING: --insecure with a minted account sends freshly created "
+                "ADMINISTRATOR credentials to a peer whose certificate was not "
+                "verified. Prefer --ca-cert, or --bmc-user with a read-only account.",
+                file=sys.stderr,
+            )
+        with TempBmcAccount() as acct:
+            if acct.slot is None or not acct.password:
+                print(f"Could not obtain BMC access: {acct.note or 'no slot'}", file=sys.stderr)
+                return exit_code([])
+            if acct.mint_errors:
+                print(f"Note: {'; '.join(acct.mint_errors)}", file=sys.stderr)
+            attrs, _, err = redfish_bios(host, acct.user, acct.password, ctx)
+
+    rows = build_rows(resolve(attrs))
+    code = exit_code(rows)
+
+    if args.json:
+        print(json.dumps(
+            {"host": host, "rows": rows, "error": err,
+             "credential_failures": CREDENTIAL_FAILURES, "exit_code": code},
+            indent=2, sort_keys=True,
+        ))
+    else:
+        if err:
+            print(f"BIOS attributes unavailable: {err}", file=sys.stderr)
+        width = max((len(r["knob"]) for r in rows), default=10)
+        for r in rows:
+            want = f"  (want {r['target']})" if r["verdict"] != "PASS" else ""
+            print(f"  {r['verdict']:<7} {r['knob']:<{width}}  {r['value']}{want}")
+        if CREDENTIAL_FAILURES:
+            print("\nCredential problems (exit 3):", file=sys.stderr)
+            for f in CREDENTIAL_FAILURES:
+                print(f"    {f}", file=sys.stderr)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_platform_audit_bmc.py
+++ b/scripts/tests/test_platform_audit_bmc.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the BMC/Redfish auditor.
+
+Nothing here talks to a real BMC: ``sudo_run`` is replaced with a fake
+``ipmitool`` whose per-command responses each case controls. That is enough to
+drive the account lifecycle, which is the part of this tool that can leave a
+privileged account behind on a service processor.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "platform_audit_bmc.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("platform_audit_bmc", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def bmc(monkeypatch):
+    """The module with a fake ipmitool, and a clean credential-failure list."""
+    mod = _load()
+    mod.CREDENTIAL_FAILURES.clear()
+    return mod
+
+
+class FakeIpmi:
+    """Records every ipmitool invocation and answers from a scripted table."""
+
+    def __init__(self, *, enabled_after_revoke=False, initially_enabled=False,
+                 fail=(), unreadable_status=False):
+        self.calls: list[list[str]] = []
+        self.fail = set(fail)
+        self.initially_enabled = initially_enabled
+        self.enabled_after_revoke = enabled_after_revoke
+        self.unreadable_status = unreadable_status
+        self._getaccess_seen = 0
+
+    def __call__(self, cmd, **kw):
+        self.calls.append(cmd)
+        joined = " ".join(cmd)
+        for token in self.fail:
+            if token in joined:
+                return False, "", f"fake failure: {token}"
+        if "user list" in joined:
+            return True, "1 root true\n3 true true\n", ""
+        if "channel getaccess" in joined:
+            self._getaccess_seen += 1
+            if self.unreadable_status:
+                return False, "", "BMC timeout"
+            first = self._getaccess_seen == 1
+            state = "enabled" if (first and self.initially_enabled) else "disabled"
+            if not first and self.enabled_after_revoke:
+                state = "enabled"
+            return True, f"Enable Status   : {state}\n", ""
+        if "user set password" in joined:
+            return True, "Set User Password command successful\n", ""
+        return True, "", ""
+
+    def ran(self, fragment: str) -> bool:
+        return any(fragment in " ".join(c) for c in self.calls)
+
+
+# ------------------------------------------------------- account lifecycle
+
+def test_revocation_runs_even_when_the_password_step_fails(bmc, monkeypatch):
+    """The slot must be claimed before any mutation.
+
+    Previously the slot was recorded only after the password was set, so a
+    password failure returned with slot=None, __exit__ returned immediately, and
+    nothing was recorded -- while the account name had already been written and,
+    on the crash-recovery path, an enabled ADMINISTRATOR account was left live.
+    """
+    fake = FakeIpmi(initially_enabled=True, fail={"user set password"})
+    monkeypatch.setattr(bmc, "sudo_run", fake)
+
+    with bmc.TempBmcAccount() as acct:
+        assert acct.slot == 3, "slot must be claimed before the password step"
+        assert not acct.password
+
+    assert fake.ran("channel setaccess 1 3 callin=off"), "revocation must still run"
+    assert fake.ran("user disable 3")
+
+
+def test_stale_enabled_sentinel_is_recorded_not_just_printed(bmc, monkeypatch):
+    """A sentinel found enabled is evidence of a previous leak, so it must exit 3."""
+    monkeypatch.setattr(bmc, "sudo_run", FakeIpmi(initially_enabled=True))
+    with bmc.TempBmcAccount():
+        pass
+    assert any("already enabled" in f for f in bmc.CREDENTIAL_FAILURES)
+    assert bmc.exit_code([]) == bmc.EXIT_CREDENTIAL
+
+
+def test_unreadable_final_state_is_not_treated_as_revoked(bmc, monkeypatch):
+    """"Could not read" must never be recorded as "confirmed disabled".
+
+    account_status used a failure-swallowing runner, so any BMC that errored or
+    timed out answered "not enabled" -- a false confirmation at the exact point
+    the design calls its trust anchor.
+    """
+    monkeypatch.setattr(bmc, "sudo_run", FakeIpmi(unreadable_status=True))
+    with bmc.TempBmcAccount():
+        pass
+    assert any("could not confirm" in f.lower() for f in bmc.CREDENTIAL_FAILURES)
+    assert bmc.exit_code([]) == bmc.EXIT_CREDENTIAL
+
+
+def test_account_still_enabled_after_revoke_is_reported(bmc, monkeypatch):
+    monkeypatch.setattr(bmc, "sudo_run", FakeIpmi(enabled_after_revoke=True))
+    with bmc.TempBmcAccount():
+        pass
+    assert any("still reports" in f for f in bmc.CREDENTIAL_FAILURES)
+
+
+def test_clean_lifecycle_leaves_no_credential_failures(bmc, monkeypatch):
+    fake = FakeIpmi()
+    monkeypatch.setattr(bmc, "sudo_run", fake)
+    with bmc.TempBmcAccount() as acct:
+        assert acct.password
+    assert bmc.CREDENTIAL_FAILURES == []
+    assert bmc.exit_code([]) == bmc.EXIT_OK
+    # Channel access is dropped while the account is still enabled, because BMCs
+    # reject setaccess on a disabled account.
+    order = [" ".join(c) for c in fake.calls]
+    assert order.index(next(c for c in order if "callin=off" in c)) < order.index(
+        next(c for c in order if "user disable" in c)
+    )
+
+
+def test_failed_grant_steps_are_surfaced(bmc, monkeypatch):
+    """A silent failure here produced a 401 that misdirected the operator."""
+    monkeypatch.setattr(bmc, "sudo_run", FakeIpmi(fail={"user enable"}))
+    with bmc.TempBmcAccount() as acct:
+        assert any("enable account" in e for e in acct.mint_errors)
+
+
+def test_signal_handlers_allow_the_context_manager_to_unwind(bmc, monkeypatch):
+    """SIGTERM is what a CI timeout sends, and it must not orphan the account."""
+    import signal
+
+    fake = FakeIpmi()
+    monkeypatch.setattr(bmc, "sudo_run", fake)
+    bmc.install_signal_handlers()
+    with pytest.raises(KeyboardInterrupt):
+        with bmc.TempBmcAccount():
+            signal.raise_signal(signal.SIGTERM)
+    assert fake.ran("user disable 3"), "revocation must run when SIGTERM arrives"
+
+
+# ------------------------------------------------------- verdicts / matching
+
+def test_verdict_is_exact_after_normalization(bmc):
+    assert bmc.verdict("df_cstates", "Disabled") == "PASS"
+    assert bmc.verdict("df_cstates", "Enabled") == "FAIL"
+    assert bmc.verdict("apbdis", "1") == "PASS"
+    assert bmc.verdict("power_profile", "High Performance Mode") == "PASS"
+    # An unresolved "Auto" is not a pass.
+    assert bmc.verdict("apbdis", "Auto") == "UNKNOWN"
+
+
+@pytest.mark.parametrize(
+    "name,blocked",
+    [
+        ("SevControl", True),        # CamelCase: no trailing word boundary
+        ("SEV_SNP_Support", True),   # SCREAMING_CASE
+        ("Sev", True),
+        ("SeverityLevel", False),    # merely contains the letters
+        ("DfCState", False),
+    ],
+)
+def test_blocklist_handles_sev_in_both_directions(bmc, name, blocked):
+    """Unanchored "sev" over-matched; a plain \\bsev\\b under-matches CamelCase."""
+    assert bool(bmc.NAME_BLOCKLIST.search(name)) is blocked
+
+
+def test_blocklist_does_not_swallow_a_real_knob(bmc):
+    attrs = {"SevControl": "Enabled", "DfCState": "Disabled", "SeverityLevel": "High"}
+    assert bmc.resolve(attrs)["df_cstates"]["value"] == "Disabled"
+
+
+def test_resolve_prefers_the_shortest_matching_attribute(bmc):
+    attrs = {"ApbDisPolicyOverride": "0", "ApbDis": "1"}
+    assert bmc.resolve(attrs)["apbdis"]["attribute"] == "ApbDis"
+
+
+def test_every_bios_target_cites_its_basis(bmc):
+    """Unlike the OS-layer knobs, all three of these are supported by 58011 ch. 5."""
+    for key, spec in bmc.BIOS_KNOBS.items():
+        assert spec["basis"].strip(), f"{key} has no cited basis"
+        assert "58011" in spec["basis"], f"{key} does not cite the guide"
+
+
+def test_exit_code_ranks_credentials_above_everything(bmc):
+    rows = [{"verdict": "FAIL"}]
+    assert bmc.exit_code(rows) == bmc.EXIT_FAIL
+    bmc.CREDENTIAL_FAILURES.append("left enabled")
+    assert bmc.exit_code(rows) == bmc.EXIT_CREDENTIAL

--- a/scripts/tests/test_platform_audit_bmc.py
+++ b/scripts/tests/test_platform_audit_bmc.py
@@ -93,6 +93,46 @@ def test_revocation_runs_even_when_the_password_step_fails(bmc, monkeypatch):
     assert fake.ran("user disable 3")
 
 
+def test_the_password_never_reaches_the_diagnostics(bmc, monkeypatch, capsys):
+    """ipmitool echoes its stdin on some failures; that must not be republished.
+
+    The revoke path prints every failure to the console and stores it in
+    CREDENTIAL_FAILURES, so returning the command's stderr from the one function
+    that handles the secret put a live BMC password on that path.
+    """
+
+    class EchoingIpmi(FakeIpmi):
+        def __init__(self):
+            super().__init__(initially_enabled=True)
+            self.secrets: list[str] = []
+
+        def __call__(self, cmd, **kw):
+            if "user set password" in " ".join(cmd):
+                self.calls.append(cmd)
+                secret = (kw.get("stdin") or "").split("\n")[0]
+                self.secrets.append(secret)
+                return False, "", f"ipmitool: cannot set password '{secret}'"
+            return super().__call__(cmd, **kw)
+
+    fake = EchoingIpmi()
+    monkeypatch.setattr(bmc, "sudo_run", fake)
+
+    with bmc.TempBmcAccount():
+        pass
+
+    assert fake.secrets, "the fake never saw a password, so it proved nothing"
+    published = "\n".join(bmc.CREDENTIAL_FAILURES) + capsys.readouterr().err
+    assert published, "the failure was meant to be reported"
+    for secret in fake.secrets:
+        assert secret, "a blank password would make this test vacuous"
+        assert secret not in published
+
+    # The contract, not just the current wording: text returned from the one
+    # function that holds the secret is what put a password on the print path.
+    ok, confirmed = bmc.set_bmc_password(3, "a-secret-that-must-not-escape")
+    assert isinstance(ok, bool) and isinstance(confirmed, bool)
+
+
 def test_stale_enabled_sentinel_is_recorded_not_just_printed(bmc, monkeypatch):
     """A sentinel found enabled is evidence of a previous leak, so it must exit 3."""
     monkeypatch.setattr(bmc, "sudo_run", FakeIpmi(initially_enabled=True))

--- a/scripts/tests/test_platform_audit_bmc.py
+++ b/scripts/tests/test_platform_audit_bmc.py
@@ -12,6 +12,7 @@ privileged account behind on a service processor.
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
@@ -28,11 +29,13 @@ def _load():
 
 
 @pytest.fixture
-def bmc(monkeypatch):
-    """The module with a fake ipmitool, and a clean credential-failure list."""
-    mod = _load()
-    mod.CREDENTIAL_FAILURES.clear()
-    return mod
+def bmc():
+    """A freshly loaded copy of the module.
+
+    Credential failures live on the account instance, so each test reads them
+    from the account it created; nothing global needs resetting between tests.
+    """
+    return _load()
 
 
 class FakeIpmi:
@@ -77,10 +80,10 @@ class FakeIpmi:
 def test_revocation_runs_even_when_the_password_step_fails(bmc, monkeypatch):
     """The slot must be claimed before any mutation.
 
-    Previously the slot was recorded only after the password was set, so a
-    password failure returned with slot=None, __exit__ returned immediately, and
-    nothing was recorded -- while the account name had already been written and,
-    on the crash-recovery path, an enabled ADMINISTRATOR account was left live.
+    __exit__ returns immediately when no slot was claimed, so recording the slot
+    any later than the first mutation means a failure in between leaves the
+    account name written -- and, on the crash-recovery path, an enabled
+    ADMINISTRATOR account live -- with nothing recorded about it.
     """
     fake = FakeIpmi(initially_enabled=True, fail={"user set password"})
     monkeypatch.setattr(bmc, "sudo_run", fake)
@@ -96,9 +99,9 @@ def test_revocation_runs_even_when_the_password_step_fails(bmc, monkeypatch):
 def test_the_password_never_reaches_the_diagnostics(bmc, monkeypatch, capsys):
     """ipmitool echoes its stdin on some failures; that must not be republished.
 
-    The revoke path prints every failure to the console and stores it in
-    CREDENTIAL_FAILURES, so returning the command's stderr from the one function
-    that handles the secret put a live BMC password on that path.
+    The revoke path prints every failure to the console and stores it among the
+    account's credential failures, so returning the command's stderr from the
+    one function that handles the secret would put a live BMC password there.
     """
 
     class EchoingIpmi(FakeIpmi):
@@ -117,11 +120,11 @@ def test_the_password_never_reaches_the_diagnostics(bmc, monkeypatch, capsys):
     fake = EchoingIpmi()
     monkeypatch.setattr(bmc, "sudo_run", fake)
 
-    with bmc.TempBmcAccount():
+    with bmc.TempBmcAccount() as acct:
         pass
 
     assert fake.secrets, "the fake never saw a password, so it proved nothing"
-    published = "\n".join(bmc.CREDENTIAL_FAILURES) + capsys.readouterr().err
+    published = "\n".join(acct.credential_failures) + capsys.readouterr().err
     assert published, "the failure was meant to be reported"
     for secret in fake.secrets:
         assert secret, "a blank password would make this test vacuous"
@@ -136,31 +139,31 @@ def test_the_password_never_reaches_the_diagnostics(bmc, monkeypatch, capsys):
 def test_stale_enabled_sentinel_is_recorded_not_just_printed(bmc, monkeypatch):
     """A sentinel found enabled is evidence of a previous leak, so it must exit 3."""
     monkeypatch.setattr(bmc, "sudo_run", FakeIpmi(initially_enabled=True))
-    with bmc.TempBmcAccount():
+    with bmc.TempBmcAccount() as acct:
         pass
-    assert any("already enabled" in f for f in bmc.CREDENTIAL_FAILURES)
-    assert bmc.exit_code([]) == bmc.EXIT_CREDENTIAL
+    assert any("already enabled" in f for f in acct.credential_failures)
+    assert bmc.exit_code([], acct.credential_failures) == bmc.EXIT_CREDENTIAL
 
 
 def test_unreadable_final_state_is_not_treated_as_revoked(bmc, monkeypatch):
     """"Could not read" must never be recorded as "confirmed disabled".
 
-    account_status used a failure-swallowing runner, so any BMC that errored or
-    timed out answered "not enabled" -- a false confirmation at the exact point
-    the design calls its trust anchor.
+    Collapsing an unreadable state into "not enabled" would hand back a false
+    confirmation for any BMC that errors or times out -- at the exact point the
+    design calls its trust anchor.
     """
     monkeypatch.setattr(bmc, "sudo_run", FakeIpmi(unreadable_status=True))
-    with bmc.TempBmcAccount():
+    with bmc.TempBmcAccount() as acct:
         pass
-    assert any("could not confirm" in f.lower() for f in bmc.CREDENTIAL_FAILURES)
-    assert bmc.exit_code([]) == bmc.EXIT_CREDENTIAL
+    assert any("could not confirm" in f.lower() for f in acct.credential_failures)
+    assert bmc.exit_code([], acct.credential_failures) == bmc.EXIT_CREDENTIAL
 
 
 def test_account_still_enabled_after_revoke_is_reported(bmc, monkeypatch):
     monkeypatch.setattr(bmc, "sudo_run", FakeIpmi(enabled_after_revoke=True))
-    with bmc.TempBmcAccount():
+    with bmc.TempBmcAccount() as acct:
         pass
-    assert any("still reports" in f for f in bmc.CREDENTIAL_FAILURES)
+    assert any("still reports" in f for f in acct.credential_failures)
 
 
 def test_clean_lifecycle_leaves_no_credential_failures(bmc, monkeypatch):
@@ -168,8 +171,8 @@ def test_clean_lifecycle_leaves_no_credential_failures(bmc, monkeypatch):
     monkeypatch.setattr(bmc, "sudo_run", fake)
     with bmc.TempBmcAccount() as acct:
         assert acct.password
-    assert bmc.CREDENTIAL_FAILURES == []
-    assert bmc.exit_code([]) == bmc.EXIT_OK
+    assert acct.credential_failures == []
+    assert bmc.exit_code([], acct.credential_failures) == bmc.EXIT_OK
     # Channel access is dropped while the account is still enabled, because BMCs
     # reject setaccess on a disabled account.
     order = [" ".join(c) for c in fake.calls]
@@ -179,10 +182,30 @@ def test_clean_lifecycle_leaves_no_credential_failures(bmc, monkeypatch):
 
 
 def test_failed_grant_steps_are_surfaced(bmc, monkeypatch):
-    """A silent failure here produced a 401 that misdirected the operator."""
+    """A silent failure here surfaces as a 401 that misdirects the operator."""
     monkeypatch.setattr(bmc, "sudo_run", FakeIpmi(fail={"user enable"}))
     with bmc.TempBmcAccount() as acct:
         assert any("enable account" in e for e in acct.mint_errors)
+
+
+def test_a_failed_name_step_aborts_before_anything_grants_access(bmc, monkeypatch):
+    """Owning the slot's name is a precondition for granting it privilege.
+
+    Continuing past a failed rename enables an ADMINISTRATOR account on a slot
+    the audit does not control, and Redfish then 401s under the sentinel name --
+    which reads as an authentication problem rather than as the rename failing.
+    """
+    fake = FakeIpmi(fail={"user set name"})
+    monkeypatch.setattr(bmc, "sudo_run", fake)
+
+    with bmc.TempBmcAccount() as acct:
+        assert any("set account name" in e for e in acct.mint_errors)
+        assert not acct.password, "no credential may be handed out after this"
+
+    for granting in ("user priv 3", "user enable 3", "callin=on"):
+        assert not fake.ran(granting), f"{granting} ran after the name step failed"
+    # The slot was still claimed, so the revoke path runs regardless.
+    assert fake.ran("user disable 3")
 
 
 def test_signal_handlers_allow_the_context_manager_to_unwind(bmc, monkeypatch):
@@ -196,6 +219,108 @@ def test_signal_handlers_allow_the_context_manager_to_unwind(bmc, monkeypatch):
         with bmc.TempBmcAccount():
             signal.raise_signal(signal.SIGTERM)
     assert fake.ran("user disable 3"), "revocation must run when SIGTERM arrives"
+
+
+# ------------------------------------------------------- main(): exit contract
+
+@pytest.fixture
+def audit_main(bmc, monkeypatch):
+    """Run ``main()`` with everything off-box stubbed out.
+
+    Only the ipmitool layer is left to each test, because the exit code on the
+    credential paths is what these cases are about.
+    """
+    monkeypatch.setattr(bmc, "install_signal_handlers", lambda: None)
+    monkeypatch.setattr(bmc, "ipmitool_present", lambda: True)
+    monkeypatch.setattr(bmc, "bmc_ip", lambda: "10.0.0.1")
+    monkeypatch.setattr(bmc, "tls_context", lambda ca_cert, insecure: None)
+    monkeypatch.setattr(bmc, "probe_reachable", lambda host, ctx: "")
+    monkeypatch.setattr(bmc, "redfish_bios", lambda *a, **k: ({}, "", ""))
+
+    def _run(*argv):
+        monkeypatch.setattr(sys, "argv", ["platform_audit_bmc.py", *argv])
+        return bmc.main()
+
+    return _run
+
+
+def test_a_failed_revocation_reaches_the_exit_code(audit_main, bmc, monkeypatch, capsys):
+    """The verdict must be computed after ``__exit__``, not inside the ``with``.
+
+    This is the path that prints the "may remain enabled with ADMINISTRATOR
+    privilege" banner, so it is the last one that may report a clean audit.
+    """
+    monkeypatch.setattr(bmc, "sudo_run", FakeIpmi(fail={"user set password"}))
+
+    code = audit_main("--allow-account-creation")
+
+    err = capsys.readouterr().err
+    assert "SECURITY" in err, "this case is only interesting with the banner"
+    assert code == bmc.EXIT_CREDENTIAL, "exit 0 here contradicts the banner above it"
+
+
+def test_no_bmc_access_is_unresolved_not_success(audit_main, bmc, monkeypatch, capsys):
+    """Never reaching a knob cannot mean "every checked knob is on target"."""
+    monkeypatch.setattr(bmc, "sudo_run", FakeIpmi(fail={"user list"}))
+
+    code = audit_main("--allow-account-creation")
+
+    assert "Could not obtain BMC access" in capsys.readouterr().err
+    assert code == bmc.EXIT_UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "revoke_fails,expected",
+    [(False, "EXIT_UNKNOWN"), (True, "EXIT_CREDENTIAL")],
+)
+def test_a_signal_mid_audit_produces_an_exit_code_not_a_traceback(
+    audit_main, bmc, monkeypatch, revoke_fails, expected
+):
+    """SIGTERM is the case the signal handler exists for, so it must be reported.
+
+    The handler raises KeyboardInterrupt to unwind the ``with``; letting that
+    escape ends the run in a traceback and exit 130, discarding the revocation
+    verdict it just produced.
+    """
+    fake = FakeIpmi(fail={"user disable"} if revoke_fails else ())
+    monkeypatch.setattr(bmc, "sudo_run", fake)
+
+    def _interrupted(*a, **k):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(bmc, "redfish_bios", _interrupted)
+
+    code = audit_main("--allow-account-creation")
+
+    assert fake.ran("channel setaccess 1 3 callin=off"), "the with block must unwind"
+    assert code == getattr(bmc, expected)
+
+
+def test_minting_an_account_requires_an_explicit_opt_in(audit_main, bmc, monkeypatch, capsys):
+    """The README calls this a deliberate choice; the default must not make it."""
+    calls: list[list[str]] = []
+    monkeypatch.setattr(bmc, "sudo_run", lambda cmd, **kw: (calls.append(cmd), (True, "", ""))[1])
+
+    code = audit_main()
+
+    assert code == bmc.EXIT_UNKNOWN
+    assert not calls, "the BMC must not be touched before the operator opts in"
+    assert "--allow-account-creation" in capsys.readouterr().err
+
+
+def test_ipmitool_is_required_to_mint_even_with_an_explicit_host(
+    audit_main, bmc, monkeypatch, capsys
+):
+    """--bmc-host removes the need to discover the address, not to mint."""
+    monkeypatch.setattr(bmc, "ipmitool_present", lambda: False)
+
+    assert audit_main("--bmc-host", "10.0.0.1", "--allow-account-creation") == bmc.EXIT_UNKNOWN
+    assert "ipmitool" in capsys.readouterr().err
+
+    # ... and it is not required when no account will be minted.
+    monkeypatch.setenv("BMC_PASSWORD", "not-a-real-password")
+    assert audit_main("--bmc-host", "10.0.0.1", "--bmc-user", "ro") == bmc.EXIT_UNKNOWN
+    assert "ipmitool" not in capsys.readouterr().err
 
 
 # ------------------------------------------------------- verdicts / matching
@@ -244,5 +369,4 @@ def test_every_bios_target_cites_its_basis(bmc):
 def test_exit_code_ranks_credentials_above_everything(bmc):
     rows = [{"verdict": "FAIL"}]
     assert bmc.exit_code(rows) == bmc.EXIT_FAIL
-    bmc.CREDENTIAL_FAILURES.append("left enabled")
-    assert bmc.exit_code(rows) == bmc.EXIT_CREDENTIAL
+    assert bmc.exit_code(rows, ["left enabled"]) == bmc.EXIT_CREDENTIAL


### PR DESCRIPTION
Split out of #1097 at the reviewers' request. Stacked on #1155; the only commit of its own is the BMC layer.

## Why this is a separate PR

Everything in PR A reads `/sys` and `/proc`. This does not. With no `--bmc-user`
on file it **mints a temporary ADMINISTRATOR account on the BMC** over the in-band
KCS channel, uses it for a handful of HTTPS GETs, then revokes it and verifies the
revocation.

Root on the host already holds full BMC authority through KCS, so this is not a
privilege escalation. But it is a different risk class from reading sysfs, many
sites prohibit creating service-processor accounts outright, and the failure mode
— a live admin account on the management network — is not one that should ride
along in a PR about provenance records. It wants its own review.

Pass `--bmc-user` with an existing read-only account to avoid account creation
entirely.

## What it covers

The three knobs the OS cannot see on kernels without `amd_hsmp`: the platform
High Performance profile, APBDIS, and DF C-states. Unlike the OS-layer knobs, all
three are supported by AMD 58011 — each is either the documented default or the
value chapter 5 selects for its latency-sensitive columns, and each cites §4.2.1,
§4.4.3 or §4.4.4 inline.

## Account lifecycle

Every path that can leave an account behind is prevented or reported. Three of
these were bugs @xiaofei-zheng and @ZhengGong-amd found on #1097, and two of them
reported success while leaving an account enabled:

- **The slot is claimed before any mutation.** It was previously recorded only
  after the password step, so a password failure returned with `slot=None`,
  `__exit__` returned immediately, and nothing was recorded — while the account
  name had already been written and, on the crash-recovery path, an enabled
  ADMINISTRATOR account was left live with a clean exit code.
- **`account_status` distinguishes "read it, disabled" from "could not read it".**
  Built on a failure-swallowing runner it answered "not enabled" for any BMC that
  errored or timed out — a false confirmation at the exact point the design calls
  its trust anchor.
- **Every access-granting step is checked.** A silent failure produced a 401 from
  Redfish that pointed the operator at authentication or OEM compatibility when
  the real cause was an account that was never enabled.
- **SIGTERM and SIGINT unwind the context manager.** SIGKILL and a power cut
  remain uncoverable, which is why a sentinel found already enabled is recorded as
  a credential exposure rather than merely printed — it is the fingerprint of a
  previous run that could not clean up.
- **Reachability and TLS are settled before anything is minted**, with an
  unauthenticated GET of the service root. The documented invocation previously
  created an account, opened the LAN channel, then failed certificate
  verification.

Exit `3` means an account was left enabled or could not be confirmed revoked, and
outranks every knob verdict. It should page someone rather than scroll past as a
generic failure.

## Other

TLS verification is on by default; most BMCs ship self-signed certificates, so
expect `--ca-cert` or an explicit `--insecure`. The password for `--bmc-user`
comes from `$BMC_PASSWORD` or a prompt, never the command line, where the process
table would expose it to every local user.

Bandit now scans `scripts/` — the one file in the tree that mints credentials was
the one the scanner never saw.

## Testing

17 tests drive the lifecycle against a fake `ipmitool`, including the two paths
that previously reported success while leaving an account enabled. Nothing in the
test suite touches a real BMC. Not yet exercised end-to-end against live
Supermicro/Dell hardware — that is the main thing I would want a reviewer with
BMC access to try.