### PR TITLE
fix(kb): accumulate the kernel-agent KB per optimization, not per document

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_kernel_kb_columns.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_kb_columns.py
@@ -12,6 +12,7 @@ from hyperloom.orchestrator.knowledge.remote_recipe.values import (
     KERNEL_AGENT_METRIC,
     build_kernel_agent_knowledge,
     kernel_agent_canonical_id,
+    merge_kernel_columns,
 )
 from hyperloom.orchestrator.knowledge.kernel_kb_columns import stage_kernel_columns
 from hyperloom.orchestrator.knowledge.remote_recipe._vendor.kb_store_client import (
@@ -288,3 +289,69 @@ def test_restaging_a_displaced_artifact_keeps_its_own_ref(tmp_path):
     assert restaged_ref != "kernel/gemm/tuned.csv"
     files_dir = kb._sections.files_dir
     assert (files_dir / restaged_ref).read_text(encoding="utf-8") == "displaced\n"
+
+
+def _cols(gemm=(), fusion=(), rewrite=()):
+    return {
+        "gemm": {"optimizations": list(gemm)},
+        "fusion": {"items": list(fusion)},
+        "rewrite": {"items": list(rewrite)},
+    }
+
+
+def test_merge_keeps_a_column_the_incoming_session_never_touched():
+    published = _cols(rewrite=[{"kernel_name": "k1", "e2e_gain_pct": 20.0}])
+    incoming = _cols(gemm=[{"variant_name": "v1", "e2e_gain_pct": 30.0}])
+
+    merged, carried = merge_kernel_columns(published, incoming)
+
+    assert [i["kernel_name"] for i in merged["rewrite"]["items"]] == ["k1"]
+    assert [o["variant_name"] for o in merged["gemm"]["optimizations"]] == ["v1"]
+    assert carried == []  # that rewrite record referenced no artifacts
+
+
+def test_merge_prefers_the_better_recording_of_the_same_optimization():
+    published = _cols(rewrite=[{"kernel_name": "k1", "e2e_gain_pct": 20.0, "id": "old"}])
+    incoming = _cols(rewrite=[{"kernel_name": "k1", "e2e_gain_pct": 25.0, "id": "new"}])
+
+    merged, _ = merge_kernel_columns(published, incoming)
+
+    assert [i["id"] for i in merged["rewrite"]["items"]] == ["new"]
+
+
+def test_merge_declines_a_worse_recording_of_the_same_optimization():
+    published = _cols(rewrite=[{"kernel_name": "k1", "e2e_gain_pct": 20.0, "id": "old"}])
+    incoming = _cols(rewrite=[{"kernel_name": "k1", "e2e_gain_pct": 5.0, "id": "new"}])
+
+    merged, _ = merge_kernel_columns(published, incoming)
+
+    assert [i["id"] for i in merged["rewrite"]["items"]] == ["old"]
+    # Nothing improved, so the caller can tell the write is pointless.
+    assert merged == published
+
+
+def test_merge_reports_the_artifacts_an_inherited_record_still_needs():
+    published = _cols(
+        rewrite=[
+            {
+                "kernel_name": "k1",
+                "e2e_gain_pct": 20.0,
+                "patch": "kernel/rewrite/k1.diff",
+                "source_files": ["kernel/rewrite/k1.py"],
+            }
+        ]
+    )
+    incoming = _cols(gemm=[{"variant_name": "v1", "e2e_gain_pct": 30.0}])
+
+    _, carried = merge_kernel_columns(published, incoming)
+
+    assert carried == ["kernel/rewrite/k1.diff", "kernel/rewrite/k1.py"]
+
+
+def test_merge_treats_different_kernels_as_different_slots():
+    published = _cols(rewrite=[{"kernel_name": "k1", "e2e_gain_pct": 20.0}])
+    incoming = _cols(rewrite=[{"kernel_name": "k2", "e2e_gain_pct": 5.0}])
+
+    merged, _ = merge_kernel_columns(published, incoming)
+
+    assert sorted(i["kernel_name"] for i in merged["rewrite"]["items"]) == ["k1", "k2"]

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_kb_columns.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_kb_columns.py
@@ -12,6 +12,7 @@ from hyperloom.orchestrator.knowledge.remote_recipe.values import (
     KERNEL_AGENT_METRIC,
     build_kernel_agent_knowledge,
     kernel_agent_canonical_id,
+    kernel_record_refs,
     merge_kernel_columns,
 )
 from hyperloom.orchestrator.knowledge.kernel_kb_columns import stage_kernel_columns
@@ -303,11 +304,11 @@ def test_merge_keeps_a_column_the_incoming_session_never_touched():
     published = _cols(rewrite=[{"kernel_name": "k1", "e2e_gain_pct": 20.0}])
     incoming = _cols(gemm=[{"variant_name": "v1", "e2e_gain_pct": 30.0}])
 
-    merged, carried = merge_kernel_columns(published, incoming)
+    merged, inherited = merge_kernel_columns(published, incoming)
 
     assert [i["kernel_name"] for i in merged["rewrite"]["items"]] == ["k1"]
     assert [o["variant_name"] for o in merged["gemm"]["optimizations"]] == ["v1"]
-    assert carried == []  # that rewrite record referenced no artifacts
+    assert kernel_record_refs(inherited[0]) == set()  # this one names no files
 
 
 def test_merge_prefers_the_better_recording_of_the_same_optimization():
@@ -330,7 +331,7 @@ def test_merge_declines_a_worse_recording_of_the_same_optimization():
     assert merged == published
 
 
-def test_merge_reports_the_artifacts_an_inherited_record_still_needs():
+def test_merge_hands_back_the_inherited_records_so_their_files_follow():
     published = _cols(
         rewrite=[
             {
@@ -343,9 +344,16 @@ def test_merge_reports_the_artifacts_an_inherited_record_still_needs():
     )
     incoming = _cols(gemm=[{"variant_name": "v1", "e2e_gain_pct": 30.0}])
 
-    _, carried = merge_kernel_columns(published, incoming)
+    merged, inherited = merge_kernel_columns(published, incoming)
 
-    assert carried == ["kernel/rewrite/k1.diff", "kernel/rewrite/k1.py"]
+    # The caller re-uploads and may re-ref these, so they must be the very
+    # objects inside the merged document, not copies of them.
+    assert inherited == [published["rewrite"]["items"][0]]
+    assert inherited[0] is merged["rewrite"]["items"][0]
+    assert kernel_record_refs(inherited[0]) == {
+        "kernel/rewrite/k1.diff",
+        "kernel/rewrite/k1.py",
+    }
 
 
 def test_merge_treats_different_kernels_as_different_slots():

--- a/src/hyperloom/inference_optimizer/tests/test_remote_recipe_v2.py
+++ b/src/hyperloom/inference_optimizer/tests/test_remote_recipe_v2.py
@@ -7,6 +7,7 @@ import hashlib
 import inspect
 import json
 import os
+import shutil
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -1883,19 +1884,87 @@ def test_kernel_agent_write_publishes_under_the_kernel_metric(tmp_path):
     assert store.published_knowledge["kernel_gain_pct"] == 12.5
 
 
-def test_kernel_agent_write_skips_a_weaker_champion(tmp_path):
+def test_kernel_agent_write_skips_when_it_improves_nothing(tmp_path):
+    """Already published, and better: republishing would only churn the record."""
     store = _FakeStore(champion=30.0, metric="kernel_gain_pct")
+    client = _kernel_client(store)
+    published = {
+        "value": {
+            "gemm": {
+                "optimizations": [
+                    {"variant_name": "forge_a8w8_blockscale", "e2e_gain_pct": 30.0}
+                ]
+            },
+            "fusion": {"items": []},
+            "rewrite": {"items": []},
+        }
+    }
+    client.read = lambda cid, dest: published  # type: ignore[method-assign]
 
     result = write_kernel_agent_kb(
-        _kernel_state(tmp_path, gain=12.5),
-        "kernel:hyperloom-m:h",
-        "sess-1",
-        client=_kernel_client(store),
+        _kernel_state(tmp_path, gain=12.5), "kernel:hyperloom-m:h", "sess-1", client=client
     )
 
     assert result.status == "skipped"
-    assert result.reason == "not_better_than_champion"
+    assert result.reason == "not_better_than_published"
     assert not [c for c in store.calls if c[0] == "put_knowledge"]
+
+
+def test_kernel_agent_write_keeps_another_column_it_did_not_touch(tmp_path):
+    """A GEMM-only session must not erase a rewrite an earlier run learned."""
+    store = _FakeStore(champion=5.0, metric="kernel_gain_pct")
+    client = _kernel_client(store)
+    published_dir = tmp_path / "published"
+    carried = published_dir / "files" / "kernel" / "rewrite" / "k1.py"
+    carried.parent.mkdir(parents=True, exist_ok=True)
+    carried.write_text("print('earlier rewrite')", encoding="utf-8")
+    published = {
+        "value": {
+            "gemm": {"optimizations": []},
+            "fusion": {"items": []},
+            "rewrite": {
+                "items": [
+                    {
+                        "kernel_name": "k1",
+                        "e2e_gain_pct": 5.0,
+                        "patch": "kernel/rewrite/k1.py",
+                        "source_files": ["kernel/rewrite/k1.py"],
+                    }
+                ]
+            },
+        }
+    }
+
+    def _read(cid, dest):
+        shutil.copytree(published_dir, dest, dirs_exist_ok=True)
+        return published
+
+    client.read = _read  # type: ignore[method-assign]
+    # The upload directory is temporary, so record what it held at upload time.
+    uploaded_paths: list[str] = []
+    inner_put_dir = store.put_dir
+
+    def _put_dir(canonical_id, session_id, files_dir):
+        uploaded_paths.extend(
+            path.relative_to(files_dir).as_posix()
+            for path in sorted(Path(files_dir).rglob("*"))
+            if path.is_file()
+        )
+        return inner_put_dir(canonical_id, session_id, files_dir)
+
+    store.put_dir = _put_dir  # type: ignore[method-assign]
+
+    result = write_kernel_agent_kb(
+        _kernel_state(tmp_path, gain=12.5), "kernel:hyperloom-m:h", "sess-1", client=client
+    )
+
+    assert result.status == "written"
+    value = store.published_knowledge["value"]
+    # This session's GEMM lands ...
+    assert len(value["gemm"]["optimizations"]) == 1
+    # ... and the rewrite it never touched survives, with its artifact re-uploaded.
+    assert [item["kernel_name"] for item in value["rewrite"]["items"]] == ["k1"]
+    assert "kernel/rewrite/k1.py" in uploaded_paths
 
 
 def test_kernel_agent_write_skips_a_session_without_kernel_work(tmp_path):

--- a/src/hyperloom/inference_optimizer/tests/test_remote_recipe_v2.py
+++ b/src/hyperloom/inference_optimizer/tests/test_remote_recipe_v2.py
@@ -44,13 +44,17 @@ from hyperloom.orchestrator.knowledge.remote_recipe.models import (
     KnowledgeBundle,
     RemoteRecipeValidationError,
     RemoteWriteResult,
+    extract_knowledge_artifact_refs,
 )
 from hyperloom.orchestrator.knowledge.remote_recipe.sanitize import (
     sanitize_publish_env_mapping,
     sanitize_publish_server_args,
     sanitize_shared_knowledge,
 )
-from hyperloom.orchestrator.knowledge.remote_recipe.values import _Files
+from hyperloom.orchestrator.knowledge.remote_recipe.values import (
+    KERNEL_AGENT_SESSION_ID,
+    _Files,
+)
 from hyperloom.orchestrator.loop.writeback import WritebackCollaborator
 
 _DOWNLOAD_BYTES = b"verified artifact"
@@ -848,6 +852,7 @@ class _FakeStore:
         metric: str | None = "optimized_throughput",
     ) -> None:
         self.champion = champion
+        self.champion_session = "champion-session"
         self.conflict = conflict
         self.metric = metric
         self.calls: list[tuple] = []
@@ -888,7 +893,7 @@ class _FakeStore:
 
     def get_rollup(self, canonical_id):
         self.calls.append(("get_rollup", canonical_id))
-        champion = {"session_id": "champion-session", "value": self.champion}
+        champion = {"session_id": self.champion_session, "value": self.champion}
         if self.metric is not None:
             champion["metric"] = self.metric
         return {"champion": champion}
@@ -1872,7 +1877,6 @@ def test_kernel_agent_write_publishes_under_the_kernel_metric(tmp_path):
     result = write_kernel_agent_kb(
         _kernel_state(tmp_path),
         "kernel:hyperloom-m:h:vllm:mt:a:0.1:fp8",
-        "sess-1",
         client=_kernel_client(store),
     )
 
@@ -1902,7 +1906,7 @@ def test_kernel_agent_write_skips_when_it_improves_nothing(tmp_path):
     client.read = lambda cid, dest: published  # type: ignore[method-assign]
 
     result = write_kernel_agent_kb(
-        _kernel_state(tmp_path, gain=12.5), "kernel:hyperloom-m:h", "sess-1", client=client
+        _kernel_state(tmp_path, gain=12.5), "kernel:hyperloom-m:h", client=client
     )
 
     assert result.status == "skipped"
@@ -1955,7 +1959,7 @@ def test_kernel_agent_write_keeps_another_column_it_did_not_touch(tmp_path):
     store.put_dir = _put_dir  # type: ignore[method-assign]
 
     result = write_kernel_agent_kb(
-        _kernel_state(tmp_path, gain=12.5), "kernel:hyperloom-m:h", "sess-1", client=client
+        _kernel_state(tmp_path, gain=12.5), "kernel:hyperloom-m:h", client=client
     )
 
     assert result.status == "written"
@@ -1980,7 +1984,7 @@ def test_kernel_agent_write_skips_a_session_without_kernel_work(tmp_path):
     )
 
     result = write_kernel_agent_kb(
-        state, "kernel:hyperloom-m:h", "sess-1", client=_kernel_client(store)
+        state, "kernel:hyperloom-m:h", client=_kernel_client(store)
     )
 
     assert result.status == "skipped"
@@ -2001,9 +2005,9 @@ def test_kernel_agent_write_runs_even_when_the_recipe_write_failed(tmp_path):
     )
     written: list[tuple] = []
 
