### PR TITLE
fix(xdit): preserve session framework for roofline

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -2019,6 +2019,48 @@ async def test_trace_analyze_handler_xdit_state_overrides_stale_payload_framewor
     assert "--framework" in cmd and cmd[cmd.index("--framework") + 1] == "xdit"
     assert "--skip-split" in cmd
     assert "--analysis-mode" not in cmd
+    warnings = res["trace_health_warnings"]
+    assert warnings[0]["code"] == "stale_framework_overridden"
+    assert warnings[0]["payload_framework"] == "sglang"
+    assert warnings[0]["session_framework"] == "xdit"
+
+
+@pytest.mark.asyncio
+async def test_trace_analyze_handler_custom_state_overrides_stale_payload_framework(
+    session_dir,
+    monkeypatch,
+):
+    """All scriptable session frameworks preserve their raw trace."""
+    from hyperloom.orchestrator.state.shared_state import SharedState
+
+    state = SharedState.load_or_init(session_dir)
+    state.framework = "custom"
+    state.save(session_dir)
+
+    fake_trace = session_dir / "fake_trace_dir"
+    fake_trace.mkdir()
+    captured: dict = {}
+
+    async def fake_run_subprocess(cmd, *, timeout_sec):
+        captured["cmd"] = list(cmd)
+        return 0, json.dumps({"status": "ok", "hot_kernels": []}), ""
+
+    monkeypatch.setattr(krh, "_run_subprocess", fake_run_subprocess)
+    res = await krh.trace_analyze_handler(
+        {
+            "trace_input": str(fake_trace),
+            "session_id": session_dir.name,
+            "framework": "sglang",
+            "top_k": 5,
+        },
+        session_dir=session_dir,
+    )
+
+    assert res["status"] == "ok"
+    cmd = captured["cmd"]
+    assert "--framework" in cmd and cmd[cmd.index("--framework") + 1] == "custom"
+    assert "--skip-split" in cmd
+    assert res["trace_health_warnings"][0]["code"] == "stale_framework_overridden"
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -1980,6 +1980,45 @@ async def test_trace_analyze_handler_xdit_defaults_to_tracelens_agent(session_di
     assert not any("bypass_trace_analysis.py" in c for c in cmd)
     assert "--analysis-route" in cmd and "agent" in cmd
     assert "--tracelens-root" in cmd
+    assert "--skip-split" in cmd
+
+
+@pytest.mark.asyncio
+async def test_trace_analyze_handler_xdit_state_overrides_stale_payload_framework(
+    session_dir,
+    monkeypatch,
+):
+    """A stale text-generation payload must not make xDiT split its raw trace."""
+    from hyperloom.orchestrator.state.shared_state import SharedState
+
+    state = SharedState.load_or_init(session_dir)
+    state.framework = "xdit"
+    state.save(session_dir)
+
+    fake_trace = session_dir / "fake_trace_dir"
+    fake_trace.mkdir()
+    captured: dict = {}
+
+    async def fake_run_subprocess(cmd, *, timeout_sec):
+        captured["cmd"] = list(cmd)
+        return 0, json.dumps({"status": "ok", "hot_kernels": []}), ""
+
+    monkeypatch.setattr(krh, "_run_subprocess", fake_run_subprocess)
+    res = await krh.trace_analyze_handler(
+        {
+            "trace_input": str(fake_trace),
+            "session_id": session_dir.name,
+            "framework": "sglang",
+            "top_k": 5,
+        },
+        session_dir=session_dir,
+    )
+
+    assert res["status"] == "ok"
+    cmd = captured["cmd"]
+    assert "--framework" in cmd and cmd[cmd.index("--framework") + 1] == "xdit"
+    assert "--skip-split" in cmd
+    assert "--analysis-mode" not in cmd
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -2022,6 +2022,44 @@ async def test_trace_analyze_handler_xdit_state_overrides_stale_payload_framewor
 
 
 @pytest.mark.asyncio
+async def test_trace_analyze_handler_payload_framework_overrides_serving_state(
+    session_dir,
+    monkeypatch,
+):
+    """Explicit serving-framework payloads keep their existing precedence."""
+    from hyperloom.orchestrator.state.shared_state import SharedState
+
+    state = SharedState.load_or_init(session_dir)
+    state.framework = "vllm"
+    state.save(session_dir)
+
+    fake_trace = session_dir / "fake_trace_dir"
+    fake_trace.mkdir()
+    captured: dict = {}
+
+    async def fake_run_subprocess(cmd, *, timeout_sec):
+        captured["cmd"] = list(cmd)
+        return 0, json.dumps({"status": "ok", "hot_kernels": []}), ""
+
+    monkeypatch.setattr(krh, "_run_subprocess", fake_run_subprocess)
+    res = await krh.trace_analyze_handler(
+        {
+            "trace_input": str(fake_trace),
+            "session_id": session_dir.name,
+            "framework": "sglang",
+            "top_k": 5,
+        },
+        session_dir=session_dir,
+    )
+
+    assert res["status"] == "ok"
+    cmd = captured["cmd"]
+    assert "--framework" in cmd and cmd[cmd.index("--framework") + 1] == "sglang"
+    assert "--analysis-mode" in cmd and cmd[cmd.index("--analysis-mode") + 1] == "inference"
+    assert "--skip-split" not in cmd
+
+
+@pytest.mark.asyncio
 async def test_trace_analyze_handler_env_route_forces_bypass(session_dir, monkeypatch):
     """HYPERLOOM_TRACE_ANALYSIS_ROUTE=bypass forces the independent backend even
     for a text-gen framework (explicit env route wins over the default)."""

--- a/src/hyperloom/inference_optimizer/tests/test_roofline_executor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_roofline_executor.py
@@ -129,6 +129,35 @@ async def test_happy_path_promotes_profile_and_caches_trace_analyze(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_roofline_passes_resolved_framework_to_trace_analysis(tmp_path, monkeypatch):
+    """The trace-analysis payload carries the same framework as the profile."""
+    state = _state()
+    state.framework = "xdit"
+    captured: list[dict] = []
+
+    async def fake_profile(_ctx):
+        return _profile_success("/tmp/xdit.trace.json.gz")
+
+    async def fake_trace_analyze(payload, *, session_dir):
+        captured.append(dict(payload))
+        return _trace_analyze_success()
+
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.actions.executors.profile.profile_executor",
+        fake_profile,
+    )
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.kernel.request_handlers.trace_analyze_handler",
+        fake_trace_analyze,
+    )
+
+    result = await RooflineExecutor(shared_state=state)(_ctx(tmp_path))
+
+    assert result["status"] == "succeeded"
+    assert captured[0]["framework"] == "xdit"
+
+
+@pytest.mark.asyncio
 async def test_profile_retry_records_successful_child_runtime(tmp_path, monkeypatch):
     state = _state()
     state.framework = "vllm"

