### PR TITLE
fix(ci): stop an ordinary PR comment from cancelling the e2e run

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -31,8 +31,21 @@ on:
 
 # A newer commit / retest on the same PR cancels the in-flight run; the cleanup step
 # below cancels the workload so no GPU is leaked.
+#
+# A comment that is NOT a `/retest` command must stay OUT of that group. GitHub
+# evaluates `concurrency` when the run is created -- before the `resolve` job's `if`
+# below -- so an ordinary review comment on a PR would otherwise cancel that PR's
+# in-flight run and then skip itself, losing a multi-hour GPU run to a comment. Such
+# comments get a group of their own (keyed by comment id) so they cancel nothing. The
+# `/retest` predicate is kept identical to the one in `resolve.if`, so exactly the
+# comments that can start a run are the comments that can cancel one.
 concurrency:
-  group: ci-e2e-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  group: >-
+    ci-e2e-${{
+      (github.event_name == 'issue_comment' && !contains(github.event.comment.body, '/retest'))
+      && format('noop-comment-{0}', github.event.comment.id)
+      || (github.event.pull_request.number || github.event.issue.number || github.ref)
+    }}
   cancel-in-progress: true
 
 # The workflow token writes the live commit status, the sticky PR report comment, and

--- a/src/hyperloom/inference_optimizer/tests/test_ci_e2e_concurrency_guard.py
+++ b/src/hyperloom/inference_optimizer/tests/test_ci_e2e_concurrency_guard.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Guard for the ``ci-e2e`` concurrency group.
+
+The workflow answers three triggers (``pull_request`` / ``issue_comment`` /
+``workflow_dispatch``) and cancels in-progress runs that share its group. GitHub
+resolves ``concurrency`` when the run is *created*, before the ``resolve`` job's
+``if`` can decline the work, so a group keyed on the PR number alone lets any
+comment on a PR cancel that PR's in-flight multi-hour GPU run and then skip
+itself.
+
+The fix keys non-``/retest`` comments to a group of their own, which only holds
+while the group expression and ``resolve.if`` agree on what a retest comment is.
+These tests pin that agreement; there is no way to unit-test the cancellation
+itself short of running the workflow.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_RETEST_COMMAND = "/retest"
+
+
+def _find_workflow() -> Path | None:
+    """Locate ``ci-e2e.yml``; returns None when running from an installed wheel."""
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / ".github" / "workflows" / "ci-e2e.yml"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+_WORKFLOW = _find_workflow()
+
+pytestmark = pytest.mark.skipif(
+    _WORKFLOW is None,
+    reason="ci-e2e guard needs the source checkout (.github/workflows/)",
+)
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    assert _WORKFLOW is not None
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def concurrency_group(workflow: dict) -> str:
+    return " ".join(str(workflow["concurrency"]["group"]).split())
+
+
+@pytest.fixture(scope="module")
+def resolve_condition(workflow: dict) -> str:
+    return " ".join(str(workflow["jobs"]["resolve"]["if"]).split())
+
+
+def test_an_in_flight_run_is_still_preempted(workflow: dict) -> None:
+    """The point of the group: a newer commit must not queue behind the old run."""
+    assert workflow["concurrency"]["cancel-in-progress"] is True
+
+
+def test_a_comment_that_cannot_start_a_run_cannot_cancel_one(concurrency_group: str) -> None:
+    """Non-retest comments must land in a group of their own, keyed per comment."""
+    assert "github.event_name == 'issue_comment'" in concurrency_group
+    assert f"!contains(github.event.comment.body, '{_RETEST_COMMAND}')" in concurrency_group
+    assert "github.event.comment.id" in concurrency_group
+
+
+def test_the_group_and_the_gate_agree_on_what_a_retest_is(
+    concurrency_group: str,
+    resolve_condition: str,
+) -> None:
+    """Drift here silently restores the bug, in one direction or the other.
+
+    A group looking for a command the gate no longer honours lets an ordinary
+    comment cancel a run again; a gate honouring a command the group does not
+    recognise stops a real retest from preempting the run it means to replace.
+    """
+    predicate = f"contains(github.event.comment.body, '{_RETEST_COMMAND}')"
+    assert predicate in resolve_condition
+    assert predicate in concurrency_group
+
+
+def test_every_trigger_still_resolves_to_a_group(concurrency_group: str) -> None:
+    """Each of the three triggers must contribute a key, or runs collide repo-wide."""
+    for key in (
+        "github.event.pull_request.number",  # pull_request
+        "github.event.issue.number",  # issue_comment (/retest)
+        "github.ref",  # workflow_dispatch
+    ):
+        assert key in concurrency_group


