### PR TITLE
fix(xdit): analyse the raw capture, not a split fragment

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -1945,6 +1945,85 @@ def test_annotation_sidecars_sort_after_a_capture_even_outside_trace_split(tmp_p
     assert traces[-1] == sidecar
 
 
+def test_fragments_flat_beside_the_capture_are_still_demoted(tmp_path):
+    """The demotion must not depend on the splitter nesting its output.
+
+    Production nests fragments under trace_split/ today, but keying only on the
+    directory would leave a flat layout exactly as broken as before: the phase
+    names sort ahead of rank files on the first letter.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    raw = _rank_trace(trace_dir / "rank_0.trace.json.gz", kernels=40)
+    flat_fragment = _rank_trace(
+        trace_dir / "decode_only_steady_state_prefill_0_decode_1_bs1_conc1"
+                    "_rank_0.trace.json.gz", kernels=0)
+
+    _kind, traces = tla.discover_trace_inputs(trace_dir)
+
+    assert traces[0] == raw
+    assert traces[-1] == flat_fragment
+
+
+def test_an_eight_rank_flat_capture_does_not_exhaust_the_probe_budget(tmp_path):
+    """xDiT runs at TP=8, so a flat layout could present eight fragments first.
+
+    With the fragments still in the default bucket they would consume the whole
+    probe budget before any rank file was opened, and the run would fail with the
+    error this change exists to remove.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    for rank in range(8):
+        _rank_trace(
+            trace_dir / f"decode_only_steady_state_x_rank_{rank}.trace.json.gz",
+            kernels=0)
+        _rank_trace(
+            trace_dir / f"mixed_steady_state_x_rank_{rank}.trace.json.gz",
+            kernels=0)
+    captures = [_rank_trace(trace_dir / f"rank_{r}.trace.json.gz", kernels=25)
+                for r in range(8)]
+
+    _kind, traces = tla.discover_trace_inputs(trace_dir)
+
+    leading = traces[:tla._KERNEL_PROBE_LIMIT]
+    assert any(p in captures for p in leading), (
+        "a real capture must be reachable inside the probe budget")
+    assert tla.count_gpu_kernel_events(traces[0]) > 0
+
+
+def test_a_non_trace_sidecar_does_not_lead_discovery(tmp_path):
+    """execution_details.json is swept in by the *.json glob but is not a trace.
+
+    It sorts ahead of rank_0.trace.json.gz alphabetically, so before size
+    ordering it was trace_files[0] in every healthy nested capture: one wasted
+    probe, and a promotion logged on every run, which made the log line
+    meaningless exactly when it should have meant something.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    raw = _xdit_roofline_capture(trace_dir)
+    sidecar = trace_dir / "trace_split" / "execution_details.json"
+    assert sidecar.exists()
+
+    _kind, traces = tla.discover_trace_inputs(trace_dir)
+
+    assert traces[0] == raw
+    assert traces.index(sidecar) > 0
+
+
+def test_the_larger_trace_leads_within_a_bucket(tmp_path):
+    """Size is the part of the ordering that needs no name recognition."""
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    small = _rank_trace(trace_dir / "aaa_unknown_shape.trace.json.gz", kernels=1)
+    large = _rank_trace(trace_dir / "zzz_unknown_shape.trace.json.gz", kernels=400)
+    assert large.stat().st_size > small.stat().st_size
+
+    _kind, traces = tla.discover_trace_inputs(trace_dir)
+
+    assert traces[0] == large
+
+
 def test_merged_trace_still_wins_over_a_raw_rank_capture(tmp_path):
     """The pre-existing preference is unchanged: merged first when present."""
     trace_dir = tmp_path / "torch_trace"
@@ -2203,12 +2282,18 @@ def _drive_main_over_capture_dir(tmp_path, trace_dir):
     return captured
 
 
-def _rank_trace(path: Path, kernels: int) -> Path:
+def _rank_trace(path: Path, kernels: int, cpu_events: int = 0) -> Path:
+    """Write a rank trace with the given number of GPU kernels.
+
+    ``cpu_events`` pads with host-side events, which is what a CPU-only capture
+    actually looks like: a large file with no kernels in it.
+    """
+    events = [{"cat": "kernel", "name": "void real_kernel<...>", "dur": 5.0}
+              for _ in range(kernels)]
+    events += [{"cat": "cpu_op", "name": f"aten::some_host_op_{i}", "dur": 1.0}
+               for i in range(cpu_events)]
     with gzip.open(path, "wt") as fh:
-        json.dump({"traceEvents": [
-            {"cat": "kernel", "name": "void real_kernel<...>", "dur": 5.0}
-            for _ in range(kernels)
-        ]}, fh)
+        json.dump({"traceEvents": events}, fh)
     return path
 
 
@@ -2222,11 +2307,13 @@ def test_analysis_input_follows_the_candidate_that_passed_the_preflight(tmp_path
     """
     trace_dir = tmp_path / "torch_trace"
     trace_dir.mkdir()
-    empty = _rank_trace(trace_dir / "rank_0.trace.json.gz", kernels=0)
+    # A CPU-only rank is a big file with no kernels in it, so size ordering puts
+    # it first on merit. Ordering cannot help here; only the promotion can.
+    empty = _rank_trace(trace_dir / "rank_0.trace.json.gz",
+                        kernels=0, cpu_events=400)
     populated = _rank_trace(trace_dir / "rank_1.trace.json.gz", kernels=12)
+    assert empty.stat().st_size > populated.stat().st_size
 
-    # Discovery still leads with rank_0: the promotion, not the ordering, is what
-    # this test is about.
     _kind, traces = tla.discover_trace_inputs(trace_dir)
     assert traces[0] == empty
 

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -2229,12 +2229,15 @@ def _find_splitter_cmd(captured):
     )
 
 
-def _drive_main_over_capture_dir(tmp_path, trace_dir):
+def _drive_main_over_capture_dir(tmp_path, trace_dir, extra_argv=None):
     """Drive tla.main() with a capture *directory* and capture subprocess argvs.
 
     A sibling of :func:`_drive_main_capturing_subprocess`, which always passes a
     single file. Multi-rank selection only shows up when discovery has more than
     one candidate to choose from.
+
+    ``extra_argv`` appends CLI flags, which is how the ``--skip-split`` route
+    that scriptable workloads actually take gets exercised.
     """
     import os as _os
     from unittest.mock import patch
@@ -2267,6 +2270,7 @@ def _drive_main_over_capture_dir(tmp_path, trace_dir):
         "--budget-minutes", "1",
         "--no-llm-orchestrator",
     ]
+    argv += list(extra_argv or [])
 
     env_backup = dict(_os.environ)
     try:
