### PR TITLE
fix(kernel): stop discarding a salvaged best over coverage nobody reports

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_forge_export_restore.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_export_restore.py
@@ -348,6 +348,52 @@ def test_validated_checkpoint_requires_commit_metrics_and_coverage(tmp_path):
     )
 
 
+def test_a_checkpoint_that_reports_no_coverage_is_still_recoverable(tmp_path):
+    """forge-loop stopped reporting case coverage when drivers took over the suite.
+
+    Vetoing on the field's absence throws away every salvageable best from a
+    timed-out campaign, silently: the run just looks like it recovered nothing.
+    """
+    env = _make_repo(tmp_path)
+    repo = env["repo"]
+    kernel = env["kernel_agent"]
+    env["other"].write_text("committed_v1\n")
+    base_commit = _git(repo, "rev-parse", "HEAD")
+    kernel.write_text("KERNEL_VALIDATED_BEST\n")
+    _commit_all(repo, "iter1: validated best")
+    best_commit = _git(repo, "rev-parse", "HEAD")
+    shapes = {"validation": [{"CASE_ID": "case_001"}, {"CASE_ID": "case_002"}]}
+    checkpoint = {
+        "schema_version": 1,
+        "experiment_id": "hyperloom",
+        "state": "best_committed",
+        "base_commit": base_commit,
+        "best_commit": best_commit,
+        "baseline_ms": 1.0,
+        "best_ms": 0.8,
+        "mean_case_speedup": 1.25,
+        "search_start_mean_case_speedup": 1.0,
+        "total_improved": True,
+        "incremental_improved": True,
+        "validation_passed": True,
+    }
+
+    def recover(payload):
+        return forge_submit._validated_forge_checkpoint(
+            payload,
+            workspace=repo,
+            base_commit=base_commit,
+            shapes=shapes,
+        )
+
+    # Absent: a current forge-loop reports no coverage key at all.
+    assert recover(dict(checkpoint)) is not None
+    # Empty: an older forge-loop reports the key with nothing in it.
+    assert recover({**checkpoint, "case_coverage": []}) is not None
+    # Present and disagreeing still vetoes: that is evidence, not silence.
+    assert recover({**checkpoint, "case_coverage": [{"CASE_ID": "case_001"}]}) is None
+
+
 def test_submit_salvages_validated_best_after_timeout(tmp_path, monkeypatch):
     env = _make_repo(tmp_path)
     repo = env["repo"]

--- a/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
+++ b/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
@@ -3299,8 +3299,13 @@ def _validated_forge_checkpoint(
                 and shape not in expected_coverage
             ):
                 expected_coverage.append(shape)
+    # forge-loop stopped reporting case coverage once drivers took over suite
+    # evaluation, so silence here says nothing about what was measured -- an
+    # older loop reports an empty list for the same reason. Only a coverage that
+    # is reported and disagrees is evidence the checkpoint measured something
+    # else; vetoing on absence discards every salvageable best from a timeout.
     actual_coverage = checkpoint.get("case_coverage")
-    if expected_coverage and actual_coverage != expected_coverage:
+    if actual_coverage and expected_coverage and actual_coverage != expected_coverage:
         return None
     normalized = dict(checkpoint)
     normalized["best_commit"] = best_commit


### PR DESCRIPTION
Split out of #1175 so it does not ride on the argv change; #1170 covers that part.

## Problem

`case_coverage` in a forge-loop checkpoint was derived from `--shapes-json`. KernelForge retired that option when drivers took over full-suite evaluation, so **no current forge-loop reports the field at all** -- the result payload carries `baseline_ms`, `best_ms`, `validation_passed` and `snr_db`, and nothing else.

`_validated_forge_checkpoint` vetoed recovery whenever the reported coverage disagreed with the expected one:

```python
actual_coverage = checkpoint.get("case_coverage")
if expected_coverage and actual_coverage != expected_coverage:
    return None
```

`expected_coverage` is derived from the candidate and is non-empty in practice, and `None` disagrees with everything, so this now vetoes every time. A timed-out campaign that committed a validated best has that best discarded, and the run looks like it simply recovered nothing -- no error, no warning, nothing in the report to suggest a working recovery path just stopped working.

This is independent of whether Hyperloom still passes `--shapes-json`: dropping the option (#1170) removes the rc=2 failure but makes the silence permanent, since an older forge-loop then reports an empty list instead.

## Fix

Absence and an empty list both carry no information. Only a coverage that is reported and disagrees is evidence the checkpoint measured something else.

## Tests

`test_a_checkpoint_that_reports_no_coverage_is_still_recoverable` covers all three: absent, empty, and reported-but-disagreeing. It fails on `main` with `assert None is not None`, and the disagreeing case still vetoes.

## Test plan

- [x] `pytest src/hyperloom/agents/kernel/tests/test_forge_export_restore.py`
- [x] `pytest src/hyperloom/agents/kernel/tests` -- no regressions
- [ ] A timed-out campaign salvages its validated best again