### PR TITLE
feat(kernel): gate a launch on the forge-loop argv contract

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_forge_cli_contract.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_cli_contract.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""The forge-loop argv contract, checked against the installed KernelForge.
+
+Hyperloom and KernelForge are separate repositories, wired together at runtime
+through ``$FORGE_PATH``, so nothing else makes them agree on this argv. click
+rejects an unknown option while parsing, before running anything, which is why a
+single retired or renamed option costs an entire attempt instead of degrading
+it: 22 attempts were lost to ``--shapes-json`` alone.
+
+Reading ``--help`` is not enough. Hidden options are absent from it, so a check
+built on help text cannot see the ones most likely to be retired -- ``--help``
+listed neither ``--shapes-json`` nor its removal.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_BACKENDS_DIR = Path(__file__).resolve().parent.parent / "tools" / "backends"
+sys.path.insert(0, str(_BACKENDS_DIR))
+import forge_submit  # noqa: E402
+
+
+def _installed_forge_loop_options() -> set[str]:
+    """Every option the installed forge-loop accepts, hidden ones included."""
+
+    cli = pytest.importorskip(
+        "kernel_agents.cli",
+        reason="KernelForge is not installed, so its argv cannot be checked",
+    )
+    command = cli.main.commands.get("forge-loop")
+    if command is None:
+        pytest.fail("the installed kernel_agents CLI has no forge-loop command")
+    supported: set[str] = set()
+    for param in command.params:
+        supported.update(param.opts)
+        supported.update(param.secondary_opts)
+    return supported
+
+
+def _maximal_launcher_argv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Build the argv with every conditional option present.
+
+    Options this launcher only adds for some candidates are exactly the ones a
+    narrower test would miss, so each condition is satisfied here.
+    """
+    workspace = tmp_path / "worktree"
+    workspace.mkdir()
+    kernel = workspace / "kernel.py"
+    driver = workspace / "driver.py"
+    program = tmp_path / "program.md"
+    invocation_spec = tmp_path / "invocation_spec.json"
+    for path, body in (
+        (kernel, "pass\n"),
+        (driver, "pass\n"),
+        (program, "# Task\n"),
+        (invocation_spec, "{}\n"),
+    ):
+        path.write_text(body)
+    experiments = tmp_path / "attempt" / "forge_experiments"
+    experiments.mkdir(parents=True)
+    captured: dict[str, list[str]] = {}
+
+    class FakeProcess:
+        pid = 43214
+        returncode = 0
+
+        def communicate(self, timeout=None):
+            return "", ""
+
+    def fake_popen(command, **kwargs):
+        captured["command"] = list(command)
+        return FakeProcess()
+
+    monkeypatch.setattr(forge_submit, "_ensure_forge_on_path", lambda: "/forge/src")
+    monkeypatch.setattr(forge_submit, "_apply_fellow_env", lambda _env: None)
+    monkeypatch.setattr(forge_submit, "_openai_only_provider", lambda: True)
+    monkeypatch.setenv("CODEX_MODEL", "gpt-5-codex")
+    monkeypatch.setattr(forge_submit.subprocess, "Popen", fake_popen)
+
+    forge_submit._run_loop_via_cli(
+        worktree_kernel=str(kernel),
+        driver=str(driver),
+        workspace=str(workspace),
+        snr_threshold=30.0,
+        max_iters=8,
+        max_hours=1.0,
+        branch="forge/session/kernel",
+        gpu_target="gfx950",
+        gpu_type="mi355x",
+        fellow="triton-fellow",
+        program_md_file=str(program),
+        invocation_spec_file=str(invocation_spec),
+        experiments_dir=experiments,
+        forge_log=tmp_path / "forge.log",
+        timeout_s=120,
+        deadline_unix=time.time() + 120.0,
+        experience_id="attempt-1",
+        operator_name="vllm::logical_op",
+        framework="vllm",
+        target_functions=["kernel_impl"],
+        source_files=[str(kernel)],
+    )
+    return captured["command"]
+
+
+def test_every_option_the_launcher_passes_exists_in_the_installed_forge_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supported = _installed_forge_loop_options()
+    argv = _maximal_launcher_argv(tmp_path, monkeypatch)
+    passed = {token for token in argv if token.startswith("--")}
+
+    assert passed, "the launcher argv carries no options; the probe is broken"
+    missing = sorted(passed - supported)
+    assert not missing, (
+        "the installed forge-loop does not accept "
+        + ", ".join(missing)
+        + ". click exits 2 on the first unknown option, so every forge attempt "
+        "would be lost. Either stop passing it or install a KernelForge that "
+        "has it."
+    )
+
+
+def test_the_probe_would_notice_an_option_that_disappeared(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A green contract test must be able to fail; pin that it can."""
+    argv = _maximal_launcher_argv(tmp_path, monkeypatch)
+    passed = {token for token in argv if token.startswith("--")}
+    supported = _installed_forge_loop_options()
+    sentinel = "--kernel"
+
+    assert sentinel in passed and sentinel in supported
+    assert sentinel in passed - (supported - {sentinel})

