### PR TITLE
fix(knowledge): stop handing the forge child a knowledge mode it cannot satisfy

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_forge_knowledge_env.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_knowledge_env.py
@@ -90,9 +90,15 @@ def test_the_card_is_resolved_from_the_candidate_when_the_environment_is_silent(
     assert forge_submit._resolve_gpu_type({"arch": "gfx942"}) == ""
 
 
-def test_remote_child_env_forwards_kb_store_alone_when_gbrain_is_absent(
+def test_a_remote_run_still_launches_the_child_against_its_local_store(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A ``remote`` run must not hand the child a mode it cannot satisfy.
+
+    KernelForge resolves remote knowledge through GBrain only, and this env
+    withholds GBrain, so a child told ``remote`` exits rc=1 on startup instead
+    of optimizing anything.
+    """
     _avoid_unrelated_fellow_setup(monkeypatch)
     monkeypatch.setenv("KNOWLEDGE_STORE_MODE", "remote")
     monkeypatch.setenv("KNOWLEDGE_LOCAL_ROOT", "unchanged/root")
@@ -108,10 +114,10 @@ def test_remote_child_env_forwards_kb_store_alone_when_gbrain_is_absent(
         "KERNELFORGE_GBRAIN_ENABLED": "true",
     }
     forge_submit._apply_fellow_env(env)
-    assert env["KNOWLEDGE_STORE_MODE"] == "remote"
+    assert env["KNOWLEDGE_STORE_MODE"] == "local"
     assert env["KNOWLEDGE_LOCAL_ROOT"] == "unchanged/root"
-    assert env["KB_STORE_URL"] == "https://kb.test"
-    assert env["KB_STORE_TOKEN"] == "token"
+    assert "KB_STORE_URL" not in env
+    assert "KB_STORE_TOKEN" not in env
     assert env["KERNELFORGE_GBRAIN_ENABLED"] == "false"
 
 
@@ -134,7 +140,8 @@ def test_remote_child_env_strips_parent_gbrain_credentials(
         "GBRAIN_TOKEN": "gbrain-token",
     }
     forge_submit._apply_fellow_env(env)
-    assert env["KB_STORE_URL"] == "https://kb.test"
+    assert env["KNOWLEDGE_STORE_MODE"] == "local"
+    assert "KB_STORE_URL" not in env
     assert "GBRAIN_BASE_URL" not in env
     assert "GBRAIN_TOKEN" not in env
     assert env["KERNELFORGE_GBRAIN_ENABLED"] == "false"

--- a/src/hyperloom/inference_optimizer/tests/test_knowledge_plane_phase1.py
+++ b/src/hyperloom/inference_optimizer/tests/test_knowledge_plane_phase1.py
@@ -123,7 +123,13 @@ def test_remote_config_uses_kb_store_backend_and_keeps_optional_gbrain() -> None
     assert config.gbrain_base_url == "https://gbrain.test"
 
 
-def test_a_remote_child_gets_only_kb_store_credentials() -> None:
+def test_a_remote_parent_never_tells_a_child_a_mode_it_cannot_satisfy() -> None:
+    """KernelForge resolves remote knowledge through GBrain and nothing else.
+
+    This contract withholds GBrain from the child on purpose, so a child told
+    ``remote`` exits before its first kernel with "KNOWLEDGE_STORE_MODE=remote
+    requires GBRAIN_BASE_URL and GBRAIN_TOKEN".
+    """
     remote = KnowledgeConfig.from_env(
         {
             "KNOWLEDGE_STORE_MODE": "remote",
@@ -135,14 +141,29 @@ def test_a_remote_child_gets_only_kb_store_credentials() -> None:
     )
     child: dict[str, str] = {}
     remote.apply_to_child_env(child)
-    assert child["KB_STORE_URL"] == "https://kb.test"
-    assert child["KB_STORE_TOKEN"] == "kb-token"
+    assert remote.mode is KnowledgeStoreMode.REMOTE
+    assert child["KNOWLEDGE_STORE_MODE"] == "local"
     assert "GBRAIN_BASE_URL" not in child
     assert "GBRAIN_TOKEN" not in child
     assert child["KERNELFORGE_GBRAIN_ENABLED"] == "false"
 
 
-def test_a_remote_child_without_gbrain_is_told_so_rather_than_left_guessing() -> None:
+def test_a_child_is_handed_no_credential_it_has_no_reader_for() -> None:
+    """KB Store is Hyperloom's own backend; the child has no client for it."""
+    remote = KnowledgeConfig.from_env(
+        {
+            "KNOWLEDGE_STORE_MODE": "remote",
+            "KB_STORE_URL": "https://kb.test",
+            "KB_STORE_TOKEN": "kb-token",
+        }
+    )
+    child: dict[str, str] = {}
+    remote.apply_to_child_env(child)
+    assert "KB_STORE_URL" not in child
+    assert "KB_STORE_TOKEN" not in child
+
+
+def test_ambient_child_credentials_are_replaced_by_a_local_store() -> None:
     remote = KnowledgeConfig.from_env(
         {
             "KNOWLEDGE_STORE_MODE": "remote",
@@ -156,7 +177,8 @@ def test_a_remote_child_without_gbrain_is_told_so_rather_than_left_guessing() ->
         "GBRAIN_TOKEN": "ambient-secret",
     }
     remote.apply_to_child_env(child)
-    assert child["KB_STORE_URL"] == "https://kb.test"
+    assert child["KNOWLEDGE_STORE_MODE"] == "local"
+    assert "KB_STORE_URL" not in child
     assert child["KERNELFORGE_GBRAIN_ENABLED"] == "false"
     assert "GBRAIN_BASE_URL" not in child
     assert "GBRAIN_TOKEN" not in child

--- a/src/hyperloom/orchestrator/knowledge/config.py
+++ b/src/hyperloom/orchestrator/knowledge/config.py
@@ -97,17 +97,19 @@ class KnowledgeConfig:
     def apply_to_child_env(self, env: MutableMapping[str, str]) -> None:
         """Apply the exact shared contract to a KernelForge child environment."""
 
-        env["KNOWLEDGE_STORE_MODE"] = self.mode.value
+        # The child resolves remote knowledge through GBrain and has no KB Store
+        # client, and this contract withholds GBrain from it (below). Passing our
+        # own ``remote`` down would therefore make the child fail closed on
+        # startup -- "KNOWLEDGE_STORE_MODE=remote requires GBRAIN_BASE_URL and
+        # GBRAIN_TOKEN" -- before it optimizes a single kernel. It reads and
+        # writes its local store instead; Hyperloom owns KB Store publication
+        # and collects the child's experience from its result document.
+        env["KNOWLEDGE_STORE_MODE"] = KnowledgeStoreMode.LOCAL.value
         env["KNOWLEDGE_LOCAL_ROOT"] = self.local_root
-        if self.mode is KnowledgeStoreMode.REMOTE:
-            env["KB_STORE_URL"] = self.kb_store_url
-            env["KB_STORE_TOKEN"] = self.kb_store_token
-        else:
-            env.pop("KB_STORE_URL", None)
-            env.pop("KB_STORE_TOKEN", None)
-        # Rewrite knowledge is owned by KB Store. Legacy GBrain credentials
-        # remain available to Hyperloom's own KG/Framework integrations but
-        # never cross into the KernelForge child.
+        env.pop("KB_STORE_URL", None)
+        env.pop("KB_STORE_TOKEN", None)
+        # Legacy GBrain credentials remain available to Hyperloom's own
+        # KG/Framework integrations but never cross into the KernelForge child.
         env.pop("GBRAIN_BASE_URL", None)
         env.pop("GBRAIN_TOKEN", None)
         env["KERNELFORGE_GBRAIN_ENABLED"] = "false"


### PR DESCRIPTION
## Problem

`KnowledgeConfig.apply_to_child_env` passed Hyperloom's own `KNOWLEDGE_STORE_MODE=remote` down to the KernelForge child while, three lines later, deleting `GBRAIN_BASE_URL` and `GBRAIN_TOKEN` from that same child environment. GBrain is the only remote backend the child knows: no KernelForge source reads `KB_STORE_URL` or `KB_STORE_TOKEN` at all.

The child therefore failed closed on startup, every time:

```
=== forge-loop (cli) stdout ===
Error: KNOWLEDGE_STORE_MODE=remote requires GBRAIN_BASE_URL and GBRAIN_TOKEN
=== forge-loop exception ===
forge-loop exited rc=1
```

This is deterministic, not a missing-credential accident in one deployment: any run with `KNOWLEDGE_STORE_MODE=remote` loses 100% of its kernel work.

## Production evidence

Classifying every `forge_loop.log` under the shared forge workspaces:

| day | forge found a gain | startup killed by this bug | total attempts |
|---|---|---|---|
| Aug 1 | 19 | 0 | 40 |
| Aug 5 | 8 | 0 | 17 |
| Aug 9 | 20 | 0 | 54 |
| Aug 10 | 15 | 95 | 128 |
| Aug 11 | 0 | 199 | 209 |
| Aug 12 | 0 | 7 | 25 |

The first affected attempt is `20260810T122220Z`; 301 attempts died this way, and per-session `integrated` kernel counts went to 0 across 197 sessions.

## Fix

A KernelForge child now always launches against its local store, and is handed no credential it has no client for. Hyperloom keeps owning KB Store publication and still collects the child's experience through its result document (`KernelExperienceBridge.collect_result`), so no data path is lost.

## Tests

- `test_a_remote_parent_never_tells_a_child_a_mode_it_cannot_satisfy` reproduces the regression: it fails on `main` with `- local + remote`.
- `test_a_child_is_handed_no_credential_it_has_no_reader_for` pins that KB Store secrets stop at the process boundary.
- Three tests that had encoded the broken contract are updated, including `test_forge_knowledge_env.py::test_a_remote_run_still_launches_the_child_against_its_local_store`.
- `258 passed` across the KB/knowledge-plane and forge-child env suites.

## Test plan

- [x] `pytest src/hyperloom/inference_optimizer/tests/test_knowledge_plane_phase1.py src/hyperloom/agents/kernel/tests/test_forge_knowledge_env.py`
- [x] Regression sweep over `test_cli_kb_unit.py`, `test_cli_local_kb_root.py`, `test_close_phase_sequencer.py`, `test_coordinator_kb_writes.py`, `test_local_graph_store.py`, `test_local_kb_requirements.py`, `test_remote_recipe_v2.py`
- [ ] One `KNOWLEDGE_STORE_MODE=remote` session reaches a forge-loop iteration instead of rc=1