-    def _fake_write(state, kernel_cid, session_id):
-        written.append((kernel_cid, session_id))
-        return RemoteWriteResult("written", "", kernel_cid, session_id, 12.5)
+    def _fake_write(state, kernel_cid):
+        written.append(kernel_cid)
+        return RemoteWriteResult("written", "", kernel_cid, "sid", 12.5)
 
     with mock.patch.dict(
         os.environ,
@@ -2019,4 +2023,202 @@ def test_kernel_agent_write_runs_even_when_the_recipe_write_failed(tmp_path):
     ), mock.patch.object(remote_recipe, "write_kernel_agent_kb", _fake_write):
         WritebackCollaborator(coordinator).finalize_recipe_and_journal()
 
-    assert written == [("kernel:hyperloom-m:h:vllm:mt:a:0.1:fp8", "s1")]
+    assert written == ["kernel:hyperloom-m:h:vllm:mt:a:0.1:fp8"]
+
+
+def _published_kernel_client(store, published: dict, published_dir: Path):
+    """A client whose read() serves ``published`` plus its downloaded files."""
+    client = _kernel_client(store)
+
+    def _read(cid, dest):
+        shutil.copytree(published_dir, dest, dirs_exist_ok=True)
+        return published
+
+    client.read = _read  # type: ignore[method-assign]
+    return client
+
+
+def _capture_uploads(store) -> dict[str, bytes]:
+    """Record what each write actually uploads; the staging dir is temporary."""
+    uploaded: dict[str, bytes] = {}
+    inner_put_dir = store.put_dir
+
+    def _put_dir(canonical_id, session_id, files_dir):
+        uploaded.clear()
+        uploaded.update(
+            {
+                path.relative_to(files_dir).as_posix(): path.read_bytes()
+                for path in sorted(Path(files_dir).rglob("*"))
+                if path.is_file()
+            }
+        )
+        return inner_put_dir(canonical_id, session_id, files_dir)
+
+    store.put_dir = _put_dir  # type: ignore[method-assign]
+    return uploaded
+
+
+def test_kernel_agent_write_carries_every_ref_an_inherited_record_declares(tmp_path):
+    """A real GEMM record names its report too, not just the tuned table.
+
+    Carrying only a hand-listed subset of ref keys leaves the rest dangling and
+    the whole write dies in validation, silently, at the caller's except.
+    """
+    store = _FakeStore(champion=40.0, metric="kernel_gain_pct")
+    published_dir = tmp_path / "published"
+    files = published_dir / "files" / "kernel" / "gemm" / "artifacts"
+    files.mkdir(parents=True, exist_ok=True)
+    (files / "other.csv").write_text("OLD-TUNED-TABLE\n", encoding="utf-8")
+    (files / "report.md").write_text("# earlier report\n", encoding="utf-8")
+    published = {
+        "value": {
+            "gemm": {
+                "optimizations": [
+                    {
+                        "variant_name": "other_variant",
+                        "e2e_gain_pct": 40.0,
+                        "tuned_file": "kernel/gemm/artifacts/other.csv",
+                        "final_report_path": "kernel/gemm/artifacts/report.md",
+                    }
+                ]
+            },
+            "fusion": {"items": []},
+            "rewrite": {"items": []},
+        }
+    }
+    client = _published_kernel_client(store, published, published_dir)
+    uploaded = _capture_uploads(store)
+
+    result = write_kernel_agent_kb(
+        _kernel_state(tmp_path, gain=12.5), "kernel:hyperloom-m:h", client=client
+    )
+
+    assert result.status == "written"
+    assert "kernel/gemm/artifacts/report.md" in uploaded
+
+
+def test_kernel_agent_write_uploads_nothing_the_merged_record_dropped(tmp_path):
+    """This session stages before the merge rules on it; a losing record's
+    files would otherwise be uploaded with nothing referencing them."""
+    store = _FakeStore(champion=40.0, metric="kernel_gain_pct")
+    published_dir = tmp_path / "published"
+    gemm_files = published_dir / "files" / "kernel" / "gemm" / "artifacts"
+    gemm_files.mkdir(parents=True, exist_ok=True)
+    (gemm_files / "won.csv").write_text("WINNING-TABLE\n", encoding="utf-8")
+    published = {
+        "value": {
+            # Same variant as the session's, and better: the session's GEMM loses.
+            "gemm": {
+                "optimizations": [
+                    {
+                        "variant_name": "forge_a8w8_blockscale",
+                        "e2e_gain_pct": 40.0,
+                        "tuned_file": "kernel/gemm/artifacts/won.csv",
+                    }
+                ]
+            },
+            "fusion": {"items": []},
+            "rewrite": {"items": []},
+        }
+    }
+    client = _published_kernel_client(store, published, published_dir)
+    uploaded = _capture_uploads(store)
+    state = _kernel_state(tmp_path, gain=12.5)
+    # A new rewrite keeps the write alive past the "nothing improved" early exit.
+    rewrite_patch = tmp_path / "k2.patch"
+    rewrite_patch.write_text("--- a/k2.py\n+++ b/k2.py\n", encoding="utf-8")
+    rewrite_source = tmp_path / "k2.py"
+    rewrite_source.write_text("print('new rewrite')", encoding="utf-8")
+    state.optimization_stack.append(
+        {
+            "action": "integrate",
+            "decision": "KEEP",
+            "kernel_id": "k2",
+            "kernel_name": "k2",
+            "gain_pct": 3.0,
+            "tput": 6700.0,
+            "patch_path": str(rewrite_patch),
+            "target_file": str(rewrite_source),
+        }
+    )
+
+    result = write_kernel_agent_kb(state, "kernel:hyperloom-m:h", client=client)
+
+    assert result.status == "written"
+    referenced = extract_knowledge_artifact_refs(store.published_knowledge)
+    assert set(uploaded) <= referenced
+    # The beaten record's tuned table is not carried along as an orphan.
+    assert "kernel/gemm/artifacts/tuned.csv" not in uploaded
+
+
+def test_kernel_agent_write_gives_a_colliding_inherited_file_its_own_ref(tmp_path):
+    """Refs are ``category/kind/<basename>``, so ``tuned.csv`` collides across
+    sessions. Resolving an inherited record to this session's bytes would make
+    PRELUDE replay the wrong table under someone else's measured gain."""
+    store = _FakeStore(champion=40.0, metric="kernel_gain_pct")
+    published_dir = tmp_path / "published"
+    files = published_dir / "files" / "kernel" / "gemm" / "artifacts"
+    files.mkdir(parents=True, exist_ok=True)
+    (files / "tuned.csv").write_text("OLD-TUNED-TABLE\n", encoding="utf-8")
+    published = {
+        "value": {
+            "gemm": {
+                "optimizations": [
+                    {
+                        "variant_name": "other_variant",
+                        "e2e_gain_pct": 40.0,
+                        "tuned_file": "kernel/gemm/artifacts/tuned.csv",
+                    }
+                ]
+            },
+            "fusion": {"items": []},
+            "rewrite": {"items": []},
+        }
+    }
+    client = _published_kernel_client(store, published, published_dir)
+    uploaded = _capture_uploads(store)
+
+    result = write_kernel_agent_kb(
+        _kernel_state(tmp_path, gain=12.5), "kernel:hyperloom-m:h", client=client
+    )
+
+    assert result.status == "written"
+    records = {
+        item["variant_name"]: item
+        for item in store.published_knowledge["value"]["gemm"]["optimizations"]
+    }
+    inherited_ref = records["other_variant"]["tuned_file"]
+    session_ref = records["forge_a8w8_blockscale"]["tuned_file"]
+    assert inherited_ref != session_ref
+    # Each record still resolves to the bytes it was measured on.
+    assert uploaded[inherited_ref] == b"OLD-TUNED-TABLE\n"
+    assert uploaded[session_ref] == b"M,N,K\n16,512,7168\n"
+
+
+def test_kernel_agent_write_accumulates_under_one_session(tmp_path):
+    """Readers resolve an identity through its champion. An accumulating record
+    that adds a kernel without raising the best gain scores no higher than the
+    incumbent, so parking it on a per-run session would hide it forever."""
+    store = _FakeStore(champion=0.0, metric="kernel_gain_pct")
+
+    write_kernel_agent_kb(
+        _kernel_state(tmp_path), "kernel:hyperloom-m:h", client=_kernel_client(store)
+    )
+
+    sessions = {call[2] for call in store.calls if call[0] == "put_knowledge"}
+    assert sessions == {KERNEL_AGENT_SESSION_ID}
+
+
+def test_kernel_agent_write_accepts_a_refused_promotion_it_already_holds(tmp_path):
+    """Re-publishing the accumulated record at an unchanged score need not move
+    the champion: it already points at the session being written."""
+    store = _FakeStore(champion=12.5, conflict=True, metric="kernel_gain_pct")
+    store.champion_session = KERNEL_AGENT_SESSION_ID
+
+    result = write_kernel_agent_kb(
+        _kernel_state(tmp_path), "kernel:hyperloom-m:h", client=_kernel_client(store)
+    )
+
+    assert result.status == "written"
+    # One refused attempt, and no retry: the incumbent is this same record.
+    assert len([c for c in store.calls if c[0] == "set_champion"]) == 1