@@ -2338,6 +2342,149 @@ def test_analysis_input_is_left_alone_when_the_first_candidate_has_kernels(tmp_p
     splitter = _find_splitter_cmd(captured)
     assert splitter is not None
     assert str(first) in [str(p) for p in splitter]
+
+
+def test_skip_split_route_analyses_the_promoted_candidate(tmp_path):
+    """The promotion must hold on the route xDiT actually takes.
+
+    Scriptable (xDiT/diffusion) workloads are dispatched with ``--skip-split``
+    plus ``--analysis-route deterministic`` (see ``request_handlers``), which
+    bypasses the splitter entirely and feeds the analysis path straight to the
+    deterministic pipeline. The other promotion tests assert on splitter argv, so
+    they cover the branch these sessions never enter -- which is to say the
+    regression this change exists to prevent was untested on the one path that
+    produced it.
+    """
+    from unittest.mock import patch
+
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    empty = _rank_trace(trace_dir / "rank_0.trace.json.gz",
+                        kernels=0, cpu_events=400)
+    populated = _rank_trace(trace_dir / "rank_1.trace.json.gz", kernels=12)
+
+    # This route runs the deterministic pipeline in-process, so the trace path
+    # never reaches a subprocess argv the way the splitter's does. Intercepting
+    # the call is the only place the decision is observable.
+    seen: list[Path] = []
+
+    def fake_steps(trace_path, *_a, **_kw):
+        seen.append(trace_path)
+        return 0
+
+    with patch.object(tla, "_run_deterministic_tracelens_steps",
+                      side_effect=fake_steps):
+        captured = _drive_main_over_capture_dir(
+            tmp_path,
+            trace_dir,
+            extra_argv=["--skip-split", "--analysis-route", "deterministic"],
+        )
+
+    assert _find_splitter_cmd(captured) is None, "--skip-split must skip the splitter"
+    assert seen, "the deterministic pipeline was never reached"
+    assert seen[0] == populated, f"analysed {seen[0].name}, expected {populated.name}"
+    assert empty not in seen
+
+
+def test_capture_under_an_ancestor_named_trace_split_still_orders_correctly(tmp_path):
+    """An ancestor directory name must not flatten the whole ranking.
+
+    ``--trace-input`` is resolved to an absolute path, so a ``trace_split``
+    component is checked against every ancestor unless the test is anchored at
+    the capture root. Pointing at a capture that happens to sit below such a
+    directory would otherwise demote every candidate into the same bucket, at
+    which point ordering falls back to filename and the original bug is exactly
+    reproduced -- from nothing but a coincidence of naming.
+    """
+    trace_dir = tmp_path / "trace_split" / "run" / "torch_trace"
+    trace_dir.mkdir(parents=True)
+    fragment = _rank_trace(trace_dir / "aaa_trace_annotation_iteration_1.json.gz",
+                           kernels=0)
+    capture = _rank_trace(trace_dir / "zzz_rank_0.trace.json.gz", kernels=30)
+
+    _kind, traces = tla.discover_trace_inputs(trace_dir)
+
+    assert traces[0] == capture, (
+        "the real capture must lead despite the ancestor directory name "
+        f"and despite sorting last alphabetically; got {[p.name for p in traces]}"
+    )
+    assert traces.index(fragment) > traces.index(capture)
+
+
+def test_unreadable_leading_candidate_is_not_reported_as_cpu_only(tmp_path):
+    """A corrupt trace and a CPU-only trace must not read as the same finding.
+
+    Both counted as zero kernels before, so a truncated rank_0 was described as
+    having "no GPU kernel events" -- sending the next reader to the profiler for
+    a file problem. That is the same misdirection this change was written to
+    remove, so it should not be reintroduced by the promotion that fixes it.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    corrupt = trace_dir / "rank_0.trace.json.gz"
+    corrupt.write_bytes(b"\x1f\x8b" + b"\x00" * 4000)  # gzip magic, truncated body
+    _rank_trace(trace_dir / "rank_1.trace.json.gz", kernels=7)
+
+    readable, count = tla._count_kernels_if_readable(corrupt)
+
+    assert readable is False, "a truncated gzip must report as unreadable"
+    assert count == 0
+    populated_readable, populated_count = tla._count_kernels_if_readable(
+        trace_dir / "rank_1.trace.json.gz"
+    )
+    assert populated_readable is True
+    assert populated_count == 7
+
+
+def test_promotion_is_recorded_as_a_trace_health_warning(tmp_path, capsys):
+    """A run that switched its own input has to be explicable afterwards.
+
+    A CLI log line is not a contract: session breakdown and roofline snapshot
+    read ``trace_health_warnings`` and the artifact map, and neither recorded
+    which of the discovered traces was actually analysed. Without this, a
+    silently promoted run is indistinguishable downstream from one that used the
+    file discovery reported.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    _rank_trace(trace_dir / "rank_0.trace.json.gz", kernels=0, cpu_events=400)
+    populated = _rank_trace(trace_dir / "rank_1.trace.json.gz", kernels=12)
+
+    _drive_main_over_capture_dir(tmp_path, trace_dir)
+
+    result = json.loads(capsys.readouterr().out)
+    promoted = [
+        w
+        for w in (result.get("trace_health_warnings") or [])
+        if w.get("code") == "trace_analysis_input_promoted"
+    ]
+    assert promoted, (
+        "promotion was not surfaced in trace_health_warnings; "
+        f"warnings seen: {result.get('trace_health_warnings')}"
+    )
+    assert promoted[0]["analysed"] == populated.name
+    assert promoted[0]["leading_candidate"] == "rank_0.trace.json.gz"
+    # The probe record is what distinguishes "rank_0 had no kernels" from
+    # "rank_0 could not be read", which are different problems.
+    assert "rank_0.trace.json.gz=0" in promoted[0]["probed"]
+
+
+def test_no_promotion_warning_when_the_leading_candidate_is_used(tmp_path, capsys):
+    """The warning must stay absent on the ordinary path.
+
+    An informational warning that fires on every healthy run is noise, and noise
+    in ``trace_health_warnings`` costs the Coordinator the signal.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    _rank_trace(trace_dir / "rank_0.trace.json.gz", kernels=9)
+    _rank_trace(trace_dir / "rank_1.trace.json.gz", kernels=9)
+
+    _drive_main_over_capture_dir(tmp_path, trace_dir)
+
+    result = json.loads(capsys.readouterr().out)
+    codes = [w.get("code") for w in (result.get("trace_health_warnings") or [])]
+    assert "trace_analysis_input_promoted" not in codes
 
 
 def test_194_3_splitter_receives_R_from_cli_arg(tmp_path):

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -1860,6 +1860,104 @@ def test_discover_trace_inputs_prefers_merged_trace_over_tp0_decode(tmp_path):
     assert traces[-1] == tp0_decode
 
 
+def _xdit_roofline_capture(trace_dir: Path) -> Path:
+    """Recreate an xDiT roofline capture directory as production writes it.
+
+    Names and sizes are taken from a real failing run: a 910 KB rank capture
+    with 30k kernel events, beside a trace_split/ directory of ~900-byte
+    per-phase fragments and annotation sidecars.
+    """
+    trace_dir.mkdir(parents=True, exist_ok=True)
+    raw = trace_dir / "rank_0.trace.json.gz"
+    with gzip.open(raw, "wt") as fh:
+        json.dump({"traceEvents": [
+            {"cat": "kernel", "name": "void flash_fwd<...>", "dur": 40}
+            for _ in range(64)
+        ]}, fh)
+
+    split = trace_dir / "trace_split"
+    split.mkdir()
+    for name in (
+        "decode_only_steady_state_prefill_0_prefilldecode_0_decode_1_bs1_conc1"
+        "_rank_0.trace.json.gz",
+        "mixed_steady_state_prefill_0_prefilldecode_0_decode_1_bs1_conc1"
+        "_rank_0.trace.json.gz",
+    ):
+        with gzip.open(split / name, "wt") as fh:
+            json.dump({"traceEvents": []}, fh)
+    for i in range(3):
+        with gzip.open(split / f"rank_0.trace_annotation_iteration_{i}.json.gz", "wt") as fh:
+            json.dump({"traceEvents": []}, fh)
+    (split / "execution_details.json").write_text('{"steps": 1}', encoding="utf-8")
+    return raw
+
+
+def test_discover_trace_inputs_prefers_raw_capture_over_split_fragments(tmp_path):
+    """The raw capture must lead, whatever the fragments are named.
+
+    Every file in this layout used to land in the same default bucket, so
+    alphabetical order decided -- and `decode_only_...` sorts ahead of
+    `rank_0.trace.json.gz`. The preflight then read a 900-byte fragment, found
+    no GPU kernels, and reported the whole capture as CPU-only.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    raw = _xdit_roofline_capture(trace_dir)
+
+    kind, traces = tla.discover_trace_inputs(trace_dir)
+
+    assert kind == "capture_dir"
+    assert traces[0] == raw, "the raw capture must be the first candidate"
+    # Nothing derived may outrank it.
+    assert all("trace_split" in p.parts for p in traces[1:])
+
+
+def test_the_leading_candidate_is_the_one_with_the_kernels(tmp_path):
+    """Ordering is only useful if it puts a probe-able trace first.
+
+    Ties the two halves of the fix together: whichever file discovery leads
+    with is the file the CPU-only preflight opens, so that file has to be the
+    one carrying GPU kernel events.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    _xdit_roofline_capture(trace_dir)
+
+    _kind, traces = tla.discover_trace_inputs(trace_dir)
+
+    assert tla.count_gpu_kernel_events(traces[0]) == 64
+    # The fragment that used to be probed first really does look CPU-only, so
+    # the old ordering failed for a real reason and not a test artefact.
+    fragment = next(p for p in traces if p.name.startswith("decode_only_"))
+    assert tla.count_gpu_kernel_events(fragment) == 0
+
+
+def test_annotation_sidecars_sort_after_a_capture_even_outside_trace_split(tmp_path):
+    """Annotation sidecars are per-iteration slivers wherever they sit."""
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    raw = trace_dir / "rank_0.trace.json.gz"
+    raw.write_text("{}", encoding="utf-8")
+    sidecar = trace_dir / "aaa.trace_annotation_iteration_0.json.gz"
+    sidecar.write_text("{}", encoding="utf-8")
+
+    _kind, traces = tla.discover_trace_inputs(trace_dir)
+
+    assert traces[0] == raw
+    assert traces[-1] == sidecar
+
+
+def test_merged_trace_still_wins_over_a_raw_rank_capture(tmp_path):
+    """The pre-existing preference is unchanged: merged first when present."""
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    (trace_dir / "rank_0.trace.json.gz").write_text("{}", encoding="utf-8")
+    merged = trace_dir / "merged-42.trace.json.gz"
+    merged.write_text("{}", encoding="utf-8")
+
+    _kind, traces = tla.discover_trace_inputs(trace_dir)
+
+    assert traces[0] == merged
+
+
 def test_127_splitter_cli_uses_positional_trace_path_and_find_steady_state(
     tmp_path,
     capsys,

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -2150,6 +2150,109 @@ def _find_splitter_cmd(captured):
     )
 
 
+def _drive_main_over_capture_dir(tmp_path, trace_dir):
+    """Drive tla.main() with a capture *directory* and capture subprocess argvs.
+
+    A sibling of :func:`_drive_main_capturing_subprocess`, which always passes a
+    single file. Multi-rank selection only shows up when discovery has more than
+    one candidate to choose from.
+    """
+    import os as _os
+    from unittest.mock import patch
+
+    tl_root = tmp_path / "TraceLens-internal"
+    skill_dir = tl_root / "TraceLens" / "Agent" / "Analysis" / "skills" / "analysis-orchestrator"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("stub")
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+
+    captured: list[list[str]] = []
+
+    class _Result:
+        def __init__(self, returncode=0, stdout=""):
+            self.returncode = returncode
+            self.stdout = stdout
+
+    def fake_run(cmd, *_a, **_kw):
+        captured.append(list(cmd))
+        return _Result(returncode=0, stdout="ok")
+
+    argv = [
+        "tracelens_analysis.py",
+        "--trace-input", str(trace_dir),
+        "--workspace-path", str(workspace),
+        "--tracelens-root", str(tl_root),
+        "--target-platform", "MI300X",
+        "--top-k", "5",
+        "--budget-minutes", "1",
+        "--no-llm-orchestrator",
+    ]
+
+    env_backup = dict(_os.environ)
+    try:
+        with patch.object(tla.subprocess, "run", side_effect=fake_run), \
+                patch.object(tla.sys, "argv", argv):
+            try:
+                tla.main()
+            except SystemExit:
+                pass
+    finally:
+        _os.environ.clear()
+        _os.environ.update(env_backup)
+    return captured
+
+
+def _rank_trace(path: Path, kernels: int) -> Path:
+    with gzip.open(path, "wt") as fh:
+        json.dump({"traceEvents": [
+            {"cat": "kernel", "name": "void real_kernel<...>", "dur": 5.0}
+            for _ in range(kernels)
+        ]}, fh)
+    return path
+
+
+def test_analysis_input_follows_the_candidate_that_passed_the_preflight(tmp_path):
+    """A CPU-only leading rank must not be what gets analysed.
+
+    The preflight probes several candidates, so it can pass on rank_1 while
+    rank_0 leads discovery. If the analysis kept using the first candidate, the
+    check would clear a capture on one rank's evidence and then hand TraceLens
+    the empty one -- quieter than the failure it replaced, and worse.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    empty = _rank_trace(trace_dir / "rank_0.trace.json.gz", kernels=0)
+    populated = _rank_trace(trace_dir / "rank_1.trace.json.gz", kernels=12)
+
+    # Discovery still leads with rank_0: the promotion, not the ordering, is what
+    # this test is about.
+    _kind, traces = tla.discover_trace_inputs(trace_dir)
+    assert traces[0] == empty
+
+    captured = _drive_main_over_capture_dir(tmp_path, trace_dir)
+
+    splitter = _find_splitter_cmd(captured)
+    assert splitter is not None, "the splitter should have been invoked"
+    args = [str(p) for p in splitter]
+    assert str(populated) in args
+    assert str(empty) not in args
+
+
+def test_analysis_input_is_left_alone_when_the_first_candidate_has_kernels(tmp_path):
+    """No promotion when the leading candidate is already the right one."""
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    first = _rank_trace(trace_dir / "rank_0.trace.json.gz", kernels=9)
+    _rank_trace(trace_dir / "rank_1.trace.json.gz", kernels=9)
+
+    captured = _drive_main_over_capture_dir(tmp_path, trace_dir)
+
+    splitter = _find_splitter_cmd(captured)
+    assert splitter is not None
+    assert str(first) in [str(p) for p in splitter]
+
+
 def test_194_3_splitter_receives_R_from_cli_arg(tmp_path):
     """`--split-r 0.5` must produce `--R 0.5` on the splitter argv (fractional ratios survive verbatim)."""
     captured, _ = _drive_main_capturing_subprocess(

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -7079,6 +7079,11 @@ def main() -> int:
         trace_input_type, trace_files = discover_trace_inputs(trace_input)
         append_log(log_path, f"trace_input_type={trace_input_type}")
         append_log(log_path, f"trace_files={len(trace_files)}")
+        # The file the analysis will actually read. Discovery order picks the
+        # default; the preflight below promotes whichever candidate it proves
+        # carries GPU kernels, because passing the check on one file and then
+        # analysing another is how an empty trace reaches TraceLens silently.
+        analysis_trace_path = trace_files[0] if trace_files else None
 
         # Fail-fast on CPU-only traces.
         #
@@ -7094,12 +7099,20 @@ def main() -> int:
                 kernel_event_count = count_gpu_kernel_events(candidate)
                 probed.append(f"{candidate.name}={kernel_event_count}")
                 if kernel_event_count:
+                    analysis_trace_path = candidate
                     break
             append_log(
                 log_path,
                 f"trace_gpu_kernel_events={kernel_event_count} "
                 f"(probed={', '.join(probed)})",
             )
+            if analysis_trace_path is not None and analysis_trace_path != trace_files[0]:
+                append_log(
+                    log_path,
+                    "trace_analysis_input promoted from "
+                    f"{trace_files[0].name} to {analysis_trace_path.name} "
+                    "(the leading candidate carried no GPU kernel events)",
+                )
             if kernel_event_count == 0:
                 raise RuntimeError(
                     "Trace contains zero GPU kernel events in any of "
@@ -7209,12 +7222,16 @@ def main() -> int:
             # Split the full-window filtered trace into steady-state chunks via
             # TraceLens's own splitter, since the perf report expects a single
             # steady-state chunk.
-            cli_trace_path = trace_files[0]
+            # Whichever candidate the preflight proved has GPU kernels, which is
+            # trace_files[0] unless it was promoted. Analysing a different file
+            # from the one that passed the check would let an empty rank through
+            # on a sibling's evidence.
+            cli_trace_path = analysis_trace_path
             # The un-split source trace: analysis runs on the steady-state chunk
             # (cli_trace_path is reassigned below), but graph-capture health is a
             # whole-run property and must be read from the original trace -- the
             # chunk may drop the graph-launch runtime events the detector needs.
-            raw_trace_path = trace_files[0]
+            raw_trace_path = analysis_trace_path
             trace_split_blocked = False
             if not args.skip_split:
                 update_status(
@@ -7233,7 +7250,7 @@ def main() -> int:
                     sys.executable,
                     "-m",
                     "TraceLens.TraceUtils.split_inference_trace_annotation",
-                    str(trace_files[0]),
+                    str(analysis_trace_path),
                     "-o",
                     str(split_dir),
                     "--find-steady-state",
@@ -7293,7 +7310,7 @@ def main() -> int:
                 # Splitter produced nothing -> trace_split_no_steady_state failure.
                 if split_rc != 0 or not (mixed_chunks or decode_chunks or prefill_chunks):
                     warning = _build_trace_split_warning(
-                        trace_input=trace_files[0],
+                        trace_input=analysis_trace_path,
                         split_dir=split_dir,
                         split_rc=split_rc,
                         mixed_count=len(mixed_chunks),
@@ -7336,7 +7353,7 @@ def main() -> int:
                             "of the available_modes (or pass --steady-state-mode "
                             "directly when invoking tracelens_analysis.py)."
                         ),
-                        "trace_input": str(trace_files[0]),
+                        "trace_input": str(analysis_trace_path),
                         "split_dir": str(split_dir),
                     }
                     trace_health_warnings.append(warning)

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -987,33 +987,60 @@ def count_gpu_kernel_events(trace_file: Path, max_events: int = 1_000_000) -> in
 _SPLIT_DIR_NAME = "trace_split"
 
 #: How many discovered files the CPU-only preflight will open before giving up.
-#: Each probe decompresses a trace, so this is a cost ceiling rather than a
-#: correctness one -- the raw capture sorts near the front, and a directory that
-#: needs more than a handful of probes has a real capture problem.
+#: A cost ceiling, not the thing that makes the preflight land on the capture --
+#: size ordering does that, and it holds whatever the fragments are called or
+#: where they sit. Reaching this limit means every large candidate was empty,
+#: which is a real capture problem rather than a selection one.
 _KERNEL_PROBE_LIMIT = 8
+
+#: Per-phase fragment names the splitter emits. Matched as well as the directory
+#: because a flat layout would otherwise leave them in the default bucket, and a
+#: capture with eight ranks would then spend the whole probe budget on fragments
+#: before reaching a rank file.
+_PHASE_FRAGMENT_RE = re.compile(
+    r"^(?:decode_only|mixed|prefill_only|prefilldecode)\w*_steady_state\w*"
+    r"_rank_\d+\.trace\.json(?:\.gz)?$"
+)
 
 
 def _is_derived_trace(path: Path) -> bool:
     """Whether a trace path is splitter output rather than a raw capture.
 
-    Two shapes, both derived: anything under the splitter's own output directory,
-    and the per-iteration annotation sidecars it writes beside a capture. They
-    are a few hundred bytes each and cover one phase of one iteration, so an
-    analysis pointed at them describes a sliver of the run.
+    Three shapes, all derived: anything under the splitter's own output
+    directory, the per-iteration annotation sidecars it writes beside a capture,
+    and the per-phase fragment names themselves. They are a few hundred bytes
+    each and cover one phase of one iteration, so an analysis pointed at them
+    describes a sliver of the run.
+
+    The name test is not redundant with the directory test. Production nests
+    these under ``trace_split/`` today -- 276 of 276 capture directories with
+    fragments -- but the demotion should not depend on a layout that the
+    splitter is free to change.
     """
     if _SPLIT_DIR_NAME in path.parts:
+        return True
+    if _PHASE_FRAGMENT_RE.match(path.name):
         return True
     return bool(re.search(r"trace_annotation_iteration_\d+", path.name))
 
 
-def _trace_input_sort_key(path: Path) -> tuple[int, str]:
+def _trace_file_size(path: Path) -> int:
+    """Size in bytes, or 0 when it cannot be read."""
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
+
+
+def _trace_input_sort_key(path: Path) -> tuple[int, int, str]:
     """Compute the discovery sort key for a trace input path.
 
     Prefers the merged annotated trace over rank/phase shards (the TraceLens
     splitter needs the large trace).
 
-    Splitter output sorts last. It used to land in the same default bucket as
-    the raw capture, which left alphabetical order to decide between them -- and
+    Splitter output sorts last, and within a bucket the largest file leads.
+    Both parts exist because of the same bug: the fragments used to share the
+    default bucket with the raw capture, so alphabetical order decided, and
     ``decode_only_steady_state_...`` beats ``rank_0.trace.json.gz`` on the first
     letter. Every xDiT roofline attempt therefore analysed a 938-byte phase
     fragment instead of the 910 KB capture beside it: runs whose fragment held
@@ -1021,22 +1048,28 @@ def _trace_input_sort_key(path: Path) -> tuple[int, str]:
     whose fragment happened to hold 512 produced a roofline computed from 2.6%
     of its own trace, with no ceiling.
 
+    Size is the part that does not depend on recognising a name. A real capture
+    is orders of magnitude larger than a per-phase fragment or a sidecar like
+    ``execution_details.json``, so ordering by descending size puts the right
+    file first even for a fragment shape nobody has seen yet.
+
     Args:
         path: The trace file path to rank.
 
     Returns:
-        A ``(priority, name)`` sort key (lower priority sorts first).
+        A ``(priority, -size, name)`` sort key (lower sorts first).
     """
     name = path.name
+    size = _trace_file_size(path)
     if _is_derived_trace(path):
-        return (4, name)
+        return (4, -size, name)
     if name.startswith("merged-"):
-        return (0, name)
+        return (0, -size, name)
     if re.search(r"TP-\d+-DECODE\.trace\.json(?:\.gz)?$", name):
-        return (2, name)
+        return (2, -size, name)
     if name.startswith("bs_") or name.startswith("graph_capture"):
-        return (3, name)
-    return (1, name)
+        return (3, -size, name)
+    return (1, -size, name)
 
 
 def discover_trace_inputs(trace_input: Path) -> tuple[str, list[Path]]:
@@ -7092,6 +7125,11 @@ def main() -> int:
         # the leading file happens to be a fragment with no kernels, and the
         # error it raises then blames the profiler for a capture that is sitting
         # in the same directory with thirty thousand kernel events in it.
+        #
+        # With size ordering the first candidate is normally the capture, so this
+        # loop exits on one probe and the promotion below stays quiet. It earns
+        # its keep on the layouts where it does not: a multi-rank capture whose
+        # leading rank recorded nothing.
         if not args.dry_run and trace_files:
             kernel_event_count = 0
             probed: list[str] = []

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -993,6 +993,13 @@ _SPLIT_DIR_NAME = "trace_split"
 #: which is a real capture problem rather than a selection one.
 _KERNEL_PROBE_LIMIT = 8
 
+#: Cumulative bytes of candidate traces the preflight will deserialise before
+#: giving up. Only the failing path spends this: with size ordering a healthy
+#: capture answers on the first probe. It exists because production rank traces
+#: reach hundreds of megabytes, and eight of those would turn a failure that
+#: used to take a second into one that takes minutes or exhausts memory.
+_KERNEL_PROBE_BYTE_BUDGET = 512 * 1024 * 1024
+
 #: Per-phase fragment names the splitter emits. Matched as well as the directory
 #: because a flat layout would otherwise leave them in the default bucket, and a
 #: capture with eight ranks would then spend the whole probe budget on fragments
@@ -1003,7 +1010,7 @@ _PHASE_FRAGMENT_RE = re.compile(
 )
 
 
-def _is_derived_trace(path: Path) -> bool:
+def _is_derived_trace(path: Path, root: Path | None = None) -> bool:
     """Whether a trace path is splitter output rather than a raw capture.
 
     Three shapes, all derived: anything under the splitter's own output
@@ -1016,8 +1023,21 @@ def _is_derived_trace(path: Path) -> bool:
     these under ``trace_split/`` today -- 276 of 276 capture directories with
     fragments -- but the demotion should not depend on a layout that the
     splitter is free to change.
+
+    ``root`` bounds the directory test to the capture being analysed. Paths
+    arrive absolute, so testing every component would demote *every* candidate
+    whenever an ancestor happened to be named ``trace_split`` -- pointing
+    ``--trace-input`` inside a previous split, say. With all candidates in the
+    same bucket the ordering collapses back to alphabetical and the original bug
+    returns, which is a lot of damage for a coincidence of naming.
     """
-    if _SPLIT_DIR_NAME in path.parts:
+    relative = path
+    if root is not None:
+        try:
+            relative = path.relative_to(root)
+        except ValueError:
+            relative = path
+    if _SPLIT_DIR_NAME in relative.parts:
         return True
     if _PHASE_FRAGMENT_RE.match(path.name):
         return True
@@ -1032,7 +1052,32 @@ def _trace_file_size(path: Path) -> int:
         return 0
 
 
-def _trace_input_sort_key(path: Path) -> tuple[int, int, str]:
+def _count_kernels_if_readable(path: Path) -> tuple[bool, int]:
+    """``(readable, kernel_count)`` for a candidate trace.
+
+    :func:`count_gpu_kernel_events` answers 0 both for a trace with no GPU work
+    and for one it could not parse. Those need different readers: the first is a
+    profiler problem, the second is a truncated or corrupt file. Collapsing them
+    is the same misdirection this module already sent people on once.
+
+    Still counts through :func:`count_gpu_kernel_events`, so it remains the one
+    place kernel events are recognised. The disambiguating parse runs only on a
+    zero answer, which is the only answer that is ambiguous -- a trace with
+    kernels in it demonstrably parsed.
+    """
+    count = count_gpu_kernel_events(path)
+    if count:
+        return True, count
+    try:
+        payload = open_json(path)
+    except Exception:  # noqa: BLE001 - unreadable is a distinct answer, not a crash
+        return False, 0
+    if not isinstance(payload, dict) or not isinstance(payload.get("traceEvents"), list):
+        return False, 0
+    return True, 0
+
+
+def _trace_input_sort_key(path: Path, root: Path | None = None) -> tuple[int, int, str]:
     """Compute the discovery sort key for a trace input path.
 
     Prefers the merged annotated trace over rank/phase shards (the TraceLens
@@ -1055,13 +1100,16 @@ def _trace_input_sort_key(path: Path) -> tuple[int, int, str]:
 
     Args:
         path: The trace file path to rank.
+        root: The capture directory being analysed, so the ``trace_split``
+            component is looked for below it rather than anywhere in an
+            absolute path.
 
     Returns:
         A ``(priority, -size, name)`` sort key (lower sorts first).
     """
     name = path.name
     size = _trace_file_size(path)
-    if _is_derived_trace(path):
+    if _is_derived_trace(path, root):
         return (4, -size, name)
     if name.startswith("merged-"):
         return (0, -size, name)
@@ -1105,7 +1153,7 @@ def discover_trace_inputs(trace_input: Path) -> tuple[str, list[Path]]:
         if trace not in seen:
             seen.add(trace)
             unique.append(trace)
-    unique.sort(key=_trace_input_sort_key)
+    unique.sort(key=lambda p: _trace_input_sort_key(p, trace_input))
     if not unique:
         raise FileNotFoundError(f"no trace files found under capture directory: {trace_input}")
     return "capture_dir", unique
@@ -7116,7 +7164,13 @@ def main() -> int:
         # default; the preflight below promotes whichever candidate it proves
         # carries GPU kernels, because passing the check on one file and then
         # analysing another is how an empty trace reaches TraceLens silently.
-        analysis_trace_path = trace_files[0] if trace_files else None
+        #
+        # Unconditional: discover_trace_inputs returns [trace_input] for a file
+        # and raises FileNotFoundError for a directory with no traces, so the
+        # list is never empty. Guarding it would type this as Path | None and
+        # push that None through every downstream call for a branch that cannot
+        # be taken.
+        analysis_trace_path = trace_files[0]
 
         # Fail-fast on CPU-only traces.
         #
@@ -7133,8 +7187,24 @@ def main() -> int:
         if not args.dry_run and trace_files:
             kernel_event_count = 0
             probed: list[str] = []
+            spent_bytes = 0
             for candidate in trace_files[:_KERNEL_PROBE_LIMIT]:
-                kernel_event_count = count_gpu_kernel_events(candidate)
+                # Each probe deserialises the whole file, so a directory of large
+                # empty captures could otherwise turn a fast failure into a slow
+                # one. Ordering puts the likeliest candidate first, so stopping
+                # on a byte budget costs the unlikely tail, not the answer.
+                if probed and spent_bytes >= _KERNEL_PROBE_BYTE_BUDGET:
+                    probed.append(f"(stopped after {spent_bytes} bytes probed)")
+                    break
+                spent_bytes += _trace_file_size(candidate)
+                readable, kernel_event_count = _count_kernels_if_readable(candidate)
+                if not readable:
+                    # Distinct from an empty trace on purpose: "unreadable" sends
+                    # a reader to the file, "no kernels" sends them to the
+                    # profiler, and conflating them is the misdirection this
+                    # whole change exists to remove.
+                    probed.append(f"{candidate.name}=unreadable")
+                    continue
                 probed.append(f"{candidate.name}={kernel_event_count}")
                 if kernel_event_count:
                     analysis_trace_path = candidate
@@ -7144,22 +7214,40 @@ def main() -> int:
                 f"trace_gpu_kernel_events={kernel_event_count} "
                 f"(probed={', '.join(probed)})",
             )
-            if analysis_trace_path is not None and analysis_trace_path != trace_files[0]:
+            if analysis_trace_path != trace_files[0]:
+                promotion_warning: dict[str, Any] = {
+                    "code": "trace_analysis_input_promoted",
+                    "severity": "info",
+                    "leading_candidate": trace_files[0].name,
+                    "analysed": analysis_trace_path.name,
+                    "probed": list(probed),
+                    "detail": (
+                        "the leading candidate carried no GPU kernel events or "
+                        "could not be read; the analysis ran on the first "
+                        "candidate that did"
+                    ),
+                }
+                # Structured as well as logged: a run that changed its own input
+                # has to be explicable from the artifacts, not only from a tool
+                # log nobody keeps.
+                trace_health_warnings.append(promotion_warning)
+                artifacts["tracelens_analysis_input"] = str(analysis_trace_path)
                 append_log(
                     log_path,
                     "trace_analysis_input promoted from "
                     f"{trace_files[0].name} to {analysis_trace_path.name} "
-                    "(the leading candidate carried no GPU kernel events)",
+                    f"(probed={', '.join(probed)})",
                 )
             if kernel_event_count == 0:
                 raise RuntimeError(
                     "Trace contains zero GPU kernel events in any of "
                     f"{len(probed)} probed file(s) under {trace_input}: "
-                    f"{', '.join(probed)}. The upstream profile run "
-                    "captured CPU-only activity. Re-run profile with the "
+                    f"{', '.join(probed)}. Either the upstream profile run "
+                    "captured CPU-only activity -- re-run profile with the "
                     "torch.profiler GPU activities enabled (no LD_PRELOAD "
-                    "competing for ROCprofiler-SDK) before invoking "
-                    "tracelens_analysis."
+                    "competing for ROCprofiler-SDK) -- or the traces listed as "
+                    "'unreadable' above are truncated or corrupt, which is a "
+                    "different problem in the same place."
                 )
 
         if not args.dry_run:
@@ -7490,7 +7578,10 @@ def main() -> int:
             capture_folder: Path | None = (
                 Path(args.capture_folder).expanduser().resolve()
                 if args.capture_folder
-                else discover_capture_folder(trace_input_path, trace_files)
+                # The analysed trace, not the leading candidate: the helper looks
+                # for capture_traces/ beside the file it is given, and after a
+                # cross-directory promotion those are different places.
+                else discover_capture_folder(trace_input_path, [analysis_trace_path])
             )
             if capture_folder:
                 append_log(

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -982,11 +982,44 @@ def count_gpu_kernel_events(trace_file: Path, max_events: int = 1_000_000) -> in
     return count
 
 
+#: Directory name the splitter writes its per-phase output into. Everything
+#: below it is derived from a raw capture, never a capture itself.
+_SPLIT_DIR_NAME = "trace_split"
+
+#: How many discovered files the CPU-only preflight will open before giving up.
+#: Each probe decompresses a trace, so this is a cost ceiling rather than a
+#: correctness one -- the raw capture sorts near the front, and a directory that
+#: needs more than a handful of probes has a real capture problem.
+_KERNEL_PROBE_LIMIT = 8
+
+
+def _is_derived_trace(path: Path) -> bool:
+    """Whether a trace path is splitter output rather than a raw capture.
+
+    Two shapes, both derived: anything under the splitter's own output directory,
+    and the per-iteration annotation sidecars it writes beside a capture. They
+    are a few hundred bytes each and cover one phase of one iteration, so an
+    analysis pointed at them describes a sliver of the run.
+    """
+    if _SPLIT_DIR_NAME in path.parts:
+        return True
+    return bool(re.search(r"trace_annotation_iteration_\d+", path.name))
+
+
 def _trace_input_sort_key(path: Path) -> tuple[int, str]:
     """Compute the discovery sort key for a trace input path.
 
     Prefers the merged annotated trace over rank/phase shards (the TraceLens
     splitter needs the large trace).
+
+    Splitter output sorts last. It used to land in the same default bucket as
+    the raw capture, which left alphabetical order to decide between them -- and
+    ``decode_only_steady_state_...`` beats ``rank_0.trace.json.gz`` on the first
+    letter. Every xDiT roofline attempt therefore analysed a 938-byte phase
+    fragment instead of the 910 KB capture beside it: runs whose fragment held
+    no GPU kernels failed the CPU-only preflight outright, and the one model
+    whose fragment happened to hold 512 produced a roofline computed from 2.6%
+    of its own trace, with no ceiling.
 
     Args:
         path: The trace file path to rank.
@@ -995,6 +1028,8 @@ def _trace_input_sort_key(path: Path) -> tuple[int, str]:
         A ``(priority, name)`` sort key (lower priority sorts first).
     """
     name = path.name
+    if _is_derived_trace(path):
+        return (4, name)
     if name.startswith("merged-"):
         return (0, name)
     if re.search(r"TP-\d+-DECODE\.trace\.json(?:\.gz)?$", name):
@@ -7046,16 +7081,30 @@ def main() -> int:
         append_log(log_path, f"trace_files={len(trace_files)}")
 
         # Fail-fast on CPU-only traces.
+        #
+        # Probes candidates in discovery order rather than only the first. A
+        # single-file probe reports the capture directory as CPU-only whenever
+        # the leading file happens to be a fragment with no kernels, and the
+        # error it raises then blames the profiler for a capture that is sitting
+        # in the same directory with thirty thousand kernel events in it.
         if not args.dry_run and trace_files:
-            kernel_event_count = count_gpu_kernel_events(trace_files[0])
+            kernel_event_count = 0
+            probed: list[str] = []
+            for candidate in trace_files[:_KERNEL_PROBE_LIMIT]:
+                kernel_event_count = count_gpu_kernel_events(candidate)
+                probed.append(f"{candidate.name}={kernel_event_count}")
+                if kernel_event_count:
+                    break
             append_log(
                 log_path,
-                f"trace_gpu_kernel_events={kernel_event_count} (probe={trace_files[0].name})",
+                f"trace_gpu_kernel_events={kernel_event_count} "
+                f"(probed={', '.join(probed)})",
             )
             if kernel_event_count == 0:
                 raise RuntimeError(
-                    "Trace contains zero GPU kernel events "
-                    f"({trace_files[0]}); the upstream profile run "
+                    "Trace contains zero GPU kernel events in any of "
+                    f"{len(probed)} probed file(s) under {trace_input}: "
+                    f"{', '.join(probed)}. The upstream profile run "
                     "captured CPU-only activity. Re-run profile with the "
                     "torch.profiler GPU activities enabled (no LD_PRELOAD "
                     "competing for ROCprofiler-SDK) before invoking "

--- a/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -29,6 +29,7 @@ from hyperloom.orchestrator.actions.executors.profile import (
     ProfileExecutor,
     _default_profile_config,
     _sanitize_profile_server_args,
+    _trace_files_for_dir,
 )
 from hyperloom.orchestrator.roles import (
     MockBackend,
@@ -4435,3 +4436,70 @@ def test_resolve_integrate_payload_falls_back_to_kernel_opt_attempts_ledger(
     assert resolved.get("source_file") == "/p/moe_op.py", (
         "source_file must fall back to kernel_opt_attempts[k001].last_source_file"
     )
+
+
+def _gz_trace(path: Path, payload_bytes: int) -> Path:
+    """Write a ``*.trace.json.gz`` of roughly the requested size."""
+    import gzip
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(path, "wt") as fh:
+        json.dump({"traceEvents": [{"n": "x" * payload_bytes}]}, fh)
+    return path
+
+
+def test_trace_files_for_dir_excludes_split_chunks_and_leads_with_the_capture(tmp_path):
+    """Splitter chunks must never lead the discovered trace list.
+
+    Two consumers fall back to ``trace_files[0]`` when ``main_trace_path`` is
+    absent (the roofline trace extractor and the writeback path). Under
+    alphabetical order a 900-byte ``trace_split/`` chunk sorted ahead of
+    ``rank_0.trace.json.gz``, and a single chunk handed to ``--trace-input``
+    takes the single-file branch of discovery, where the multi-candidate probing
+    downstream cannot rescue it. This function already excludes ``capture_traces``
+    sidecars for the same reason.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    chunk = _gz_trace(trace_dir / "trace_split" / "aaa_mixed_0.trace.json.gz", 32)
+    capture = _gz_trace(trace_dir / "zzz_rank_0.trace.json.gz", 40_000)
+    sidecar = _gz_trace(
+        trace_dir / "capture_traces" / "aaa_graph_capture_0.pt.trace.json.gz", 32
+    )
+
+    found = _trace_files_for_dir(trace_dir)
+
+    assert chunk not in found, "trace_split chunks must be excluded"
+    assert sidecar not in found, "capture_traces sidecars must stay excluded"
+    assert found[0] == capture
+
+
+def test_trace_files_for_dir_orders_by_size_not_name(tmp_path):
+    """Size ordering, so the fallback does not depend on a naming rule.
+
+    The real discriminator between a fragment and a capture is that one is
+    hundreds of bytes and the other is hundreds of kilobytes. Ranking on size
+    gets this right without knowing any of the splitter's filename conventions,
+    which it is free to change.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    small = _gz_trace(trace_dir / "aaa_first_by_name.trace.json.gz", 16)
+    large = _gz_trace(trace_dir / "zzz_last_by_name.trace.json.gz", 60_000)
+
+    found = _trace_files_for_dir(trace_dir)
+
+    assert found == [large, small]
+
+
+def test_trace_files_for_dir_survives_an_ancestor_named_trace_split(tmp_path):
+    """An ancestor named ``trace_split`` must not empty the list.
+
+    The exclusion is relative to the scanned directory. Tested absolutely, a
+    capture that happened to live below such a directory would have every one of
+    its traces excluded, and the caller reads an empty list as "no traces here".
+    """
+    trace_dir = tmp_path / "trace_split" / "run" / "torch_trace"
+    capture = _gz_trace(trace_dir / "rank_0.trace.json.gz", 40_000)
+
+    found = _trace_files_for_dir(trace_dir)
+
+    assert found == [capture]

--- a/src/hyperloom/orchestrator/actions/executors/profile.py
+++ b/src/hyperloom/orchestrator/actions/executors/profile.py
@@ -410,20 +410,60 @@ def _is_capture_trace(path: Path) -> bool:
     return any(part == "capture_traces" for part in path.parts)
 
 
+def _trace_size_bytes(path: Path) -> int:
+    """Size in bytes, or 0 when it cannot be read."""
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
+
+
+def _is_split_chunk(path: Path, root: Path) -> bool:
+    """True when ``path`` is steady-state splitter output below ``root``.
+
+    Same reasoning as :func:`_is_capture_trace`, one directory along: the
+    splitter's per-phase chunks also end in ``.trace.json.gz`` and would
+    otherwise be mistaken for a real annotated trace. They are a few hundred
+    bytes covering one phase of one iteration, and they sort ahead of
+    ``rank_0.trace.json.gz`` alphabetically, so a caller falling back to
+    ``trace_files[0]`` would analyse a sliver of the run.
+
+    Relative to ``root`` rather than over the whole absolute path, so a capture
+    that happens to live under some ancestor named ``trace_split`` does not have
+    every one of its traces excluded.
+    """
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        relative = path
+    return any(part == "trace_split" for part in relative.parts)
+
+
 def _trace_files_for_dir(trace_dir: Path) -> list[Path]:
     """Return annotated ``*.trace.json.gz`` files under ``trace_dir``.
 
     Excludes capture sidecars under ``capture_traces/`` (see
     :func:`_is_capture_trace`) so a vLLM ``graph_capture_*.pt.trace.json.gz`` is
-    never promoted as the primary annotated trace.
+    never promoted as the primary annotated trace, and steady-state chunks under
+    ``trace_split/`` for the same reason.
+
+    Ordered largest first. Consumers fall back to ``trace_files[0]`` when
+    ``main_trace_path`` is absent, and at that point a 938-byte chunk and a
+    910 KB capture are indistinguishable by name -- alphabetical order picked the
+    chunk. Size needs no naming rule to get this right.
 
     Args:
         trace_dir: The directory to scan recursively.
 
     Returns:
-        Sorted annotated ``*.trace.json.gz`` paths, capture sidecars removed.
+        ``*.trace.json.gz`` paths largest first, capture sidecars and split
+        chunks removed.
     """
-    return sorted(p for p in trace_dir.rglob("*.trace.json.gz") if not _is_capture_trace(p))
+    candidates = [
+        p for p in trace_dir.rglob("*.trace.json.gz")
+        if not _is_capture_trace(p) and not _is_split_chunk(p, trace_dir)
+    ]
+    return sorted(candidates, key=lambda p: (-_trace_size_bytes(p), str(p)))
 
 
 def _capture_sidecar_traces_for_dir(trace_dir: Path) -> list[Path]:


### PR DESCRIPTION
## Why

Over the last three days, 48 of 56 xDiT sessions produced no roofline snapshot at
all, and the one model that did produce them produced garbage: an empty ceiling
and a throughput of 0.1 tok/s/GPU. The failing runs all raised the same error:

```
RuntimeError: Trace contains zero GPU kernel events (...); the upstream profile
run captured CPU-only activity. Re-run profile with the torch.profiler GPU
activities enabled (no LD_PRELOAD competing for ROCprofiler-SDK) ...
```

The profiler was not the problem. The GPU data was captured correctly every
time.

## Root cause

`discover_trace_inputs` put the raw capture and the splitter's fragments in the
same priority bucket, leaving alphabetical order to choose between them. From a
real failing FLUX.1-dev roofline directory:

| prio | file | size | gpu kernels |
|---|---|---|---|
| 1 | `decode_only_steady_state_..._rank_0.trace.json.gz` | 938 | **0** ΓåÉ probed |
| 1 | `execution_details.json` | 3965 | no traceEvents |
| 1 | `mixed_steady_state_..._rank_0.trace.json.gz` | 932 | 0 |
| 1 | `rank_0.trace.json.gz` | **910818** | **30196** ΓåÉ wanted |
| 1 | `rank_0.trace_annotation_iteration_{0,1,2}.json.gz` | ~890 | 0 |

`decode_only_...` beats `rank_0...` on the first letter. The CPU-only preflight
opens `trace_files[0]` and nothing else, so it read a 938-byte fragment, counted
zero kernels, and blamed the profiler for a capture with 30k kernel events in the
same directory.

**One selection bug, both symptoms:**

- Fragment holds no kernels ΓåÆ preflight fails ΓåÆ no roofline. 48 of 56 sessions.
- Fragment holds *some* kernels ΓåÆ preflight passes and the analysis then runs on
  the fragment. `ERNIE-Image-Turbo`'s fragment held 512 of its 19,635 kernels, so
  its roofline was computed from 2.6% of the trace: no ceiling, 0.1 tok/s/GPU.
  This is why ERNIE looked like the one model that worked.

## Why #1160 did not help

[#1160](https://github.com/AMD-AGI/Hyperloom/pull/1160) stopped xDiT traces being
split going forward, which was a real fix at a different layer. It is deployed ΓÇö
`stale_framework_overridden` and `--skip-split` are present in the source the
sessions stage from, `roofline.py` was updated two minutes after the merge, and
the merge commit is an ancestor of the `main` the sessions run. It could not help
here because the fragments already on disk still won the sort, and the selection
itself was never what it changed.

## What changed

- Splitter output sorts last, keyed on the containing `trace_split/` directory and
  the annotation-sidecar name rather than on guessing from phase names, so a new
  phase name cannot silently reintroduce this.
- The CPU-only preflight probes candidates in discovery order instead of only the
  first, bounded at 8 opens. A leading fragment can no longer condemn the capture
  behind it, and the error now names every file it probed.

## Test plan

- [x] 4 new tests reproduce the production layout (real filenames and sizes) and
      assert the raw capture leads, that the leading candidate is the one holding
      the kernels, and that the pre-existing merged-trace preference is unchanged
- [x] Verified the new tests fail with the fix reverted ΓÇö all 3 ordering
      assertions flip
- [x] Full file: 9 failed / 208 passed before, 9 failed / 212 passed after. The 9
      are pre-existing Windows path artifacts in unrelated `resolve_launcher` /
      `grep_for_keyword` tests
- [ ] Confirm on the next xDiT roofline run that `trace_gpu_kernel_events` logs a
      non-zero count and a ceiling reaches the dashboard

## Note for whoever picks this up

Sessions stage Hyperloom from `/shared_nfs/haiskong/Hyperloom` rather than a
pinned SHA ΓÇö the logs say `using existing Hyperloom source (no clone)` and carry
no source SHA. That checkout needs updating for this to reach running sessions,
and it also means there is no record in any session of which code it ran.

## Decision: size ordering applies to every capture, not only xDiT

`_trace_input_sort_key` is shared, so this changes rank selection beyond the
workload being fixed. For a multi-rank capture with no `merged-` trace -- where
`_preferred_main_trace_path` falls through and hands the directory to discovery --
the analysed rank moves from "rank_0, alphabetically" to "the largest rank".

That is deliberate. Alphabetical order carries no information about which rank
recorded a usable window, whereas the largest file is the one most likely to hold
a complete one, and the preflight already has to reject empty candidates either
way.

Two consequences worth stating plainly rather than discovering later:

- Which rank represents a run can now differ between two analyses of the same
  session, because rank sizes vary between captures. Previously it was always
  rank_0.
- This is a behaviour change for frameworks other than xDiT, even though nothing
  about them was broken. xDiT captures hold a single `rank_N.trace.json.gz`
  (measured: 276 of 276 directories), so the workload this PR fixes is not
  affected by it at all.

If per-rank stability matters more than picking the fullest rank for some
framework, the ordering should become conditional rather than shared -- but that
is a different change from this one, and nothing observed so far needs it.