### PR DESCRIPTION
## Problem

`ci-e2e` listens on `issue_comment` so `/retest` can re-run it without a new
commit, and its concurrency group was keyed on the PR number with
`cancel-in-progress: true`:

```yaml
group: ci-e2e-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
```

GitHub resolves `concurrency` when a run is **created** — before the `resolve`
job's `if` can decline the work. So **any** comment on a PR created a run that
joined that PR's group, cancelled the in-flight run, and only then skipped
itself.

The cost is a whole single-GPU e2e run, and the evidence is on this repo:

| | |
|---|---|
| 05:36:52Z | PR #1161 e2e starts (run `31670922249`, `pull_request`) |
| 05:39:25Z | a review reply is posted on #1161 |
| 05:39:28Z | run `31671071877` created (`issue_comment`, branch `main`) → **`skipped`** |
| 05:39:42Z | run `31670922249` → **`cancelled`**, 49s in, workload deleted |

The skipped run never ran a step; taking the group was its entire effect. Recent
history holds four more `issue_comment` runs of this shape, so the failure is not
a one-off — commenting on a PR while its e2e is in flight has been silently
killing it, and the run reports red as `e2e fail`, which reads as a test failure.

## Fix

Key a comment that *cannot* start a run to a group of its own, so it cancels
nothing. Everything that could preempt a run before still does:

| trigger | group | preempts |
|---|---|---|
| `pull_request` (new commit / label) | `ci-e2e-<pr>` | yes |
| `issue_comment` with `/retest` | `ci-e2e-<pr>` | yes — intended |
| `issue_comment`, anything else | `ci-e2e-noop-comment-<id>` | no |
| `workflow_dispatch` | `ci-e2e-<ref>` | yes |

The `/retest` predicate is spelled exactly as in `resolve.if`, so the comments
that can start a run are precisely the comments that can cancel one. That
equality is what the fix rests on, so it is pinned by a test rather than a
comment.

## Test plan

- [x] `test_ci_e2e_concurrency_guard.py` — 4 tests: `cancel-in-progress` still
      set; a non-retest comment is keyed per comment id; the group and
      `resolve.if` agree on the retest predicate; all three triggers still
      contribute a key
- [x] Reverting the group to its previous value fails exactly the two tests that
      describe the bug (`test_a_comment_that_cannot_start_a_run_cannot_cancel_one`,
      `test_the_group_and_the_gate_agree_on_what_a_retest_is`) and leaves the
      other two passing
- [x] `test_packaging_lint.py` still green (new test module stays out of the wheel)
- [ ] Behaviour itself needs a real run to observe: after merge, a comment on a PR
      with e2e in flight should leave the run alive, and `/retest` should still
      preempt it

## Note

Drift guard aside, the group expression cannot be unit-tested as an expression —
there is no local evaluator for GitHub's `&&`/`||` ternary. I walked the four
trigger cases by hand against the truthiness rules; the table above is that
walk-through.

Separately: `_find_repo_root()` is now duplicated verbatim in
`test_packaging_lint.py` and `common/tests/test_llm_client_architecture.py`. This
PR does not add a third copy (it looks for the workflow it guards, not the repo
root), but a shared checkout-discovery helper for tests looks worth extracting on
its own.

Made with [Cursor](https://cursor.com)