--- a/src/hyperloom/agents/kernel/tests/test_forge_cli_contract.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_cli_contract.py
@@ -1,17 +1,17 @@
 # SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""The forge-loop argv contract, checked against the installed KernelForge.
+"""The declared forge-loop option set, pinned against the argv really built.
 
-Hyperloom and KernelForge are separate repositories, wired together at runtime
-through ``$FORGE_PATH``, so nothing else makes them agree on this argv. click
-rejects an unknown option while parsing, before running anything, which is why a
-single retired or renamed option costs an entire attempt instead of degrading
-it: 22 attempts were lost to ``--shapes-json`` alone.
+`FORGE_LOOP_OPTIONS` is what the launch-time gate compares against the installed
+KernelForge. Nothing in a running image can capture an argv, so the declaration
+is the gate's only account of what the launcher sends -- and a stale declaration
+makes the gate worse than useless: it would pass while the run still lost every
+attempt to an option the declaration forgot.
 
-Reading ``--help`` is not enough. Hidden options are absent from it, so a check
-built on help text cannot see the ones most likely to be retired -- ``--help``
-listed neither ``--shapes-json`` nor its removal.
+The gate itself, and the KernelForge it reads, are covered by
+``inference_optimizer/tests/test_preflight_forge_contract.py``. Nothing here
+touches KernelForge, so this holds wherever the suite runs.
 """
 
 from __future__ import annotations
@@ -27,28 +27,11 @@ sys.path.insert(0, str(_BACKENDS_DIR))
 import forge_submit  # noqa: E402
 
 
-def _installed_forge_loop_options() -> set[str]:
-    """Every option the installed forge-loop accepts, hidden ones included."""
-
-    cli = pytest.importorskip(
-        "kernel_agents.cli",
-        reason="KernelForge is not installed, so its argv cannot be checked",
-    )
-    command = cli.main.commands.get("forge-loop")
-    if command is None:
-        pytest.fail("the installed kernel_agents CLI has no forge-loop command")
-    supported: set[str] = set()
-    for param in command.params:
-        supported.update(param.opts)
-        supported.update(param.secondary_opts)
-    return supported
-
-
 def _maximal_launcher_argv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[str]:
     """Build the argv with every conditional option present.
 
-    Options this launcher only adds for some candidates are exactly the ones a
-    narrower test would miss, so each condition is satisfied here.
+    Options the launcher only adds for some candidates are exactly the ones a
+    narrower probe would miss, so each condition is satisfied here.
     """
     workspace = tmp_path / "worktree"
     workspace.mkdir()
@@ -110,50 +93,12 @@ def _maximal_launcher_argv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> l
     return captured["command"]
 
 
