### PR TITLE
fix(kernel): let a rejected advisory forge-loop option cost the option, not the attempt

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_forge_long_horizon_cli.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_long_horizon_cli.py
@@ -3485,3 +3485,124 @@ def test_submit_falls_back_to_forge_loop_on_an_incompatible_producer(tmp_path, m
     assert verdict["eligible"] is False
     assert verdict["reason"] == "capability_artifact_schema_unsupported"
     assert result["best_ms"] == 1.0
+
+
+def _forge_loop_result_stdout() -> str:
+    payload = {
+        "baseline_ms": 2.0,
+        "best_ms": 1.0,
+        "mean_case_speedup": 2.0,
+        "search_start_mean_case_speedup": 1.0,
+        "total_improved": True,
+        "incremental_improved": True,
+    }
+    return f"__FORGE_RESULT__{json.dumps(payload)}__FORGE_RESULT__"
+
+
+def _run_loop_with_popen(tmp_path, monkeypatch, fake_popen):
+    workspace = tmp_path / "worktree"
+    workspace.mkdir()
+    kernel = workspace / "kernel.py"
+    driver = workspace / "driver.py"
+    kernel.write_text("pass\n")
+    driver.write_text("pass\n")
+    experiments = tmp_path / "attempt" / "forge_experiments"
+    experiments.mkdir(parents=True)
+
+    monkeypatch.setattr(forge_submit, "_ensure_forge_on_path", lambda: "/forge/src")
+    monkeypatch.setattr(forge_submit, "_apply_fellow_env", lambda _env: None)
+    monkeypatch.setattr(forge_submit.subprocess, "Popen", fake_popen)
+
+    return forge_submit._run_loop_via_cli(
+        worktree_kernel=str(kernel),
+        driver=str(driver),
+        workspace=str(workspace),
+        shapes={"primary": {"M": 128}},
+        snr_threshold=30.0,
+        max_iters=8,
+        max_hours=1.0,
+        branch="forge/session/kernel",
+        gpu_target="gfx950",
+        gpu_type="mi355x",
+        fellow="triton-fellow",
+        program_md_file="",
+        invocation_spec_file="",
+        experiments_dir=experiments,
+        forge_log=tmp_path / "forge.log",
+        timeout_s=120,
+        deadline_unix=time.time() + 120.0,
+        experience_id="attempt-1",
+    )
+
+
+class _RejectingProcess:
+    """A forge-loop that predates one of the options this launcher passes."""
+
+    pid = 43211
+    returncode = 2
+
+    def __init__(self, option: str) -> None:
+        self._option = option
+
+    def communicate(self, timeout=None):
+        return (
+            "Usage: python -m kernel_agents.cli forge-loop [OPTIONS]\n"
+            "Try 'python -m kernel_agents.cli forge-loop --help' for help.\n"
+            f"\nError: No such option '{self._option}'. "
+            "(Did you mean one of: '--agent-options-json', '--result-json'?)\n",
+            "",
+        )
+
+
+class _SucceedingProcess:
+    pid = 43212
+    returncode = 0
+
+    def communicate(self, timeout=None):
+        return _forge_loop_result_stdout(), ""
+
+
+def test_a_rejected_compat_option_costs_the_option_not_the_attempt(tmp_path, monkeypatch):
+    """Click exits 2 on the first unknown option, before running anything.
+
+    ``--shapes-json`` is deprecated and ignored by forge-loop's evaluation, yet
+    an installed KernelForge without it turned every attempt into a total loss.
+    """
+    commands: list[list[str]] = []
+
+    def fake_popen(command, **kwargs):
+        commands.append(list(command))
+        if len(commands) == 1:
+            return _RejectingProcess("--shapes-json")
+        return _SucceedingProcess()
+
+    outcome = _run_loop_with_popen(tmp_path, monkeypatch, fake_popen)
+
+    assert len(commands) == 2
+    assert "--shapes-json" in commands[0]
+    assert "--shapes-json" not in commands[1]
+    # The dropped value must go with the option, not be left as a stray token.
+    assert json.dumps({"primary": {"M": 128}}) not in commands[1]
+    assert outcome.error is None
+    assert outcome.best_ms == 1.0
+    assert outcome.total_improved is True
+    assert "--shapes-json" in (tmp_path / "forge.log").read_text()
+
+
+def test_a_rejected_load_bearing_option_still_fails_the_attempt(tmp_path, monkeypatch):
+    """Only advisory options may be dropped.
+
+    Retrying without ``--kernel`` would optimize something other than the
+    candidate, so this skew has to stay loud.
+    """
+    commands: list[list[str]] = []
+
+    def fake_popen(command, **kwargs):
+        commands.append(list(command))
+        return _RejectingProcess("--kernel")
+
+    outcome = _run_loop_with_popen(tmp_path, monkeypatch, fake_popen)
+
+    assert len(commands) == 1
+    assert outcome.error is not None
+    assert "rc=2" in str(outcome.error)

--- a/src/hyperloom/agents/kernel/tests/test_forge_long_horizon_cli.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_long_horizon_cli.py
@@ -3499,7 +3499,7 @@ def _forge_loop_result_stdout() -> str:
     return f"__FORGE_RESULT__{json.dumps(payload)}__FORGE_RESULT__"
 
 
-def _run_loop_with_popen(tmp_path, monkeypatch, fake_popen):
+def _run_loop_with_popen(tmp_path, monkeypatch, fake_popen, **overrides):
     workspace = tmp_path / "worktree"
     workspace.mkdir()
     kernel = workspace / "kernel.py"
@@ -3532,6 +3532,7 @@ def _run_loop_with_popen(tmp_path, monkeypatch, fake_popen):
         timeout_s=120,
         deadline_unix=time.time() + 120.0,
         experience_id="attempt-1",
+        **overrides,
     )
 
 