--- a/src/hyperloom/inference_optimizer/tests/test_remote_recipe_v2.py
+++ b/src/hyperloom/inference_optimizer/tests/test_remote_recipe_v2.py
@@ -920,6 +920,10 @@ class _FakeStore:
         if self.conflict:
             self.conflict = False
             raise KBStoreError("POST champion -> HTTP 409: write_conflict")
+        # The store promotes whatever it is told: measured against the real
+        # service, it accepts an equal or even a lower value.
+        self.champion = value
+        self.champion_session = session_id
 
     def list_session_files(self, canonical_id, session_id, *, kind=""):
         self.calls.append(("list_session_files", canonical_id, session_id, kind))
@@ -2315,3 +2319,56 @@ def test_kernel_agent_write_displaces_one_ref_without_touching_its_namesake(tmp_
     assert inherited["source_files"] == ["kernel/rewrite/source/x.py"]
     assert uploaded[inherited["patch"]] == b"OLD-PATCH"
     assert uploaded["kernel/rewrite/source/x.py"] == b"OLD-SOURCE"
+
+
+def test_kernel_agent_write_takes_over_an_equally_scored_foreign_champion(tmp_path):
+    """Records written before this scheme sit on per-run sessions. Adding a
+    kernel that does not raise the best gain leaves the score equal, so without
+    an equal-score takeover the accumulated document stays off-champion and no
+    reader ever sees it. The store promotes whatever it is told, so a conflict
+    is worth retrying at an unchanged score."""
+    store = _FakeStore(champion=12.5, conflict=True, metric="kernel_gain_pct")
+    store.champion_session = "old-run-session"
+
+    result = write_kernel_agent_kb(
+        _kernel_state(tmp_path), "kernel:hyperloom-m:h", client=_kernel_client(store)
+    )
+
+    assert result.status == "written"
+    promotions = [c for c in store.calls if c[0] == "set_champion"]
+    assert len(promotions) == 2  # the refused one, then the takeover
+    assert promotions[-1][2] == KERNEL_AGENT_SESSION_ID
+    assert store.champion_session == KERNEL_AGENT_SESSION_ID
+
+
+def test_recipe_write_leaves_an_equally_scored_champion_alone(tmp_path):
+    """The recipe record competes rather than accumulates: an equal throughput
+    is not a reason to displace a concurrent winner and churn the identity."""
+    store = _FakeStore(champion=100.0, conflict=True)
+    store.champion_session = "other-session"
+    client = RemoteRecipeClient(store)  # type: ignore[arg-type]
+    # Gating sees the old champion; the conflict re-read sees a concurrent
+    # winner that landed exactly this run's score.
+    values = [100.0, 130.0]
+
+    def _rollup(canonical_id):
+        store.calls.append(("get_rollup", canonical_id))
+        value = values.pop(0) if len(values) > 1 else values[0]
+        return {
+            "champion": {
+                "session_id": "other-session",
+                "value": value,
+                "metric": "optimized_throughput",
+            }
+        }
+
+    store.get_rollup = _rollup  # type: ignore[method-assign]
+
+    result = write_final_remote_recipe(
+        _state(tmp_path), "inference:m:h:f:mt:a:v:p", "session-1", client=client
+    )
+
+    assert result.status == "written"
+    # One refused promotion, and no retry over the equal-scored incumbent.
+    assert len([c for c in store.calls if c[0] == "set_champion"]) == 1
+    assert store.champion_session == "other-session"

--- a/src/hyperloom/inference_optimizer/tests/test_remote_recipe_v2.py
+++ b/src/hyperloom/inference_optimizer/tests/test_remote_recipe_v2.py
@@ -919,7 +919,6 @@ class _FakeStore:
         self.calls.append(("set_champion", canonical_id, session_id, metric, value))
         if self.conflict:
             self.conflict = False
-            self.champion = value - 1
             raise KBStoreError("POST champion -> HTTP 409: write_conflict")
 
     def list_session_files(self, canonical_id, session_id, *, kind=""):
@@ -1866,8 +1865,15 @@ def _kernel_state(tmp_path: Path, *, gain: float = 12.5):
 
 
 def _kernel_client(store):
+    """A client for an identity the kernel-agent KB holds nothing for yet.
+
+    The fake store's envelope belongs to a recipe identity, and a read that
+    fails is no longer treated as an empty record, so say "nothing published"
+    the way the store does: an absent best record.
+    """
     client = RemoteRecipeClient.__new__(RemoteRecipeClient)
     client.store = store
+    client.read = lambda cid, dest: None  # type: ignore[method-assign]
     return client
 
 
@@ -2028,7 +2034,8 @@ def test_kernel_agent_write_runs_even_when_the_recipe_write_failed(tmp_path):
 
 def _published_kernel_client(store, published: dict, published_dir: Path):
     """A client whose read() serves ``published`` plus its downloaded files."""
-    client = _kernel_client(store)
+    client = RemoteRecipeClient.__new__(RemoteRecipeClient)
+    client.store = store
 
     def _read(cid, dest):
         shutil.copytree(published_dir, dest, dirs_exist_ok=True)
@@ -2222,3 +2229,89 @@ def test_kernel_agent_write_accepts_a_refused_promotion_it_already_holds(tmp_pat
     assert result.status == "written"
     # One refused attempt, and no retry: the incumbent is this same record.
     assert len([c for c in store.calls if c[0] == "set_champion"]) == 1
+
+
+def test_kernel_agent_write_refuses_to_publish_over_an_unreadable_record(tmp_path):
+    """The published record is the base of every merge, and the write replaces
+    the document wholesale: merging against a failed read would publish this
+    run's columns alone and destroy the identity's accumulated kernels."""
+    store = _FakeStore(champion=40.0, metric="kernel_gain_pct")
+    client = _kernel_client(store)
+
+    def _read(cid, dest):
+        raise KBStoreError("GET best-record -> HTTP 500")
+
+    client.read = _read  # type: ignore[method-assign]
+
+    result = write_kernel_agent_kb(
+        _kernel_state(tmp_path), "kernel:hyperloom-m:h", client=client
+    )
+
+    assert result.status == "error"
+    assert "published_record_unreadable" in result.reason
+    assert not [c for c in store.calls if c[0] in ("put_knowledge", "put_dir")]
+    assert store.published_knowledge is None
+
+
+def test_kernel_agent_write_displaces_one_ref_without_touching_its_namesake(tmp_path):
+    """A record can name two files sharing a basename across directories. Moving
+    the colliding one must not repoint the other, whose bytes would then be
+    referenced by nothing, dropped from the upload, and replayed as a patch."""
+    store = _FakeStore(champion=40.0, metric="kernel_gain_pct")
+    published_dir = tmp_path / "published"
+    patches = published_dir / "files" / "kernel" / "rewrite" / "patches"
+    sources = published_dir / "files" / "kernel" / "rewrite" / "source"
+    patches.mkdir(parents=True, exist_ok=True)
+    sources.mkdir(parents=True, exist_ok=True)
+    (patches / "x.py").write_text("OLD-PATCH", encoding="utf-8")
+    (sources / "x.py").write_text("OLD-SOURCE", encoding="utf-8")
+    published = {
+        "value": {
+            "gemm": {"optimizations": []},
+            "fusion": {"items": []},
+            "rewrite": {
+                "items": [
+                    {
+                        "kernel_name": "kOLD",
+                        "e2e_gain_pct": 40.0,
+                        "patch": "kernel/rewrite/patches/x.py",
+                        "source_files": ["kernel/rewrite/source/x.py"],
+                    }
+                ]
+            },
+        }
+    }
+    client = _published_kernel_client(store, published, published_dir)
+    uploaded = _capture_uploads(store)
+    state = _kernel_state(tmp_path, gain=12.5)
+    # This session's own rewrite collides on the patch basename only.
+    session_patch = tmp_path / "x.py"
+    session_patch.write_text("NEW-PATCH", encoding="utf-8")
+    session_source = tmp_path / "target.py"
+    session_source.write_text("print('new')", encoding="utf-8")
+    state.optimization_stack.append(
+        {
+            "action": "integrate",
+            "decision": "KEEP",
+            "kernel_id": "kNEW",
+            "kernel_name": "kNEW",
+            "gain_pct": 3.0,
+            "tput": 6700.0,
+            "patch_path": str(session_patch),
+            "target_file": str(session_source),
+        }
+    )
+
+    result = write_kernel_agent_kb(state, "kernel:hyperloom-m:h", client=client)
+
+    assert result.status == "written"
+    inherited = next(
+        item
+        for item in store.published_knowledge["value"]["rewrite"]["items"]
+        if item["kernel_name"] == "kOLD"
+    )
+    # The displaced patch moved; the same-named source kept its own ref.
+    assert inherited["patch"] != "kernel/rewrite/patches/x.py"
+    assert inherited["source_files"] == ["kernel/rewrite/source/x.py"]
+    assert uploaded[inherited["patch"]] == b"OLD-PATCH"
+    assert uploaded["kernel/rewrite/source/x.py"] == b"OLD-SOURCE"

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/__init__.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/__init__.py
@@ -95,9 +95,21 @@ def write_kernel_agent_kb(
             return RemoteWriteResult(
                 "skipped", "no_kernel_optimization", kernel_canonical_id, session_id
             )
-        published, published_dir = _published_kernel_record(
-            resolved, kernel_canonical_id, root / "published"
-        )
+        try:
+            published, published_dir = _published_kernel_record(
+                resolved, kernel_canonical_id, root / "published"
+            )
+        except Exception as exc:  # noqa: BLE001 — reported, never written past
+            log.warning(
+                "kernel-agent KB: not writing, the published record is unreadable",
+                exc_info=True,
+            )
+            return RemoteWriteResult(
+                "error",
+                f"published_record_unreadable: {exc}",
+                kernel_canonical_id,
+                session_id,
+            )
         merged, inherited = merge_kernel_columns(published, value)
         if merged == published:
             # Every optimization this session recorded is already published at
@@ -138,15 +150,13 @@ def _published_kernel_record(
 ) -> tuple[dict[str, Any] | None, Path | None]:
     """Download what the kernel-agent KB already holds for this identity.
 
-    Best-effort: a record that cannot be read is treated as absent, so a
-    transport failure degrades to publishing this session's own columns rather
-    than losing them.
+    Raises when the record cannot be read. It is the base every merge builds
+    on, and the write replaces the accumulated document wholesale: treating an
+    unreadable incumbent as an absent one would publish this run's columns
+    alone, destroying every kernel this identity has ever learned. One 500,
+    one timeout or one failed digest check is not a licence to do that.
     """
-    try:
-        document = client.read(canonical_id, destination)
-    except Exception:  # noqa: BLE001 — an unreadable incumbent must not block
-        log.warning("kernel-agent KB: cannot read the published record", exc_info=True)
-        return None, None
+    document = client.read(canonical_id, destination)
     if not isinstance(document, dict):
         return None, None
     value = document.get("value")
@@ -181,9 +191,10 @@ def _carry_published_artifacts(
                 break
             target = files_dir / ref
             if target.exists() and not _same_bytes(source, target):
-                ref = _displaced_ref(ref, source)
+                displaced = _displaced_ref(ref, source)
+                _rewrite_record_ref(record, ref, displaced)
+                ref = displaced
                 target = files_dir / ref
-                _rewrite_record_ref(record, source.name, ref)
             if target.exists():
                 continue
             target.parent.mkdir(parents=True, exist_ok=True)
@@ -218,23 +229,29 @@ def _displaced_ref(ref: str, source: Path) -> str:
     return (original.parent / f"{original.stem}-{digest}{original.suffix}").as_posix()
 
 
-def _rewrite_record_ref(record: Any, basename: str, new_ref: str) -> None:
-    """Point every ref in one record that names ``basename`` at ``new_ref``."""
+def _rewrite_record_ref(record: Any, old_ref: str, new_ref: str) -> None:
+    """Repoint the refs in one record that are exactly ``old_ref``.
+
+    Matching on the whole ref, not its basename: a record can name two files
+    that share a basename across directories, and repointing the other one at
+    this file would leave its own bytes referenced by nothing, dropped from the
+    upload, and replayed as the wrong kind of artifact.
+    """
     if isinstance(record, dict):
         for key, value in record.items():
             if isinstance(value, str):
-                if value.endswith(f"/{basename}"):
+                if value == old_ref:
                     record[key] = new_ref
             else:
-                _rewrite_record_ref(value, basename, new_ref)
+                _rewrite_record_ref(value, old_ref, new_ref)
         return
     if isinstance(record, list):
         for index, item in enumerate(record):
             if isinstance(item, str):
-                if item.endswith(f"/{basename}"):
+                if item == old_ref:
                     record[index] = new_ref
             else:
-                _rewrite_record_ref(item, basename, new_ref)
+                _rewrite_record_ref(item, old_ref, new_ref)
 
 
 def _rebuild_kernel_bundle(

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/__init__.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/__init__.py
@@ -6,8 +6,11 @@
 from __future__ import annotations
 
 import logging
+import logging
 import math
+import shutil
 import tempfile
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -18,16 +21,21 @@ from .client import (
     RemoteRecipeClient,
     RemoteRecipeConfigurationError,
 )
-from .models import RemoteRecipeValidationError, RemoteWriteResult
+from .models import Artifact, KnowledgeBundle, RemoteRecipeValidationError, RemoteWriteResult
+from .sanitize import sanitize_shared_knowledge
 from .values import (
     KERNEL_AGENT_METRIC,
+    _kernel_agent_score,
     build_kernel_agent_knowledge,
     build_remote_knowledge,
     convert_v1_recipe_to_knowledge,
     envelope_to_v1_recipe,
     has_new_keep,
     kernel_agent_canonical_id,
+    merge_kernel_columns,
 )
+
+log = logging.getLogger(__name__)
 
 log = logging.getLogger(__name__)
 
@@ -68,31 +76,105 @@ def write_kernel_agent_kb(
     if resolved is None:
         return RemoteWriteResult("disabled", "KB_STORE_URL/TOKEN not configured")
     with tempfile.TemporaryDirectory(prefix="hyperloom-kernel-agent-") as temporary:
-        files_dir = Path(temporary) / "files"
-        bundle, score = build_kernel_agent_knowledge(
+        root = Path(temporary)
+        files_dir = root / "files"
+        bundle, _score = build_kernel_agent_knowledge(
             state, files_dir, sections=KnowledgeSections.from_env()
         )
         value = bundle.knowledge.get("value") or {}
-        has_opt = bool(
-            (value.get("gemm") or {}).get("optimizations")
-            or (value.get("fusion") or {}).get("items")
-            or (value.get("rewrite") or {}).get("items")
-        )
-        if not has_opt:
+        if not _has_kernel_optimization(value):
             return RemoteWriteResult(
                 "skipped", "no_kernel_optimization", kernel_canonical_id, session_id
             )
-        # Ensure a first kernel optimization always lands even if its gain field
-        # is missing; real KEEPs carry a positive gain that drives keep-if-better.
-        score_value = score if score > 0 else 1e-6
-        return resolved.write_if_better(
+        published, published_dir = _published_kernel_record(
+            resolved, kernel_canonical_id, root / "published"
+        )
+        merged, carried = merge_kernel_columns(published, value)
+        if merged == published:
+            # Every optimization this session recorded is already published at
+            # least as good; republishing would only churn the record.
+            return RemoteWriteResult(
+                "skipped", "not_better_than_published", kernel_canonical_id, session_id
+            )
+        if carried and published_dir is not None:
+            _carry_published_artifacts(published_dir, files_dir, carried)
+        bundle = _rebuild_kernel_bundle(bundle, merged, files_dir)
+        score = _kernel_agent_score(merged)
+        return resolved.write_record(
             kernel_canonical_id,
             session_id,
             bundle,
-            optimized_throughput=score_value,
+            # A first optimization must land even if its gain field is missing;
+            # real KEEPs carry a positive gain that drives keep-if-better.
+            score=score if score > 0 else 1e-6,
             files_dir=files_dir,
             metric=KERNEL_AGENT_METRIC,
         )
+
+
+def _has_kernel_optimization(value: Mapping[str, Any]) -> bool:
+    return bool(
+        (value.get("gemm") or {}).get("optimizations")
+        or (value.get("fusion") or {}).get("items")
+        or (value.get("rewrite") or {}).get("items")
+    )
+
+
+def _published_kernel_record(
+    client: RemoteRecipeClient,
+    canonical_id: str,
+    destination: Path,
+) -> tuple[dict[str, Any] | None, Path | None]:
+    """Download what the kernel-agent KB already holds for this identity.
+
+    Best-effort: a record that cannot be read is treated as absent, so a
+    transport failure degrades to publishing this session's own columns rather
+    than losing them.
+    """
+    try:
+        document = client.read(canonical_id, destination)
+    except Exception:  # noqa: BLE001 — an unreadable incumbent must not block
+        log.warning("kernel-agent KB: cannot read the published record", exc_info=True)
+        return None, None
+    if not isinstance(document, dict):
+        return None, None
+    value = document.get("value")
+    return (dict(value) if isinstance(value, Mapping) else None), destination
+
+
+def _carry_published_artifacts(
+    published_dir: Path, files_dir: Path, refs: Iterable[str]
+) -> None:
+    """Re-stage the files of records inherited from the published document.
+
+    The record is replaced wholesale on write, so an inherited entry's artifact
+    has to be uploaded again for its ref to keep resolving.
+    """
+    source_root = published_dir / "files"
+    for ref in dict.fromkeys(refs):
+        source = source_root / ref
+        target = files_dir / ref
+        if not source.is_file() or target.exists():
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+
+
+def _rebuild_kernel_bundle(
+    bundle: KnowledgeBundle, merged: dict[str, Any], files_dir: Path
+) -> KnowledgeBundle:
+    """Re-describe the bundle around the merged columns and the files on disk."""
+    knowledge = dict(bundle.knowledge)
+    knowledge["value"] = merged
+    knowledge[KERNEL_AGENT_METRIC] = _kernel_agent_score(merged)
+    artifacts = [
+        Artifact(path=path.relative_to(files_dir).as_posix(), source=path)
+        for path in sorted(files_dir.rglob("*"))
+        if path.is_file()
+    ]
+    rebuilt = KnowledgeBundle(knowledge=sanitize_shared_knowledge(knowledge), artifacts=artifacts)
+    rebuilt.validate()
+    return rebuilt
 
 
 def write_final_remote_recipe(
@@ -267,6 +349,7 @@ __all__ = [
     "envelope_to_v1_recipe",
     "has_new_keep",
     "kernel_agent_canonical_id",
+    "merge_kernel_columns",
     "read_remote_champion",
     "read_remote_recipe",
     "write_final_remote_recipe",

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/__init__.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/__init__.py
@@ -5,12 +5,12 @@
 
 from __future__ import annotations
 
-import logging
+import hashlib
 import logging
 import math
 import shutil
 import tempfile
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -21,10 +21,17 @@ from .client import (
     RemoteRecipeClient,
     RemoteRecipeConfigurationError,
 )
-from .models import Artifact, KnowledgeBundle, RemoteRecipeValidationError, RemoteWriteResult
+from .models import (
+    Artifact,
+    KnowledgeBundle,
+    RemoteRecipeValidationError,
+    RemoteWriteResult,
+    extract_knowledge_artifact_refs,
+)
 from .sanitize import sanitize_shared_knowledge
 from .values import (
     KERNEL_AGENT_METRIC,
+    KERNEL_AGENT_SESSION_ID,
     _kernel_agent_score,
     build_kernel_agent_knowledge,
     build_remote_knowledge,
@@ -32,10 +39,9 @@ from .values import (
     envelope_to_v1_recipe,
     has_new_keep,
     kernel_agent_canonical_id,
+    kernel_record_refs,
     merge_kernel_columns,
 )
-
-log = logging.getLogger(__name__)
 
 log = logging.getLogger(__name__)
 
@@ -60,7 +66,6 @@ read_remote_champion = read_remote_recipe
 def write_kernel_agent_kb(
     state: Any,
     kernel_canonical_id: str,
-    session_id: str,
     *,
     client: RemoteRecipeClient | None = None,
 ) -> RemoteWriteResult:
@@ -71,10 +76,14 @@ def write_kernel_agent_kb(
     rewrite) into their own KB Store record and keeps whichever beats what the
     kernel-agent KB already holds, scored by the kernel's own gain. Overlap with
     KernelForge's ``kernel:`` records is by design and not consulted here.
+
+    The record is not written under the run's session: it accumulates across
+    runs under one storage session, see KERNEL_AGENT_SESSION_ID.
     """
     resolved = client or RemoteRecipeClient.from_env_optional()
     if resolved is None:
         return RemoteWriteResult("disabled", "KB_STORE_URL/TOKEN not configured")
+    session_id = KERNEL_AGENT_SESSION_ID
     with tempfile.TemporaryDirectory(prefix="hyperloom-kernel-agent-") as temporary:
         root = Path(temporary)
         files_dir = root / "files"
@@ -89,15 +98,17 @@ def write_kernel_agent_kb(
         published, published_dir = _published_kernel_record(
             resolved, kernel_canonical_id, root / "published"
         )
-        merged, carried = merge_kernel_columns(published, value)
+        merged, inherited = merge_kernel_columns(published, value)
         if merged == published:
             # Every optimization this session recorded is already published at
             # least as good; republishing would only churn the record.
             return RemoteWriteResult(
                 "skipped", "not_better_than_published", kernel_canonical_id, session_id
             )
-        if carried and published_dir is not None:
-            _carry_published_artifacts(published_dir, files_dir, carried)
+        if inherited:
+            unusable = _carry_published_artifacts(published_dir, files_dir, inherited)
+            if unusable:
+                _drop_records(merged, unusable)
         bundle = _rebuild_kernel_bundle(bundle, merged, files_dir)
         score = _kernel_agent_score(merged)
         return resolved.write_record(
@@ -143,36 +154,114 @@ def _published_kernel_record(
 
 
 def _carry_published_artifacts(
-    published_dir: Path, files_dir: Path, refs: Iterable[str]
-) -> None:
-    """Re-stage the files of records inherited from the published document.
+    published_dir: Path | None,
+    files_dir: Path,
+    inherited: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Re-stage the artifacts of records inherited from the published document.
 
-    The record is replaced wholesale on write, so an inherited entry's artifact
-    has to be uploaded again for its ref to keep resolving.
+    The record is replaced wholesale on write, so an inherited entry's files
+    have to be uploaded again for its refs to keep resolving. Refs are only
+    ``category/kind/<basename>``, so an inherited file regularly collides with a
+    same-named one this session produced; the inherited copy then takes a
+    digest-suffixed ref and the record that owns it is rewritten to match.
+    Leaving it to resolve to this session's bytes would silently replay the
+    wrong table or patch under the inherited record's measured gain.
+
+    Returns the inherited records whose files could not be re-staged, which the
+    caller drops: one undownloadable artifact must not fail the whole write.
     """
-    source_root = published_dir / "files"
-    for ref in dict.fromkeys(refs):
-        source = source_root / ref
-        target = files_dir / ref
-        if not source.is_file() or target.exists():
+    source_root = None if published_dir is None else published_dir / "files"
+    unusable: list[dict[str, Any]] = []
+    for record in inherited:
+        for ref in sorted(kernel_record_refs(record)):
+            source = None if source_root is None else source_root / ref
+            if source is None or not source.is_file():
+                unusable.append(record)
+                break
+            target = files_dir / ref
+            if target.exists() and not _same_bytes(source, target):
+                ref = _displaced_ref(ref, source)
+                target = files_dir / ref
+                _rewrite_record_ref(record, source.name, ref)
+            if target.exists():
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+    if unusable:
+        log.warning(
+            "kernel-agent KB: dropping %d inherited record(s) whose artifacts are unavailable",
+            len(unusable),
+        )
+    return unusable
+
+
+def _drop_records(merged: dict[str, Any], drops: list[dict[str, Any]]) -> None:
+    """Remove specific record objects from the merged columns, by identity."""
+    dropped = {id(record) for record in drops}
+    for column in merged.values():
+        if not isinstance(column, dict):
             continue
-        target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source, target)
+        for key, rows in column.items():
+            if isinstance(rows, list):
+                column[key] = [row for row in rows if id(row) not in dropped]
+
+
+def _same_bytes(left: Path, right: Path) -> bool:
+    return left.stat().st_size == right.stat().st_size and left.read_bytes() == right.read_bytes()
+
+
+def _displaced_ref(ref: str, source: Path) -> str:
+    """Name a colliding inherited artifact after its own content."""
+    original = Path(ref)
+    digest = hashlib.sha256(source.read_bytes()).hexdigest()[:10]
+    return (original.parent / f"{original.stem}-{digest}{original.suffix}").as_posix()
+
+
+def _rewrite_record_ref(record: Any, basename: str, new_ref: str) -> None:
+    """Point every ref in one record that names ``basename`` at ``new_ref``."""
+    if isinstance(record, dict):
+        for key, value in record.items():
+            if isinstance(value, str):
+                if value.endswith(f"/{basename}"):
+                    record[key] = new_ref
+            else:
+                _rewrite_record_ref(value, basename, new_ref)
+        return
+    if isinstance(record, list):
+        for index, item in enumerate(record):
+            if isinstance(item, str):
+                if item.endswith(f"/{basename}"):
+                    record[index] = new_ref
+            else:
+                _rewrite_record_ref(item, basename, new_ref)
 
 
 def _rebuild_kernel_bundle(
     bundle: KnowledgeBundle, merged: dict[str, Any], files_dir: Path
 ) -> KnowledgeBundle:
-    """Re-describe the bundle around the merged columns and the files on disk."""
+    """Re-describe the bundle around the merged columns and the files they name.
+
+    Only files the merged document actually references are uploaded: this
+    session stages every record it produced before the merge decides which of
+    them survive, and a record that lost its slot would otherwise leave its
+    files behind as artifacts nothing references.
+    """
     knowledge = dict(bundle.knowledge)
     knowledge["value"] = merged
     knowledge[KERNEL_AGENT_METRIC] = _kernel_agent_score(merged)
-    artifacts = [
-        Artifact(path=path.relative_to(files_dir).as_posix(), source=path)
-        for path in sorted(files_dir.rglob("*"))
-        if path.is_file()
-    ]
-    rebuilt = KnowledgeBundle(knowledge=sanitize_shared_knowledge(knowledge), artifacts=artifacts)
+    knowledge = sanitize_shared_knowledge(knowledge)
+    referenced = extract_knowledge_artifact_refs(knowledge)
+    artifacts = []
+    for path in sorted(files_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(files_dir).as_posix()
+        if rel in referenced:
+            artifacts.append(Artifact(path=rel, source=path))
+        else:
+            path.unlink()
+    rebuilt = KnowledgeBundle(knowledge=knowledge, artifacts=artifacts)
     rebuilt.validate()
     return rebuilt
 

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/client.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/client.py
@@ -480,11 +480,15 @@ class RemoteRecipeClient:
         except KBStoreError as exc:
             if "HTTP 409" not in str(exc):
                 raise
-            _, winner, _ = _champion(
+            incumbent, winner, _ = _champion(
                 self.store.get_rollup(canonical_id),
                 validate_metric=True,
                 expected_metric=metric,
             )
+            if incumbent == session_id:
+                # The record just written is already the one readers resolve to,
+                # so a refused promotion changes nothing.
+                return RemoteWriteResult("written", "", canonical_id, session_id, score)
             if winner < score:
                 self.store.set_champion(
                     canonical_id,

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/client.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/client.py
@@ -404,6 +404,56 @@ class RemoteRecipeClient:
                 session_id,
                 optimized_throughput,
             )
+        return self._publish(
+            canonical_id,
+            session_id,
+            bundle,
+            score=optimized_throughput,
+            files_dir=files_dir,
+            metric=metric,
+        )
+
+    def write_record(
+        self,
+        canonical_id: str,
+        session_id: str,
+        bundle: KnowledgeBundle,
+        *,
+        score: float,
+        files_dir: Path,
+        metric: str,
+    ) -> RemoteWriteResult:
+        """Publish a record whose contents were already reconciled by the caller.
+
+        An identity that accumulates — where a session contributes some entries
+        and inherits the rest — cannot be gated on a single document score:
+        adding a second kernel does not raise the best gain, yet still has to be
+        published. Such a caller decides what survives and hands the result
+        here.
+        """
+        if not math.isfinite(score):
+            raise RemoteRecipeValidationError(f"score must be finite, got {score!r}")
+        bundle.knowledge = sanitize_shared_knowledge(bundle.knowledge)
+        return self._publish(
+            canonical_id,
+            session_id,
+            bundle,
+            score=score,
+            files_dir=files_dir,
+            metric=metric,
+        )
+
+    def _publish(
+        self,
+        canonical_id: str,
+        session_id: str,
+        bundle: KnowledgeBundle,
+        *,
+        score: float,
+        files_dir: Path,
+        metric: str,
+    ) -> RemoteWriteResult:
+        """Upload the files, replace the knowledge, then move the champion."""
         expected = {artifact.path for artifact in bundle.artifacts}
         if expected:
             refs = self.store.put_dir(canonical_id, session_id, files_dir)
@@ -425,7 +475,7 @@ class RemoteRecipeClient:
                 canonical_id,
                 session_id,
                 metric=metric,
-                value=optimized_throughput,
+                value=score,
             )
         except KBStoreError as exc:
             if "HTTP 409" not in str(exc):
@@ -435,20 +485,14 @@ class RemoteRecipeClient:
                 validate_metric=True,
                 expected_metric=metric,
             )
-            if winner < optimized_throughput:
+            if winner < score:
                 self.store.set_champion(
                     canonical_id,
                     session_id,
                     metric=metric,
-                    value=optimized_throughput,
+                    value=score,
                 )
-        return RemoteWriteResult(
-            "written",
-            "",
-            canonical_id,
-            session_id,
-            optimized_throughput,
-        )
+        return RemoteWriteResult("written", "", canonical_id, session_id, score)
 
 
 __all__ = [

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/client.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/client.py
@@ -441,6 +441,7 @@ class RemoteRecipeClient:
             score=score,
             files_dir=files_dir,
             metric=metric,
+            supersede_equal=True,
         )
 
     def _publish(
@@ -452,8 +453,20 @@ class RemoteRecipeClient:
         score: float,
         files_dir: Path,
         metric: str,
+        supersede_equal: bool = False,
     ) -> RemoteWriteResult:
-        """Upload the files, replace the knowledge, then move the champion."""
+        """Upload the files, replace the knowledge, then move the champion.
+
+        The store promotes whatever it is told — it accepts an equal or even a
+        lower value and moves the champion down — so keep-if-better lives here,
+        and a 409 means a concurrent write, not a refused value.
+
+        ``supersede_equal`` re-promotes over an equally scored incumbent after
+        such a conflict. A record that accumulates entries needs it: adding a
+        kernel that does not raise the best gain leaves the score unchanged, and
+        leaving the champion on the older session would hide the addition from
+        every reader. Records that merely compete keep the strict comparison.
+        """
         expected = {artifact.path for artifact in bundle.artifacts}
         if expected:
             refs = self.store.put_dir(canonical_id, session_id, files_dir)
@@ -489,7 +502,7 @@ class RemoteRecipeClient:
                 # The record just written is already the one readers resolve to,
                 # so a refused promotion changes nothing.
                 return RemoteWriteResult("written", "", canonical_id, session_id, score)
-            if winner < score:
+            if winner < score or (supersede_equal and winner == score):
                 self.store.set_champion(
                     canonical_id,
                     session_id,

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
@@ -780,6 +780,108 @@ def _kernel_agent_score(value: Mapping[str, Any]) -> float:
     return best
 
 
+_KERNEL_COLUMN_LISTS = (("gemm", "optimizations"), ("fusion", "items"), ("rewrite", "items"))
+
+
+def _kernel_record_key(column: str, record: Mapping[str, Any]) -> str:
+    """Identify the optimization a record describes, within its column.
+
+    Two sessions optimizing the same kernel compete for one slot; two sessions
+    optimizing different kernels must both survive the merge.
+    """
+    if column == "gemm":
+        candidates = (
+            record.get("variant_name"),
+            record.get("task_id"),
+            Path(str(record.get("tuned_file") or "")).name,
+        )
+    else:
+        candidates = (
+            record.get("kernel_name"),
+            record.get("best_pattern"),
+            record.get("id"),
+        )
+    for candidate in candidates:
+        text = str(candidate or "").strip()
+        if text:
+            return f"{column}:{text}"
+    return f"{column}:{hashlib.sha256(repr(sorted(record.items())).encode()).hexdigest()[:10]}"
+
+
+def _kernel_record_score(record: Mapping[str, Any]) -> float:
+    """How good one recorded optimization was, in end-to-end gain percent."""
+    e2e = record.get("e2e") if isinstance(record.get("e2e"), Mapping) else {}
+    return max(
+        _number(record.get("e2e_gain_pct")),
+        _number(record.get("gain_pct")),
+        _number(e2e.get("gain_pct")),
+    )
+
+
+def merge_kernel_columns(
+    published: Mapping[str, Any] | None,
+    incoming: Mapping[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    """Keep the better recording of each optimization, not the better document.
+
+    The kernel-agent record accumulates across sessions: a run that only tuned
+    GEMM must not erase a rewrite an earlier run learned. Records are matched
+    per column by the optimization they describe and the higher end-to-end gain
+    wins, so a session contributes exactly what it improved.
+
+    Returns the merged columns and the refs carried over from the published
+    record, which the caller has to re-upload for those refs to keep resolving.
+    """
+    merged: dict[str, Any] = {}
+    carried: list[str] = []
+    published = published if isinstance(published, Mapping) else {}
+    for column, list_key in _KERNEL_COLUMN_LISTS:
+        prior_node = published.get(column)
+        prior = list((prior_node or {}).get(list_key) or []) if isinstance(prior_node, Mapping) else []
+        fresh_node = incoming.get(column)
+        fresh = list((fresh_node or {}).get(list_key) or []) if isinstance(fresh_node, Mapping) else []
+        by_key: dict[str, tuple[Mapping[str, Any], bool]] = {}
+        order: list[str] = []
+        for record in prior:
+            if not isinstance(record, Mapping):
+                continue
+            key = _kernel_record_key(column, record)
+            if key not in by_key:
+                order.append(key)
+            by_key[key] = (record, True)
+        for record in fresh:
+            if not isinstance(record, Mapping):
+                continue
+            key = _kernel_record_key(column, record)
+            held = by_key.get(key)
+            if held is None:
+                order.append(key)
+                by_key[key] = (record, False)
+            elif _kernel_record_score(record) > _kernel_record_score(held[0]):
+                by_key[key] = (record, False)
+        rows = []
+        for key in order:
+            record, from_published = by_key[key]
+            rows.append(dict(record))
+            if from_published:
+                carried.extend(_kernel_record_refs(record))
+        merged[column] = {list_key: rows}
+    return merged, carried
+
+
+def _kernel_record_refs(record: Mapping[str, Any]) -> list[str]:
+    """Artifact refs one record depends on, so a carried record keeps its files."""
+    refs: list[str] = []
+    for key in ("patch", "source_file", "tuned_file", "experience_document"):
+        value = str(record.get(key) or "").strip()
+        if value:
+            refs.append(value)
+    sources = record.get("source_files")
+    if isinstance(sources, list):
+        refs.extend(str(ref).strip() for ref in sources if str(ref or "").strip())
+    return refs
+
+
 def build_kernel_agent_knowledge(
     state: Any,
     files_dir: str | Path,
@@ -961,6 +1063,7 @@ __all__ = [
     "envelope_to_v1_recipe",
     "has_new_keep",
     "kernel_agent_canonical_id",
+    "merge_kernel_columns",
     "match_rewrite_attempt",
     "merge_staged_sections",
 ]

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
@@ -718,6 +718,17 @@ _KERNEL_SECTION = "kernel"
 _KERNEL_ID_PREFIX = "hyperloom-"
 # Champion metric for the kernel-agent record: a percentage, not a throughput.
 KERNEL_AGENT_METRIC = "kernel_gain_pct"
+# Storage session the accumulating kernel-agent record lives under.
+#
+# Readers resolve an identity through its champion session, but this record
+# accumulates instead of competing: a run that adds a second kernel without
+# raising the best gain scores no higher than the incumbent, so a per-run
+# session would leave the merged document on a session the champion never moves
+# to, invisible to every later read. Writing every merge back to one session
+# keeps the champion pointing at the accumulated document whatever the server
+# does with an equal-valued promotion. The contributing run stays recorded in
+# the document's provenance.
+KERNEL_AGENT_SESSION_ID = "hyperloom-kernel-agent"
 
 
 def kernel_agent_canonical_id(recipe_canonical_id: str) -> str:
@@ -821,7 +832,7 @@ def _kernel_record_score(record: Mapping[str, Any]) -> float:
 def merge_kernel_columns(
     published: Mapping[str, Any] | None,
     incoming: Mapping[str, Any],
-) -> tuple[dict[str, Any], list[str]]:
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Keep the better recording of each optimization, not the better document.
 
     The kernel-agent record accumulates across sessions: a run that only tuned
@@ -829,11 +840,13 @@ def merge_kernel_columns(
     per column by the optimization they describe and the higher end-to-end gain
     wins, so a session contributes exactly what it improved.
 
-    Returns the merged columns and the refs carried over from the published
-    record, which the caller has to re-upload for those refs to keep resolving.
+    Returns the merged columns and the records inherited from the published
+    document. The caller has to re-upload those records' artifacts for their
+    refs to keep resolving, and the returned dicts are the ones inside
+    ``merged``, so rewriting a ref on one updates the document.
     """
     merged: dict[str, Any] = {}
-    carried: list[str] = []
+    inherited: list[dict[str, Any]] = []
     published = published if isinstance(published, Mapping) else {}
     for column, list_key in _KERNEL_COLUMN_LISTS:
         prior_node = published.get(column)
@@ -862,24 +875,22 @@ def merge_kernel_columns(
         rows = []
         for key in order:
             record, from_published = by_key[key]
-            rows.append(dict(record))
+            row = dict(record)
+            rows.append(row)
             if from_published:
-                carried.extend(_kernel_record_refs(record))
+                inherited.append(row)
         merged[column] = {list_key: rows}
-    return merged, carried
+    return merged, inherited
 
 
-def _kernel_record_refs(record: Mapping[str, Any]) -> list[str]:
-    """Artifact refs one record depends on, so a carried record keeps its files."""
-    refs: list[str] = []
-    for key in ("patch", "source_file", "tuned_file", "experience_document"):
-        value = str(record.get(key) or "").strip()
-        if value:
-            refs.append(value)
-    sources = record.get("source_files")
-    if isinstance(sources, list):
-        refs.extend(str(ref).strip() for ref in sources if str(ref or "").strip())
-    return refs
+def kernel_record_refs(record: Mapping[str, Any]) -> set[str]:
+    """Artifact refs one record depends on.
+
+    Delegates to the same extractor the bundle validates with, so a record
+    cannot depend on a ref the caller forgot to carry: hand-listing key names
+    missed nested sections and the report/artifact paths a real record carries.
+    """
+    return extract_knowledge_artifact_refs(record)
 
 
 def build_kernel_agent_knowledge(
@@ -1063,6 +1074,7 @@ __all__ = [
     "envelope_to_v1_recipe",
     "has_new_keep",
     "kernel_agent_canonical_id",
+    "kernel_record_refs",
     "merge_kernel_columns",
     "match_rewrite_attempt",
     "merge_staged_sections",

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -1638,12 +1638,7 @@ class WritebackCollaborator:
         except Exception:  # noqa: BLE001 - audit cannot break finalization
             log.debug("Remote Recipe KB audit append failed", exc_info=True)
 
-    def _finalize_kernel_agent_kb(
-        self,
-        remote_cid: str,
-        remote_sid: str,
-        source: str,
-    ) -> None:
+    def _finalize_kernel_agent_kb(self, remote_cid: str, source: str) -> None:
         """Publish the independent kernel-agent KB record for this session.
 
         A separate ``kernel:`` record with its own keep-if-better on kernel
@@ -1673,9 +1668,7 @@ class WritebackCollaborator:
                 # The recipe write failed before resolving the workload identity.
                 log.info("Kernel-agent KB finalize skipped: no workload identity")
                 return
-            kernel_result = write_kernel_agent_kb(
-                self.shared_state, kernel_cid, remote_sid
-            )
+            kernel_result = write_kernel_agent_kb(self.shared_state, kernel_cid)
             log.info(
                 "Kernel-agent KB finalize: status=%s reason=%s cid=%s sid=%s",
                 kernel_result.status,
@@ -1772,7 +1765,7 @@ class WritebackCollaborator:
                     optimized_throughput=remote_result.optimized_throughput,
                     reason=remote_result.reason,
                 )
-                self._finalize_kernel_agent_kb(remote_cid, remote_sid, source)
+                self._finalize_kernel_agent_kb(remote_cid, source)
                 return {
                     "status": remote_result.status,
                     "reason": remote_result.reason,
@@ -1793,7 +1786,7 @@ class WritebackCollaborator:
                     error_type=type(exc).__name__,
                 )
                 log.exception("Remote Recipe KB finalize failed (non-fatal)")
-                self._finalize_kernel_agent_kb(remote_cid, remote_sid, source)
+                self._finalize_kernel_agent_kb(remote_cid, source)
                 return {
                     "status": "error",
                     "reason": type(exc).__name__,


### PR DESCRIPTION
## Problem

The kernel-agent record holds one column per backend (`gemm`/`fusion`/`rewrite`),
but it was published as an indivisible document:

- a single document score (the best kernel gain in the session) decided whether
  to write at all, and
- the write replaced the whole record.

So a session that only tuned GEMM, and scored higher than what was published,
erased a rewrite an earlier session had learned — even though nothing better
about that rewrite had been found:

| step | session | published record |
| --- | --- | --- |
| 1 | learns a rewrite, gain 20% | `rewrite=k1` |
| 2 | tunes only GEMM, gain 30% | `gemm=v1` — **`k1` gone** |

Giving the kernel agent its own record removed this all-or-nothing behaviour at
the recipe level and reintroduced it one level down. The KB therefore did not
accumulate: a later run could leave it holding less than an earlier one, and
PRELUDE's warm replay silently had less to restore over time.

The publish gate had the mirror-image flaw. Because it compared one score,
adding a *second* kernel that did not raise the best gain looked like no
improvement, and the new column was dropped.

## Fix

Reconcile against what is already published rather than replacing it.

- **Match per optimization, not per document.** Records are keyed within their
  column by the optimization they describe — GEMM by variant name or tuned
  table, fusion and rewrite by kernel — and the higher end-to-end gain wins each
  slot. A session contributes exactly what it improved and inherits the rest;
  different kernels occupy different slots.
- **Re-stage inherited artifacts.** The document is still replaced wholesale, so
  the files behind an inherited record are copied back into the upload set;
  otherwise its refs would dangle.
- **Gate on the merge, not on a score.** A write happens when the merge changed
  something. `write_record` performs that ungated publish and shares its
  implementation with `write_if_better`, which keeps its own score gate.
- Reading the published record is best-effort: an unreadable incumbent degrades
  to publishing this session's own columns rather than losing them.