-def test_every_option_the_launcher_passes_exists_in_the_installed_forge_loop(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    supported = _installed_forge_loop_options()
-    argv = _maximal_launcher_argv(tmp_path, monkeypatch)
-    passed = {token for token in argv if token.startswith("--")}
-
-    assert passed, "the launcher argv carries no options; the probe is broken"
-    missing = sorted(passed - supported)
-    assert not missing, (
-        "the installed forge-loop does not accept "
-        + ", ".join(missing)
-        + ". click exits 2 on the first unknown option, so every forge attempt "
-        "would be lost. Either stop passing it or install a KernelForge that "
-        "has it."
-    )
-
-
 def test_the_declared_option_set_matches_the_argv_the_launcher_builds(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The launcher preflight checks a declared set, so it must not drift.
-
-    Nothing in the image can capture an argv, so the preflight compares
-    ``FORGE_LOOP_OPTIONS`` against the installed CLI. That is only meaningful
-    while this holds.
-    """
     argv = _maximal_launcher_argv(tmp_path, monkeypatch)
     passed = {token for token in argv if token.startswith("--")}
 
+    assert passed, "the launcher argv carries no options; the probe is broken"
     assert passed == set(forge_submit.FORGE_LOOP_OPTIONS)
-
-
-def test_the_probe_would_notice_an_option_that_disappeared(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A green contract test must be able to fail; pin that it can."""
-    argv = _maximal_launcher_argv(tmp_path, monkeypatch)
-    passed = {token for token in argv if token.startswith("--")}
-    supported = _installed_forge_loop_options()
-    sentinel = "--kernel"
-
-    assert sentinel in passed and sentinel in supported
-    assert sentinel in passed - (supported - {sentinel})

--- a/src/hyperloom/agents/kernel/tests/test_forge_cli_contract.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_cli_contract.py
@@ -129,6 +129,22 @@ def test_every_option_the_launcher_passes_exists_in_the_installed_forge_loop(
     )
 
 
+def test_the_declared_option_set_matches_the_argv_the_launcher_builds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The launcher preflight checks a declared set, so it must not drift.
+
+    Nothing in the image can capture an argv, so the preflight compares
+    ``FORGE_LOOP_OPTIONS`` against the installed CLI. That is only meaningful
+    while this holds.
+    """
+    argv = _maximal_launcher_argv(tmp_path, monkeypatch)
+    passed = {token for token in argv if token.startswith("--")}
+
+    assert passed == set(forge_submit.FORGE_LOOP_OPTIONS)
+
+
 def test_the_probe_would_notice_an_option_that_disappeared(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
+++ b/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
@@ -98,6 +98,41 @@ def _knowledge_config_for_forge():
         _KNOWLEDGE_CONFIG_RESOLVED = True
         return config
 
+# Every option _run_loop_via_cli may pass to `kernel_agents.cli forge-loop`.
+# click rejects an unknown option while parsing, before running anything, so one
+# option the installed KernelForge lacks costs a whole attempt rather than
+# degrading it. Two consumers keep this honest: a unit test pins it against the
+# argv the launcher really builds, and the launcher preflight compares it against
+# the installed CLI so a mismatch fails the launch instead of every attempt.
+FORGE_LOOP_OPTIONS = frozenset(
+    {
+        "--agent-backend",
+        "--agent-fallback-provider",
+        "--deadline-unix",
+        "--driver",
+        "--experience-id",
+        "--experiment-id",
+        "--experiments-dir",
+        "--fellow",
+        "--framework",
+        "--git-branch",
+        "--gpu-target",
+        "--gpu-type",
+        "--invocation-spec-file",
+        "--kernel",
+        "--max-hours",
+        "--max-iters",
+        "--model",
+        "--operator-name",
+        "--program-md-file",
+        "--result-json",
+        "--snr-threshold",
+        "--source-files",
+        "--target-functions",
+        "--workspace",
+    }
+)
+
 _FORGE_EXPERIMENT_ID = "hyperloom"
 # Mirrors kernel_agents.cli.MIN_MAX_HOURS (1.0h): forge-loop refuses a shorter
 # runtime budget rather than running a non-productive campaign.

--- a/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
+++ b/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
@@ -133,6 +133,37 @@ FORGE_LOOP_OPTIONS = frozenset(
     }
 )
 
+def forge_loop_contract_gaps() -> list[str] | None:
+    """Return the options in :data:`FORGE_LOOP_OPTIONS` that forge-loop rejects.
+
+    Resolves the same KernelForge a dispatch would, so the answer describes the
+    build that will actually run rather than whatever is newest upstream.
+    Introspects the click command instead of ``--help`` because a hidden option
+    is absent from help text -- ``--shapes-json`` was hidden.
+
+    Returns:
+        The rejected options, ``[]`` when the contract holds, or ``None`` when
+        KernelForge cannot be introspected (a run without it has no forge
+        backend to break).
+    """
+    _ensure_forge_on_path()
+    try:
+        from kernel_agents import cli as forge_cli  # type: ignore[import-not-found]
+    except Exception:
+        return None
+
+    group = getattr(forge_cli, "main", None)
+    command = getattr(group, "commands", {}).get("forge-loop") if group else None
+    if command is None:
+        return None
+
+    accepted: set[str] = set()
+    for param in command.params:
+        accepted.update(param.opts)
+        accepted.update(param.secondary_opts)
+    return sorted(FORGE_LOOP_OPTIONS - accepted)
+
+
 _FORGE_EXPERIMENT_ID = "hyperloom"
 # Mirrors kernel_agents.cli.MIN_MAX_HOURS (1.0h): forge-loop refuses a shorter
 # runtime budget rather than running a non-productive campaign.

--- a/src/hyperloom/inference_optimizer/cli/preflight.py
+++ b/src/hyperloom/inference_optimizer/cli/preflight.py
@@ -1030,6 +1030,41 @@ def _check_tracelens_cli() -> None:
     sys.exit(2)
 
 
+def _check_forge_loop_contract() -> None:
+    """Hard-gate the forge-loop argv against the KernelForge this run will use.
+
+    click rejects an unknown option while parsing, before running anything, so a
+    KernelForge that retired one of the options the launcher passes loses every
+    forge attempt with rc=2 -- and the session still finishes looking healthy,
+    with no kernel work and nothing in the report to say why. Hyperloom and
+    KernelForge are separate repositories resolved through ``$FORGE_PATH``, so
+    this pairing is only knowable here, at launch.
+    """
+    try:
+        from hyperloom.agents.kernel.tools.backends import forge_submit
+    except Exception as exc:  # noqa: BLE001 - a broken import is not this gate's news
+        print(f"Preflight: WARNING — forge-loop contract unchecked ({exc})")
+        return
+
+    missing = forge_submit.forge_loop_contract_gaps()
+    if missing is None:
+        print("Preflight: forge-loop contract unchecked (KernelForge not importable)")
+        return
+    if not missing:
+        print(f"Preflight: forge-loop contract OK ({len(forge_submit.FORGE_LOOP_OPTIONS)} options)")
+        return
+
+    print(
+        f"ERROR: the installed forge-loop rejects {missing}. click exits 2 on the "
+        f"first unknown option, so every forge attempt would be lost while the "
+        f"session still reported success with no kernel work. Either install a "
+        f"KernelForge that declares them (check $FORGE_PATH) or stop passing them "
+        f"from forge_submit.FORGE_LOOP_OPTIONS. Refusing to start.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
 def _check_tracelens_root_exists() -> None:
     """Hard-gate an explicitly set ``TRACELENS_ROOT`` at preflight.
 
@@ -1710,6 +1745,12 @@ def _preflight(
                 f"Preflight: WARNING — TraceLens CLI(s) not on PATH: {_missing_tl} "
                 f"(skipped; --no-kernel + roofline disabled)"
             )
+
+    # --- forge-loop argv contract (HARD-FAIL unless --no-kernel) ---
+    # A retired option costs every forge attempt while the session still reports
+    # success, so this pairing is checked before the Coordinator starts.
+    if not no_kernel:
+        _check_forge_loop_contract()
 
     # --- IR-3: PR Monitor reachability probe (soft degrade) ---
     if args is not None:

--- a/src/hyperloom/inference_optimizer/tests/test_preflight_forge_contract.py
+++ b/src/hyperloom/inference_optimizer/tests/test_preflight_forge_contract.py
@@ -1,78 +1,77 @@
 # SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Launcher preflight for the forge-loop argv contract.
+"""The launch-time gate on the forge-loop argv contract.
 
-The image that runs a session is the only place that knows which KernelForge is
-installed, and a retired option there costs every forge attempt rc=2 -- hours
-into the run, visible only in per-attempt logs. The preflight turns that into a
-launch-time failure that names the option.
+Hyperloom resolves KernelForge through ``$FORGE_PATH``, so which build a session
+will dispatch is only knowable at launch. A retired option costs every forge
+attempt with rc=2 while the session still finishes reporting success, so the
+preflight refuses to start instead.
 """
 
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
-
 import pytest
 
-_MODULE_PATH = (
-    Path(__file__).resolve().parents[1] / "tools" / "preflight_optimizer.py"
-)
-_SPEC = importlib.util.spec_from_file_location("preflight_optimizer", _MODULE_PATH)
-assert _SPEC and _SPEC.loader
-preflight = importlib.util.module_from_spec(_SPEC)
-_SPEC.loader.exec_module(preflight)
+from hyperloom.agents.kernel.tools.backends import forge_submit
+from hyperloom.inference_optimizer.cli import preflight
 
 
-def _declared_options() -> set[str]:
-    import sys
-
-    backends = (
-        Path(__file__).resolve().parents[3]
-        / "hyperloom"
-        / "agents"
-        / "kernel"
-        / "tools"
-        / "backends"
-    )
-    sys.path.insert(0, str(backends))
-    import forge_submit
-
-    return set(forge_submit.FORGE_LOOP_OPTIONS)
-
-
-def test_a_forge_loop_missing_one_option_fails_the_launch(
+def test_a_forge_loop_missing_one_option_refuses_to_start(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    declared = _declared_options()
     retired = "--gpu-type"
-    assert retired in declared, "pick an option the launcher actually passes"
-    monkeypatch.setattr(
-        preflight, "_forge_loop_options", lambda _path: declared - {retired}
-    )
+    assert retired in forge_submit.FORGE_LOOP_OPTIONS
+    monkeypatch.setattr(forge_submit, "forge_loop_contract_gaps", lambda: [retired])
 
-    assert preflight._print_forge_loop_contract() is False
+    with pytest.raises(SystemExit) as exit_info:
+        preflight._check_forge_loop_contract()
+
+    assert exit_info.value.code == 2
     assert retired in capsys.readouterr().err
 
 
-def test_a_matching_forge_loop_passes(
+def test_a_matching_forge_loop_starts(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    # A newer KernelForge may accept more than we pass; only shortfalls matter.
-    accepted = _declared_options() | {"--some-new-option"}
-    monkeypatch.setattr(preflight, "_forge_loop_options", lambda _path: accepted)
+    monkeypatch.setattr(forge_submit, "forge_loop_contract_gaps", lambda: [])
 
-    assert preflight._print_forge_loop_contract() is True
-    assert "forge_loop_contract_ok" in capsys.readouterr().out
+    preflight._check_forge_loop_contract()
+
+    assert "forge-loop contract OK" in capsys.readouterr().out
 
 
-def test_an_absent_kernelforge_does_not_fail_the_launch(
+def test_an_uninspectable_kernelforge_does_not_block_the_launch(
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """A run without KernelForge has no forge backend to break."""
-    monkeypatch.setattr(preflight, "_forge_loop_options", lambda _path: None)
+    """A run that cannot import KernelForge has no forge backend to break."""
+    monkeypatch.setattr(forge_submit, "forge_loop_contract_gaps", lambda: None)
 
-    assert preflight._print_forge_loop_contract() is True
+    preflight._check_forge_loop_contract()
+
+    assert "unchecked" in capsys.readouterr().out
+
+
+def test_the_gate_reads_the_kernelforge_a_dispatch_would_use(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """`$FORGE_PATH` decides, so the gate must resolve it the same way.
+
+    Reading an installed package while a dispatch would use $FORGE_PATH would
+    check a build that never runs.
+    """
+    resolved: list[str] = []
+    monkeypatch.setattr(
+        forge_submit,
+        "_ensure_forge_on_path",
+        lambda: resolved.append("resolved") or "",
+    )
+    monkeypatch.setenv("FORGE_PATH", str(tmp_path))
+
+    forge_submit.forge_loop_contract_gaps()
+
+    assert resolved == ["resolved"]

--- a/src/hyperloom/inference_optimizer/tests/test_preflight_forge_contract.py
+++ b/src/hyperloom/inference_optimizer/tests/test_preflight_forge_contract.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Launcher preflight for the forge-loop argv contract.
+
+The image that runs a session is the only place that knows which KernelForge is
+installed, and a retired option there costs every forge attempt rc=2 -- hours
+into the run, visible only in per-attempt logs. The preflight turns that into a
+launch-time failure that names the option.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "preflight_optimizer.py"
+)
+_SPEC = importlib.util.spec_from_file_location("preflight_optimizer", _MODULE_PATH)
+assert _SPEC and _SPEC.loader
+preflight = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(preflight)
+
+
+def _declared_options() -> set[str]:
+    import sys
+
+    backends = (
+        Path(__file__).resolve().parents[3]
+        / "hyperloom"
+        / "agents"
+        / "kernel"
+        / "tools"
+        / "backends"
+    )
+    sys.path.insert(0, str(backends))
+    import forge_submit
+
+    return set(forge_submit.FORGE_LOOP_OPTIONS)
+
+
+def test_a_forge_loop_missing_one_option_fails_the_launch(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    declared = _declared_options()
+    retired = "--gpu-type"
+    assert retired in declared, "pick an option the launcher actually passes"
+    monkeypatch.setattr(
+        preflight, "_forge_loop_options", lambda _path: declared - {retired}
+    )
+
+    assert preflight._print_forge_loop_contract() is False
+    assert retired in capsys.readouterr().err
+
+
+def test_a_matching_forge_loop_passes(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A newer KernelForge may accept more than we pass; only shortfalls matter.
+    accepted = _declared_options() | {"--some-new-option"}
+    monkeypatch.setattr(preflight, "_forge_loop_options", lambda _path: accepted)
+
+    assert preflight._print_forge_loop_contract() is True
+    assert "forge_loop_contract_ok" in capsys.readouterr().out
+
+
+def test_an_absent_kernelforge_does_not_fail_the_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run without KernelForge has no forge backend to break."""
+    monkeypatch.setattr(preflight, "_forge_loop_options", lambda _path: None)
+
+    assert preflight._print_forge_loop_contract() is True

--- a/src/hyperloom/inference_optimizer/tools/preflight_optimizer.py
+++ b/src/hyperloom/inference_optimizer/tools/preflight_optimizer.py
@@ -88,6 +88,82 @@ def _print_rocm_snapshot() -> None:
         print("rocm_smi_stderr=", result.stderr.strip()[:500])
 
 
+def _forge_loop_options(forge_path: str) -> set[str] | None:
+    """Return the options the installed forge-loop accepts, hidden ones included.
+
+    Args:
+        forge_path: Directory holding ``kernel_agents``, as ``$FORGE_PATH`` names
+            it; empty relies on an installed package.
+
+    Returns:
+        The accepted option strings, or ``None`` when KernelForge cannot be
+        imported or exposes no ``forge-loop`` command.
+    """
+    if forge_path and forge_path not in sys.path:
+        sys.path.insert(0, forge_path)
+    try:
+        from kernel_agents import cli  # type: ignore[import-not-found]
+    except Exception as exc:
+        print("forge_loop_contract=unavailable", type(exc).__name__, str(exc)[:200])
+        return None
+
+    command = getattr(cli, "main", None)
+    command = getattr(command, "commands", {}).get("forge-loop") if command else None
+    if command is None:
+        print("forge_loop_contract=unavailable no forge-loop command")
+        return None
+
+    accepted: set[str] = set()
+    for param in command.params:
+        accepted.update(param.opts)
+        accepted.update(param.secondary_opts)
+    return accepted
+
+
+def _print_forge_loop_contract() -> bool:
+    """Report whether the installed forge-loop accepts every option we pass.
+
+    click rejects an unknown option while parsing, before running anything, so a
+    KernelForge that retired one of these loses every forge attempt with rc=2 --
+    hours into a run, and only in the per-attempt logs. Saying so at launch costs
+    a second and names the option.
+
+    Returns:
+        ``True`` when the contract holds or KernelForge is absent (a run without
+        it simply has no forge backend to break), ``False`` on a real mismatch.
+    """
+    accepted = _forge_loop_options(os.environ.get("FORGE_PATH", "").strip())
+    if accepted is None:
+        return True
+
+    repo_root = pathlib.Path(__file__).resolve().parents[3]
+    backends = repo_root / "hyperloom" / "agents" / "kernel" / "tools" / "backends"
+    if str(backends) not in sys.path:
+        sys.path.insert(0, str(backends))
+    try:
+        import forge_submit  # type: ignore[import-not-found]
+    except Exception as exc:
+        print("forge_loop_contract=unchecked", type(exc).__name__, str(exc)[:200])
+        return True
+
+    missing = sorted(set(forge_submit.FORGE_LOOP_OPTIONS) - accepted)
+    if missing:
+        print(
+            "forge_loop_contract_missing=" + ",".join(missing),
+            file=sys.stderr,
+        )
+        print(
+            "the installed forge-loop rejects these, so every forge attempt "
+            "would exit rc=2; install a KernelForge that has them or stop "
+            "passing them",
+            file=sys.stderr,
+        )
+        return False
+
+    print("forge_loop_contract_ok=", len(forge_submit.FORGE_LOOP_OPTIONS))
+    return True
+
+
 def _find_stale_processes() -> list[tuple[str, str]]:
     """Scan ``/proc`` for running processes matching known stale patterns.
 
@@ -108,8 +184,9 @@ def _find_stale_processes() -> list[tuple[str, str]]:
 def main() -> int:
     """Run launcher preflight checks and return a process exit code.
 
-    Validates the model path, prints torch/ROCm visibility, and reports any
-    stale optimizer/server processes.
+    Validates the model path, prints torch/ROCm visibility, checks the forge-loop
+    argv contract against the installed KernelForge, and reports any stale
+    optimizer/server processes.
 
     Returns:
         ``0`` when every check passes, otherwise ``2``.
@@ -128,6 +205,9 @@ def main() -> int:
         print(f"model_path_ok={model_path}")
 
     if not _print_torch_visibility():
+        ok = False
+
+    if not _print_forge_loop_contract():
         ok = False
 
     _print_rocm_snapshot()


### PR DESCRIPTION
Stacked on #1170; review that one first.

## Why

Hyperloom and KernelForge are separate repositories, resolved against each other at runtime through `$FORGE_PATH`, and deployments track KernelForge closely -- during the Aug 11-12 failures the deployed build had already retired `--shapes-json` two days before that removal reached KernelForge main. So the standing risk is Hyperloom lagging behind the KernelForge it will actually run against.

click rejects an unknown option *while parsing*, before running anything, so that lag does not degrade an attempt, it costs the whole thing. Worse, the session does not fail: it finishes reporting success with zero kernel optimizations, which is how Aug 10-12 stayed unnoticed for three days across 301 attempts. rc=2 at least leaves a message; this leaves a healthy-looking run.

The existing guard, `test_forge_loop_cli_accepts_the_provider_flags`, greps `forge-loop --help` for three flags. That cannot see the options most likely to be retired: `--shapes-json` was `hidden=True`, so it never appeared in help text, before or after removal.

## The gate

`cli/preflight.py` runs on every launch and exits 2 on a hard failure. The new check sits next to the TraceLens hard-gate and follows it: skipped for `--no-kernel`, since a run that will not dispatch forge has nothing to break.

It resolves KernelForge through `_ensure_forge_on_path()` -- the same resolution a dispatch performs -- so it reads the build this session will use rather than whatever is newest upstream, and introspects the click command rather than `--help` so hidden options are visible. On a mismatch it names the options and refuses to start, turning "finishes healthy with no kernel work, three days unnoticed" into "fails in seconds, names the option".

## What is in the test suite, and why only that

`FORGE_LOOP_OPTIONS` is the gate's only account of what the launcher sends, because nothing in a running image can capture an argv. `test_the_declared_option_set_matches_the_argv_the_launcher_builds` pins that declaration against the argv actually built, with every conditional option satisfied. Without it a stale declaration would let the gate pass while the run still lost every attempt.

That test needs no KernelForge, so it holds wherever the suite runs. An earlier revision of this PR also compared against the locally installed KernelForge; that has been dropped. CI installs none, so it skipped there, and on a dev node it inspected a stale pip install and reported a mismatch no deployment would ever see. The gate covers that ground properly, in the only place that knows which build will run.

## Verified

| environment | outcome |
|---|---|
| KernelForge main on `$FORGE_PATH` | `forge_loop_contract_gaps()` returns `[]`; preflight prints contract OK |
| the stale pip-installed build on this node | returns `['--gpu-type']`; preflight exits 2 naming it |
| no KernelForge importable | returns `None`; preflight reports unchecked and does not block |

Suites: `src/hyperloom/agents/kernel/tests` plus the gate tests -- 1675 passed, 5 skipped. The same two files pass with no KernelForge (5 passed) and against KernelForge main (5 passed).

## Follow-up worth deciding

`main` carries no `required_status_checks` rule (only `deletion`, `non_fast_forward`, and one required review), so no check gates a merge today. Catching this class at PR time rather than at launch would mean comparing the argv against KernelForge main in CI, which needs a credential for `AMD-BRAIN-Internal`; the workflows have no secret for it.

## Test plan

- [x] `pytest src/hyperloom/agents/kernel/tests src/hyperloom/inference_optimizer/tests/test_preflight_forge_contract.py`
- [x] Same two contract files with KernelForge absent, stale, and at main
- [ ] A launch against a KernelForge missing an option refuses to start
- [ ] Decide whether CI should compare against KernelForge main