@@ -3606,3 +3607,30 @@ def test_a_rejected_load_bearing_option_still_fails_the_attempt(tmp_path, monkey
     assert len(commands) == 1
     assert outcome.error is not None
     assert "rc=2" in str(outcome.error)
+
+
+def test_two_rejected_options_in_a_row_are_both_dropped(tmp_path, monkeypatch):
+    """The installed forge-loop can be missing more than one advisory option.
+
+    KernelForge main currently has neither ``--shapes-json`` nor ``--e2e-pct``,
+    and click reports only the first one it hits, so recovery has to survive
+    being told about them one at a time.
+    """
+    commands: list[list[str]] = []
+    rejections = ["--shapes-json", "--e2e-pct"]
+
+    def fake_popen(command, **kwargs):
+        commands.append(list(command))
+        for option in rejections:
+            if option in command:
+                return _RejectingProcess(option)
+        return _SucceedingProcess()
+
+    outcome = _run_loop_with_popen(tmp_path, monkeypatch, fake_popen, e2e_pct=12.5)
+
+    assert len(commands) == 3
+    assert "--shapes-json" in commands[0] and "--e2e-pct" in commands[0]
+    assert "--shapes-json" not in commands[2]
+    assert "--e2e-pct" not in commands[2]
+    assert outcome.error is None
+    assert outcome.best_ms == 1.0

--- a/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
+++ b/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
@@ -3402,6 +3402,45 @@ def _validated_warm_start_result(
     }
 
 
+_REJECTED_OPTION_RE = re.compile(r"No such option:?\s*'?(--[A-Za-z0-9][\w-]*)'?")
+
+# forge-loop options this launcher may drop when the installed KernelForge does
+# not have them. Each is advisory or a compatibility shim, so a campaign without
+# it is still the campaign we asked for; click rejects an unknown option before
+# running anything, so keeping them mandatory costs the whole attempt instead.
+_DROPPABLE_FORGE_LOOP_OPTIONS = frozenset(
+    {
+        # Deprecated upstream and ignored by forge-loop's evaluation.
+        "--shapes-json",
+        # Input to an end-to-end projection, not to the search itself.
+        "--e2e-pct",
+        # forge-loop infers the framework from the kernel path when omitted.
+        "--framework",
+    }
+)
+
+
+def _rejected_forge_loop_option(output: str) -> str:
+    """Return the option an unknown-option rejection names, else empty."""
+
+    match = _REJECTED_OPTION_RE.search(output or "")
+    return match.group(1) if match else ""
+
+
+def _forge_loop_cmd_without(cmd: list[str], option: str) -> list[str] | None:
+    """Drop a droppable ``option`` and its value from a forge-loop argv.
+
+    Returns ``None`` when the option is load-bearing or absent, so the caller
+    reports the original failure rather than retrying on a guess.
+    """
+
+    if option not in _DROPPABLE_FORGE_LOOP_OPTIONS or option not in cmd:
+        return None
+    index = cmd.index(option)
+    # Every droppable option takes exactly one value.
+    return cmd[:index] + cmd[index + 2 :]
+
+
 def _run_loop_via_cli(
     *,
     worktree_kernel: str,
@@ -3550,34 +3589,54 @@ def _run_loop_via_cli(
     loop_exc = None
     out = ""
     timed_out = False
-    try:
-        proc = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            env=env,
-            cwd=workspace,
-            start_new_session=True,
-        )
+    # An installed forge-loop that predates an advisory option rejects it before
+    # running anything, which used to lose the whole attempt. Retry without it --
+    # once per droppable option, so a skew can never loop.
+    for _launch in range(1 + len(_DROPPABLE_FORGE_LOOP_OPTIONS)):
+        loop_exc = None
+        launch_out = ""
         try:
-            remaining = max(1.0, deadline_unix - time.time())
-            stdout, stderr = proc.communicate(timeout=remaining)
-        except subprocess.TimeoutExpired:
-            timed_out = True
-            stdout, stderr = _terminate_forge_process(proc)
-        out = (stdout or "") + "\n" + (stderr or "")
-        if timed_out:
-            loop_exc = RuntimeError(
-                f"forge-loop exceeded absolute deadline after {timeout_s}s"
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+                cwd=workspace,
+                start_new_session=True,
             )
-        if proc.returncode != 0:
-            if loop_exc is None:
+            try:
+                remaining = max(1.0, deadline_unix - time.time())
+                stdout, stderr = proc.communicate(timeout=remaining)
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                stdout, stderr = _terminate_forge_process(proc)
+            launch_out = (stdout or "") + "\n" + (stderr or "")
+            if timed_out:
                 loop_exc = RuntimeError(
-                    f"forge-loop exited rc={proc.returncode}"
+                    f"forge-loop exceeded absolute deadline after {timeout_s}s"
                 )
-    except Exception as exc:  # noqa: BLE001
-        loop_exc = exc
+            if proc.returncode != 0:
+                if loop_exc is None:
+                    loop_exc = RuntimeError(
+                        f"forge-loop exited rc={proc.returncode}"
+                    )
+        except Exception as exc:  # noqa: BLE001
+            loop_exc = exc
+        out += launch_out
+        if loop_exc is None or timed_out:
+            break
+        rejected = _rejected_forge_loop_option(launch_out)
+        retry_cmd = _forge_loop_cmd_without(cmd, rejected)
+        if retry_cmd is None:
+            break
+        log.warning(
+            "Installed forge-loop rejected %s; retrying without it. Upgrade "
+            "KernelForge to keep this option's contribution.",
+            rejected,
+        )
+        out += f"\n=== retrying forge-loop without {rejected} ===\n"
+        cmd = retry_cmd
 
     try:
         with open(forge_log, "a") as f:


### PR DESCRIPTION
## Problem

`_run_loop_via_cli` builds one argv and launches `python -m kernel_agents.cli forge-loop`. click rejects an unknown option *before* running anything, so an installed KernelForge that predates a single option this launcher passes turns the entire attempt into a loss:

```
Usage: python -m kernel_agents.cli forge-loop [OPTIONS]
Error: No such option '--shapes-json'. (Did you mean one of: '--agent-options-json', '--result-json'?)
forge-loop exited rc=2
```

`--shapes-json` is the option that hit production. KernelForge itself prints `--shapes-json is deprecated and ignored by evaluation; it is retained only for schema-v1 checkpoint compatibility` — so the attempt was lost over an option that contributes nothing to the search. Hyperloom and KernelForge are separate repos wired together through `$FORGE_PATH`, so this skew is a normal operating condition, not an anomaly.

## Production evidence

Classifying every `forge_loop.log` under the shared forge workspaces:

| day | attempts killed by a rejected option | total attempts |
|---|---|---|
| Aug 11 | 4 | 209 |
| Aug 12 | 18 | 25 |

On Aug 12 this was the dominant failure mode. Earlier the same class showed up as `Invalid value for '--max-hours'` (26 attempts, Jul 25-28).

## Fix

When a launch fails with an unknown-option rejection, the launcher drops that option and relaunches — at most once per droppable option, so a skew cannot loop. Only advisory options are droppable, each for a stated reason:

- `--shapes-json` — deprecated upstream and ignored by evaluation
- `--e2e-pct` — input to an end-to-end projection, not to the search
- `--framework` — forge-loop infers it from the kernel path when omitted

Load-bearing options stay loud: retrying without `--kernel` would optimize something other than the candidate. The drop is logged as a warning and written into `forge_loop.log`, so a version skew stays diagnosable instead of silently changing the run.

## Tests

- `test_a_rejected_compat_option_costs_the_option_not_the_attempt` reproduces the regression: it fails on `main` with `assert 1 == 2` (no relaunch) and pins that the dropped option's value goes with it.
- `test_a_rejected_load_bearing_option_still_fails_the_attempt` pins that `--kernel` is not silently dropped.
- `132 passed, 2 skipped` across the forge CLI, codex-provider, export/restore, knowledge-env and driver-fallback suites.

## Test plan

- [x] `pytest src/hyperloom/agents/kernel/tests/test_forge_long_horizon_cli.py`
- [x] Regression sweep over `test_forge_codex_provider.py`, `test_forge_export_restore.py`, `test_forge_knowledge_env.py`, `test_forge_submit_driver_fallback.py`
- [ ] A session against a KernelForge without `--shapes-json` reaches a forge-loop iteration