### PR TITLE
fix(kernel): stop the install-time credential snapshot from overriding .env

### DIFF
--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -47,6 +47,35 @@ See [Hyperloom authentication and credentials](authentication.md) for credential
 
 ---
 
+## A rotated API key does not take effect
+
+**Symptom**: A new key is written into `.env`, but the run keeps failing on
+credentials. `tr '\0' '\n' < /proc/<pid>/environ | grep ANTHROPIC_API_KEY` on the
+running optimizer shows the previous key.
+
+**Cause**: `install.sh` snapshots the resolved credentials into
+`$USER_DATA_PATH/runtime/kernel-agent.env.sh`, and every launch sources `.env`
+first and that file second. The snapshot is a fallback, so the rotated value
+wins — but only if it is in the environment when the file is sourced. Sourcing
+the file in a shell that never loaded the new `.env` still yields the old key.
+
+**Fix**:
+
+1. Source `.env` before `kernel-agent.env.sh`, which is the documented launch
+   order:
+   ```bash
+   set -a; . "$REPO_ROOT/.env"; set +a
+   . "$USER_DATA_PATH/runtime/kernel-agent.env.sh"
+   ```
+   The file prints `ANTHROPIC_API_KEY differs from the install-time snapshot` on
+   a mismatch; that line means the rotated value is the one in effect.
+2. To refresh the snapshot itself, re-run the installer:
+   ```bash
+   bash "$REPO_ROOT/src/hyperloom/inference_optimizer/assets/install.sh"
+   ```
+
+---
+
 ## TLS or certificate errors against the LLM gateway
 
 **Symptom**: Preflight or an LLM client fails before authentication with one of:

--- a/src/hyperloom/agents/kernel/scripts/install.sh
+++ b/src/hyperloom/agents/kernel/scripts/install.sh
@@ -1075,6 +1075,28 @@ write_env_file() {
   if [ "$CHECK_ONLY" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then
     return 0
   fi
+  # Emit one credential into the env file as a fallback, not an override.
+  #
+  # Credentials are runtime input owned by .env / the caller; the paths beside
+  # them in that file are install-time results owned by this script. Every
+  # documented launch sources .env first and the env file second, and only the
+  # first install runs install.sh -- so a credential re-exported unconditionally
+  # outranks a key the operator just rotated, on every later launch, with nothing
+  # to show for it (#1169). Assigning only when unset keeps the snapshot useful
+  # for the slurm/Ray paths that source the env file alone, and announces a
+  # mismatch (never a value) so a rotation that has not reached this file stays
+  # visible at launch. Defined here so the emitted block travels with the
+  # function body.
+  _emit_credential_fallback() {
+    local _name="$1"
+    local _value="$2"
+    echo "if [ -n \"\${${_name}:-}\" ]; then"
+    echo "  [ \"\${${_name}}\" = '${_value}' ] || \\"
+    echo "    echo '[kernel-agent] ${_name} differs from the install-time snapshot in this file; keeping the value already in the environment (re-run install.sh to refresh it)' >&2"
+    echo "else"
+    echo "  export ${_name}='${_value}'"
+    echo "fi"
+  }
   # Strict protocol-side separation: each side keeps its own canonical values;
   # GEAK aliases are never written back to provider slots.
   local _anthropic_url="${_ANTHROPIC_BASE_URL_VAL:-}"
@@ -1110,12 +1132,12 @@ write_env_file() {
     [ -n "${INFERENCEX_PATH:-}" ] && echo "export INFERENCEX_PATH='${INFERENCEX_PATH}'"
     # The kernel-agent drives Claude Code, so only the Anthropic side is
     # exported here; gateway/OpenAI credentials are never persisted.
-    [ -n "${_anthropic_url}" ] && echo "export ANTHROPIC_BASE_URL='${_anthropic_url}'"
-    [ -n "${_anthropic_key}" ] && echo "export ANTHROPIC_API_KEY='${_anthropic_key}'"
+    [ -n "${_anthropic_url}" ] && _emit_credential_fallback ANTHROPIC_BASE_URL "${_anthropic_url}"
+    [ -n "${_anthropic_key}" ] && _emit_credential_fallback ANTHROPIC_API_KEY "${_anthropic_key}"
     # A subscription token is the Anthropic side on its own: an oauth-only host
     # resolves neither URL nor key, so without this line sourcing the file
     # leaves the kernel-agent with no Anthropic credential at all.
-    [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && echo "export CLAUDE_CODE_OAUTH_TOKEN='${CLAUDE_CODE_OAUTH_TOKEN}'"
+    [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && _emit_credential_fallback CLAUDE_CODE_OAUTH_TOKEN "${CLAUDE_CODE_OAUTH_TOKEN}"
     # Pin TRACELENS_ROOT and TRACELENS_INTERNAL_ROOT to the (possibly
     # mirrored) values resolved by ensure_tracelens(). This is what lets
     # setsid nohup python -m hyperloom.inference_optimizer.cli optimize →

--- a/src/hyperloom/agents/kernel/tests/test_install_env_credentials.py
+++ b/src/hyperloom/agents/kernel/tests/test_install_env_credentials.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Regression tests for credential precedence in kernel-agent runtime env.
+
+Context: every documented launch path sources ``.env`` first and the generated
+``kernel-agent.env.sh`` second, and only the first install runs ``install.sh``.
+A credential the file re-exports unconditionally therefore outranks the one the
+operator just rotated in ``.env``, on every launch, until the installer is run
+again -- so rotating a key does not actually rotate it (#1169).
+
+Credentials are runtime input owned by ``.env``/the caller; the paths this file
+also carries are install-time results owned by the installer. These tests pin
+both halves: credentials fall back, paths still win.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SCRIPT = ROOT / "scripts" / "install.sh"
+
+_INSTALL_KEY = "ak-install-time-key"
+_INSTALL_URL = "https://gateway.install-time.example/v1"
+_INSTALL_TOKEN = "sk-ant-oat01-install-time-token"
+_ROTATED_KEY = "ak-rotated-key"
+_ROTATED_URL = "https://gateway.rotated.example/v1"
+_ROTATED_TOKEN = "sk-ant-oat01-rotated-token"
+
+
+def _sourceable_installer(dest_dir: Path) -> Path:
+    """Write a copy of install.sh with the top-level ``main "$@"`` call removed.
+
+    The installer ends with an unguarded ``main "$@"``; sourcing it directly
+    would run the whole install. Strip that single trailing invocation so the
+    copy only defines functions and top-level variables, letting a test source
+    it and call an individual function (``write_env_file``) in isolation.
+    """
+    text = INSTALL_SCRIPT.read_text(encoding="utf-8")
+    patched = re.sub(r"(?m)^main \"\$@\"\s*$", "", text)
+    copy = dest_dir / "install_sourceable.sh"
+    copy.write_text(patched, encoding="utf-8")
+    return copy
+
+
+class KernelAgentEnvCredentialPrecedenceTest(unittest.TestCase):
+    """``kernel-agent.env.sh`` must not outrank a rotated ``.env`` credential."""
+
+    def _write_env_file(self, workdir: Path, repo_root: Path) -> Path:
+        """Generate ``kernel-agent.env.sh`` with the install-time credentials.
+
+        Returns:
+            Path: The generated env file.
+        """
+        sourceable = _sourceable_installer(workdir)
+        kernel_agent_env = workdir / "runtime" / "kernel-agent.env.sh"
+        # GEAK_ROOT preset: an unset one makes the installer resolve GEAK_REF
+        # through ``git ls-remote``, which would put this test on the network.
+        script = f"""
+set -euo pipefail
+export ANTHROPIC_API_KEY={_INSTALL_KEY}
+export ANTHROPIC_BASE_URL={_INSTALL_URL}
+export CLAUDE_CODE_OAUTH_TOKEN={_INSTALL_TOKEN}
+export REPO_ROOT={repo_root!s}
+export USER_DATA_PATH={workdir!s}
+export HYPERLOOM_RUNTIME_DIR={workdir / "runtime"!s}
+export KERNEL_AGENT_ENV={kernel_agent_env!s}
+export MAGPIE_PATH=/data/.cache/Magpie@abc1234
+export GEAK_ROOT={workdir / "geak"!s}
+CHECK_ONLY=0
+DRY_RUN=0
+source {sourceable!s}
+write_env_file
+"""
+        proc = subprocess.run(
+            ["bash", "-c", script],
+            text=True,
+            capture_output=True,
+            timeout=60,
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            f"write_env_file failed\nstdout={proc.stdout}\nstderr={proc.stderr}",
+        )
+        return kernel_agent_env
+
+    def _source_and_report(self, env_file: Path, exported: dict[str, str]) -> tuple[dict[str, str], str]:
+        """Source ``env_file`` after exporting ``exported``, like a real launch.
+
+        Returns:
+            tuple[dict[str, str], str]: The resulting values of the reported
+            variables, and the file's stderr output.
+        """
+        reported = (
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_BASE_URL",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "MAGPIE_PATH",
+        )
+        exports = "".join(f"export {k}={v}\n" for k, v in exported.items())
+        script = exports + f'. {env_file!s}\n' + "".join(
+            f'echo "{name}=${{{name}:-}}"\n' for name in reported
+        )
+        proc = subprocess.run(
+            ["bash", "-c", script],
+            text=True,
+            capture_output=True,
+            timeout=60,
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            f"sourcing the env file failed\nstdout={proc.stdout}\nstderr={proc.stderr}",
+        )
+        values = dict(
+            line.split("=", 1) for line in proc.stdout.splitlines() if "=" in line
+        )
+        return values, proc.stderr
+
+    def test_rotated_dotenv_credentials_survive_the_env_file(self) -> None:
+        """The launch order (.env then this file) must keep the rotated values."""
+        with tempfile.TemporaryDirectory() as td:
+            work = Path(td)
+            repo_root = work / "repo"
+            repo_root.mkdir()
+            env_file = self._write_env_file(work, repo_root)
+            values, stderr = self._source_and_report(
+                env_file,
+                {
+                    "ANTHROPIC_API_KEY": _ROTATED_KEY,
+                    "ANTHROPIC_BASE_URL": _ROTATED_URL,
+                    "CLAUDE_CODE_OAUTH_TOKEN": _ROTATED_TOKEN,
+                },
+            )
+
+        self.assertEqual(
+            values["ANTHROPIC_API_KEY"],
+            _ROTATED_KEY,
+            "the install-time key snapshot overrode the rotated .env key",
+        )
+        self.assertEqual(values["ANTHROPIC_BASE_URL"], _ROTATED_URL)
+        self.assertEqual(values["CLAUDE_CODE_OAUTH_TOKEN"], _ROTATED_TOKEN)
+        # A silent override is what made #1169 expensive to diagnose, so the
+        # mismatch must be announced -- without disclosing either value.
+        self.assertIn("ANTHROPIC_API_KEY", stderr)
+        self.assertNotIn(_INSTALL_KEY, stderr)
+        self.assertNotIn(_ROTATED_KEY, stderr)
+
+    def test_env_file_still_supplies_credentials_when_unset(self) -> None:
+        """Slurm/Ray paths source only this file, so the snapshot must remain."""
+        with tempfile.TemporaryDirectory() as td:
+            work = Path(td)
+            repo_root = work / "repo"
+            repo_root.mkdir()
+            env_file = self._write_env_file(work, repo_root)
+            values, _ = self._source_and_report(env_file, {})
+
+        self.assertEqual(values["ANTHROPIC_API_KEY"], _INSTALL_KEY)
+        self.assertEqual(values["ANTHROPIC_BASE_URL"], _INSTALL_URL)
+        self.assertEqual(values["CLAUDE_CODE_OAUTH_TOKEN"], _INSTALL_TOKEN)
+
+    def test_matching_credentials_are_not_announced(self) -> None:
+        """No rotation happened, so there is nothing to warn about."""
+        with tempfile.TemporaryDirectory() as td:
+            work = Path(td)
+            repo_root = work / "repo"
+            repo_root.mkdir()
+            env_file = self._write_env_file(work, repo_root)
+            values, stderr = self._source_and_report(
+                env_file, {"ANTHROPIC_API_KEY": _INSTALL_KEY}
+            )
+
+        self.assertEqual(values["ANTHROPIC_API_KEY"], _INSTALL_KEY)
+        self.assertEqual(stderr, "")
+
+    def test_install_resolved_paths_still_win(self) -> None:
+        """Paths are install-time results, not runtime input: the file owns them.
+
+        Losing this would reintroduce the workspace mixup that made the
+        installer-written path vars authoritative in the first place.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            work = Path(td)
+            repo_root = work / "repo"
+            repo_root.mkdir()
+            env_file = self._write_env_file(work, repo_root)
+            values, _ = self._source_and_report(
+                env_file, {"MAGPIE_PATH": "/stale/other-workspace/Magpie"}
+            )
+
+        self.assertEqual(values["MAGPIE_PATH"], "/data/.cache/Magpie@abc1234")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/hyperloom/inference_optimizer/cli/preflight.py
+++ b/src/hyperloom/inference_optimizer/cli/preflight.py
@@ -270,9 +270,16 @@ def _derive_runtime_paths() -> None:
 
 _KERNEL_AGENT_PATH_VARS: tuple[str, ...] = ("TRACELENS_ROOT",)
 
+_SHELL_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
 
 def _parse_env_assignments(text: str) -> dict[str, str]:
-    """Parse ``[export] KEY=VALUE`` shell assignments into a dict (first wins)."""
+    """Parse ``[export] KEY=VALUE`` shell assignments into a dict (first wins).
+
+    Lines that merely contain ``=`` are skipped rather than parsed: the file is
+    real shell, so a conditional such as ``[ "$X" = 'v' ] || ...`` would
+    otherwise yield a bogus key and a spurious "unsupported env key" warning.
+    """
     out: dict[str, str] = {}
     for raw in text.splitlines():
         line = raw.strip()
@@ -284,7 +291,7 @@ def _parse_env_assignments(text: str) -> dict[str, str]:
             continue
         key, _, value = line.partition("=")
         key = key.strip()
-        if not key:
+        if not _SHELL_NAME_RE.match(key):
             continue
         value = value.strip()
         if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):

--- a/src/hyperloom/inference_optimizer/tests/test_resume.py
+++ b/src/hyperloom/inference_optimizer/tests/test_resume.py
@@ -510,6 +510,45 @@ class TestN24KernelAgentEnvHardFail:
         assert _os.environ["HYPERLOOM_KERNEL_AGENT_ROOT"] == "/from/file"
         assert _os.environ["KERNEL_AGENT_LOG_LEVEL"] == "DEBUG"
 
+    def test_credential_fallback_block_parses_without_warnings(
+        self,
+        tmp_path,
+        monkeypatch,
+        capsys,
+    ):
+        """The installer emits credentials as a conditional block (#1169).
+
+        The comparison line inside it contains ``=`` without being an
+        assignment, so a parser that splits on ``=`` alone would invent a key
+        and warn about it on every launch.
+        """
+        runtime = tmp_path / "runtime"
+        runtime.mkdir()
+        (runtime / "kernel-agent.env.sh").write_text(
+            "export HYPERLOOM_KERNEL_AGENT_ROOT=/opt/kernel-agent\n"
+            'if [ -n "${ANTHROPIC_API_KEY:-}" ]; then\n'
+            "  [ \"${ANTHROPIC_API_KEY}\" = 'ak-install-time' ] || \\\n"
+            "    echo '[kernel-agent] ANTHROPIC_API_KEY differs' >&2\n"
+            "else\n"
+            "  export ANTHROPIC_API_KEY='ak-install-time'\n"
+            "fi\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("USER_DATA_PATH", str(tmp_path))
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        import os as _os
+
+        try:
+            cli_preflight._load_kernel_agent_env_fallback()
+            loaded_key = _os.environ.get("ANTHROPIC_API_KEY")
+        finally:
+            # The loader writes straight into os.environ, which monkeypatch
+            # cannot roll back; a leaked credential reshapes later auth tests.
+            _os.environ.pop("ANTHROPIC_API_KEY", None)
+
+        assert loaded_key == "ak-install-time"
+        assert "unsupported kernel-agent env key" not in capsys.readouterr().err
+
     def test_explicit_kernel_agent_env_overrides_user_data_path(
         self,
         tmp_path,


### PR DESCRIPTION
Fixes #1169.

## Problem

`install.sh` writes the resolved credentials into
`$USER_DATA_PATH/runtime/kernel-agent.env.sh` as unconditional exports:

```sh
[ -n "${_anthropic_key}" ] && echo "export ANTHROPIC_API_KEY='${_anthropic_key}'"
```

Every documented launch sources `.env` first and that file second, and only the
first install runs `install.sh` -- `references/operations.md` "Launch New
Optimization", the three example skills and `setup_env.sh.example` all source
the file alone. A key rotated in `.env` was therefore overwritten by the
install-time snapshot on every later launch, until the installer happened to be
re-run.

Nothing reported it. The downstream failure (`Claude Code returned an error
result: success`, zero intents per orchestration tick) names nothing to do with
credentials, so the only way to see it was to read the running subprocess's
`/proc/<pid>/environ`.

The same file also carries install-resolved paths, and those are correct to
keep authoritative. The two classes were sharing one precedence rule; only
credentials are runtime input owned by `.env`.

## Fix

- `write_env_file()` emits `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL` and
  `CLAUDE_CODE_OAUTH_TOKEN` as a fallback that assigns only when the variable
  is unset, and prints a mismatch notice (never a value) otherwise. The
  snapshot still serves the slurm/Ray paths that source this file alone. Path
  variables keep their install-time precedence.
- `_parse_env_assignments()` skips lines that merely contain `=`, so the
  conditional block does not yield a bogus key and a spurious "unsupported
  kernel-agent env key" warning on every launch.
- `troubleshooting.md` gains a "rotated API key does not take effect" entry.

Generated block:

```sh
if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
  [ "${ANTHROPIC_API_KEY}" = 'ak-...' ] || \
    echo '[kernel-agent] ANTHROPIC_API_KEY differs from the install-time snapshot in this file; keeping the value already in the environment (re-run install.sh to refresh it)' >&2
else
  export ANTHROPIC_API_KEY='ak-...'
fi
```

## Tests

`test_install_env_credentials.py` pins both halves: a rotated credential
survives the env file, an unset one still gets the snapshot, a matching one is
not announced, and path variables still win. `test_resume.py` covers the
parser. Both fail on the unfixed tree with `'ak-install-time-key' !=
'ak-rotated-key'` and the bogus-key warning respectively.