--- a/src/hyperloom/orchestrator/actions/executors/roofline.py
+++ b/src/hyperloom/orchestrator/actions/executors/roofline.py
@@ -481,7 +481,10 @@ class RooflineExecutor:
             roofline_output_name = "kernel_roofline_opt.json"
         else:
             roofline_output_name = "kernel_roofline_current.json"
-        ta_payload: dict[str, Any] = {"trace_input": str(trace_path)}
+        ta_payload: dict[str, Any] = {
+            "trace_input": str(trace_path),
+            "framework": framework,
+        }
         workspace_path = _task_params.get("workspace_path")
         if workspace_path not in (None, ""):
             ta_payload["workspace_path"] = workspace_path
@@ -534,6 +537,7 @@ class RooflineExecutor:
             )
             ta_payload_retry: dict[str, Any] = {
                 "trace_input": str(trace_path),
+                "framework": framework,
                 "steady_state_mode": retry_mode,
                 # Marker against retry loops.
                 "_n26_auto_retry": True,
@@ -663,7 +667,10 @@ class RooflineExecutor:
                 cb_profile = await profile_executor(cb_ctx)
                 cb_trace = _extract_trace_path(cb_profile) if isinstance(cb_profile, dict) else ""
                 if cb_trace:
-                    cb_payload: dict[str, Any] = {"trace_input": str(cb_trace)}
+                    cb_payload: dict[str, Any] = {
+                        "trace_input": str(cb_trace),
+                        "framework": framework,
+                    }
                     if roofline_arm:
                         cb_payload["roofline_arm"] = roofline_arm
                     if roofline_output_name:

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -4201,20 +4201,22 @@ async def trace_analyze_handler(
     state = SharedState.load_or_init(session_dir)
     state_framework = str(state.framework or "").strip()
     payload_framework = str(payload.get("framework") or "").strip()
-    # The persisted session framework is the runtime authority.  Internal
-    # roofline tasks can otherwise inherit a stale/default payload framework
-    # (commonly ``sglang``), which makes xDiT follow the LLM trace splitter.
-    # That splitter selects a prefill/decode window that diffusion traces do
-    # not have, discarding the raw GPU kernels before TraceLens sees them.
-    framework = state_framework or payload_framework
+    from hyperloom.inference_optimizer.framework_registry import is_scriptable
+
+    # Payload metadata remains authoritative for ordinary serving frameworks.
+    # The exception is a scriptable session receiving a stale non-scriptable
+    # default (commonly ``sglang``): that would make xDiT follow the LLM trace
+    # splitter, which discards its raw diffusion GPU kernels.
+    framework = payload_framework or state_framework
     if (
-        state_framework
-        and payload_framework
-        and state_framework.lower() != payload_framework.lower()
+        payload_framework
+        and is_scriptable(state_framework)
+        and not is_scriptable(payload_framework)
     ):
+        framework = state_framework
         log.warning(
             "trace_analyze: overriding payload framework %r with session "
-            "framework %r so analysis matches the captured workload",
+            "scriptable framework %r to preserve the raw trace",
             payload_framework,
             state_framework,
         )
@@ -4270,8 +4272,6 @@ async def trace_analyze_handler(
 
     # Scriptable frameworks (xDiT) have no decode steady-state window, so feed the
     # raw trace and drop the --split-* hints.
-    from hyperloom.inference_optimizer.framework_registry import is_scriptable
-
     scriptable = is_scriptable(framework)
 
     # Load materialized baseline workload metadata once.

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -4177,6 +4177,11 @@ async def trace_analyze_handler(
 ) -> HandlerResult:
     """Run Hyperloom/kernel-agent's tracelens_analysis.py on a trace dir.
 
+    The explicit payload framework normally takes precedence over the persisted
+    session value.  A scriptable session overrides a conflicting non-scriptable
+    payload framework so a diffusion trace is not sent through the LLM
+    prefill/decode splitter.
+
     Args:
         payload (dict): Request payload (see ``Required payload`` /
             ``Optional payload`` below for the recognized keys).
@@ -4208,12 +4213,26 @@ async def trace_analyze_handler(
     # default (commonly ``sglang``): that would make xDiT follow the LLM trace
     # splitter, which discards its raw diffusion GPU kernels.
     framework = payload_framework or state_framework
+    framework_warnings: list[dict[str, Any]] = []
     if (
         payload_framework
         and is_scriptable(state_framework)
         and not is_scriptable(payload_framework)
     ):
         framework = state_framework
+        framework_warnings.append(
+            {
+                "code": "stale_framework_overridden",
+                "severity": "warning",
+                "message": (
+                    f"overrode non-scriptable payload framework {payload_framework!r} "
+                    f"with scriptable session framework {state_framework!r} "
+                    "to preserve the raw trace"
+                ),
+                "payload_framework": payload_framework,
+                "session_framework": state_framework,
+            }
+        )
         log.warning(
             "trace_analyze: overriding payload framework %r with session "
             "scriptable framework %r to preserve the raw trace",
@@ -4348,8 +4367,12 @@ async def trace_analyze_handler(
             result["hot_kernels"] = []
             result.setdefault("orchestrator_error", failure_warning.get("error", ""))
 
-        # Prepend any route-validation warning so it reaches the LLM.
-        result["trace_health_warnings"] = route_health_warnings + list(result.get("trace_health_warnings") or [])
+        # Prepend handler validation warnings so they reach the LLM.
+        result["trace_health_warnings"] = (
+            framework_warnings
+            + route_health_warnings
+            + list(result.get("trace_health_warnings") or [])
+        )
 
         _enrich_candidate_runtime_metadata(result.get("hot_kernels"), metadata)
         candidates_path = result.get("candidates_path")

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -4199,7 +4199,25 @@ async def trace_analyze_handler(
     from ..state.shared_state import SharedState
 
     state = SharedState.load_or_init(session_dir)
-    framework = (payload.get("framework") or state.framework or "").strip()
+    state_framework = str(state.framework or "").strip()
+    payload_framework = str(payload.get("framework") or "").strip()
+    # The persisted session framework is the runtime authority.  Internal
+    # roofline tasks can otherwise inherit a stale/default payload framework
+    # (commonly ``sglang``), which makes xDiT follow the LLM trace splitter.
+    # That splitter selects a prefill/decode window that diffusion traces do
+    # not have, discarding the raw GPU kernels before TraceLens sees them.
+    framework = state_framework or payload_framework
+    if (
+        state_framework
+        and payload_framework
+        and state_framework.lower() != payload_framework.lower()
+    ):
+        log.warning(
+            "trace_analyze: overriding payload framework %r with session "
+            "framework %r so analysis matches the captured workload",
+            payload_framework,
+            state_framework,
+        )
     target_platform = (payload.get("target_platform") or state.gpu_type or "").strip()
     model_name = (payload.get("model_name") or state.model_name or state.model_path or "").strip()
     analysis_mode = (payload.get("analysis_mode") or "").strip()


### PR DESCRIPTION
## Summary
- Prefer the persisted session framework over stale trace-analysis payload metadata.
- Ensure xDiT routes use the raw GPU trace path and regress against LLM-style splitting.

## Test plan
- [x] Targeted xDiT trace-analysis tests: 3 passed (Windows fcntl shim for Linux-only import).
- [x] Python compile check for both changed files.
