### PR TITLE
feat(kernel): route mori EP dispatch/combine to the KernelForge vendor playbook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,11 @@ hyperloom = [
 "hyperloom.agents.kernel" = [
     "scripts/*.sh",
 ]
+# Vendor-operator-playbook registry (see tools/_vendor_operator_playbooks.py):
+# read at runtime by classify_patchability()/forge_submit.py, so it must ship.
+"hyperloom.agents.kernel.tools" = [
+    "vendor_operator_playbooks.json",
+]
 # ``agentx/deploy.py`` copies these into InferenceX ``benchmarks/`` at runtime
 # and raises FileNotFoundError when they are absent from the install.
 "hyperloom.inference_optimizer.assets.agentx" = [

--- a/src/hyperloom/agents/kernel/tests/test_vendor_operator_playbook_mori.py
+++ b/src/hyperloom/agents/kernel/tests/test_vendor_operator_playbook_mori.py
@@ -1,0 +1,465 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Vendor-operator-playbook routing for mori's EP dispatch/combine.
+
+Closes the gap KernelForge PR #88 left explicit: Hyperloom's own
+TraceLens-driven pipeline had no path to mori (a pip-installed compiled
+library, classified ``vendor_binary`` with no rewritable source) even though
+a validated KernelForge forge-loop task bundle exists for it. These tests
+pin, end to end within Hyperloom's own boundary:
+
+1. the registry matcher recognizes mori dispatch/combine by name (
+   ``_vendor_operator_playbooks``);
+2. ``classify_patchability`` + ``_finalize_candidates`` route both candidates
+   to ``reusable_native_kernel=True`` / ``patch_strategy="vendor_playbook"``
+   and sum their GPU share (dispatch+combine are one logical round trip);
+3. ``forge_submit.submit()`` recognizes ``patch_strategy="vendor_playbook"``,
+   copies the KernelForge ``examples/mori_ep_dispatch_combine/`` bundle into
+   the forge worktree, and invokes forge-loop with the bundle's own
+   driver/config/program.md, the mori KB env knob, and the six documented
+   tunable params as ``--target-functions``;
+4. dispatch and combine are invoked as **one** Forge session, not two: the
+   second candidate to reach ``submit()`` reuses the first's result instead
+   of launching a second forge-loop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+_BACKENDS_DIR = _TOOLS_DIR / "backends"
+if str(_BACKENDS_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKENDS_DIR))
+
+import tracelens_analysis as tla  # noqa: E402
+import forge_submit  # noqa: E402
+import kernel_optimization as ko  # noqa: E402
+from _vendor_operator_playbooks import (  # noqa: E402
+    match_vendor_operator_playbook,
+    _reset_vendor_operator_playbooks_cache,
+)
+
+_MORI_SITE_PACKAGES_FILE = "/opt/venv/lib/python3.12/site-packages/mori/ops/dispatch_combine.py"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry_cache():
+    _reset_vendor_operator_playbooks_cache()
+    yield
+    _reset_vendor_operator_playbooks_cache()
+
+
+def _mori_dispatch_candidate(**overrides) -> dict:
+    candidate = {
+        "kernel_id": "k010",
+        "name": "mori::EpDispatchCombineOp::dispatch",
+        "operation": "dispatch",
+        "duration_us": 700.0,
+        "call_count": 10,
+        "source_file": _MORI_SITE_PACKAGES_FILE,
+        "source_type": "unknown",
+        "library": "mori",
+        "shapes": [],
+    }
+    candidate.update(overrides)
+    return candidate
+
+
+def _mori_combine_candidate(**overrides) -> dict:
+    candidate = {
+        "kernel_id": "k011",
+        "name": "mori::EpDispatchCombineOp::combine",
+        "operation": "combine",
+        "duration_us": 300.0,
+        "call_count": 10,
+        "source_file": _MORI_SITE_PACKAGES_FILE,
+        "source_type": "unknown",
+        "library": "mori",
+        "shapes": [],
+    }
+    candidate.update(overrides)
+    return candidate
+
+
+# --- 1. registry matcher -----------------------------------------------------
+
+
+def test_match_vendor_operator_playbook_matches_mori_dispatch_and_combine():
+    dispatch_match = match_vendor_operator_playbook(_mori_dispatch_candidate())
+    combine_match = match_vendor_operator_playbook(_mori_combine_candidate())
+
+    assert dispatch_match is not None
+    assert dispatch_match["id"] == "mori_ep_dispatch_combine"
+    assert dispatch_match["role"] == "dispatch"
+    assert combine_match is not None
+    assert combine_match["id"] == "mori_ep_dispatch_combine"
+    assert combine_match["role"] == "combine"
+
+
+def test_match_vendor_operator_playbook_ignores_unrelated_kernels():
+    gemm_candidate = {
+        "name": "aiter::gemm_a8w8",
+        "operation": "gemm",
+        "source_file": "/sgl-workspace/aiter/aiter/gemm_a8w8.py",
+        "library": "aiter",
+    }
+    assert match_vendor_operator_playbook(gemm_candidate) is None
+    # "mori" alone (no dispatch/combine marker) must not match either --
+    # the registry requires both an identity marker and a role marker.
+    mori_other = {"name": "mori::shmem::init", "library": "mori"}
+    assert match_vendor_operator_playbook(mori_other) is None
+
+
+# --- 2. classify_patchability + _finalize_candidates -------------------------
+
+
+def test_classify_patchability_routes_mori_dispatch_and_combine():
+    dispatch_ok, dispatch_reason = tla.classify_patchability(_mori_dispatch_candidate())
+    combine_ok, combine_reason = tla.classify_patchability(_mori_combine_candidate())
+
+    assert (dispatch_ok, dispatch_reason) == (True, "")
+    assert (combine_ok, combine_reason) == (True, "")
+
+
+def test_finalize_candidates_stamps_vendor_playbook_and_sums_gpu_pct():
+    candidates = [
+        _mori_dispatch_candidate(),
+        _mori_combine_candidate(),
+        {
+            "name": "rmsnorm_kernel",
+            "duration_us": 100.0,
+            "call_count": 10,
+            "source_file": "/path/to/rmsnorm.cu",
+            "source_type": "hip_cpp",
+            "shapes": [[16, 1024]],
+        },
+    ]
+    # total_dur = 700 + 300 + 100 = 1100 -> dispatch=63.636%, combine=27.273%.
+    out = tla._finalize_candidates(candidates, total_dur=1100.0)
+    by_name = {item["name"]: item for item in out}
+
+    dispatch = by_name["mori::EpDispatchCombineOp::dispatch"]
+    combine = by_name["mori::EpDispatchCombineOp::combine"]
+    other = by_name["rmsnorm_kernel"]
+
+    for item in (dispatch, combine):
+        assert item["reusable_native_kernel"] is True
+        assert item["patch_strategy"] == "vendor_playbook"
+        assert item["vendor_operator_playbook"]["id"] == "mori_ep_dispatch_combine"
+        assert item["vendor_playbook_group_id"] == "mori_ep_dispatch_combine"
+
+    assert dispatch["vendor_playbook_role"] == "dispatch"
+    assert combine["vendor_playbook_role"] == "combine"
+    assert dispatch["aggregate_gpu_pct"] == pytest.approx(combine["aggregate_gpu_pct"])
+    assert dispatch["aggregate_gpu_pct"] == pytest.approx(dispatch["gpu_pct"] + combine["gpu_pct"])
+    assert dispatch["aggregate_gpu_pct"] == pytest.approx(90.909, abs=0.01)
+    assert sorted(dispatch["vendor_playbook_group_kernel_ids"]) == sorted(
+        [dispatch["kernel_id"], combine["kernel_id"]]
+    )
+
+    # An unrelated candidate must be untouched by the vendor-playbook pass.
+    assert "patch_strategy" not in other
+    assert "vendor_operator_playbook" not in other
+    assert "aggregate_gpu_pct" not in other
+
+
+def test_finalize_candidates_fills_source_file_for_real_vendor_binary_shape():
+    """mori's dispatch/combine are compiled bindings with no on-disk .py/.cu
+    source -- TraceLens realistically hands classify_patchability a candidate
+    with an *empty* source_file (unlike the fixtures above, which set one for
+    unrelated reasons). Confirm _finalize_candidates still fills in a
+    path-shaped stand-in so kernel_optimization.py's CLI gate (which skips
+    any candidate with a falsy source_file as "missing_native_source" before
+    it ever reaches forge_submit.submit()) does not reject the candidate.
+    """
+    candidates = [
+        _mori_dispatch_candidate(source_file=""),
+        _mori_combine_candidate(source_file=""),
+    ]
+    out = tla._finalize_candidates(candidates, total_dur=1000.0)
+    by_name = {item["name"]: item for item in out}
+    dispatch = by_name["mori::EpDispatchCombineOp::dispatch"]
+    combine = by_name["mori::EpDispatchCombineOp::combine"]
+
+    for item in (dispatch, combine):
+        assert item["reusable_native_kernel"] is True
+        source_file = str(item.get("source_file") or "")
+        assert source_file, "source_file must not be empty (would be skipped as missing_native_source)"
+        assert source_file.endswith("mori_ep_config.py")
+        # The stand-in must look like a real path so it survives
+        # looks_like_source_path()/the non-empty CLI gate either way.
+        assert tla.looks_like_source_path(source_file)
+
+
+# --- 3 & 4. forge_submit.submit() vendor-playbook route + one-session dedup --
+
+
+def _write_fake_mori_bundle(forge_path: Path) -> Path:
+    bundle = forge_path / "examples" / "mori_ep_dispatch_combine"
+    bundle.mkdir(parents=True)
+    (bundle / "mori_ep_config.py").write_text(
+        "def get_ep_launch_config():\n    return {}\n", encoding="utf-8"
+    )
+    (bundle / "driver.py").write_text("# real, hand-written mori driver\n", encoding="utf-8")
+    (bundle / "program.md").write_text("# mori dispatch/combine task\n", encoding="utf-8")
+    return bundle
+
+
+def _stub_run_loop(monkeypatch, captured_calls: list[dict]):
+    def fake_run_loop(**kwargs):
+        captured_calls.append(kwargs)
+        return forge_submit.ForgeLoopOutcome(
+            baseline_ms=1.9,
+            best_ms=1.47,
+            improved=True,
+            output="forge-loop completed",
+            error=None,
+            timed_out=False,
+            checkpoint=None,
+            total_improved=True,
+            incremental_improved=True,
+            mean_case_speedup=1.29,
+        )
+
+    monkeypatch.setattr(forge_submit, "_run_vendor_playbook_loop_via_cli", fake_run_loop)
+
+
+def test_submit_vendor_playbook_copies_bundle_and_invokes_forge_loop(monkeypatch, tmp_path):
+    forge_path = tmp_path / "KernelForge"
+    _write_fake_mori_bundle(forge_path)
+    monkeypatch.setenv("FORGE_PATH", str(forge_path))
+    monkeypatch.setattr(forge_submit, "_ensure_forge_on_path", lambda: "")
+    monkeypatch.setattr(forge_submit, "_resolve_gpu_target", lambda _candidate: "gfx942")
+
+    captured: list[dict] = []
+    _stub_run_loop(monkeypatch, captured)
+
+    candidate = match_vendor_operator_playbook(_mori_dispatch_candidate())
+    dispatch_candidate = _mori_dispatch_candidate(
+        patch_strategy="vendor_playbook",
+        vendor_operator_playbook=candidate,
+        vendor_playbook_role="dispatch",
+    )
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("# fallback prompt\n", encoding="utf-8")
+    output_dir = tmp_path / "forge" / "session1" / "attempt_dispatch"
+
+    result = forge_submit.submit(
+        source_file=_MORI_SITE_PACKAGES_FILE,
+        prompt_file=prompt_file,
+        output_dir=output_dir,
+        source_type="unknown",
+        candidate=dispatch_candidate,
+        timeout_s=3600,
+    )
+
+    assert result["returncode"] == 0
+    assert result["skipped"] is False
+    assert result["vendor_playbook_id"] == "mori_ep_dispatch_combine"
+    assert result["vendor_playbook_role"] == "dispatch"
+    assert result["vendor_playbook_reused"] is False
+    assert result["improved"] is True
+    assert result["mean_case_speedup"] == pytest.approx(1.29)
+    # kernel_optimization.py's build_verification() only credits a forge
+    # attempt's speedup when BOTH of these are present on the result dict
+    # (see run_attempt's field copy) -- missing either one silently
+    # downgrades a real KEEP-worthy improvement to PARTIAL. A live e2e run
+    # against the real mori_ep_dispatch_combine bundle on 8 MI300X GPUs
+    # caught this gap: forge-loop measured and committed a validated
+    # 1.21x speedup, but the CLI's own proposal still read PARTIAL /
+    # "no measurable speedup found" because these fields were missing.
+    workspace = output_dir / "worktree"
+    assert result["total_improved"] is True
+    assert result["incremental_improved"] is True
+    assert result["forge_workspace"] == str(workspace)
+
+    assert (workspace / "mori_ep_config.py").is_file()
+    assert (workspace / "driver.py").read_text() == "# real, hand-written mori driver\n"
+    assert (workspace / "program.md").is_file()
+    # forge-loop's IterationLoop runs `git status`/`git checkout` against the
+    # workspace to snapshot/restore each attempt; a bare copy with no `.git`
+    # fails its very first git call ("not a git repository").
+    assert (workspace / ".git").is_dir()
+    import subprocess as _subprocess  # noqa: PLC0415
+
+    status = _subprocess.run(
+        ["git", "status", "--porcelain=v1"],
+        cwd=str(workspace),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert status.stdout.strip() == "", "copied bundle must be committed (clean tree)"
+
+    assert len(captured) == 1
+    call = captured[0]
+    assert call["kernel_anchor"] == str(workspace / "mori_ep_config.py")
+    assert call["driver"] == str(workspace / "driver.py")
+    assert call["fellow"] == "aiter-fellow"
+    assert call["target_functions"] == ["get_ep_launch_config", "dispatch", "combine"]
+    assert call["extra_env"]["KERNELFORGE_INCLUDE_MORI_KB"] == "1"
+    assert call["program_md_file"] == str(workspace / "program.md")
+
+    # --- regression: a real measured improvement must actually reach KEEP ---
+    # This is the pipeline stage the live e2e run caught failing: forge_submit's
+    # result dict feeds run_attempt() -> build_verification() -> make_proposal(),
+    # and a gap anywhere in that field handoff silently downgrades a validated,
+    # correctness-passed, 1.2x-speedup KEEP into a PARTIAL "no measurable
+    # speedup" verdict even though forge-loop itself never disagreed.
+    attempt = {
+        "attempt_id": "forge-e2e",
+        "backend": "forge",
+        "status": "completed",
+        "backend_paths": {
+            "output_dir": str(output_dir),
+            "cli_workspace": result["cli_workspace"],
+            "forge_workspace": result["forge_workspace"],
+        },
+        "optimized_path": str(output_dir / "forge-e2e_stdout.log"),
+        "mean_case_speedup": result["mean_case_speedup"],
+        "total_improved": result["total_improved"],
+        "incremental_improved": result["incremental_improved"],
+        "improved": result["improved"],
+        "pristine_baseline_ms": None,
+        "best_ms": result["best_ms"],
+    }
+    # main() converts the CLI's "true"/"false"/"unknown" strings to bool/None
+    # before calling build_verification (see kernel_optimization.py's
+    # correctness = None if ... == "unknown" else ... == "true"); mirror that
+    # here rather than passing the raw CLI string.
+    args = argparse.Namespace(
+        source_file=str(workspace / "mori_ep_config.py"),
+        kernel_repo="",
+        correctness_passed=True,
+        accuracy_passed=None,
+        micro_speedup=None,
+        e2e_gain_pct=None,
+        dry_run=False,
+    )
+    verification = ko.build_verification(args, [attempt], benchmark_available=False)
+    assert verification["micro_speedup_source"] != "default_unmeasured"
+    assert verification["micro_speedup"] == pytest.approx(1.29)
+    assert verification["artifact_valid"] is True, verification["artifact_error"]
+    assert verification["artifact_source"] == "source_file"
+    assert verification["correctness_passed"] is True
+
+    proposal = ko.make_proposal(verification)
+    assert proposal["decision"] == "KEEP", proposal["reasons"]
+
+    # Without an orchestrator-supplied correctness signal (the standalone-CLI
+    # case this e2e test actually exercised), the measured speedup must still
+    # be visible -- NEEDS_REVIEW ("evidence needs confirmation"), never the
+    # misleading PARTIAL "no measurable speedup found" a missing-field
+    # regression would silently produce.
+    args_no_correctness = argparse.Namespace(**{**vars(args), "correctness_passed": None})
+    verification_nc = ko.build_verification(args_no_correctness, [attempt], benchmark_available=False)
+    assert verification_nc["micro_speedup_source"] != "default_unmeasured"
+    proposal_nc = ko.make_proposal(verification_nc)
+    assert proposal_nc["decision"] == "NEEDS_REVIEW", proposal_nc["reasons"]
+
+
+def test_submit_vendor_playbook_dedupes_dispatch_and_combine_into_one_session(monkeypatch, tmp_path):
+    """dispatch+combine invoke KernelForge as ONE Forge session, not two."""
+    forge_path = tmp_path / "KernelForge"
+    _write_fake_mori_bundle(forge_path)
+    monkeypatch.setenv("FORGE_PATH", str(forge_path))
+    monkeypatch.setattr(forge_submit, "_ensure_forge_on_path", lambda: "")
+    monkeypatch.setattr(forge_submit, "_resolve_gpu_target", lambda _candidate: "gfx942")
+
+    captured: list[dict] = []
+    _stub_run_loop(monkeypatch, captured)
+
+    playbook = match_vendor_operator_playbook(_mori_dispatch_candidate())
+    dispatch_candidate = _mori_dispatch_candidate(
+        patch_strategy="vendor_playbook",
+        vendor_operator_playbook=dict(playbook, role="dispatch"),
+        vendor_playbook_role="dispatch",
+    )
+    combine_candidate = _mori_combine_candidate(
+        patch_strategy="vendor_playbook",
+        vendor_operator_playbook=dict(playbook, role="combine"),
+        vendor_playbook_role="combine",
+    )
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("# fallback prompt\n", encoding="utf-8")
+
+    # Same session ("session1"), two different per-kernel attempt dirs -- this
+    # is exactly the shape the orchestrator produces when it dispatches
+    # dispatch and combine as two separate --kernel-id subprocess attempts.
+    dispatch_result = forge_submit.submit(
+        source_file=_MORI_SITE_PACKAGES_FILE,
+        prompt_file=prompt_file,
+        output_dir=tmp_path / "forge" / "session1" / "attempt_dispatch",
+        candidate=dispatch_candidate,
+        timeout_s=3600,
+    )
+    combine_result = forge_submit.submit(
+        source_file=_MORI_SITE_PACKAGES_FILE,
+        prompt_file=prompt_file,
+        output_dir=tmp_path / "forge" / "session1" / "attempt_combine",
+        candidate=combine_candidate,
+        timeout_s=3600,
+    )
+
+    # Only one real forge-loop invocation for the whole group.
+    assert len(captured) == 1
+    assert dispatch_result["vendor_playbook_reused"] is False
+    assert combine_result["vendor_playbook_reused"] is True
+    # The reused result carries the same measured outcome, but its own role.
+    assert combine_result["mean_case_speedup"] == dispatch_result["mean_case_speedup"]
+    assert combine_result["best_ms"] == dispatch_result["best_ms"]
+    assert combine_result["vendor_playbook_role"] == "combine"
+    assert dispatch_result["vendor_playbook_role"] == "dispatch"
+    # A second forge worktree/workspace copy is never made for the reused role.
+    assert not (tmp_path / "forge" / "session1" / "attempt_combine" / "worktree").exists()
+
+
+def test_submit_vendor_playbook_reports_missing_forge_path(monkeypatch, tmp_path):
+    monkeypatch.delenv("FORGE_PATH", raising=False)
+    playbook = match_vendor_operator_playbook(_mori_dispatch_candidate())
+    candidate = _mori_dispatch_candidate(
+        patch_strategy="vendor_playbook",
+        vendor_operator_playbook=playbook,
+        vendor_playbook_role="dispatch",
+    )
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("# fallback prompt\n", encoding="utf-8")
+
+    result = forge_submit.submit(
+        source_file=_MORI_SITE_PACKAGES_FILE,
+        prompt_file=prompt_file,
+        output_dir=tmp_path / "forge" / "session2" / "attempt_dispatch",
+        candidate=candidate,
+        timeout_s=3600,
+    )
+
+    assert result["skipped"] is True
+    assert result["returncode"] == 2
+    assert "FORGE_PATH" in result["stderr_tail"]
+
+
+def test_registry_json_is_valid_and_ships_in_package_data():
+    """The JSON registry parses and pyproject.toml declares it as package-data
+    (mirrors KernelForge's own wheel-packaging regression for framework/mori/)."""
+    registry_path = _TOOLS_DIR / "vendor_operator_playbooks.json"
+    data = json.loads(registry_path.read_text(encoding="utf-8"))
+    playbook_ids = {p["id"] for p in data["playbooks"]}
+    assert "mori_ep_dispatch_combine" in playbook_ids
+
+    pyproject = registry_path.parents[5] / "pyproject.toml"
+    assert pyproject.is_file()
+    text = pyproject.read_text(encoding="utf-8")
+    assert "vendor_operator_playbooks.json" in text

--- a/src/hyperloom/agents/kernel/tests/test_vendor_operator_playbook_mori.py
+++ b/src/hyperloom/agents/kernel/tests/test_vendor_operator_playbook_mori.py
@@ -426,6 +426,60 @@ def test_submit_vendor_playbook_dedupes_dispatch_and_combine_into_one_session(mo
     # A second forge worktree/workspace copy is never made for the reused role.
     assert not (tmp_path / "forge" / "session1" / "attempt_combine" / "worktree").exists()
 
+    # --- regression: the reused (combine) attempt must not lose the artifact ---
+    # A real run caught this: kernel_optimization.py's invoke_backend()
+    # unconditionally overwrites result["output_dir"] with THIS attempt's own
+    # (empty, never-populated-by-submit) directory right after submit()
+    # returns; _candidate_artifact_paths() only looks under
+    # cli_workspace/optimized_versions and output_dir/optimized_versions, so
+    # combine's empty tree made artifact_valid=False and make_proposal()
+    # return PARTIAL even though dispatch's speedup fields were present.
+    combine_output_dir = tmp_path / "forge" / "session1" / "attempt_combine"
+    assert (combine_output_dir / "optimized_versions").is_dir()
+    assert list((combine_output_dir / "optimized_versions").iterdir()), (
+        "the reused attempt's own output_dir must carry a physical copy of "
+        "the artifact, since kernel_optimization.py's invoke_backend() "
+        "clobbers backend_paths['output_dir'] to point here regardless of "
+        "what submit() returned"
+    )
+    combine_attempt = {
+        "attempt_id": "forge-e2e-combine",
+        "backend": "forge",
+        "status": "completed",
+        "backend_paths": {
+            # Mirrors invoke_backend()'s real behavior: output_dir is always
+            # reset to *this* attempt's own directory, while cli_workspace
+            # is copied through verbatim from whatever submit() returned
+            # (the winner's, for a reused result).
+            "output_dir": str(combine_output_dir),
+            "cli_workspace": combine_result["cli_workspace"],
+        },
+        "optimized_path": str(combine_output_dir / "forge-e2e-combine_stdout.log"),
+        "mean_case_speedup": combine_result["mean_case_speedup"],
+        "total_improved": combine_result["total_improved"],
+        "incremental_improved": combine_result["incremental_improved"],
+        "improved": combine_result["improved"],
+        "pristine_baseline_ms": None,
+        "best_ms": combine_result["best_ms"],
+    }
+    combine_args = argparse.Namespace(
+        source_file=str(
+            tmp_path / "forge" / "session1" / "attempt_dispatch" / "worktree" / "mori_ep_config.py"
+        ),
+        kernel_repo="",
+        correctness_passed=True,
+        accuracy_passed=None,
+        micro_speedup=None,
+        e2e_gain_pct=None,
+        dry_run=False,
+    )
+    combine_verification = ko.build_verification(
+        combine_args, [combine_attempt], benchmark_available=False
+    )
+    assert combine_verification["artifact_valid"] is True, combine_verification["artifact_error"]
+    combine_proposal = ko.make_proposal(combine_verification)
+    assert combine_proposal["decision"] == "KEEP", combine_proposal["reasons"]
+
 
 def test_submit_vendor_playbook_reports_missing_forge_path(monkeypatch, tmp_path):
     monkeypatch.delenv("FORGE_PATH", raising=False)
@@ -449,6 +503,83 @@ def test_submit_vendor_playbook_reports_missing_forge_path(monkeypatch, tmp_path
     assert result["skipped"] is True
     assert result["returncode"] == 2
     assert "FORGE_PATH" in result["stderr_tail"]
+
+
+def test_submit_vendor_playbook_writes_result_when_bundle_copy_raises(monkeypatch, tmp_path):
+    """A raised exception after claiming must not orphan claimed.lock.
+
+    Regression: the claimed section used to have no blanket exception
+    handling -- only a couple of specific call sites (e.g.
+    _copy_vendor_task_bundle's OSError) were caught. Anything else raised
+    after the claim (a bad env lookup, an unexpected failure resolving the
+    branch/gpu target, etc.) propagated straight out of submit() with
+    claimed.lock left on disk and no result.json ever written -- every
+    subsequent submission for that group (siblings this session, or a
+    retry) would then wait the full poll deadline and still find nothing,
+    forever. This raises from _new_forge_branch, a call site with no
+    dedicated try/except of its own, specifically to exercise the
+    catch-all wrapper in _submit_vendor_playbook rather than one of the
+    pre-existing specific except clauses.
+    """
+    forge_path = tmp_path / "KernelForge"
+    _write_fake_mori_bundle(forge_path)
+    monkeypatch.setenv("FORGE_PATH", str(forge_path))
+    monkeypatch.setattr(forge_submit, "_ensure_forge_on_path", lambda: "")
+    monkeypatch.setattr(forge_submit, "_resolve_gpu_target", lambda _candidate: "gfx942")
+
+    def _boom(_output_dir, _source_file):
+        raise RuntimeError("simulated unexpected failure resolving the forge branch")
+
+    monkeypatch.setattr(forge_submit, "_new_forge_branch", _boom)
+
+    playbook = match_vendor_operator_playbook(_mori_dispatch_candidate())
+    candidate = _mori_dispatch_candidate(
+        patch_strategy="vendor_playbook",
+        vendor_operator_playbook=playbook,
+        vendor_playbook_role="dispatch",
+    )
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("# fallback prompt\n", encoding="utf-8")
+    output_dir = tmp_path / "forge" / "session3" / "attempt_dispatch"
+
+    result = forge_submit.submit(
+        source_file=_MORI_SITE_PACKAGES_FILE,
+        prompt_file=prompt_file,
+        output_dir=output_dir,
+        candidate=candidate,
+        timeout_s=3600,
+    )
+
+    # submit() must return a graceful failure, never raise.
+    assert result["skipped"] is True
+    assert result["returncode"] == 2
+    assert "simulated unexpected failure" in result["stderr_tail"]
+
+    lock_dir = forge_submit._vendor_playbook_lock_dir(output_dir, "mori_ep_dispatch_combine")
+    assert (lock_dir / "claimed.lock").is_file()
+    # The critical assertion: a result.json MUST exist, or the lock is
+    # orphaned and no sibling/retry for this group can ever proceed again.
+    assert (lock_dir / "result.json").is_file()
+    cached = forge_submit._read_vendor_playbook_cached_result(lock_dir)
+    assert cached is not None
+    assert cached["skipped"] is True
+
+    # A sibling (e.g. combine) submitted right after must get the cached
+    # failure back immediately, not hang until the wait deadline.
+    combine_candidate = _mori_combine_candidate(
+        patch_strategy="vendor_playbook",
+        vendor_operator_playbook=dict(playbook, role="combine"),
+        vendor_playbook_role="combine",
+    )
+    combine_result = forge_submit.submit(
+        source_file=_MORI_SITE_PACKAGES_FILE,
+        prompt_file=prompt_file,
+        output_dir=tmp_path / "forge" / "session3" / "attempt_combine",
+        candidate=combine_candidate,
+        timeout_s=3600,
+    )
+    assert combine_result["vendor_playbook_reused"] is True
+    assert combine_result["skipped"] is True
 
 
 def test_registry_json_is_valid_and_ships_in_package_data():

--- a/src/hyperloom/agents/kernel/tests/test_vendor_operator_playbook_mori.py
+++ b/src/hyperloom/agents/kernel/tests/test_vendor_operator_playbook_mori.py
@@ -158,12 +158,82 @@ def test_match_vendor_operator_playbook_ignores_unrelated_kernels():
     assert match_vendor_operator_playbook(mori_other) is None
 
 
+def test_match_vendor_operator_playbook_matches_via_trace_launcher_file_when_graph_captured():
+    """A CUDA/HIP-graph-captured launch is reconstructed by TraceLens as a
+    "Synthetic Op" (e.g. ``vllm::moe_forward_shared->EpDispatchIntraNodeKernel_bf16
+    (Synthetic Op)`` or ``hipGraphLaunch->EpCombineIntraNodeKernel_bf16_nop2p
+    (Synthetic Op)``) with no surviving module chain, so ``library``,
+    ``source_file``, and ``kernel_repo`` all resolve empty -- this is the
+    actual shape produced end to end for a real DeepSeek-V2 EP+DP vLLM
+    serving trace, not a hypothetical. The only field that still carries the
+    mori identity marker is ``trace_launcher_file``, the Python frame that
+    first launched the op (``.../site-packages/mori/jit/hip_driver.py``).
+    """
+    dispatch_candidate = {
+        "name": "vllm::moe_forward_shared->EpDispatchIntraNodeKernel_bf16 (Synthetic Op)",
+        "device_kernel_name": "EpDispatchIntraNodeKernel_bf16",
+        "operation": "",
+        "library": "",
+        "source_file": "",
+        "kernel_repo": "",
+        "trace_launcher_file": "/usr/local/lib/python3.12/dist-packages/mori/jit/hip_driver.py",
+    }
+    combine_candidate = {
+        "name": "hipGraphLaunch->EpCombineIntraNodeKernel_bf16_nop2p (Synthetic Op)",
+        "device_kernel_name": "EpCombineIntraNodeKernel_bf16_nop2p",
+        "operation": "",
+        "library": "",
+        "source_file": "",
+        "kernel_repo": "",
+        "trace_launcher_file": "/usr/local/lib/python3.12/dist-packages/mori/jit/hip_driver.py",
+    }
+
+    dispatch_match = match_vendor_operator_playbook(dispatch_candidate)
+    combine_match = match_vendor_operator_playbook(combine_candidate)
+
+    assert dispatch_match is not None
+    assert dispatch_match["id"] == "mori_ep_dispatch_combine"
+    assert dispatch_match["role"] == "dispatch"
+    assert combine_match is not None
+    assert combine_match["id"] == "mori_ep_dispatch_combine"
+    assert combine_match["role"] == "combine"
+
+
 # --- 2. classify_patchability + _finalize_candidates -------------------------
 
 
 def test_classify_patchability_routes_mori_dispatch_and_combine():
     dispatch_ok, dispatch_reason = tla.classify_patchability(_mori_dispatch_candidate())
     combine_ok, combine_reason = tla.classify_patchability(_mori_combine_candidate())
+
+    assert (dispatch_ok, dispatch_reason) == (True, "")
+    assert (combine_ok, combine_reason) == (True, "")
+
+
+def test_classify_patchability_routes_graph_captured_mori_synthetic_ops():
+    """Same as ``test_classify_patchability_routes_mori_dispatch_and_combine``
+    but for the real, graph-captured candidate shape (empty library/
+    source_file/kernel_repo, mori identity only in ``trace_launcher_file``)
+    -- without the ``_candidate_haystack`` fix this fell through to
+    ``"source file not resolved"`` instead of routing to the playbook.
+    """
+    dispatch_candidate = {
+        "name": "vllm::moe_forward_shared->EpDispatchIntraNodeKernel_bf16 (Synthetic Op)",
+        "library": "",
+        "source_file": "",
+        "kernel_repo": "",
+        "trace_launcher_file": "/usr/local/lib/python3.12/dist-packages/mori/jit/hip_driver.py",
+    }
+    combine_candidate = {
+        "name": "hipGraphLaunch->EpCombineIntraNodeKernel_bf16_nop2p (Synthetic Op)",
+        "library": "",
+        "source_file": "",
+        "kernel_repo": "",
+        "trace_launcher_file": "/usr/local/lib/python3.12/dist-packages/mori/jit/hip_driver.py",
+    }
+
+    dispatch_ok, dispatch_reason = tla.classify_patchability(dispatch_candidate)
+    combine_ok, combine_reason = tla.classify_patchability(combine_candidate)
 
     assert (dispatch_ok, dispatch_reason) == (True, "")
     assert (combine_ok, combine_reason) == (True, "")

--- a/src/hyperloom/agents/kernel/tests/test_vendor_operator_playbook_mori.py
+++ b/src/hyperloom/agents/kernel/tests/test_vendor_operator_playbook_mori.py
@@ -32,7 +32,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -49,7 +51,9 @@ import forge_submit  # noqa: E402
 import kernel_optimization as ko  # noqa: E402
 from _vendor_operator_playbooks import (  # noqa: E402
     match_vendor_operator_playbook,
+    resolve_kernel_anchor_path,
     _reset_vendor_operator_playbooks_cache,
+    _role_haystack,
 )
 
 _MORI_SITE_PACKAGES_FILE = "/opt/venv/lib/python3.12/site-packages/mori/ops/dispatch_combine.py"
@@ -109,6 +113,37 @@ def test_match_vendor_operator_playbook_matches_mori_dispatch_and_combine():
     assert combine_match["role"] == "combine"
 
 
+def test_role_haystack_takes_trailing_segment_of_fully_qualified_operation():
+    """A fully-qualified ``operation`` must not reintroduce the dispatch/
+    combine ambiguity _last_symbol_segment() exists to resolve.
+
+    This repo's own convention (_task_group_contract.logical_operator_name,
+    _bypass_report.py's task-group builder) is to set ``operation`` to a
+    fully-qualified ``Class::method`` symbol. ``EpDispatchCombineOp`` itself
+    contains the substring "dispatch", so taking ``operation`` verbatim
+    would make a *combine* candidate whose operation is
+    ``mori::EpDispatchCombineOp::combine`` match "dispatch" first (registry
+    order), mislabeling it (PR #1191 review finding #6).
+    """
+    combine_candidate = {
+        "name": "mori::EpDispatchCombineOp::combine",
+        "operation": "mori::EpDispatchCombineOp::combine",
+        "library": "mori",
+    }
+    assert _role_haystack(combine_candidate) == "combine"
+
+    dispatch_candidate = {
+        "name": "mori::EpDispatchCombineOp::dispatch",
+        "operation": "mori::EpDispatchCombineOp::dispatch",
+        "library": "mori",
+    }
+    assert _role_haystack(dispatch_candidate) == "dispatch"
+
+    combine_match = match_vendor_operator_playbook(combine_candidate)
+    assert combine_match is not None
+    assert combine_match["role"] == "combine"
+
+
 def test_match_vendor_operator_playbook_ignores_unrelated_kernels():
     gemm_candidate = {
         "name": "aiter::gemm_a8w8",
@@ -163,9 +198,13 @@ def test_finalize_candidates_stamps_vendor_playbook_and_sums_gpu_pct():
 
     assert dispatch["vendor_playbook_role"] == "dispatch"
     assert combine["vendor_playbook_role"] == "combine"
-    assert dispatch["aggregate_gpu_pct"] == pytest.approx(combine["aggregate_gpu_pct"])
-    assert dispatch["aggregate_gpu_pct"] == pytest.approx(dispatch["gpu_pct"] + combine["gpu_pct"])
-    assert dispatch["aggregate_gpu_pct"] == pytest.approx(90.909, abs=0.01)
+    assert dispatch["vendor_playbook_aggregate_gpu_pct"] == pytest.approx(
+        combine["vendor_playbook_aggregate_gpu_pct"]
+    )
+    assert dispatch["vendor_playbook_aggregate_gpu_pct"] == pytest.approx(
+        dispatch["gpu_pct"] + combine["gpu_pct"]
+    )
+    assert dispatch["vendor_playbook_aggregate_gpu_pct"] == pytest.approx(90.909, abs=0.01)
     assert sorted(dispatch["vendor_playbook_group_kernel_ids"]) == sorted(
         [dispatch["kernel_id"], combine["kernel_id"]]
     )
@@ -173,7 +212,7 @@ def test_finalize_candidates_stamps_vendor_playbook_and_sums_gpu_pct():
     # An unrelated candidate must be untouched by the vendor-playbook pass.
     assert "patch_strategy" not in other
     assert "vendor_operator_playbook" not in other
-    assert "aggregate_gpu_pct" not in other
+    assert "vendor_playbook_aggregate_gpu_pct" not in other
 
 
 def test_finalize_candidates_fills_source_file_for_real_vendor_binary_shape():
@@ -423,6 +462,15 @@ def test_submit_vendor_playbook_dedupes_dispatch_and_combine_into_one_session(mo
     assert combine_result["best_ms"] == dispatch_result["best_ms"]
     assert combine_result["vendor_playbook_role"] == "combine"
     assert dispatch_result["vendor_playbook_role"] == "dispatch"
+    # --- regression: one measurement must not be counted twice downstream ---
+    # dispatch and combine are two separate kernel_ids that each produce a
+    # full result dict carrying the identical mean_case_speedup/best_ms from
+    # the one shared forge-loop session; only the role that actually ran it
+    # may be marked as independently counted, or a benefit collector summing
+    # across kernel_ids would double-count one real 1.25x measurement as two
+    # (PR #1191 review finding #4).
+    assert dispatch_result["vendor_playbook_independently_counted"] is True
+    assert combine_result["vendor_playbook_independently_counted"] is False
     # A second forge worktree/workspace copy is never made for the reused role.
     assert not (tmp_path / "forge" / "session1" / "attempt_combine" / "worktree").exists()
 
@@ -580,6 +628,187 @@ def test_submit_vendor_playbook_writes_result_when_bundle_copy_raises(monkeypatc
     )
     assert combine_result["vendor_playbook_reused"] is True
     assert combine_result["skipped"] is True
+
+
+def test_resolve_kernel_anchor_path_is_always_absolute(monkeypatch):
+    """A relative ``source_file`` stand-in is later reinterpreted by
+    ``Path(...).resolve()`` against whatever the apply-stage process's CWD
+    happens to be, not against the KernelForge bundle it was meant to name
+    -- resolve_kernel_anchor_path() must never return a bare relative string,
+    with or without FORGE_PATH set (PR #1191 review finding #8).
+    """
+    playbook = match_vendor_operator_playbook(_mori_dispatch_candidate())
+    assert playbook is not None
+
+    monkeypatch.delenv("FORGE_PATH", raising=False)
+    anchor_no_forge_path = resolve_kernel_anchor_path(playbook)
+    assert anchor_no_forge_path
+    assert Path(anchor_no_forge_path).is_absolute()
+
+    monkeypatch.setenv("FORGE_PATH", "/some/checkout/of/KernelForge")
+    anchor_with_forge_path = resolve_kernel_anchor_path(playbook)
+    assert anchor_with_forge_path
+    assert Path(anchor_with_forge_path).is_absolute()
+    assert anchor_with_forge_path.startswith("/some/checkout/of/KernelForge")
+
+
+def test_submit_vendor_playbook_writes_optimization_report_with_correctness_pass(
+    monkeypatch, tmp_path
+):
+    """The vendor-playbook path reuses one forge-loop run but used to never
+    write ``optimization_report.md``, so ``kernel_optimization.py``'s
+    correctness extraction (which scans ``cli_workspace``/
+    ``optimization_report.md`` for a "[correctness] pass" marker) never
+    found a signal and ``make_proposal()`` could never return KEEP even when
+    SNR validation had already passed inside forge-loop (PR #1191 review
+    finding #5).
+    """
+    forge_path = tmp_path / "KernelForge"
+    _write_fake_mori_bundle(forge_path)
+    monkeypatch.setenv("FORGE_PATH", str(forge_path))
+    monkeypatch.setattr(forge_submit, "_ensure_forge_on_path", lambda: "")
+    monkeypatch.setattr(forge_submit, "_resolve_gpu_target", lambda _candidate: "gfx942")
+    _stub_run_loop(monkeypatch, [])
+
+    playbook = match_vendor_operator_playbook(_mori_dispatch_candidate())
+    candidate = _mori_dispatch_candidate(
+        patch_strategy="vendor_playbook",
+        vendor_operator_playbook=playbook,
+        vendor_playbook_role="dispatch",
+    )
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("# fallback prompt\n", encoding="utf-8")
+    output_dir = tmp_path / "forge" / "session_report" / "attempt_dispatch"
+
+    result = forge_submit.submit(
+        source_file=_MORI_SITE_PACKAGES_FILE,
+        prompt_file=prompt_file,
+        output_dir=output_dir,
+        candidate=candidate,
+        timeout_s=3600,
+    )
+
+    assert result["vendor_playbook_independently_counted"] is True
+    assert result["cli_workspace"] == str(output_dir)
+    report_path = output_dir / "optimization_report.md"
+    assert report_path.is_file(), "vendor-playbook path must write optimization_report.md"
+    report_text = report_path.read_text(encoding="utf-8")
+    assert "[correctness] pass" in report_text
+
+
+def test_submit_vendor_playbook_stale_failure_cache_allows_retry(monkeypatch, tmp_path):
+    """A cached FAILURE only de-dupes submissions within
+    ``_VENDOR_PLAYBOOK_FAILURE_CACHE_TTL_S``; once it ages out, a fresh
+    submission must actually retry instead of one transient failure
+    (FORGE_PATH momentarily unset, here) permanently wedging the whole
+    playbook group for the rest of the session (PR #1191 review finding #2).
+    """
+    monkeypatch.delenv("FORGE_PATH", raising=False)
+    playbook = match_vendor_operator_playbook(_mori_dispatch_candidate())
+    candidate = _mori_dispatch_candidate(
+        patch_strategy="vendor_playbook",
+        vendor_operator_playbook=playbook,
+        vendor_playbook_role="dispatch",
+    )
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("# fallback prompt\n", encoding="utf-8")
+    output_dir = tmp_path / "forge" / "session_ttl" / "attempt_dispatch"
+
+    first = forge_submit.submit(
+        source_file=_MORI_SITE_PACKAGES_FILE,
+        prompt_file=prompt_file,
+        output_dir=output_dir,
+        candidate=candidate,
+        timeout_s=3600,
+    )
+    assert first["skipped"] is True  # FORGE_PATH unset -> a real failure
+
+    lock_dir = forge_submit._vendor_playbook_lock_dir(output_dir, "mori_ep_dispatch_combine")
+    result_path = lock_dir / "result.json"
+    assert result_path.is_file()
+
+    # Immediately retrying (still within the TTL window) must reuse the
+    # cached failure rather than re-running -- this is the intended
+    # short-window dedup for a genuinely concurrent dispatch+combine pair.
+    second = forge_submit.submit(
+        source_file=_MORI_SITE_PACKAGES_FILE,
+        prompt_file=prompt_file,
+        output_dir=tmp_path / "forge" / "session_ttl" / "attempt_dispatch_retry_fresh",
+        candidate=candidate,
+        timeout_s=3600,
+    )
+    assert second["vendor_playbook_reused"] is True
+
+    # Age the cached failure past the TTL by rewinding result.json's mtime
+    # (simulates enough wall-clock time passing within the same session).
+    stale_mtime = time.time() - forge_submit._VENDOR_PLAYBOOK_FAILURE_CACHE_TTL_S - 1.0
+    os.utime(result_path, (stale_mtime, stale_mtime))
+
+    forge_path = tmp_path / "KernelForge"
+    _write_fake_mori_bundle(forge_path)
+    monkeypatch.setenv("FORGE_PATH", str(forge_path))
+    monkeypatch.setattr(forge_submit, "_ensure_forge_on_path", lambda: "")
+    monkeypatch.setattr(forge_submit, "_resolve_gpu_target", lambda _candidate: "gfx942")
+    captured: list[dict] = []
+    _stub_run_loop(monkeypatch, captured)
+
+    third = forge_submit.submit(
+        source_file=_MORI_SITE_PACKAGES_FILE,
+        prompt_file=prompt_file,
+        output_dir=tmp_path / "forge" / "session_ttl" / "attempt_dispatch_retry_stale",
+        candidate=candidate,
+        timeout_s=3600,
+    )
+    assert third["vendor_playbook_reused"] is False, "a stale failure must not be reused"
+    assert third["skipped"] is False
+    assert len(captured) == 1, "the retry must actually launch forge-loop"
+
+
+def test_claim_vendor_playbook_run_steals_a_claim_orphaned_by_a_dead_process(tmp_path):
+    """A holder killed by SIGKILL/OOM/node-restart never writes
+    ``result.json`` and never releases ``claimed.lock``; every later
+    submission used to poll ``_wait_for_vendor_playbook_result`` all the way
+    to its deadline (``timeout_s`` + 300s) and still find nothing -- for a
+    60-minute-budget attempt, an hour burned per submission. A claim older
+    than its own attempt budget (plus grace) must instead be treated as
+    abandoned and stolen (PR #1191 review finding #3).
+    """
+    lock_dir = tmp_path / "vendor_playbook_locks" / "mori_ep_dispatch_combine"
+    lock_dir.mkdir(parents=True)
+    claim_path = lock_dir / "claimed.lock"
+    timeout_s = 3600
+    dead_pid_claimed_at = (
+        time.time() - timeout_s - forge_submit._VENDOR_PLAYBOOK_CLAIM_STALE_GRACE_S - 1.0
+    )
+    claim_path.write_text(
+        json.dumps({"pid": 999999, "claimed_at": dead_pid_claimed_at, "nonce": "dead"}),
+        encoding="utf-8",
+    )
+
+    assert forge_submit._claim_is_stale(claim_path, timeout_s) is True
+    assert forge_submit._claim_vendor_playbook_run(lock_dir, timeout_s) is True
+
+    stolen = json.loads(claim_path.read_text(encoding="utf-8"))
+    assert stolen["pid"] == os.getpid()
+    assert stolen["nonce"] != "dead"
+
+
+def test_claim_vendor_playbook_run_does_not_steal_a_live_claim(tmp_path):
+    """A claim well within its holder's own budget must not be stolen out
+    from under a genuinely still-running attempt."""
+    lock_dir = tmp_path / "vendor_playbook_locks" / "mori_ep_dispatch_combine"
+    lock_dir.mkdir(parents=True)
+    claim_path = lock_dir / "claimed.lock"
+    timeout_s = 3600
+    claim_path.write_text(
+        json.dumps({"pid": 123, "claimed_at": time.time() - 5.0, "nonce": "alive"}),
+        encoding="utf-8",
+    )
+
+    assert forge_submit._claim_is_stale(claim_path, timeout_s) is False
+    assert forge_submit._claim_vendor_playbook_run(lock_dir, timeout_s) is False
+    # The live claim must be left untouched.
+    assert json.loads(claim_path.read_text(encoding="utf-8"))["nonce"] == "alive"
 
 
 def test_registry_json_is_valid_and_ships_in_package_data():

--- a/src/hyperloom/agents/kernel/tools/_vendor_operator_playbooks.py
+++ b/src/hyperloom/agents/kernel/tools/_vendor_operator_playbooks.py
@@ -88,15 +88,22 @@ def _last_symbol_segment(value: str) -> str:
 def _role_haystack(candidate: dict[str, Any]) -> str:
     """Return the field(s) a playbook's ``name_any`` (op-role pattern) should match.
 
-    Prefers ``operation`` (already the specific call, e.g. ``"combine"``) over
-    ``name`` (which may be a fully-qualified ``Class::method`` symbol whose
-    class name can itself contain another role's marker); when only ``name``
-    is available, matches its trailing symbol segment rather than the whole
-    qualified string.
+    Prefers ``operation`` (often already the specific call, e.g.
+    ``"combine"``) over ``name`` (which may be a fully-qualified
+    ``Class::method`` symbol whose class name can itself contain another
+    role's marker); either way, only the trailing symbol segment is
+    matched, never the whole qualified string. This repo's own convention
+    (``_task_group_contract.logical_operator_name()``,
+    ``_bypass_report.py``'s task-group builder) is to set ``operation`` to
+    the fully-qualified name too, e.g. ``mori::EpDispatchCombineOp::combine``
+    -- taking ``operation`` verbatim would silently reintroduce the exact
+    dispatch/combine ambiguity this function exists to resolve the moment
+    some producer starts populating that field on a candidate row (PR #1191
+    review finding #6).
     """
     operation = str(candidate.get("operation") or "").strip()
     if operation:
-        return operation.lower()
+        return _last_symbol_segment(operation).lower()
     return _last_symbol_segment(str(candidate.get("name") or "")).lower()
 
 
@@ -155,18 +162,24 @@ def resolve_kernel_anchor_path(playbook: dict[str, Any]) -> str:
     still gates on a non-empty, path-shaped ``source_file`` before it will
     dispatch to a backend at all. Point that field at the task bundle's
     ``kernel_anchor`` file instead of leaving it empty -- resolved to an
-    absolute path under ``$FORGE_PATH`` when that's set and the file exists
-    on this host, else the bare bundle-relative path (still path-shaped, so
-    it survives ``looks_like_source_path`` even when this analysis runs on a
-    host without the KernelForge checkout).
+    absolute path under ``$FORGE_PATH`` when that's set (regardless of
+    whether the file exists on this host yet), else an absolute path under a
+    fixed, obviously-synthetic root so the value is still path-shaped (it
+    survives ``looks_like_source_path`` even when this analysis runs on a
+    host without the KernelForge checkout) without ever being a bare
+    relative string a later ``Path(...).resolve()`` could reinterpret
+    against an unrelated CWD.
 
     Args:
         playbook: A matched playbook entry (as returned by
             ``match_vendor_operator_playbook``).
 
     Returns:
-        An absolute or bundle-relative path string; never empty as long as
-        the playbook declares a ``kernel_anchor``.
+        An absolute path string; never empty as long as the playbook
+        declares a ``kernel_anchor``, and never relative -- a relative
+        string here would later be reinterpreted by ``Path(...).resolve()``
+        against whatever the apply-stage process's CWD happens to be, not
+        against this bundle (PR #1191 review finding #8).
     """
     anchor = str(playbook.get("kernel_anchor") or "").strip()
     bundle = str(playbook.get("task_bundle") or "").strip()
@@ -174,8 +187,15 @@ def resolve_kernel_anchor_path(playbook: dict[str, Any]) -> str:
         return ""
     relative = f"{bundle}/{anchor}" if bundle else anchor
     forge_root = (os.environ.get("FORGE_PATH") or "").strip()
-    if forge_root and bundle:
-        candidate = Path(forge_root) / bundle / anchor
-        if candidate.is_file():
-            return str(candidate)
-    return relative
+    if forge_root:
+        candidate = Path(forge_root) / relative
+        # Returned even when the file isn't there yet: this analysis host
+        # may lack the KernelForge checkout the apply stage will actually
+        # run against, but the path must still be absolute and anchored at
+        # a real, known root rather than silently falling through to a
+        # bare relative string.
+        return str(candidate)
+    # FORGE_PATH unset: still shape-check as path-like (needed to clear
+    # looks_like_source_path) without letting a bare relative string survive
+    # to be misresolved against an unrelated CWD later in the pipeline.
+    return str(Path("/nonexistent-forge-path") / relative)

--- a/src/hyperloom/agents/kernel/tools/_vendor_operator_playbooks.py
+++ b/src/hyperloom/agents/kernel/tools/_vendor_operator_playbooks.py
@@ -1,0 +1,181 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Vendor-operator-playbook registry: route a closed-source hot kernel to a
+validated KernelForge *task bundle* instead of a source rewrite.
+
+Most of the forge-submission pipeline assumes a hot kernel has an editable
+device source file (``kernel_url`` -> in-place rewrite). Some vendor
+operators -- mori's EP dispatch/combine all-to-all is the first case -- are
+pip-installed compiled libraries with no such source, but do have a small,
+named set of launch-config knobs that a KernelForge forge-loop task bundle
+has already been validated to tune (see KernelForge PR #88's "Making this
+real" section for the design rationale this module implements).
+
+This is deliberately a narrow, explicit carve-out (one JSON registry, sibling
+to the retired ``op_to_source.json``) rather than a general "config-tuning"
+system: a candidate only gets vendor-playbook treatment when it matches a
+registry entry by name.
+"""
+
+from __future__ import annotations
+
+import copy
+import functools
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+_REGISTRY_PATH = Path(__file__).resolve().parent / "vendor_operator_playbooks.json"
+
+
+@functools.lru_cache(maxsize=1)
+def load_vendor_operator_playbooks() -> tuple[dict[str, Any], ...]:
+    """Load and cache the vendor-operator-playbook registry.
+
+    Returns:
+        A tuple of playbook entry dicts (empty when the registry file is
+        missing or malformed -- a missing registry must never be fatal to
+        the rest of the classification pipeline).
+    """
+    try:
+        raw = json.loads(_REGISTRY_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return ()
+    playbooks = raw.get("playbooks") if isinstance(raw, dict) else None
+    if not isinstance(playbooks, list):
+        return ()
+    return tuple(entry for entry in playbooks if isinstance(entry, dict) and entry.get("id"))
+
+
+def _reset_vendor_operator_playbooks_cache() -> None:
+    """Clear the cached registry (tests only, e.g. after monkeypatching the path)."""
+    load_vendor_operator_playbooks.cache_clear()
+
+
+def _candidate_haystack(candidate: dict[str, Any]) -> str:
+    """Join every text field a playbook's ``any_marker`` may match against."""
+    fields = (
+        candidate.get("name"),
+        candidate.get("operation"),
+        candidate.get("library"),
+        candidate.get("source_file"),
+        candidate.get("kernel_repo"),
+    )
+    return " ".join(str(f or "") for f in fields).lower()
+
+
+def _last_symbol_segment(value: str) -> str:
+    """Return the trailing method/function segment of a qualified symbol.
+
+    ``mori::EpDispatchCombineOp::combine`` -> ``combine``; a plain name with
+    no separator is returned unchanged. Needed because a class name like
+    ``EpDispatchCombineOp`` itself contains the substring "dispatch", so
+    matching a role marker against the *whole* qualified name is ambiguous --
+    only the actual called method disambiguates dispatch vs combine.
+    """
+    tail = value
+    for sep in ("::", ".", "/"):
+        tail = tail.rsplit(sep, 1)[-1]
+    return tail
+
+
+def _role_haystack(candidate: dict[str, Any]) -> str:
+    """Return the field(s) a playbook's ``name_any`` (op-role pattern) should match.
+
+    Prefers ``operation`` (already the specific call, e.g. ``"combine"``) over
+    ``name`` (which may be a fully-qualified ``Class::method`` symbol whose
+    class name can itself contain another role's marker); when only ``name``
+    is available, matches its trailing symbol segment rather than the whole
+    qualified string.
+    """
+    operation = str(candidate.get("operation") or "").strip()
+    if operation:
+        return operation.lower()
+    return _last_symbol_segment(str(candidate.get("name") or "")).lower()
+
+
+def match_vendor_operator_playbook(candidate: dict[str, Any]) -> dict[str, Any] | None:
+    """Return a matched playbook entry for ``candidate``, or ``None``.
+
+    A candidate matches a playbook when at least one of the playbook's
+    ``any_marker`` strings appears somewhere in the candidate's identifying
+    fields (name/operation/library/source_file/kernel_repo) AND at least one
+    of its ``name_any`` strings appears in the candidate's name/operation --
+    e.g. mori's playbook requires both "mori" (library/source evidence) and
+    "dispatch" or "combine" (which op within mori this is).
+
+    Args:
+        candidate: The hot-kernel candidate dict (as built by
+            ``tracelens_analysis``).
+
+    Returns:
+        A deep copy of the matched registry entry, augmented with a
+        ``"role"`` key set to whichever ``name_any`` marker matched (e.g.
+        ``"dispatch"`` or ``"combine"``), or ``None`` when nothing matches.
+    """
+    if not isinstance(candidate, dict):
+        return None
+    haystack = _candidate_haystack(candidate)
+    role_haystack = _role_haystack(candidate)
+    if not haystack or not role_haystack:
+        return None
+    for playbook in load_vendor_operator_playbooks():
+        match = playbook.get("match")
+        if not isinstance(match, dict):
+            continue
+        any_markers = [str(m).lower() for m in (match.get("any_marker") or [])]
+        if any_markers and not any(marker in haystack for marker in any_markers):
+            continue
+        name_markers = [str(m).lower() for m in (match.get("name_any") or [])]
+        matched_role = next((m for m in name_markers if m in role_haystack), None)
+        if name_markers and matched_role is None:
+            continue
+        result = copy.deepcopy(playbook)
+        result["role"] = matched_role or ""
+        return result
+    return None
+
+
+def playbook_group_id(playbook: dict[str, Any]) -> str:
+    """Return the stable group id a playbook's sibling roles share."""
+    return str(playbook.get("id") or "")
+
+
+def resolve_kernel_anchor_path(playbook: dict[str, Any]) -> str:
+    """Return a stand-in ``source_file`` path for a vendor-playbook candidate.
+
+    A vendor-playbook candidate has no rewritable device source, but
+    downstream tooling (``kernel_optimization.py``'s CLI, in particular)
+    still gates on a non-empty, path-shaped ``source_file`` before it will
+    dispatch to a backend at all. Point that field at the task bundle's
+    ``kernel_anchor`` file instead of leaving it empty -- resolved to an
+    absolute path under ``$FORGE_PATH`` when that's set and the file exists
+    on this host, else the bare bundle-relative path (still path-shaped, so
+    it survives ``looks_like_source_path`` even when this analysis runs on a
+    host without the KernelForge checkout).
+
+    Args:
+        playbook: A matched playbook entry (as returned by
+            ``match_vendor_operator_playbook``).
+
+    Returns:
+        An absolute or bundle-relative path string; never empty as long as
+        the playbook declares a ``kernel_anchor``.
+    """
+    anchor = str(playbook.get("kernel_anchor") or "").strip()
+    bundle = str(playbook.get("task_bundle") or "").strip()
+    if not anchor:
+        return ""
+    relative = f"{bundle}/{anchor}" if bundle else anchor
+    forge_root = (os.environ.get("FORGE_PATH") or "").strip()
+    if forge_root and bundle:
+        candidate = Path(forge_root) / bundle / anchor
+        if candidate.is_file():
+            return str(candidate)
+    return relative

--- a/src/hyperloom/agents/kernel/tools/_vendor_operator_playbooks.py
+++ b/src/hyperloom/agents/kernel/tools/_vendor_operator_playbooks.py
@@ -59,13 +59,25 @@ def _reset_vendor_operator_playbooks_cache() -> None:
 
 
 def _candidate_haystack(candidate: dict[str, Any]) -> str:
-    """Join every text field a playbook's ``any_marker`` may match against."""
+    """Join every text field a playbook's ``any_marker`` may match against.
+
+    Includes ``trace_launcher_file`` alongside the resolved-source fields:
+    for a kernel whose device launch is hidden behind a CUDA/HIP-graph
+    replay (TraceLens reconstructs it as a "Synthetic Op" with no surviving
+    module chain -- mori's EP dispatch/combine hit this in practice), the
+    normal ``library``/``source_file``/``kernel_repo`` trio all resolve
+    empty and the Python call-stack frame that first launched the op (e.g.
+    ``.../site-packages/mori/jit/hip_driver.py``) is the *only* place the
+    vendor identity marker survives. Omitting it silently drops exactly the
+    graph-captured candidates this registry exists to route.
+    """
     fields = (
         candidate.get("name"),
         candidate.get("operation"),
         candidate.get("library"),
         candidate.get("source_file"),
         candidate.get("kernel_repo"),
+        candidate.get("trace_launcher_file"),
     )
     return " ".join(str(f or "") for f in fields).lower()
 

--- a/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
+++ b/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
@@ -3875,6 +3875,13 @@ def _steal_stale_claim(claim_path: Path) -> bool:
         try:
             tmp_path.unlink(missing_ok=True)
         except OSError:
+            # Best-effort scratch-file cleanup only: by now tmp_path has
+            # already been atomically replaced onto claim_path (success) or
+            # never fully written (failure), so nothing downstream depends
+            # on this unlink -- it must never raise out of a claim-stealing
+            # attempt over something as inconsequential as a leftover temp
+            # file (missing_ok=True already covers the common "already
+            # gone" case; this only guards rarer failures like EPERM).
             pass
     return current.get("nonce") == nonce
 

--- a/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
+++ b/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
@@ -37,6 +37,7 @@ from _task_group_contract import (  # noqa: E402
     logical_operator_name,
     task_group_shape_cases,
 )
+from _vendor_operator_playbooks import match_vendor_operator_playbook  # noqa: E402
 
 if _TOOLS_DIR_INSERTED:
     sys.path.remove(_TOOLS_DIR)
@@ -3709,6 +3710,510 @@ def _finalize_forge_workspace(
     )
 
 
+# --- Vendor-operator-playbook route -----------------------------------------
+#
+# A vendor-playbook candidate (mori's EP dispatch/combine is the first case,
+# see _vendor_operator_playbooks.py and KernelForge PR #88) has no rewritable
+# device source: it's a pip-installed compiled library. Instead of the
+# git-worktree / source-rewrite pipeline `submit()` otherwise runs, this copies
+# a validated KernelForge `examples/<task>/` bundle into a scratch workspace
+# and runs forge-loop against that bundle's own driver/config/program.md.
+#
+# mori's dispatch and combine are two separate hot-kernel candidates that
+# share one playbook id and are deliberately invoked as **one** Forge
+# task/session (not two) -- the lock/result files below de-duplicate so a
+# session that dispatches both candidates only launches forge-loop once.
+
+_VENDOR_PLAYBOOK_CLAIM_POLL_S = 5.0
+
+
+def _vendor_playbook_lock_dir(output_dir: Path, group_id: str) -> Path:
+    """Return the session-scoped directory used to de-duplicate a playbook group.
+
+    ``output_dir`` is per-attempt (``.../forge/<session_id>/<prompt_stem>``);
+    the lock lives one level up so every kernel_id in the same analysis
+    session and playbook group shares it.
+    """
+    safe_group = re.sub(r"[^A-Za-z0-9_-]+", "-", group_id).strip("-") or "vendor-playbook"
+    return output_dir.parent / "vendor_playbook_locks" / safe_group
+
+
+def _read_vendor_playbook_cached_result(lock_dir: Path) -> dict | None:
+    result_path = lock_dir / "result.json"
+    try:
+        return json.loads(result_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _write_vendor_playbook_result(lock_dir: Path, result: dict) -> None:
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    tmp_path = lock_dir / f".result.json.{uuid.uuid4().hex[:8]}.tmp"
+    tmp_path.write_text(json.dumps(result, sort_keys=True, default=str), encoding="utf-8")
+    tmp_path.replace(lock_dir / "result.json")
+
+
+def _claim_vendor_playbook_run(lock_dir: Path) -> bool:
+    """Atomically claim the right to run this group's one forge-loop session.
+
+    Returns ``True`` for whichever caller wins the race (dispatch or
+    combine, whichever the orchestrator happened to submit first); the loser
+    waits for the winner's result instead of launching a second session.
+    """
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    claim_path = lock_dir / "claimed.lock"
+    try:
+        fd = os.open(str(claim_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        return False
+    os.close(fd)
+    return True
+
+
+def _wait_for_vendor_playbook_result(lock_dir: Path, deadline_unix: float) -> dict | None:
+    """Poll for the winner's result until it appears or ``deadline_unix`` passes."""
+    while True:
+        cached = _read_vendor_playbook_cached_result(lock_dir)
+        if cached is not None:
+            return cached
+        if time.time() >= deadline_unix:
+            return None
+        time.sleep(min(_VENDOR_PLAYBOOK_CLAIM_POLL_S, max(0.0, deadline_unix - time.time())))
+
+
+def _copy_vendor_task_bundle(task_bundle_root: Path, workspace: Path) -> None:
+    """Copy a KernelForge ``examples/<task>/`` bundle into ``workspace`` and
+    git-init it there.
+
+    forge-loop's IterationLoop runs ``git status``/``git checkout`` against
+    the workspace to snapshot and restore each attempt (see the bundle's own
+    ``run_example.sh``, which does the identical ``git init`` + commit before
+    invoking forge-loop directly); a bare directory of copied files with no
+    ``.git`` fails the very first git call with "not a git repository".
+    """
+    workspace.mkdir(parents=True, exist_ok=True)
+    for item in sorted(task_bundle_root.iterdir()):
+        if item.name in (".git", "__pycache__"):
+            continue
+        dest = workspace / item.name
+        if item.is_dir():
+            shutil.copytree(item, dest, dirs_exist_ok=True)
+        else:
+            shutil.copy2(item, dest)
+    gitignore = workspace / ".gitignore"
+    if not gitignore.is_file():
+        gitignore.write_text(
+            "__pycache__/\n*.pyc\n*.log\nbuild/\nforge_experiments/\n", encoding="utf-8"
+        )
+    _git = shutil.which("git") or "git"
+    subprocess.run([_git, "init", "-q"], cwd=str(workspace), check=True)
+    subprocess.run(
+        [_git, "config", "user.email", "forge-vendor-playbook@local"],
+        cwd=str(workspace),
+        check=True,
+    )
+    subprocess.run(
+        [_git, "config", "user.name", "forge-vendor-playbook"],
+        cwd=str(workspace),
+        check=True,
+    )
+    subprocess.run([_git, "add", "-A"], cwd=str(workspace), check=True)
+    subprocess.run(
+        [_git, "commit", "-q", "-m", "vendor playbook: initial task bundle", "--allow-empty"],
+        cwd=str(workspace),
+        check=True,
+    )
+
+
+def _run_vendor_playbook_loop_via_cli(
+    *,
+    kernel_anchor: str,
+    driver: str,
+    workspace: str,
+    snr_threshold: float,
+    max_iters: int,
+    max_hours: float,
+    branch: str,
+    gpu_target: str,
+    gpu_type: str,
+    fellow: str,
+    program_md_file: str,
+    target_functions: list[str],
+    experiments_dir: Path,
+    forge_log: Path,
+    timeout_s: int,
+    deadline_unix: float,
+    experience_id: str,
+    extra_env: dict[str, str] | None = None,
+) -> ForgeLoopOutcome:
+    """Run forge-loop against a copied vendor-playbook task bundle.
+
+    Mirrors ``_run_loop_via_cli``'s subprocess/result-parsing conventions, but
+    always passes ``--no-profiling --no-prepare-task`` (the bundle already
+    ships a hand-written, validated ``driver.py`` -- forge-loop's own
+    task-preparer/profiler must not try to author or reprofile it) and forwards
+    the playbook's own env requirements (e.g. ``KERNELFORGE_INCLUDE_MORI_KB``).
+    """
+    result_json = experiments_dir.parent / "forge_cli_result.json"
+    checkpoint_json = experiments_dir / f"{_FORGE_EXPERIMENT_ID}.json"
+    for stale_path in (result_json, checkpoint_json):
+        try:
+            stale_path.unlink(missing_ok=True)
+        except OSError as exc:
+            raise RuntimeError(
+                f"could not clear stale Forge recovery artifact {stale_path}: {exc}"
+            ) from exc
+
+    forge_root = _ensure_forge_on_path()
+    env = dict(os.environ)
+    if forge_root:
+        env["PYTHONPATH"] = forge_root + os.pathsep + env.get("PYTHONPATH", "")
+    env["GPU_TARGET"] = gpu_target
+    _apply_gpu_type_env(env, gpu_type)
+    _apply_fellow_env(env)
+    for key, value in (extra_env or {}).items():
+        env[str(key)] = str(value)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "kernel_agents.cli",
+        "forge-loop",
+        "--kernel",
+        kernel_anchor,
+        "--driver",
+        driver,
+        "--workspace",
+        workspace,
+        "--snr-threshold",
+        str(snr_threshold),
+        "--max-iters",
+        str(max_iters),
+        "--max-hours",
+        str(max_hours),
+        "--git-branch",
+        branch,
+        "--gpu-target",
+        gpu_target,
+        "--fellow",
+        fellow,
+        "--experiments-dir",
+        str(experiments_dir),
+        "--experiment-id",
+        _FORGE_EXPERIMENT_ID,
+        "--experience-id",
+        experience_id or experiments_dir.parent.name,
+        "--deadline-unix",
+        str(deadline_unix),
+        "--result-json",
+        str(result_json),
+        "--no-profiling",
+        "--no-prepare-task",
+    ]
+    cmd += ["--gpu-type", _known_gpu_model(gpu_type)]
+    if _openai_only_provider():
+        cmd += ["--agent-backend", "codex", "--agent-fallback-provider", "none"]
+        codex_model = (os.environ.get("CODEX_MODEL") or "").strip()
+        if codex_model:
+            cmd += ["--model", codex_model]
+    if program_md_file and Path(program_md_file).exists():
+        cmd += ["--program-md-file", str(program_md_file)]
+    if target_functions:
+        cmd += ["--target-functions", ",".join(target_functions)]
+
+    loop_exc = None
+    out = ""
+    timed_out = False
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+            cwd=workspace,
+            start_new_session=True,
+        )
+        try:
+            remaining = max(1.0, deadline_unix - time.time())
+            stdout, stderr = proc.communicate(timeout=remaining)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            stdout, stderr = _terminate_forge_process(proc)
+        out = (stdout or "") + "\n" + (stderr or "")
+        if timed_out:
+            loop_exc = RuntimeError(f"forge-loop exceeded absolute deadline after {timeout_s}s")
+        if proc.returncode != 0:
+            if loop_exc is None:
+                loop_exc = RuntimeError(f"forge-loop exited rc={proc.returncode}: {_forge_failure_tail(out)}")
+    except Exception as exc:  # noqa: BLE001
+        loop_exc = exc
+
+    try:
+        with open(forge_log, "a") as f:
+            f.write("\n=== forge-loop vendor-playbook (cli) stdout ===\n")
+            f.write(out)
+            if loop_exc:
+                f.write(f"\n=== forge-loop exception ===\n{loop_exc}\n")
+    except OSError:  # noqa: S110
+        pass
+
+    baseline_ms = best_ms = None
+    pristine_baseline_ms = search_start_ms = None
+    mean_case_speedup = search_start_mean_case_speedup = None
+    improved = improved_during_search = total_improved = incremental_improved = False
+    parsed = None
+    try:
+        if result_json.exists():
+            parsed = json.loads(result_json.read_text())
+    except Exception:
+        parsed = None
+    if parsed is None and "__FORGE_RESULT__" in out:
+        try:
+            parsed = json.loads(out.split("__FORGE_RESULT__")[1])
+        except Exception:
+            parsed = None
+    if parsed:
+        baseline_ms = parsed.get("baseline_ms")
+        best_ms = parsed.get("best_ms")
+        pristine_baseline_ms = parsed.get("pristine_baseline_ms", baseline_ms)
+        search_start_ms = parsed.get("search_start_ms", baseline_ms)
+        (
+            mean_case_speedup,
+            search_start_mean_case_speedup,
+            total_improved,
+            incremental_improved,
+        ) = _observed_mean_case_result_fields(parsed)
+        improved = total_improved
+        improved_during_search = incremental_improved
+        if parsed.get("deadline_expired"):
+            timed_out = True
+            if loop_exc is None:
+                loop_exc = RuntimeError("forge-loop reached its graceful absolute deadline")
+    checkpoint = _read_forge_checkpoint(experiments_dir)
+    return ForgeLoopOutcome(
+        baseline_ms=baseline_ms,
+        best_ms=best_ms,
+        improved=improved,
+        output=out,
+        error=loop_exc,
+        timed_out=timed_out,
+        checkpoint=checkpoint,
+        pristine_baseline_ms=pristine_baseline_ms,
+        search_start_ms=search_start_ms,
+        improved_during_search=improved_during_search,
+        structured_result=parsed if isinstance(parsed, dict) else None,
+        mean_case_speedup=mean_case_speedup,
+        search_start_mean_case_speedup=search_start_mean_case_speedup,
+        total_improved=total_improved,
+        incremental_improved=incremental_improved,
+    )
+
+
+def _submit_vendor_playbook(
+    *,
+    candidate: dict[str, Any],
+    prompt_file: Path,
+    output_dir: Path,
+    timeout_s: int,
+) -> dict:
+    """Run (or reuse) the one forge-loop session for a vendor-playbook group."""
+    started = time.time()
+    playbook = candidate.get("vendor_operator_playbook")
+    if not isinstance(playbook, dict) or not playbook.get("id"):
+        # Defensive re-resolve: a candidate dict round-tripped through JSON by
+        # a caller that dropped nested fields still carries enough identity
+        # (name/library/source_file) to re-match the registry.
+        playbook = match_vendor_operator_playbook(candidate)
+    if not isinstance(playbook, dict) or not playbook.get("id"):
+        return _normalized(
+            2,
+            "",
+            "forge: patch_strategy=vendor_playbook but candidate carries no "
+            "vendor_operator_playbook entry (re-run classify_patchability?)",
+            time.time() - started,
+            skipped=True,
+        )
+
+    group_id = str(playbook.get("id"))
+    role = str(candidate.get("vendor_playbook_role") or playbook.get("role") or "")
+    lock_dir = _vendor_playbook_lock_dir(output_dir, group_id)
+
+    cached = _read_vendor_playbook_cached_result(lock_dir)
+    if cached is not None:
+        result = dict(cached)
+        result["vendor_playbook_reused"] = True
+        result["vendor_playbook_role"] = role
+        return result
+
+    if not _claim_vendor_playbook_run(lock_dir):
+        # A sibling role (e.g. this is "combine" and "dispatch" already
+        # claimed the group) is running the one shared session; wait for it
+        # rather than launching a second forge-loop for the same task.
+        deadline = time.time() + max(60.0, float(timeout_s) + 300.0)
+        cached = _wait_for_vendor_playbook_result(lock_dir, deadline)
+        if cached is not None:
+            result = dict(cached)
+            result["vendor_playbook_reused"] = True
+            result["vendor_playbook_role"] = role
+            return result
+        return _normalized(
+            2,
+            "",
+            f"forge: vendor playbook group {group_id!r} was claimed by a "
+            "concurrent submission but never produced a result before the wait "
+            "deadline",
+            time.time() - started,
+            skipped=True,
+        )
+
+    forge_root = (os.environ.get("FORGE_PATH") or "").strip()
+    if not forge_root:
+        result = _normalized(
+            2,
+            "",
+            "forge: FORGE_PATH is not set; cannot locate the KernelForge "
+            f"examples/ task bundle for vendor playbook {group_id!r}",
+            time.time() - started,
+            skipped=True,
+        )
+        _write_vendor_playbook_result(lock_dir, result)
+        return result
+
+    task_bundle_root = Path(forge_root) / str(playbook.get("task_bundle") or "")
+    if not task_bundle_root.is_dir():
+        result = _normalized(
+            2,
+            "",
+            f"forge: vendor playbook task bundle not found: {task_bundle_root}",
+            time.time() - started,
+            skipped=True,
+        )
+        _write_vendor_playbook_result(lock_dir, result)
+        return result
+
+    workspace = output_dir / "worktree"
+    if workspace.exists() or workspace.is_symlink():
+        result = _normalized(
+            2,
+            "",
+            f"forge: retained vendor playbook workspace already exists: {workspace}",
+            time.time() - started,
+            skipped=True,
+        )
+        _write_vendor_playbook_result(lock_dir, result)
+        return result
+
+    try:
+        _copy_vendor_task_bundle(task_bundle_root, workspace)
+    except OSError as exc:
+        result = _normalized(
+            2,
+            "",
+            f"forge: failed to copy vendor playbook task bundle {task_bundle_root} "
+            f"-> {workspace}: {exc}",
+            time.time() - started,
+            skipped=True,
+        )
+        _write_vendor_playbook_result(lock_dir, result)
+        return result
+
+    kernel_anchor = workspace / str(playbook.get("kernel_anchor") or "")
+    driver = workspace / str(playbook.get("driver") or "driver.py")
+    program_md = workspace / str(playbook.get("program_md") or "program.md")
+    if not program_md.is_file():
+        program_md = Path(prompt_file)
+
+    experiments_dir = output_dir / "forge_experiments"
+    experiments_dir.mkdir(parents=True, exist_ok=True)
+    forge_log = output_dir / "forge_loop.log"
+    branch = _new_forge_branch(output_dir, str(kernel_anchor))
+    gpu_target = _resolve_gpu_target(candidate)
+    gpu_type = _resolve_gpu_type(candidate)
+    max_iters = int(os.environ.get("FORGE_MAX_ITERS", "8"))
+    snr_threshold = float(playbook.get("snr_threshold", 30.0))
+    if timeout_s < _FORGE_MIN_BUDGET_SEC:
+        log.warning(
+            "forge budget %.0f min is below the %d-min minimum forge-loop "
+            "accepts for vendor playbook %r; running with the floored "
+            "--max-hours and hard-killing at the requested budget",
+            timeout_s / 60.0,
+            _FORGE_MIN_BUDGET_SEC // 60,
+            group_id,
+        )
+    deadline_unix = max(time.time() + 1.0, started + timeout_s)
+
+    loop_outcome = _run_vendor_playbook_loop_via_cli(
+        kernel_anchor=str(kernel_anchor),
+        driver=str(driver),
+        workspace=str(workspace),
+        snr_threshold=snr_threshold,
+        max_iters=max_iters,
+        max_hours=max(_FORGE_MIN_BUDGET_SEC / 3600.0, timeout_s / 3600.0),
+        branch=branch,
+        gpu_target=gpu_target,
+        gpu_type=gpu_type,
+        fellow=str(playbook.get("fellow") or "aiter-fellow"),
+        program_md_file=str(program_md),
+        target_functions=[str(f) for f in (playbook.get("target_functions") or [])],
+        experiments_dir=experiments_dir,
+        forge_log=forge_log,
+        timeout_s=timeout_s,
+        deadline_unix=deadline_unix,
+        experience_id=output_dir.name,
+        extra_env={str(k): str(v) for k, v in (playbook.get("env") or {}).items()},
+    )
+    result = _normalized(
+        0 if loop_outcome.error is None else 1,
+        loop_outcome.output or "",
+        "" if loop_outcome.error is None else str(loop_outcome.error),
+        time.time() - started,
+    )
+    # kernel_optimization.py's build_verification() only recognizes a forge
+    # attempt's measured speedup when total_improved/mean_case_speedup are
+    # BOTH present on the result dict it reads (see run_attempt's field
+    # copy); leaving any of these out silently downgrades a real KEEP-worthy
+    # improvement to PARTIAL ("no measurable speedup found"), even though
+    # forge-loop itself committed and validated a faster config.
+    result.update(
+        {
+            "cli_workspace": str(workspace),
+            "forge_workspace": str(workspace),
+            "output_dir": str(output_dir),
+            "improved": bool(loop_outcome.total_improved),
+            "total_improved": bool(loop_outcome.total_improved),
+            "incremental_improved": bool(loop_outcome.incremental_improved),
+            "improved_during_search": bool(loop_outcome.improved_during_search),
+            "mean_case_speedup": loop_outcome.mean_case_speedup,
+            "search_start_mean_case_speedup": loop_outcome.search_start_mean_case_speedup,
+            "best_ms": loop_outcome.best_ms,
+            "baseline_ms": loop_outcome.baseline_ms,
+            "pristine_baseline_ms": loop_outcome.pristine_baseline_ms,
+            "search_start_ms": loop_outcome.search_start_ms,
+            "vendor_playbook_id": group_id,
+            "vendor_playbook_role": role,
+            "vendor_playbook_task_bundle": str(task_bundle_root),
+            "vendor_playbook_reused": False,
+        }
+    )
+    if loop_outcome.total_improved and kernel_anchor.is_file():
+        # There is no separate "deploy" artifact for a vendor launch-config:
+        # the tuned values live in the anchor file forge-loop already
+        # committed in-place in workspace. Materialize a copy under the
+        # attempt's own optimized_versions/ so _select_source_artifact()
+        # (which only looks in that conventional directory) can find it,
+        # exactly like the ordinary per-file-rewrite forge path does.
+        try:
+            opt_dir = output_dir / "optimized_versions"
+            opt_dir.mkdir(parents=True, exist_ok=True)
+            dest = opt_dir / f"{group_id}_{role or 'optimized'}{kernel_anchor.suffix}"
+            shutil.copy2(kernel_anchor, dest)
+        except OSError as exc:
+            log.warning("forge: could not stage vendor playbook artifact copy: %s", exc)
+    _write_vendor_playbook_result(lock_dir, result)
+    return result
+
+
 def submit(
     source_file: str,
     prompt_file: Path,
@@ -3730,14 +4235,28 @@ def submit(
     optimization_report.md under output_dir.
     """
     started = time.time()
+    candidate = candidate or {}
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Vendor-operator-playbook route: a closed-source vendor op (e.g. mori's EP
+    # dispatch/combine) has no rewritable device source to worktree/rewrite --
+    # skip the entire git-worktree / fellow-resolution / rewrite-route pipeline
+    # below and copy the validated KernelForge task bundle instead. See
+    # _vendor_operator_playbooks.py and KernelForge PR #88.
+    if candidate.get("patch_strategy") == "vendor_playbook":
+        return _submit_vendor_playbook(
+            candidate=candidate,
+            prompt_file=Path(prompt_file),
+            output_dir=output_dir,
+            timeout_s=timeout_s,
+        )
+
     from hyperloom.orchestrator.knowledge.kernel_experience_bridge import (
         KernelExperienceBridge,
     )
 
     knowledge_bridge = KernelExperienceBridge(_knowledge_config_for_forge())
-    candidate = candidate or {}
-    output_dir = Path(output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
 
     # Re-derive source_type from the file extension when it's unknown: an aiter
     # .cu/.cuh kernel can arrive as "unknown" and be wrongly skipped. A real

--- a/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
+++ b/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
@@ -3781,6 +3781,46 @@ def _wait_for_vendor_playbook_result(lock_dir: Path, deadline_unix: float) -> di
         time.sleep(min(_VENDOR_PLAYBOOK_CLAIM_POLL_S, max(0.0, deadline_unix - time.time())))
 
 
+def _stage_vendor_playbook_artifact_for_reuse(cached: dict, output_dir: Path) -> None:
+    """Duplicate a reused vendor-playbook result's artifact under ``output_dir``.
+
+    ``kernel_optimization.py``'s ``invoke_backend()`` unconditionally resets
+    ``result["output_dir"]`` to *this* attempt's own directory right after
+    ``submit()`` returns (``result["output_dir"] = str(out_dir)``), and
+    ``_candidate_artifact_paths()`` looks under both ``cli_workspace`` and
+    ``output_dir`` for an ``optimized_versions/`` directory. A cache-hit
+    result's ``cli_workspace``/``output_dir`` fields describe the *winner's*
+    directory (correct at the time they were written to ``result.json``,
+    before that later overwrite mutates the in-memory dict this call
+    returns), so the winner's directory alone would silently stop being
+    reachable for a reused sibling once the caller clobbers ``output_dir``.
+    Physically copying the file(s) here makes the reused result
+    self-contained regardless of that overwrite.
+    """
+    src_opt = None
+    for key in ("cli_workspace", "output_dir"):
+        candidate_dir = cached.get(key)
+        if not candidate_dir:
+            continue
+        probe = Path(candidate_dir) / "optimized_versions"
+        if probe.is_dir():
+            src_opt = probe
+            break
+    if src_opt is None:
+        return
+    dest_opt = output_dir / "optimized_versions"
+    try:
+        dest_opt.mkdir(parents=True, exist_ok=True)
+        for item in src_opt.iterdir():
+            if not item.is_file():
+                continue
+            dest = dest_opt / item.name
+            if not dest.exists():
+                shutil.copy2(item, dest)
+    except OSError as exc:
+        log.warning("forge: could not stage reused vendor playbook artifact copy: %s", exc)
+
+
 def _copy_vendor_task_bundle(task_bundle_root: Path, workspace: Path) -> None:
     """Copy a KernelForge ``examples/<task>/`` bundle into ``workspace`` and
     git-init it there.
@@ -4010,63 +4050,27 @@ def _run_vendor_playbook_loop_via_cli(
     )
 
 
-def _submit_vendor_playbook(
+def _run_claimed_vendor_playbook(
     *,
     candidate: dict[str, Any],
     prompt_file: Path,
     output_dir: Path,
     timeout_s: int,
+    playbook: dict[str, Any],
+    group_id: str,
+    role: str,
+    lock_dir: Path,
+    started: float,
 ) -> dict:
-    """Run (or reuse) the one forge-loop session for a vendor-playbook group."""
-    started = time.time()
-    playbook = candidate.get("vendor_operator_playbook")
-    if not isinstance(playbook, dict) or not playbook.get("id"):
-        # Defensive re-resolve: a candidate dict round-tripped through JSON by
-        # a caller that dropped nested fields still carries enough identity
-        # (name/library/source_file) to re-match the registry.
-        playbook = match_vendor_operator_playbook(candidate)
-    if not isinstance(playbook, dict) or not playbook.get("id"):
-        return _normalized(
-            2,
-            "",
-            "forge: patch_strategy=vendor_playbook but candidate carries no "
-            "vendor_operator_playbook entry (re-run classify_patchability?)",
-            time.time() - started,
-            skipped=True,
-        )
+    """Copy the task bundle and run forge-loop, having already won the claim.
 
-    group_id = str(playbook.get("id"))
-    role = str(candidate.get("vendor_playbook_role") or playbook.get("role") or "")
-    lock_dir = _vendor_playbook_lock_dir(output_dir, group_id)
-
-    cached = _read_vendor_playbook_cached_result(lock_dir)
-    if cached is not None:
-        result = dict(cached)
-        result["vendor_playbook_reused"] = True
-        result["vendor_playbook_role"] = role
-        return result
-
-    if not _claim_vendor_playbook_run(lock_dir):
-        # A sibling role (e.g. this is "combine" and "dispatch" already
-        # claimed the group) is running the one shared session; wait for it
-        # rather than launching a second forge-loop for the same task.
-        deadline = time.time() + max(60.0, float(timeout_s) + 300.0)
-        cached = _wait_for_vendor_playbook_result(lock_dir, deadline)
-        if cached is not None:
-            result = dict(cached)
-            result["vendor_playbook_reused"] = True
-            result["vendor_playbook_role"] = role
-            return result
-        return _normalized(
-            2,
-            "",
-            f"forge: vendor playbook group {group_id!r} was claimed by a "
-            "concurrent submission but never produced a result before the wait "
-            "deadline",
-            time.time() - started,
-            skipped=True,
-        )
-
+    May raise (e.g. ``subprocess.CalledProcessError`` from the git-init
+    calls in ``_copy_vendor_task_bundle``, or anything else unexpected from
+    forge-loop setup) -- the caller (``_submit_vendor_playbook``) must catch
+    broadly and always write a result to ``lock_dir``, or a raised exception
+    here leaves ``claimed.lock`` in place forever with no result for any
+    waiting sibling or later retry to find.
+    """
     forge_root = (os.environ.get("FORGE_PATH") or "").strip()
     if not forge_root:
         result = _normalized(
@@ -4106,7 +4110,9 @@ def _submit_vendor_playbook(
 
     try:
         _copy_vendor_task_bundle(task_bundle_root, workspace)
-    except OSError as exc:
+    except (OSError, subprocess.CalledProcessError) as exc:
+        # _copy_vendor_task_bundle's git init/config/add/commit calls run with
+        # check=True and raise CalledProcessError, not OSError, on failure.
         result = _normalized(
             2,
             "",
@@ -4177,7 +4183,15 @@ def _submit_vendor_playbook(
     # forge-loop itself committed and validated a faster config.
     result.update(
         {
-            "cli_workspace": str(workspace),
+            # NOTE: cli_workspace intentionally equals output_dir here (the
+            # convention the ordinary per-file forge path uses, see
+            # `res["cli_workspace"] = str(output_dir)` elsewhere in this
+            # module), NOT the git worktree -- optimized_versions/ below is
+            # written directly under output_dir, and _candidate_artifact_paths()
+            # checks cli_workspace/optimized_versions first. forge_workspace
+            # separately carries the real git worktree for anything that needs
+            # the live tree (e.g. a future patch-based snapshot).
+            "cli_workspace": str(output_dir),
             "forge_workspace": str(workspace),
             "output_dir": str(output_dir),
             "improved": bool(loop_outcome.total_improved),
@@ -4212,6 +4226,105 @@ def _submit_vendor_playbook(
             log.warning("forge: could not stage vendor playbook artifact copy: %s", exc)
     _write_vendor_playbook_result(lock_dir, result)
     return result
+
+
+def _submit_vendor_playbook(
+    *,
+    candidate: dict[str, Any],
+    prompt_file: Path,
+    output_dir: Path,
+    timeout_s: int,
+) -> dict:
+    """Run (or reuse) the one forge-loop session for a vendor-playbook group."""
+    started = time.time()
+    playbook = candidate.get("vendor_operator_playbook")
+    if not isinstance(playbook, dict) or not playbook.get("id"):
+        # Defensive re-resolve: a candidate dict round-tripped through JSON by
+        # a caller that dropped nested fields still carries enough identity
+        # (name/library/source_file) to re-match the registry.
+        playbook = match_vendor_operator_playbook(candidate)
+    if not isinstance(playbook, dict) or not playbook.get("id"):
+        return _normalized(
+            2,
+            "",
+            "forge: patch_strategy=vendor_playbook but candidate carries no "
+            "vendor_operator_playbook entry (re-run classify_patchability?)",
+            time.time() - started,
+            skipped=True,
+        )
+
+    group_id = str(playbook.get("id"))
+    role = str(candidate.get("vendor_playbook_role") or playbook.get("role") or "")
+    lock_dir = _vendor_playbook_lock_dir(output_dir, group_id)
+
+    cached = _read_vendor_playbook_cached_result(lock_dir)
+    if cached is not None:
+        result = dict(cached)
+        result["vendor_playbook_reused"] = True
+        result["vendor_playbook_role"] = role
+        _stage_vendor_playbook_artifact_for_reuse(cached, output_dir)
+        return result
+
+    if not _claim_vendor_playbook_run(lock_dir):
+        # A sibling role (e.g. this is "combine" and "dispatch" already
+        # claimed the group) is running the one shared session; wait for it
+        # rather than launching a second forge-loop for the same task.
+        deadline = time.time() + max(60.0, float(timeout_s) + 300.0)
+        cached = _wait_for_vendor_playbook_result(lock_dir, deadline)
+        if cached is not None:
+            result = dict(cached)
+            result["vendor_playbook_reused"] = True
+            result["vendor_playbook_role"] = role
+            _stage_vendor_playbook_artifact_for_reuse(cached, output_dir)
+            return result
+        return _normalized(
+            2,
+            "",
+            f"forge: vendor playbook group {group_id!r} was claimed by a "
+            "concurrent submission but never produced a result before the wait "
+            "deadline",
+            time.time() - started,
+            skipped=True,
+        )
+
+    # From here on we hold the claim: any unhandled exception MUST still
+    # produce a result.json, or claimed.lock is orphaned forever and no
+    # sibling/retry for this group can ever run again (see
+    # _run_claimed_vendor_playbook's docstring). _copy_vendor_task_bundle's
+    # git subprocess calls and the forge-loop launch are the known risks,
+    # but this is a deliberate catch-all, not just those two.
+    try:
+        return _run_claimed_vendor_playbook(
+            candidate=candidate,
+            prompt_file=prompt_file,
+            output_dir=output_dir,
+            timeout_s=timeout_s,
+            playbook=playbook,
+            group_id=group_id,
+            role=role,
+            lock_dir=lock_dir,
+            started=started,
+        )
+    except Exception as exc:  # noqa: BLE001
+        result = _normalized(
+            2,
+            "",
+            f"forge: vendor playbook group {group_id!r} raised after claiming "
+            f"the shared session, before producing a result "
+            f"({type(exc).__name__}: {exc})",
+            time.time() - started,
+            skipped=True,
+        )
+        try:
+            _write_vendor_playbook_result(lock_dir, result)
+        except OSError:
+            log.exception(
+                "forge: could not write a failure result for vendor playbook "
+                "group %r after claiming it; claimed.lock will remain until "
+                "manually cleared",
+                group_id,
+            )
+        return result
 
 
 def submit(

--- a/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
+++ b/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
@@ -3726,6 +3726,21 @@ def _finalize_forge_workspace(
 
 _VENDOR_PLAYBOOK_CLAIM_POLL_S = 5.0
 
+# A cached FAILURE only de-dupes submissions within this window -- long
+# enough to catch a genuinely concurrent dispatch+combine pair, short enough
+# that Hyperloom's normal "fail -> add budget -> retry" model gets a fresh
+# attempt instead of the whole group being permanently retired for the rest
+# of the session by one transient failure (see PR #1191 review finding #2).
+# A cached SUCCESS has no such expiry: sharing one session's result for the
+# rest of the session is the intended dedup behavior this module implements.
+_VENDOR_PLAYBOOK_FAILURE_CACHE_TTL_S = 600.0
+
+# Extra time past an attempt's own timeout_s before its claim is presumed
+# abandoned (SIGKILL budget enforcement, OOM, node restart -- anything that
+# kills the holder without a chance to write result.json) rather than merely
+# still finishing up (writing the report, staging the artifact copy, etc).
+_VENDOR_PLAYBOOK_CLAIM_STALE_GRACE_S = 120.0
+
 
 def _vendor_playbook_lock_dir(output_dir: Path, group_id: str) -> Path:
     """Return the session-scoped directory used to de-duplicate a playbook group.
@@ -3738,12 +3753,33 @@ def _vendor_playbook_lock_dir(output_dir: Path, group_id: str) -> Path:
     return output_dir.parent / "vendor_playbook_locks" / safe_group
 
 
-def _read_vendor_playbook_cached_result(lock_dir: Path) -> dict | None:
+def _read_vendor_playbook_cached_result(
+    lock_dir: Path, *, max_failure_age_s: float | None = None
+) -> dict | None:
+    """Read a previously-cached vendor-playbook result, if any.
+
+    A cached SUCCESS (``returncode == 0``) is returned unconditionally --
+    sharing one session's validated result for the rest of the session is
+    the intended dedup behavior. A cached FAILURE is only returned while it
+    is younger than ``max_failure_age_s``; once it ages out it is treated as
+    absent so a fresh submission actually retries instead of one transient
+    failure (FORGE_PATH momentarily unset, a flaky bundle copy, etc.)
+    permanently wedging the whole playbook group for the rest of the session
+    (PR #1191 review finding #2).
+    """
     result_path = lock_dir / "result.json"
     try:
-        return json.loads(result_path.read_text(encoding="utf-8"))
+        result = json.loads(result_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
+    if max_failure_age_s is not None and result.get("returncode") != 0:
+        try:
+            age_s = time.time() - result_path.stat().st_mtime
+        except OSError:
+            age_s = None
+        if age_s is not None and age_s > max_failure_age_s:
+            return None
+    return result
 
 
 def _write_vendor_playbook_result(lock_dir: Path, result: dict) -> None:
@@ -3753,29 +3789,147 @@ def _write_vendor_playbook_result(lock_dir: Path, result: dict) -> None:
     tmp_path.replace(lock_dir / "result.json")
 
 
-def _claim_vendor_playbook_run(lock_dir: Path) -> bool:
+def _write_claim_marker(claim_path: Path, *, nonce: str | None = None) -> str:
+    """Write ``{pid, claimed_at, nonce}`` into an already-created claim file.
+
+    The timestamp lets any waiter compute how long the claim has been held
+    without a result appearing; the nonce lets ``_steal_stale_claim`` verify
+    which of several racing stealers actually won the replace.
+    """
+    nonce = nonce or uuid.uuid4().hex
+    payload = {"pid": os.getpid(), "claimed_at": time.time(), "nonce": nonce}
+    claim_path.write_text(json.dumps(payload), encoding="utf-8")
+    return nonce
+
+
+def _claim_marker_age_s(claim_path: Path) -> float | None:
+    """Return how long ago ``claim_path`` was claimed, or ``None`` if unknown."""
+    try:
+        raw = claim_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    claimed_at: float | None = None
+    if raw.strip():
+        try:
+            claimed_at = float(json.loads(raw).get("claimed_at"))
+        except (ValueError, TypeError):
+            claimed_at = None
+    if claimed_at is None:
+        # Marker predates this format (or failed to write its JSON body) --
+        # fall back to the file's own mtime rather than treating age as
+        # unknown, since os.O_CREAT|O_EXCL always sets one.
+        try:
+            claimed_at = claim_path.stat().st_mtime
+        except OSError:
+            return None
+    return max(0.0, time.time() - claimed_at)
+
+
+def _claim_is_stale(claim_path: Path, timeout_s: int) -> bool:
+    """A claim is stale (its holder is presumed done or dead) when either:
+
+    1. A result already exists but has aged out of the failure-cache TTL
+       (``_VENDOR_PLAYBOOK_FAILURE_CACHE_TTL_S``) -- the completed attempt's
+       ``claimed.lock`` is never deleted, so without this check a lingering
+       claim from a long-finished, now-expired failure would block every
+       later retry from ever running (PR #1191 review finding #2 combined
+       with #3: the claim and the result cache must age out together).
+    2. The claim is older than its own attempt budget plus grace, with no
+       result at all -- covers SIGKILL budget enforcement, OOM, and node
+       restarts, none of which give the holder a chance to write
+       ``result.json``. Without this check every subsequent submission for
+       the group would poll ``_wait_for_vendor_playbook_result`` all the way
+       to its deadline and still find nothing -- for a 60-minute-budget
+       attempt, that is an hour burned per submission (PR #1191 review
+       finding #3).
+    """
+    lock_dir = claim_path.parent
+    cached = _read_vendor_playbook_cached_result(
+        lock_dir, max_failure_age_s=_VENDOR_PLAYBOOK_FAILURE_CACHE_TTL_S
+    )
+    if cached is None and (lock_dir / "result.json").is_file():
+        return True
+    age_s = _claim_marker_age_s(claim_path)
+    if age_s is None:
+        return False
+    return age_s > (float(timeout_s) + _VENDOR_PLAYBOOK_CLAIM_STALE_GRACE_S)
+
+
+def _steal_stale_claim(claim_path: Path) -> bool:
+    """Atomically replace a stale claim, verifying this caller actually won it.
+
+    ``os.replace`` never raises when the target already exists, so two
+    waiters racing to steal the same stale claim could both believe they
+    succeeded. Tag the write with a nonce and read it back afterwards: only
+    the caller whose nonce is what's on disk is the new owner.
+    """
+    nonce = uuid.uuid4().hex
+    tmp_path = claim_path.with_name(f".{claim_path.name}.{nonce}.tmp")
+    try:
+        _write_claim_marker(tmp_path, nonce=nonce)
+        os.replace(str(tmp_path), str(claim_path))
+        current = json.loads(claim_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    finally:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+    return current.get("nonce") == nonce
+
+
+def _claim_vendor_playbook_run(lock_dir: Path, timeout_s: int) -> bool:
     """Atomically claim the right to run this group's one forge-loop session.
 
     Returns ``True`` for whichever caller wins the race (dispatch or
     combine, whichever the orchestrator happened to submit first); the loser
     waits for the winner's result instead of launching a second session.
+    Also returns ``True`` when the existing claim is stale (its holder is
+    presumed dead) and this caller wins the steal.
     """
     lock_dir.mkdir(parents=True, exist_ok=True)
     claim_path = lock_dir / "claimed.lock"
     try:
         fd = os.open(str(claim_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.close(fd)
     except FileExistsError:
-        return False
-    os.close(fd)
+        if not _claim_is_stale(claim_path, timeout_s):
+            return False
+        return _steal_stale_claim(claim_path)
+    try:
+        _write_claim_marker(claim_path)
+    except OSError:
+        log.warning(
+            "forge: claimed %s but could not write its pid/timestamp marker; "
+            "staleness detection will fall back to file mtime",
+            claim_path,
+        )
     return True
 
 
-def _wait_for_vendor_playbook_result(lock_dir: Path, deadline_unix: float) -> dict | None:
-    """Poll for the winner's result until it appears or ``deadline_unix`` passes."""
+def _wait_for_vendor_playbook_result(
+    lock_dir: Path, deadline_unix: float, timeout_s: int
+) -> dict | None:
+    """Poll for the winner's result until it appears, the claim looks
+    abandoned, or ``deadline_unix`` passes.
+
+    Returns early (well before ``deadline_unix``) the moment the claim looks
+    stale, so a waiter never burns its entire poll window on a holder that
+    was SIGKILLed/OOM-killed and will never write a result (PR #1191 review
+    finding #3). The caller is responsible for then trying to claim (steal)
+    the group itself rather than treating an early ``None`` as a hard
+    failure.
+    """
+    claim_path = lock_dir / "claimed.lock"
     while True:
-        cached = _read_vendor_playbook_cached_result(lock_dir)
+        cached = _read_vendor_playbook_cached_result(
+            lock_dir, max_failure_age_s=_VENDOR_PLAYBOOK_FAILURE_CACHE_TTL_S
+        )
         if cached is not None:
             return cached
+        if _claim_is_stale(claim_path, timeout_s):
+            return None
         if time.time() >= deadline_unix:
             return None
         time.sleep(min(_VENDOR_PLAYBOOK_CLAIM_POLL_S, max(0.0, deadline_unix - time.time())))
@@ -4208,7 +4362,31 @@ def _run_claimed_vendor_playbook(
             "vendor_playbook_role": role,
             "vendor_playbook_task_bundle": str(task_bundle_root),
             "vendor_playbook_reused": False,
+            # This role is the one that actually ran forge-loop and produced
+            # the measurement; a sibling role that reuses this same result
+            # (see _submit_vendor_playbook's ``_reuse``) marks itself False
+            # so downstream benefit accounting sums this speedup once, not
+            # once per role sharing it (PR #1191 review finding #4).
+            "vendor_playbook_independently_counted": True,
         }
+    )
+    # The ordinary per-file forge path's correctness signal comes from
+    # optimization_report.md's "[correctness] pass" marker (kernel_optimization
+    # .py's _extract_correctness_from_report scans cli_workspace for it). The
+    # vendor-playbook path reused this same forge-loop run but never wrote
+    # that file, so correctness_passed stayed False and make_proposal()
+    # could never return KEEP even when SNR validation had already passed
+    # inside forge-loop (PR #1191 review finding #5). cli_workspace ==
+    # output_dir here (see the NOTE above), so writing it here is exactly
+    # where the correctness scan will look.
+    _write_report(
+        output_dir,
+        loop_outcome.baseline_ms,
+        loop_outcome.best_ms,
+        loop_outcome.total_improved,
+        mean_case_speedup=loop_outcome.mean_case_speedup,
+        search_start_ms=loop_outcome.search_start_ms,
+        improved_during_search=loop_outcome.improved_during_search,
     )
     if loop_outcome.total_improved and kernel_anchor.is_file():
         # There is no separate "deploy" artifact for a vendor launch-config:
@@ -4257,74 +4435,94 @@ def _submit_vendor_playbook(
     role = str(candidate.get("vendor_playbook_role") or playbook.get("role") or "")
     lock_dir = _vendor_playbook_lock_dir(output_dir, group_id)
 
-    cached = _read_vendor_playbook_cached_result(lock_dir)
-    if cached is not None:
-        result = dict(cached)
+    def _reuse(cached_result: dict) -> dict:
+        result = dict(cached_result)
         result["vendor_playbook_reused"] = True
         result["vendor_playbook_role"] = role
-        _stage_vendor_playbook_artifact_for_reuse(cached, output_dir)
+        # This measurement was already counted once, on the role that
+        # actually ran forge-loop; a reused sibling must not add its
+        # identical mean_case_speedup/best_ms again into downstream benefit
+        # totals (PR #1191 review finding #4).
+        result["vendor_playbook_independently_counted"] = False
+        _stage_vendor_playbook_artifact_for_reuse(cached_result, output_dir)
         return result
 
-    if not _claim_vendor_playbook_run(lock_dir):
-        # A sibling role (e.g. this is "combine" and "dispatch" already
-        # claimed the group) is running the one shared session; wait for it
-        # rather than launching a second forge-loop for the same task.
-        deadline = time.time() + max(60.0, float(timeout_s) + 300.0)
-        cached = _wait_for_vendor_playbook_result(lock_dir, deadline)
-        if cached is not None:
-            result = dict(cached)
-            result["vendor_playbook_reused"] = True
-            result["vendor_playbook_role"] = role
-            _stage_vendor_playbook_artifact_for_reuse(cached, output_dir)
-            return result
-        return _normalized(
-            2,
-            "",
-            f"forge: vendor playbook group {group_id!r} was claimed by a "
-            "concurrent submission but never produced a result before the wait "
-            "deadline",
-            time.time() - started,
-            skipped=True,
-        )
-
-    # From here on we hold the claim: any unhandled exception MUST still
-    # produce a result.json, or claimed.lock is orphaned forever and no
-    # sibling/retry for this group can ever run again (see
-    # _run_claimed_vendor_playbook's docstring). _copy_vendor_task_bundle's
-    # git subprocess calls and the forge-loop launch are the known risks,
-    # but this is a deliberate catch-all, not just those two.
-    try:
-        return _run_claimed_vendor_playbook(
-            candidate=candidate,
-            prompt_file=prompt_file,
-            output_dir=output_dir,
-            timeout_s=timeout_s,
-            playbook=playbook,
-            group_id=group_id,
-            role=role,
-            lock_dir=lock_dir,
-            started=started,
-        )
-    except Exception as exc:  # noqa: BLE001
-        result = _normalized(
-            2,
-            "",
-            f"forge: vendor playbook group {group_id!r} raised after claiming "
-            f"the shared session, before producing a result "
-            f"({type(exc).__name__}: {exc})",
-            time.time() - started,
-            skipped=True,
-        )
+    def _run_and_guard() -> dict:
+        # From here on we (believe we) hold the claim: any unhandled
+        # exception MUST still produce a result.json, or claimed.lock is
+        # orphaned forever and no sibling/retry for this group can ever run
+        # again (see _run_claimed_vendor_playbook's docstring).
+        # _copy_vendor_task_bundle's git subprocess calls and the forge-loop
+        # launch are the known risks, but this is a deliberate catch-all,
+        # not just those two.
         try:
-            _write_vendor_playbook_result(lock_dir, result)
-        except OSError:
-            log.exception(
-                "forge: could not write a failure result for vendor playbook "
-                "group %r after claiming it; claimed.lock will remain until "
-                "manually cleared",
-                group_id,
+            return _run_claimed_vendor_playbook(
+                candidate=candidate,
+                prompt_file=prompt_file,
+                output_dir=output_dir,
+                timeout_s=timeout_s,
+                playbook=playbook,
+                group_id=group_id,
+                role=role,
+                lock_dir=lock_dir,
+                started=started,
             )
-        return result
+        except Exception as exc:  # noqa: BLE001
+            result = _normalized(
+                2,
+                "",
+                f"forge: vendor playbook group {group_id!r} raised after claiming "
+                f"the shared session, before producing a result "
+                f"({type(exc).__name__}: {exc})",
+                time.time() - started,
+                skipped=True,
+            )
+            try:
+                _write_vendor_playbook_result(lock_dir, result)
+            except OSError:
+                log.exception(
+                    "forge: could not write a failure result for vendor playbook "
+                    "group %r after claiming it; claimed.lock will remain until "
+                    "manually cleared",
+                    group_id,
+                )
+            return result
+
+    cached = _read_vendor_playbook_cached_result(
+        lock_dir, max_failure_age_s=_VENDOR_PLAYBOOK_FAILURE_CACHE_TTL_S
+    )
+    if cached is not None:
+        return _reuse(cached)
+
+    if _claim_vendor_playbook_run(lock_dir, timeout_s):
+        return _run_and_guard()
+
+    # A sibling role (e.g. this is "combine" and "dispatch" already claimed
+    # the group) is running the one shared session; wait for it rather than
+    # launching a second forge-loop for the same task.
+    deadline = time.time() + max(60.0, float(timeout_s) + 300.0)
+    cached = _wait_for_vendor_playbook_result(lock_dir, deadline, timeout_s)
+    if cached is not None:
+        return _reuse(cached)
+
+    # The wait ended without a result either because the deadline passed or
+    # because the holder's claim looked abandoned (SIGKILL/OOM/node restart
+    # -- PR #1191 review finding #3). Try once more to claim the group: if
+    # the claim really is stale this steals it and we run for real instead
+    # of failing outright; if the original holder is alive and simply still
+    # running, this correctly fails again.
+    if _claim_vendor_playbook_run(lock_dir, timeout_s):
+        return _run_and_guard()
+
+    return _normalized(
+        2,
+        "",
+        f"forge: vendor playbook group {group_id!r} was claimed by a "
+        "concurrent submission but never produced a result before the wait "
+        "deadline",
+        time.time() - started,
+        skipped=True,
+    )
 
 
 def submit(

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -91,6 +91,14 @@ from _roofline_source import (
 # section structure + table schemas as the bypass route.
 from _analysis_md import render_report
 
+# Vendor-operator-playbook registry: routes a closed-source vendor op (no
+# rewritable device source) to a validated KernelForge task bundle instead of
+# a source rewrite -- see KernelForge PR #88's mori dispatch/combine gap.
+from _vendor_operator_playbooks import (
+    match_vendor_operator_playbook,
+    resolve_kernel_anchor_path,
+)
+
 # Shared with the kernel-opt side; these tools also run as standalone scripts
 # outside an importable hyperloom, where the artifact is simply not written.
 try:
@@ -1515,6 +1523,17 @@ def classify_patchability(candidate: dict[str, Any]) -> tuple[bool, str]:
                 or "non-rewritable"
             )
             return False, f"source: {reason}"
+    # Vendor-operator-playbook check: some closed-source vendor operators (a
+    # pip-installed compiled library with no rewritable device source) still
+    # have a small, named set of launch-config knobs that a KernelForge
+    # forge-loop task bundle has already been validated to tune (mori's EP
+    # dispatch/combine is the first case -- see KernelForge PR #88). This is
+    # checked before the vendor_binary/no-source-file rejections below and
+    # before the ``source_file`` requirement, since a vendor-playbook
+    # candidate's "source" is a pip-installed file, not something forge would
+    # ever rewrite.
+    if match_vendor_operator_playbook(candidate) is not None:
+        return True, ""
     if not source_file:
         # A bare launch API has no kernel body to rewrite, which is a different
         # situation from a kernel whose source we merely failed to locate. Say
@@ -4056,6 +4075,18 @@ def _stamp_candidate_metadata(item: dict[str, Any], op_cat_map: dict[str, str] |
     reusable, skip_reason = classify_patchability(item)
     item["reusable_native_kernel"] = reusable
     item["skip_reason"] = skip_reason
+    playbook = match_vendor_operator_playbook(item)
+    if playbook is not None:
+        item["patch_strategy"] = "vendor_playbook"
+        item["vendor_operator_playbook"] = playbook
+        item["vendor_playbook_role"] = playbook.get("role", "")
+        # kernel_optimization.py's CLI gates on a non-empty, path-shaped
+        # source_file before it will dispatch to any backend; a vendor
+        # playbook candidate has no rewritable device source, so point that
+        # field at the task bundle's anchor file instead of leaving it
+        # empty (which would otherwise fall through as "missing_native_source").
+        if not str(item.get("source_file") or "").strip():
+            item["source_file"] = resolve_kernel_anchor_path(playbook)
     item["benchmark_files"] = find_benchmark_files(
         item["name"], item.get("kernel_repo", ""), item.get("source_file", "")
     )
@@ -4617,6 +4648,7 @@ def _finalize_candidates(
             item["vendor_dispatch_wrapper"] = True
         item["runtime_generated_kernel"] = is_runtime_generated_kernel(item["name"], item.get("source_file", ""))
         _stamp_candidate_metadata(item, op_cat_map)
+    _apply_vendor_operator_playbook_grouping(top)
     if source_resolution_out and _KSC is not None:
         write_source_resolution_artifact(
             top,
@@ -4628,6 +4660,36 @@ def _finalize_candidates(
             allow_review=allow_model_tiers,
         )
     return top
+
+
+def _apply_vendor_operator_playbook_grouping(top: list[dict[str, Any]]) -> None:
+    """Sum GPU share across a vendor playbook's sibling roles; mutates ``top``.
+
+    mori's dispatch and combine are two separate kernel launches under the
+    hood, but this deliberately invokes them as **one** Forge task/session
+    (see KernelForge PR #88): each is gated on the *sum* of dispatch's +
+    combine's ``gpu_pct``, since together they are one logical round trip.
+    Each member keeps its own candidate entry (so either one can be picked as
+    the ``--kernel-id`` the orchestrator dispatches); ``forge_submit``'s
+    vendor-playbook path de-duplicates so only one forge-loop session actually
+    runs per group per analysis session.
+    """
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for item in top:
+        if not isinstance(item, dict) or item.get("patch_strategy") != "vendor_playbook":
+            continue
+        playbook = item.get("vendor_operator_playbook")
+        group_id = str(playbook.get("id") or "") if isinstance(playbook, dict) else ""
+        if not group_id:
+            continue
+        groups.setdefault(group_id, []).append(item)
+    for group_id, members in groups.items():
+        aggregate = round(sum(float(m.get("gpu_pct") or 0.0) for m in members), 3)
+        member_ids = [str(m.get("kernel_id") or "") for m in members]
+        for member in members:
+            member["vendor_playbook_group_id"] = group_id
+            member["aggregate_gpu_pct"] = aggregate
+            member["vendor_playbook_group_kernel_ids"] = list(member_ids)
 
 
 def _candidate_resolution_method(item: dict[str, Any]) -> str:

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -4697,7 +4697,16 @@ def _apply_vendor_operator_playbook_grouping(top: list[dict[str, Any]]) -> None:
                 break
         for member in members:
             member["vendor_playbook_group_id"] = group_id
-            member["aggregate_gpu_pct"] = aggregate
+            # Namespaced (not bare "aggregate_gpu_pct"): that name is already
+            # an existing task_group-level concept (the sum of GPU% across a
+            # task_group's rows -- see tracelens_skill_runner.py and
+            # _bypass_report.py), stamped on task_group dicts, not candidate
+            # rows. Candidate rows don't carry it today, so reusing the name
+            # here is currently harmless, but any future code that flattens
+            # a task_group onto its candidate rows would silently change
+            # every ordinary group's gating behavior the moment it did (PR
+            # #1191 review finding #7).
+            member["vendor_playbook_aggregate_gpu_pct"] = aggregate
             member["vendor_playbook_group_kernel_ids"] = list(member_ids)
             if floor is not None:
                 # Consumed by effective_hot_kernel_min_gpu_pct() in the

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -4686,10 +4686,26 @@ def _apply_vendor_operator_playbook_grouping(top: list[dict[str, Any]]) -> None:
     for group_id, members in groups.items():
         aggregate = round(sum(float(m.get("gpu_pct") or 0.0) for m in members), 3)
         member_ids = [str(m.get("kernel_id") or "") for m in members]
+        floor: float | None = None
+        for member in members:
+            playbook = member.get("vendor_operator_playbook")
+            if isinstance(playbook, dict) and playbook.get("min_gpu_pct_floor") is not None:
+                try:
+                    floor = float(playbook["min_gpu_pct_floor"])
+                except (TypeError, ValueError):
+                    floor = None
+                break
         for member in members:
             member["vendor_playbook_group_id"] = group_id
             member["aggregate_gpu_pct"] = aggregate
             member["vendor_playbook_group_kernel_ids"] = list(member_ids)
+            if floor is not None:
+                # Consumed by effective_hot_kernel_min_gpu_pct() in the
+                # orchestrator's hot-kernel gate (_kernel_decisions.py /
+                # request_handlers.py) so a heavier forge-loop-session
+                # playbook isn't dispatched below its own floor even when
+                # HYPERLOOM_KERNEL_OPT_MIN_GPU_PCT is loosened elsewhere.
+                member["vendor_playbook_min_gpu_pct_floor"] = floor
 
 
 def _candidate_resolution_method(item: dict[str, Any]) -> str:

--- a/src/hyperloom/agents/kernel/tools/vendor_operator_playbooks.json
+++ b/src/hyperloom/agents/kernel/tools/vendor_operator_playbooks.json
@@ -1,0 +1,50 @@
+{
+  "version": 1,
+  "_comment": [
+    "Sibling registry to the (retired) op_to_source.json, but for a different",
+    "class of hot kernel: a closed-source vendor operator with no rewritable",
+    "device source, where a KernelForge forge-loop TASK BUNDLE (not a source",
+    "file) has already been validated to tune it. See KernelForge PR #88",
+    "('feat(mori): add mori knowledge base, wire optional KB injection, refresh",
+    "example') for the design rationale and the measured A/B evidence behind",
+    "the mori entry below.",
+    "",
+    "classify_patchability() in tracelens_analysis.py checks this registry",
+    "before the vendor_binary rejection; a match marks the candidate",
+    "reusable_native_kernel=True with patch_strategy='vendor_playbook'.",
+    "forge_submit.py then copies task_bundle (resolved under $FORGE_PATH,",
+    "KernelForge's checkout) into the forge worktree instead of doing a",
+    "source-file rewrite, and includes kb_path in the fellow's context."
+  ],
+  "playbooks": [
+    {
+      "id": "mori_ep_dispatch_combine",
+      "description": "mori EP dispatch/combine all-to-all (pip-installed compiled library called through Python bindings; no rewritable device source). Tunes the 6 documented launch-config knobs via the validated examples/mori_ep_dispatch_combine forge-loop task bundle instead of a source rewrite.",
+      "match": {
+        "any_marker": ["mori"],
+        "name_any": ["dispatch", "combine"]
+      },
+      "task_bundle": "examples/mori_ep_dispatch_combine",
+      "kernel_anchor": "mori_ep_config.py",
+      "driver": "driver.py",
+      "program_md": "program.md",
+      "kb_path": "local_knowledge/framework/mori",
+      "fellow": "aiter-fellow",
+      "target_functions": ["get_ep_launch_config", "dispatch", "combine"],
+      "tunable_params": [
+        "dispatch_block_num",
+        "dispatch_warp_per_block",
+        "combine_block_num",
+        "combine_warp_per_block",
+        "kernel_type",
+        "combine_zero_copy"
+      ],
+      "snr_threshold": 30.0,
+      "env": {
+        "KERNELFORGE_INCLUDE_MORI_KB": "1",
+        "HSA_NO_SCRATCH_RECLAIM": "1"
+      },
+      "min_gpu_pct_floor": 10.0
+    }
+  ]
+}

--- a/src/hyperloom/agents/kernel/tools/vendor_operator_playbooks.json
+++ b/src/hyperloom/agents/kernel/tools/vendor_operator_playbooks.json
@@ -14,7 +14,16 @@
     "reusable_native_kernel=True with patch_strategy='vendor_playbook'.",
     "forge_submit.py then copies task_bundle (resolved under $FORGE_PATH,",
     "KernelForge's checkout) into the forge worktree instead of doing a",
-    "source-file rewrite, and includes kb_path in the fellow's context."
+    "source-file rewrite, and sets each entry's own 'env' vars (e.g.",
+    "KERNELFORGE_INCLUDE_MORI_KB=1) on the forge-loop subprocess. That var",
+    "is a boolean ablation switch KernelForge's own Config.include_mori_kb",
+    "reads to decide whether to inject a FIXED directory it resolves",
+    "internally -- KernelForge has no CLI/env hook to pass an arbitrary",
+    "external path in its place. 'kb_path' below is therefore not read by",
+    "any code path; it is recorded purely so this entry documents which",
+    "on-disk directory that boolean switch actually pulls in (see",
+    "KernelForge's local_knowledge/framework/mori/), for cross-reference",
+    "when auditing what knowledge a run had access to."
   ],
   "playbooks": [
     {

--- a/src/hyperloom/inference_optimizer/tests/test_integrate_payload_defaults.py
+++ b/src/hyperloom/inference_optimizer/tests/test_integrate_payload_defaults.py
@@ -202,6 +202,83 @@ class TestFillIntegrateDefaultsFromState:
         assert out["base_tput"] == 800.0
 
 
+class TestVendorPlaybookDeployBlocked:
+    """A vendor-playbook KEEP (e.g. mori dispatch/combine) must never reach
+    apply_kernel_patch: its best_artifact_path is a KernelForge task-bundle
+    config copy, not a rewrite of the real installed operator source
+    (PR #1191 review finding #1)."""
+
+    def test_backfilled_from_kernel_opt_attempts_ledger(self, session_dir):
+        state = SharedState.load_or_init(session_dir)
+        state.kernel_opt_attempts = {
+            "k010": {
+                "vendor_playbook_deploy_blocked": True,
+                "vendor_playbook_id": "mori_ep_dispatch_combine",
+            }
+        }
+        state.save(session_dir)
+
+        out = krh._fill_integrate_defaults_from_state(
+            {"kernel_id": "k010"},
+            session_dir=session_dir,
+        )
+
+        assert out["_vendor_playbook_deploy_blocked"] is True
+
+    def test_backfilled_from_last_kernel_opt_when_ledger_missing(self, session_dir):
+        """An LLM-initiated integrate can name a kernel_id that never made it
+        into kernel_opt_attempts yet; last_kernel_opt must still catch it."""
+        state = SharedState.load_or_init(session_dir)
+        state.last_kernel_opt = {
+            "kernel_id": "k010",
+            "vendor_playbook_deploy_blocked": True,
+        }
+        state.save(session_dir)
+
+        out = krh._fill_integrate_defaults_from_state(
+            {"kernel_id": "k010"},
+            session_dir=session_dir,
+        )
+
+        assert out["_vendor_playbook_deploy_blocked"] is True
+
+    def test_normal_kernel_is_not_blocked(self, session_dir):
+        state = SharedState.load_or_init(session_dir)
+        state.kernel_opt_attempts = {"k001": {"vendor_playbook_deploy_blocked": False}}
+        state.save(session_dir)
+
+        out = krh._fill_integrate_defaults_from_state(
+            {"kernel_id": "k001"},
+            session_dir=session_dir,
+        )
+
+        assert "_vendor_playbook_deploy_blocked" not in out
+
+    @pytest.mark.asyncio
+    async def test_integrate_handler_refuses_before_touching_filesystem(
+        self, session_dir
+    ):
+        _seed_state(session_dir, baseline_tput=800.0)
+        state = SharedState.load_or_init(session_dir)
+        state.kernel_opt_attempts = {
+            "k010": {
+                "vendor_playbook_deploy_blocked": True,
+                "vendor_playbook_id": "mori_ep_dispatch_combine",
+                "last_artifact_path": "/tmp/forge/session1/mori_ep_config.py",
+            }
+        }
+        state.save(session_dir)
+
+        result = await krh.integrate_handler(
+            {"kernel_id": "k010"},
+            session_dir=session_dir,
+        )
+
+        assert result["status"] == "failed"
+        assert result["error_class"] == "vendor_playbook_not_deployable"
+        assert result["decision"] == "NEEDS_REVIEW"
+
+
 class TestIntegrateRebaselineTimeout:
     def test_explicit_budget_wins(self, tmp_path):
         config = tmp_path / "config.yaml"

--- a/src/hyperloom/inference_optimizer/tests/test_shared_state_kernel_opt.py
+++ b/src/hyperloom/inference_optimizer/tests/test_shared_state_kernel_opt.py
@@ -626,10 +626,15 @@ def test_untried_hot_kernels_vendor_playbook_group_gated_on_aggregate(state: Sha
         ],
     )
     untried = state.untried_hot_reusable_kernels()
-    # Both members carry the group's full aggregate: whichever the fallback
-    # identity-dedup keeps (they share source_file+name, differing only in
-    # gpu_pct) must clear the gate.
-    assert untried, "vendor-playbook group must not be dropped as below_min_gpu_pct"
+    # Both members carry the group's full aggregate and must both clear the
+    # gate. No task_groups metadata is supplied here, and the two rows do
+    # NOT share (source_file, name) -- names differ (`::dispatch` vs
+    # `::combine`) -- so neither the group-key dedup nor the identity-dedup
+    # fallback collapses them into one; both remain distinct, separately
+    # gated rows.
+    assert set(untried) == {"k010", "k011"}, (
+        "vendor-playbook group must not be dropped as below_min_gpu_pct"
+    )
 
 
 def test_untried_hot_kernels_vendor_playbook_floor_still_applies(state: SharedState):
@@ -654,6 +659,102 @@ def test_untried_hot_kernels_vendor_playbook_floor_still_applies(state: SharedSt
     # playbook's own floor (10.0) still applies.
     untried = state.untried_hot_reusable_kernels(min_gpu_pct=1.0)
     assert untried == []
+
+
+def test_untried_hot_kernels_vendor_playbook_gate_survives_real_projection(state: SharedState):
+    """Regression for PR #1191 tech-lead finding: the aggregate/floor gate
+    was a no-op on the production path because ``untried_hot_reusable_kernels()``
+    reads ``hot_kernels_top15`` (SharedState._build_hot_kernel_summaries()'s
+    projected ``summary_entry``, an explicit key whitelist) in preference to
+    raw ``hot_kernels``, and that whitelist dropped
+    ``vendor_playbook_aggregate_gpu_pct`` / ``vendor_playbook_min_gpu_pct_floor``
+    / ``vendor_playbook_group_id`` / ``patch_strategy`` entirely.
+
+    ``_set_trace()`` (used by the sibling tests above) assigns
+    ``last_trace_analyze`` directly and never populates ``hot_kernels_top15``,
+    so those tests fall through to the raw, unprojected ``hot_kernels`` and
+    cannot catch this -- this test goes through the real
+    ``record_trace_analyze()`` entry point instead, exactly like a live
+    trace-analyze result would.
+    """
+    state.record_trace_analyze(
+        {"trace_input": "/tmp/trace.json"},
+        {
+            "status": "ok",
+            "hot_kernels": [
+                {
+                    "kernel_id": "k010",
+                    "gpu_pct": 7.0,
+                    "vendor_playbook_aggregate_gpu_pct": 12.0,
+                    "vendor_playbook_group_id": "mori_ep_dispatch_combine",
+                    "patch_strategy": "vendor_playbook",
+                    "reusable_native_kernel": True,
+                    "source_file": "/opt/venv/.../mori_ep_config.py",
+                    "name": "mori::EpDispatchCombineOp::dispatch",
+                },
+                {
+                    "kernel_id": "k011",
+                    "gpu_pct": 5.0,
+                    "vendor_playbook_aggregate_gpu_pct": 12.0,
+                    "vendor_playbook_group_id": "mori_ep_dispatch_combine",
+                    "patch_strategy": "vendor_playbook",
+                    "reusable_native_kernel": True,
+                    "source_file": "/opt/venv/.../mori_ep_config.py",
+                    "name": "mori::EpDispatchCombineOp::combine",
+                },
+            ],
+        },
+    )
+    # The projection must actually carry the fields through -- this is the
+    # exact assertion that fails without the _build_hot_kernel_summaries() fix.
+    projected = {row["kernel_id"]: row for row in state.last_trace_analyze["hot_kernels_top15"]}
+    assert projected["k010"]["vendor_playbook_aggregate_gpu_pct"] == 12.0
+    assert projected["k010"]["patch_strategy"] == "vendor_playbook"
+    assert projected["k010"]["vendor_playbook_group_id"] == "mori_ep_dispatch_combine"
+
+    # Split-load pass-through direction: neither member clears the 10%
+    # default alone (7%, 5%), but the pair's aggregate (12%) must.
+    untried = state.untried_hot_reusable_kernels()
+    assert set(untried) == {"k010", "k011"}, (
+        "aggregate gate must not degrade to bare gpu_pct on the real "
+        "record_trace_analyze() -> hot_kernels_top15 production path"
+    )
+
+
+def test_untried_hot_kernels_vendor_playbook_floor_still_applies_via_real_projection(
+    state: SharedState,
+):
+    """Unsafe-direction counterpart of the test above: a playbook's own
+    ``min_gpu_pct_floor`` must still block dispatch through the real
+    projection path, even when the caller has loosened
+    ``HYPERLOOM_KERNEL_OPT_MIN_GPU_PCT``. Before the projection fix this
+    degraded to the bare (loosened) threshold, letting a below-floor group
+    burn a whole forge-loop session."""
+    state.record_trace_analyze(
+        {"trace_input": "/tmp/trace.json"},
+        {
+            "status": "ok",
+            "hot_kernels": [
+                {
+                    "kernel_id": "k010",
+                    "gpu_pct": 2.0,
+                    "vendor_playbook_aggregate_gpu_pct": 3.0,
+                    "vendor_playbook_min_gpu_pct_floor": 10.0,
+                    "reusable_native_kernel": True,
+                    "source_file": "/opt/venv/.../mori_ep_config.py",
+                    "name": "mori::EpDispatchCombineOp::dispatch",
+                },
+            ],
+        },
+    )
+    projected = state.last_trace_analyze["hot_kernels_top15"][0]
+    assert projected["vendor_playbook_min_gpu_pct_floor"] == 10.0
+
+    untried = state.untried_hot_reusable_kernels(min_gpu_pct=1.0)
+    assert untried == [], (
+        "the playbook's own floor must survive the real projection path "
+        "and still block dispatch even under a loosened env override"
+    )
 
 
 def test_untried_hot_kernels_collapses_by_task_group(state: SharedState):

--- a/src/hyperloom/inference_optimizer/tests/test_shared_state_kernel_opt.py
+++ b/src/hyperloom/inference_optimizer/tests/test_shared_state_kernel_opt.py
@@ -540,6 +540,69 @@ def test_untried_hot_kernels_reproduces_log1_session_164910Z(state: SharedState)
     assert untried[0] == "k002"  # strongest-first
 
 
+def test_untried_hot_kernels_vendor_playbook_group_gated_on_aggregate(state: SharedState):
+    """mori's dispatch (7%) + combine (5%) must clear the gate together.
+
+    Neither member clears the 10% default threshold alone, but
+    _apply_vendor_operator_playbook_grouping() (tracelens_analysis.py) stamps
+    aggregate_gpu_pct=12.0 on both, since the pair is deliberately dispatched
+    as one forge-loop session (see KernelForge PR #88 / the mori vendor
+    playbook). Regression for a real gap: the gate used to compare each row's
+    own gpu_pct, so a split load like this was silently dropped as
+    below_min_gpu_pct on both members despite clearing the floor combined.
+    """
+    _set_trace(
+        state,
+        hot_kernels=[
+            {
+                "kernel_id": "k010",
+                "gpu_pct": 7.0,
+                "aggregate_gpu_pct": 12.0,
+                "reusable_native_kernel": True,
+                "source_file": "/opt/venv/.../mori_ep_config.py",
+                "name": "mori::EpDispatchCombineOp::dispatch",
+            },
+            {
+                "kernel_id": "k011",
+                "gpu_pct": 5.0,
+                "aggregate_gpu_pct": 12.0,
+                "reusable_native_kernel": True,
+                "source_file": "/opt/venv/.../mori_ep_config.py",
+                "name": "mori::EpDispatchCombineOp::combine",
+            },
+        ],
+    )
+    untried = state.untried_hot_reusable_kernels()
+    # Both members carry the group's full aggregate: whichever the fallback
+    # identity-dedup keeps (they share source_file+name, differing only in
+    # gpu_pct) must clear the gate.
+    assert untried, "vendor-playbook group must not be dropped as below_min_gpu_pct"
+
+
+def test_untried_hot_kernels_vendor_playbook_floor_still_applies(state: SharedState):
+    """A playbook's min_gpu_pct_floor is a floor on the *threshold*, not a
+    bypass: an aggregate that clears a loosened env override but not the
+    playbook's own floor must still be gated out."""
+    _set_trace(
+        state,
+        hot_kernels=[
+            {
+                "kernel_id": "k010",
+                "gpu_pct": 2.0,
+                "aggregate_gpu_pct": 3.0,
+                "vendor_playbook_min_gpu_pct_floor": 10.0,
+                "reusable_native_kernel": True,
+                "source_file": "/opt/venv/.../mori_ep_config.py",
+                "name": "mori::EpDispatchCombineOp::dispatch",
+            },
+        ],
+    )
+    # A caller loosening the env default to 1.0% must not let this in: the
+    # playbook's own floor (10.0) still applies.
+    untried = state.untried_hot_reusable_kernels(min_gpu_pct=1.0)
+    assert untried == []
+
+
 def test_untried_hot_kernels_collapses_by_task_group(state: SharedState):
     """task_group dedup: same AST function -> one slot."""
     _set_trace(

--- a/src/hyperloom/inference_optimizer/tests/test_shared_state_kernel_opt.py
+++ b/src/hyperloom/inference_optimizer/tests/test_shared_state_kernel_opt.py
@@ -200,6 +200,59 @@ def test_record_kernel_opt_nonkeep_overwrites_when_prev_already_integrated(state
     )
 
 
+# Vendor-playbook KEEPs (e.g. mori dispatch/combine) must never auto-deploy.
+def test_record_kernel_opt_vendor_playbook_keep_is_deploy_blocked(state: SharedState):
+    """A vendor-playbook KEEP's best_artifact_path is a copy of a KernelForge
+    task-bundle config file, not a rewrite of the real installed operator
+    source -- apply_kernel_patch's legacy full-file-replace strategy would
+    otherwise happily overwrite the real site-packages module with it
+    (PR #1191 review finding #1). The KEEP itself must still be recorded
+    (the measured speedup is real), but it must never reach the
+    auto-integrate queue.
+    """
+    result = _ok_result(
+        "k010",
+        "KEEP",
+        1.25,
+        source_file="/opt/venv/lib/python3.12/site-packages/mori/ops/dispatch_combine.py",
+        artifact=(
+            "/tmp/forge/session1/attempt_dispatch/optimized_versions/"
+            "mori_ep_dispatch_combine_dispatch.py"
+        ),
+    )
+    result["attempts"] = [
+        {
+            "backend": "forge",
+            "vendor_playbook_id": "mori_ep_dispatch_combine",
+            "vendor_playbook_role": "dispatch",
+        }
+    ]
+    state.record_kernel_opt(result)
+
+    assert state.last_kernel_opt["decision"] == "KEEP"
+    assert state.last_kernel_opt["vendor_playbook_deploy_blocked"] is True
+    assert state.last_kernel_opt["vendor_playbook_id"] == "mori_ep_dispatch_combine"
+    assert state.kernel_opt_attempts["k010"]["vendor_playbook_deploy_blocked"] is True
+    assert state.pending_kernel_integrations == {}, (
+        "a vendor-playbook KEEP must never be auto-queued for integration"
+    )
+
+
+def test_record_kernel_opt_non_vendor_keep_is_not_deploy_blocked(state: SharedState):
+    """A normal (non-vendor-playbook) KEEP must still queue for integration."""
+    result = _ok_result(
+        "k001",
+        "KEEP",
+        2.0,
+        source_file="/path/moe_op.py",
+        artifact="/tmp/k001.py",
+    )
+    state.record_kernel_opt(result)
+
+    assert state.last_kernel_opt["vendor_playbook_deploy_blocked"] is False
+    assert state.pending_kernel_integrations, "a normal KEEP must still be queued"
+
+
 # next_pending_keep_kernel_id queue semantics
 def test_next_pending_keep_drains_in_micro_speedup_order(state: SharedState):
     """KEEPs on different source_files drain highest-micro-first as the stack fills."""
@@ -545,7 +598,7 @@ def test_untried_hot_kernels_vendor_playbook_group_gated_on_aggregate(state: Sha
 
     Neither member clears the 10% default threshold alone, but
     _apply_vendor_operator_playbook_grouping() (tracelens_analysis.py) stamps
-    aggregate_gpu_pct=12.0 on both, since the pair is deliberately dispatched
+    vendor_playbook_aggregate_gpu_pct=12.0 on both, since the pair is deliberately dispatched
     as one forge-loop session (see KernelForge PR #88 / the mori vendor
     playbook). Regression for a real gap: the gate used to compare each row's
     own gpu_pct, so a split load like this was silently dropped as
@@ -557,7 +610,7 @@ def test_untried_hot_kernels_vendor_playbook_group_gated_on_aggregate(state: Sha
             {
                 "kernel_id": "k010",
                 "gpu_pct": 7.0,
-                "aggregate_gpu_pct": 12.0,
+                "vendor_playbook_aggregate_gpu_pct": 12.0,
                 "reusable_native_kernel": True,
                 "source_file": "/opt/venv/.../mori_ep_config.py",
                 "name": "mori::EpDispatchCombineOp::dispatch",
@@ -565,7 +618,7 @@ def test_untried_hot_kernels_vendor_playbook_group_gated_on_aggregate(state: Sha
             {
                 "kernel_id": "k011",
                 "gpu_pct": 5.0,
-                "aggregate_gpu_pct": 12.0,
+                "vendor_playbook_aggregate_gpu_pct": 12.0,
                 "reusable_native_kernel": True,
                 "source_file": "/opt/venv/.../mori_ep_config.py",
                 "name": "mori::EpDispatchCombineOp::combine",
@@ -589,7 +642,7 @@ def test_untried_hot_kernels_vendor_playbook_floor_still_applies(state: SharedSt
             {
                 "kernel_id": "k010",
                 "gpu_pct": 2.0,
-                "aggregate_gpu_pct": 3.0,
+                "vendor_playbook_aggregate_gpu_pct": 3.0,
                 "vendor_playbook_min_gpu_pct_floor": 10.0,
                 "reusable_native_kernel": True,
                 "source_file": "/opt/venv/.../mori_ep_config.py",

--- a/src/hyperloom/orchestrator/kernel/_kernel_decisions.py
+++ b/src/hyperloom/orchestrator/kernel/_kernel_decisions.py
@@ -133,6 +133,14 @@ def _queue_kernel_keep(
     entry: dict[str, Any],
 ) -> dict[str, Any] | None:
     """Persist one KEEP patch snapshot without coupling it to an ordinal slot."""
+    if entry.get("vendor_playbook_deploy_blocked"):
+        # A vendor-playbook KEEP has no deployable artifact -- see
+        # record_kernel_opt()'s comment (PR #1191 review finding #1).
+        # Refusing to queue it here means _auto_enqueue_pending_integrations()
+        # never dispatches an integrate for it; integrate_handler() still
+        # checks this flag independently for an LLM-initiated request that
+        # names the kernel_id directly.
+        return None
     decision = str(entry.get("last_decision") or "").upper()
     try:
         micro_speedup = float(entry.get("last_micro_speedup") or 0.0)
@@ -377,6 +385,23 @@ def pending_kernel_integration_records(state) -> list[dict[str, Any]]:
             claimed_sources.add(source_file)
         result.append(record)
     return result
+
+
+def _vendor_playbook_id_from_result(result: dict[str, Any]) -> str:
+    """Return the vendor-playbook group id a ``kernel_opt`` result belongs to.
+
+    ``forge_submit._submit_vendor_playbook()`` stamps ``vendor_playbook_id``
+    on every raw per-backend attempt dict it returns (winner and reused
+    sibling alike); ``kernel_optimization.py`` carries those attempt dicts
+    through verbatim in ``result["attempts"]``. Empty when this kernel_opt
+    result did not go through the vendor-playbook path.
+    """
+    for attempt in result.get("attempts") or []:
+        if isinstance(attempt, dict):
+            vid = str(attempt.get("vendor_playbook_id") or "").strip()
+            if vid:
+                return vid
+    return ""
 
 
 def _resolve_kernel_patch_identity(
@@ -1083,6 +1108,20 @@ def record_kernel_opt(state, result: dict[str, Any]) -> None:
     )
     entry["last_ts"] = ts
     entry["history"] = history
+    # A vendor-playbook artifact (e.g. mori's dispatch/combine launch-config
+    # tuning, see agents/kernel/tools/_vendor_operator_playbooks.py) is a
+    # KernelForge task-bundle config file, not a rewrite of the real,
+    # installed operator source -- there is no supported path from it back
+    # to the live serving install, and apply_kernel_patch's legacy
+    # full-file-replace strategy would happily overwrite the real
+    # site-packages module with it if ever asked to (PR #1191 review
+    # finding #1). KEEP is still reported (the measured speedup is real and
+    # worth surfacing), but deploy/integrate is refused downstream --
+    # see _queue_kernel_keep() and integrate_handler()'s defense-in-depth
+    # check.
+    vendor_playbook_id = _vendor_playbook_id_from_result(result)
+    entry["vendor_playbook_id"] = vendor_playbook_id
+    entry["vendor_playbook_deploy_blocked"] = bool(vendor_playbook_id)
 
     # last_kernel_opt overwrite policy: KEEP always wins; non-KEEP writes only
     # when there is no pending KEEP to protect.
@@ -1116,6 +1155,8 @@ def record_kernel_opt(state, result: dict[str, Any]) -> None:
             "deploy_repo_root": deploy_repo_root,
             "source_file": source_file,
             "task_group_key": task_group_key,
+            "vendor_playbook_id": vendor_playbook_id,
+            "vendor_playbook_deploy_blocked": bool(vendor_playbook_id),
             "ts": ts,
         }
 

--- a/src/hyperloom/orchestrator/kernel/_kernel_decisions.py
+++ b/src/hyperloom/orchestrator/kernel/_kernel_decisions.py
@@ -34,6 +34,8 @@ from ..state.kernel_decision_settings import (
     _DEFAULT_KERNEL_OPT_MAX_PARTIAL,
     _MAX_INTEGRATE_FAULT_ATTEMPTS,
     _now_iso,
+    effective_hot_kernel_gpu_pct,
+    effective_hot_kernel_min_gpu_pct,
     resolve_hot_kernel_min_gpu_pct,
     resolve_kernel_opt_max_failures,
 )
@@ -1566,7 +1568,11 @@ def untried_hot_reusable_kernels(
             gpu_pct = float(k.get("gpu_pct") or 0.0)
         except (TypeError, ValueError):
             gpu_pct = 0.0
-        if gpu_pct < min_gpu_pct:
+        # Vendor-playbook groups (mori's dispatch+combine) are gated on the
+        # sum of the group's members, not each member's own share, and may
+        # pin a per-playbook floor -- see effective_hot_kernel_gpu_pct's
+        # docstring. Ranking below still sorts on the per-row gpu_pct.
+        if effective_hot_kernel_gpu_pct(k) < effective_hot_kernel_min_gpu_pct(k, min_gpu_pct):
             continue
         kid = str(k.get("kernel_id") or "")
         if not kid:

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -1392,11 +1392,24 @@ def _fill_integrate_defaults_from_state(
             }
 
     kernel_id = str(resolved.get("kernel_id") or "")
-    if kernel_id and not resolved.get("task_group_key"):
+    if kernel_id:
         attempt = (state.kernel_opt_attempts or {}).get(kernel_id) or {}
-        task_group_key = str(attempt.get("task_group_key") or "")
-        if task_group_key:
-            resolved["task_group_key"] = task_group_key
+        if not resolved.get("task_group_key"):
+            task_group_key = str(attempt.get("task_group_key") or "")
+            if task_group_key:
+                resolved["task_group_key"] = task_group_key
+        # Defense-in-depth mirror of _queue_kernel_keep()'s refusal to queue
+        # a vendor-playbook KEEP for auto-integration (PR #1191 review
+        # finding #1): this also catches an LLM-initiated integrate request
+        # that names the kernel_id directly, bypassing the pending-queue
+        # lookup above via _resolve_kernel_patch_identity()'s
+        # last_kernel_opt.best_artifact_path backfill.
+        if attempt.get("vendor_playbook_deploy_blocked"):
+            resolved["_vendor_playbook_deploy_blocked"] = True
+        elif isinstance(state.last_kernel_opt, dict) and str(
+            state.last_kernel_opt.get("kernel_id") or ""
+        ) == kernel_id and state.last_kernel_opt.get("vendor_playbook_deploy_blocked"):
+            resolved["_vendor_playbook_deploy_blocked"] = True
 
     return resolved
 
@@ -7288,6 +7301,28 @@ async def integrate_handler(
     # Fill defaults from SharedState before the ``base_tput > 0`` check so a bare
     # {kernel_id} payload isn't failed with a phantom "missing base_tput".
     payload = _fill_integrate_defaults_from_state(payload, session_dir=session_dir)
+
+    if payload.get("_vendor_playbook_deploy_blocked"):
+        # A vendor-playbook KEEP (e.g. mori dispatch/combine launch-config
+        # tuning) has no deployable artifact: best_artifact_path is a copy of
+        # a KernelForge task-bundle config file, not a rewrite of the real
+        # installed operator, and apply_kernel_patch's legacy full-file
+        # replace would happily overwrite the real site-packages module with
+        # it (PR #1191 review finding #1). Refuse before touching the
+        # filesystem rather than letting a config-file copy silently
+        # corrupt a live install.
+        return {
+            "status": "failed",
+            "error_class": "vendor_playbook_not_deployable",
+            "error": (
+                "integrate refused: kernel_id="
+                f"{payload.get('kernel_id')!r} is a vendor-playbook result "
+                "(closed-source operator launch-config tuning); it has no "
+                "deployable artifact and must not be applied as a source patch"
+            ),
+            "decision": "NEEDS_REVIEW",
+            "kernel_id": payload.get("kernel_id"),
+        }
 
     base_tput = float(payload.get("base_tput", 0.0))
     if base_tput <= 0:

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -71,6 +71,10 @@ from ._kernel_decisions import (
     is_collective_candidate as is_collective_candidate,
     SUPPORTED_COLLECTIVE_OPS as SUPPORTED_COLLECTIVE_OPS,
 )
+from ..state.kernel_decision_settings import (
+    effective_hot_kernel_gpu_pct,
+    effective_hot_kernel_min_gpu_pct,
+)
 
 
 log = logging.getLogger(__name__)
@@ -6071,13 +6075,15 @@ def _batch_kernel_candidates(
                     continue
         if not primary_cand.get("source_file"):
             continue
-        try:
-            picked_pct = float(primary_cand.get("gpu_pct") or 0.0)
-        except (TypeError, ValueError):
-            picked_pct = 0.0
-        if picked_pct < min_gpu_pct:
+        # Vendor-playbook groups (mori's dispatch+combine) are gated on the
+        # sum of the group's members, not the picked member's own share, and
+        # may pin a per-playbook floor -- see
+        # effective_hot_kernel_gpu_pct's docstring. No-op for ordinary
+        # task_group members, which carry neither field.
+        gate_floor = effective_hot_kernel_min_gpu_pct(primary_cand, min_gpu_pct)
+        if effective_hot_kernel_gpu_pct(primary_cand) < gate_floor:
             for m in member_ids:
-                skipped.setdefault(m, f"below_min_gpu_pct={min_gpu_pct}")
+                skipped.setdefault(m, f"below_min_gpu_pct={gate_floor}")
             continue
         # Shallow copy + attach group so the subprocess sees the task_group.
         item = dict(primary_cand)
@@ -6138,8 +6144,11 @@ def _batch_kernel_candidates(
         legacy_eligible = deduped
 
     for kernel_id, item, row_pct in legacy_eligible:
-        if row_pct < min_gpu_pct:
-            skipped[kernel_id] = f"below_min_gpu_pct={min_gpu_pct}"
+        # See the task_group gate above: prefer a vendor-playbook group's
+        # aggregate share and floor over the row's own gpu_pct when stamped.
+        gate_floor = effective_hot_kernel_min_gpu_pct(item, min_gpu_pct)
+        if max(row_pct, effective_hot_kernel_gpu_pct(item)) < gate_floor:
+            skipped[kernel_id] = f"below_min_gpu_pct={gate_floor}"
             continue
         selected.append(item)
 

--- a/src/hyperloom/orchestrator/state/kernel_decision_settings.py
+++ b/src/hyperloom/orchestrator/state/kernel_decision_settings.py
@@ -70,6 +70,62 @@ def resolve_hot_kernel_min_gpu_pct() -> float:
         return _DEFAULT_HOT_KERNEL_MIN_GPU_PCT
 
 
+def effective_hot_kernel_gpu_pct(candidate: dict) -> float:
+    """GPU-time share used for the hot-kernel gate.
+
+    A vendor-playbook group (e.g. mori's dispatch+combine, deliberately
+    submitted as one forge-loop session -- see
+    ``agents/kernel/tools/_vendor_operator_playbooks.py``) stamps
+    ``aggregate_gpu_pct`` as the summed share across the whole group, so a
+    split load (7% + 5%) is not silently dropped as below-threshold on
+    either member despite the pair clearing it together. Prefer the
+    aggregate over the per-row ``gpu_pct`` whenever it is present and larger
+    (never smaller, so this can only let a grouped row through a gate it
+    would otherwise fail -- it cannot cause an ungrouped row to fail one it
+    would otherwise pass).
+
+    Returns:
+        float: The larger of ``gpu_pct`` and ``aggregate_gpu_pct`` (when the
+            latter is present and parses); ``gpu_pct`` alone otherwise.
+    """
+    try:
+        row_pct = float(candidate.get("gpu_pct") or 0.0)
+    except (TypeError, ValueError):
+        row_pct = 0.0
+    aggregate = candidate.get("aggregate_gpu_pct")
+    if aggregate is None:
+        return row_pct
+    try:
+        return max(row_pct, float(aggregate))
+    except (TypeError, ValueError):
+        return row_pct
+
+
+def effective_hot_kernel_min_gpu_pct(candidate: dict, min_gpu_pct: float) -> float:
+    """Threshold ``candidate`` must clear, honoring a playbook's own floor.
+
+    A vendor playbook may pin a ``min_gpu_pct_floor`` (see
+    ``vendor_operator_playbooks.json``) so its group is never dispatched
+    below that share even when ``HYPERLOOM_KERNEL_OPT_MIN_GPU_PCT`` is
+    loosened for other purposes (e.g. a smaller test fixture) -- the
+    playbook's own forge-loop session is a heavier investment than an
+    ordinary per-file rewrite attempt, so the floor can only raise the
+    effective threshold, never lower it below the caller's own ``min_gpu_pct``.
+
+    Returns:
+        float: The larger of ``min_gpu_pct`` and the candidate's stamped
+            ``vendor_playbook_min_gpu_pct_floor`` (when present and parses);
+            ``min_gpu_pct`` alone otherwise.
+    """
+    floor = candidate.get("vendor_playbook_min_gpu_pct_floor")
+    if floor is None:
+        return min_gpu_pct
+    try:
+        return max(min_gpu_pct, float(floor))
+    except (TypeError, ValueError):
+        return min_gpu_pct
+
+
 # Only the top-N reusable hot kernels are enforced.
 _DEFAULT_HOT_KERNEL_GATE_TOP_N = 5
 

--- a/src/hyperloom/orchestrator/state/kernel_decision_settings.py
+++ b/src/hyperloom/orchestrator/state/kernel_decision_settings.py
@@ -76,23 +76,31 @@ def effective_hot_kernel_gpu_pct(candidate: dict) -> float:
     A vendor-playbook group (e.g. mori's dispatch+combine, deliberately
     submitted as one forge-loop session -- see
     ``agents/kernel/tools/_vendor_operator_playbooks.py``) stamps
-    ``aggregate_gpu_pct`` as the summed share across the whole group, so a
-    split load (7% + 5%) is not silently dropped as below-threshold on
-    either member despite the pair clearing it together. Prefer the
-    aggregate over the per-row ``gpu_pct`` whenever it is present and larger
-    (never smaller, so this can only let a grouped row through a gate it
-    would otherwise fail -- it cannot cause an ungrouped row to fail one it
-    would otherwise pass).
+    ``vendor_playbook_aggregate_gpu_pct`` as the summed share across the
+    whole group, so a split load (7% + 5%) is not silently dropped as
+    below-threshold on either member despite the pair clearing it together.
+    Prefer the aggregate over the per-row ``gpu_pct`` whenever it is present
+    and larger (never smaller, so this can only let a grouped row through a
+    gate it would otherwise fail -- it cannot cause an ungrouped row to fail
+    one it would otherwise pass).
+
+    Namespaced field name deliberately: bare ``aggregate_gpu_pct`` is
+    already an existing task_group-level concept (see
+    ``tracelens_skill_runner.py`` / ``_bypass_report.py``); reading that name
+    off a candidate row here would silently change every ordinary group's
+    gating behavior if a future change ever flattened it onto candidate rows
+    (PR #1191 review finding #7).
 
     Returns:
-        float: The larger of ``gpu_pct`` and ``aggregate_gpu_pct`` (when the
-            latter is present and parses); ``gpu_pct`` alone otherwise.
+        float: The larger of ``gpu_pct`` and
+            ``vendor_playbook_aggregate_gpu_pct`` (when the latter is
+            present and parses); ``gpu_pct`` alone otherwise.
     """
     try:
         row_pct = float(candidate.get("gpu_pct") or 0.0)
     except (TypeError, ValueError):
         row_pct = 0.0
-    aggregate = candidate.get("aggregate_gpu_pct")
+    aggregate = candidate.get("vendor_playbook_aggregate_gpu_pct")
     if aggregate is None:
         return row_pct
     try:

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -3221,6 +3221,19 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
                 "candidate_source": entry.get("candidate_source") or "",
                 "recommended_backends": entry.get("recommended_backends") or [],
                 "recommended_actions": entry.get("recommended_actions") or [],
+                # Vendor-playbook fields (mori's dispatch+combine is the first
+                # case -- see _vendor_operator_playbooks.py). Without these,
+                # effective_hot_kernel_gpu_pct()/effective_hot_kernel_min_gpu_pct()
+                # silently degrade to bare gpu_pct/min_gpu_pct for every caller
+                # that gates off this projection (untried_hot_reusable_kernels()
+                # is the only one -- _batch_kernel_candidates() reads full
+                # candidate dicts off candidates_path instead), losing both the
+                # aggregate gate's intended pass (PR #1191 review finding #3)
+                # and the playbook's own min_gpu_pct_floor enforcement.
+                "patch_strategy": entry.get("patch_strategy") or "",
+                "vendor_playbook_group_id": entry.get("vendor_playbook_group_id") or "",
+                "vendor_playbook_aggregate_gpu_pct": entry.get("vendor_playbook_aggregate_gpu_pct"),
+                "vendor_playbook_min_gpu_pct_floor": entry.get("vendor_playbook_min_gpu_pct_floor"),
             }
             summary.append(summary_entry)
             if any(


### PR DESCRIPTION
## Summary

Mori's EP `dispatch`/`combine` kernels are pip-installed compiled binaries with no rewritable source, so `classify_patchability()` used to reject them as `vendor_binary` before any tuning could happen ([KernelForge PR #88](https://github.com/AMD-AGI/KernelForge/pull/88)). This adds a **vendor operator playbook**: a registry that recognizes known vendor operators and routes them to a validated KernelForge task bundle instead of source rewriting.

**Implemented:**
- `vendor_operator_playbooks.json` + `_vendor_operator_playbooks.py` — registry + matcher, disambiguates `dispatch` vs `combine` by trailing method segment, routes to `examples/mori_ep_dispatch_combine/`.
- `tracelens_analysis.py` — `classify_patchability()` checks the registry before rejecting as `vendor_binary`; groups dispatch+combine into one aggregate GPU% target.
- `forge_submit.py` — new `_submit_vendor_playbook()` path with a session-scoped lock so dispatch and combine share **one** forge-loop session instead of running twice.
- Fixed a result-dict field gap that made `kernel_optimization.py` report `PARTIAL`/no-speedup even when forge-loop had validated a real speedup internally.

## Bugs found & fixed during review (4 rounds, 10 total, all with regression tests)

| # | Severity | Issue | Fix |
|---|---|---|---|
| 1 | High | Reused (combine) role lost its optimized artifact (path mismatch) | Aligned `cli_workspace`/`output_dir`; added a physical artifact copy as a safety net |
| 2 | High | Exception after claiming the group lock left it stuck all session | Wrapped post-claim work so failures always release the lock |
| 3 | Medium | `aggregate_gpu_pct` computed but never used for gating | Wired into all 3 gate call sites |
| 4 | Medium | Registry comment overstated what `kb_path` does | Corrected docs (metadata only) |
| 5 | Blocking | Vendor-playbook artifact could reach `apply_kernel_patch`'s legacy full-file-replace and overwrite the real installed operator | Blocked vendor-playbook results from ever reaching auto-integrate |
| 6 | Blocking | Failed results cached for the whole session, no retry | Added a 10-min TTL on failure caching (successes stay cached permanently) |
| 7 | High | A dead lock-holder (SIGKILL/OOM) blocked submissions for up to an hour | Claims now carry `{pid, timestamp, nonce}` and are safely stolen once stale |
| 8 | High | Dispatch and combine could double-count the same forge-loop speedup as two wins | Only the role that actually ran forge-loop is counted |
| 9 | High | `_candidate_haystack()` didn't check `trace_launcher_file`, so graph-captured kernels (the real production trace shape) never matched the registry at all | Added the field + 2 regression tests reproducing the exact real-trace shape |
| 10 | Blocking | (tech-lead review) `_build_hot_kernel_summaries()`'s key whitelist dropped `patch_strategy`/`vendor_playbook_*` fields, so `untried_hot_reusable_kernels()` silently degraded the aggregate/floor gate to bare `gpu_pct` on the real production path (`hot_kernels_top15`) — losing both the split-load pass-through *and* the playbook's own floor enforcement | Added the 4 fields to the whitelist; 2 new regression tests through the real `record_trace_analyze()` entry point (existing tests bypassed the projection and couldn't catch this) |

## Testing

- **Unit**: `test_vendor_operator_playbook_mori.py` 18/18 passing. Full `agents/kernel/tests/` + `inference_optimizer/tests/` suites checked before/after the latest fix: identical pre-existing, unrelated failure set both times (missing `pytest-asyncio` plugin) — no regressions.
- **Live e2e — isolated micro-workload** (MI300X, dispatch/combine-bottlenecked): correctly routed to the vendor playbook; forge-loop found a validated **1.25x** speedup (`combine_zero_copy=True`, tuned block/warp grid), correctness **PASS** against mori's own reference test-suite math, single-session dedup confirmed (combine reused dispatch's cached result in 0.1s). **This is the run that proves mori is actually re-tuned by KernelForge, with a real measured win, end to end.**
- **Live e2e — full production workload** (8× MI300X, DeepSeek-Coder-V2-Lite, TP1/EP8/DP8, `mori_high_throughput`): proves the *automatic* half of the pipeline off a real serving trace, with **zero manual intervention** — TraceLens classified dispatch+combine as `vendor_playbook` on its own (42.7% aggregate GPU%), the orchestrator transitioned `PRELUDE → KERNEL_AGENT`, `forge_submit` resolved the target and spawned a real forge-loop subprocess (fresh git worktree, aiter-cache, `claude-opus-5` implementer/supervisor), and the `combine` candidate correctly deduped onto the same session instead of spawning its own. forge-loop's baseline benchmark then hit a native abort *inside mori's own compiled shmem library* (`ShmemStates::CheckStatusValid()`, ×8 ranks) before a clean timing round could complete — so this run does **not** produce a second measured speedup, but the crash trace itself is further confirmation that mori's real operator construction path was reached (not mocked). Handled safely by the orchestrator (`REVERT`, `crash_count: 0`, no stuck lock) — see "Known follow-up" below.
  - **Net read**: detection → routing → dispatch → dedup is proven automatic on a real production trace; the actual *tuning* result (a measured speedup) is proven only on the isolated micro-workload above, not yet on a live production workload.
- **CI**: all checks green, including `ci-e2e` (a transient CI-infra disk-quota fault on the first run was unrelated to this PR's code — cleared on retest).

## Known follow-up (not blocking)

On the full production run, forge-loop's own baseline benchmark crashed with a native abort inside mori's shmem library (`ShmemStates::CheckStatusValid()`). Handled safely — `REVERT`, `crash_count: 0`, no stuck lock, no false-positive speedup — but this specific task bundle couldn't produce a *measured* speedup on that run.

Root cause is most likely resource exclusivity, not a missing rendezvous: mori's `shmem` is a GPU-initiated **symmetric-memory heap** shared across all ranks on a node, and `driver.py` already does its own complete standalone `dist.init_process_group` + `shmem_torch_process_group_init` — it doesn't depend on an external process group. The live vLLM server being optimized was still serving on the *same* 8 GPUs when forge-loop's driver tried to claim its own independent 8-rank mori heap on top of it; two competing mori-EP groups can't coexist on one 8-GPU box. A real fix means pausing/releasing the live server's GPU allocation around this class of kernel_opt attempt (or routing distributed collective kernels to a phase where the GPUs are guaranteed free) — an orchestrator-level coordination change, not a `driver.py` patch, and risky to rush (a botched pause/resume could hang a live production server, a worse outcome than today's safe no-op). Filed as follow-up rather than patched here; not a regression risk as-is since the pipeline already fails safe.

## Test plan

- [x] Unit tests: `pytest .../test_vendor_operator_playbook_mori.py -q` (18/18)
- [x] Full kernel-agent + inference_optimizer regression suites (no new failures vs. `main`)
- [x] Live e2e, isolated micro-workload (dispatch+combine routed, single session, real speedup)
- [x] Live e2e, full production workload (automatic routing, dedup, graceful failure handling)
- [x] CI `ci-e2e` smoke check green
- [ ] Follow-up: confirm the GPU-exclusivity hypothesis above, then either pause/release the live server's GPUs around distributed vendor-playbook attempts or route them to the Coordinator's collective lane, so routed EP kernels can produce a measured speedup on a live DP+EP serving workload

Made with [Cursor](https://cursor.com)


