### PR TITLE
Bump the recommended vLLM stack to v0.27.1 (ROCm 7.2.3)

### DIFF
--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -122,7 +122,7 @@ The following inference frameworks are supported:
      - 7.2.0
      - Default framework
    * - vLLM
-     - 7.2.0
+     - 7.2.3
      - Do not mix frameworks within one session
    * - Atom
      - 7.2.0
@@ -149,7 +149,7 @@ accordingly.
      - MI300X / MI325X
    * - ``rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi350x``
      - MI355X
-   * - ``rocm/hyperloom:vllm-v0.24.0-rocm7.2.0``
+   * - ``rocm/hyperloom:vllm-v0.27.1-rocm7.2.3``
      - MI300X / MI325X / MI355X
 
 Browse all available tags at
@@ -170,7 +170,7 @@ Hyperloom does not install ROCm or torch itself.
      - Notes
    * - ROCm
      - 7.2.x
-     - Bare-metal patch level differs per framework: the vLLM stack uses ROCm 7.2.3 and the SGLang stack uses ROCm 7.2.0 (see the note below). ``docker`` mode uses the ``rocm/hyperloom`` images (ROCm 7.2.x) for both frameworks.
+     - The patch level differs per framework and is the same in both setup modes: the vLLM stack uses ROCm 7.2.3 and the SGLang stack uses ROCm 7.2.0 (see the note below).
    * - Python
      - 3.12
      - Required by the vLLM ROCm wheel.
@@ -181,16 +181,16 @@ Hyperloom does not install ROCm or torch itself.
      - v0.5.16 (rocm720)
      - Installed in ``shared`` mode (reuses the host torch). Uses the ROCm 7.2.0 AMD wheel index (``SGLANG_ROCM_EXTRA=rocm720``), so the SGLang ROCm layer is 7.2.0. Note: ``SGLANG_REF`` (v0.5.16) only pins the version on the source-install branch (non-3.10 Python); on Python 3.10 the AMD wheel index installs ``amd-sglang`` unpinned, which may resolve to a different patch release.
    * - vLLM
-     - v0.24.0 (rocm723), isolated venv
-     - Installs ``vllm==0.24.0+rocm723`` from the wheels.vllm.ai pip index. vLLM's ROCm wheel pins its own torch, so it installs into a dedicated venv (``--framework-env isolated``, the default for vLLM) and never touches the host torch.
+     - v0.27.1 (rocm723), isolated venv
+     - Installs ``vllm==0.27.1+rocm723`` from the wheels.vllm.ai pip index. vLLM's ROCm wheel pins its own torch, so it installs into a dedicated venv (``--framework-env isolated``, the default for vLLM) and never touches the host torch.
 
-Bare-metal ROCm patch levels differ per framework. The vLLM version matches the
-``v0.24.0`` Docker image; the pip index publishes 0.24.0 only as the ``rocm723``
-variant (ROCm 7.2.3), so the bare-metal vLLM ROCm layer is 7.2.3. The SGLang
-stack installs from the ROCm 7.2.0 AMD wheel index, so its ROCm layer is 7.2.0.
-In ``docker`` mode both frameworks use the ``rocm/hyperloom`` images (ROCm
-7.2.x). For a fully validated, pre-aligned vLLM stack, prefer ``docker`` mode
-with ``rocm/hyperloom:vllm-v0.24.0-rocm7.2.0``.
+Bare-metal ROCm patch levels differ per framework, and each one matches its
+``rocm/hyperloom`` image. The vLLM stack installs the ``rocm723`` variant (ROCm
+7.2.3), matching ``rocm/hyperloom:vllm-v0.27.1-rocm7.2.3``; the SGLang stack
+installs from the ROCm 7.2.0 AMD wheel index, matching the two
+``sglang-v0.5.16-rocm7.2.0`` images. ``docker`` mode is still the preferred
+route for a pre-validated stack, since the images also pin the surrounding
+torch, Triton, and AITER builds.
 
 These are recommended defaults, not hard pins. Framework and ROCm versions are
 overridable via env (``SGLANG_REF``, ``SGLANG_ROCM_EXTRA``, ``VLLM_VERSION``,

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -375,7 +375,7 @@ It is recommended that you use a ROCm image that already ships the serving
 framework, so nothing needs to be installed inside the container beyond
 Hyperloom's runtime deps. The following images are recommended:
 
-- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.24.0-rocm7.2.0`
+- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.27.1-rocm7.2.3`
 - `sglang` MI300X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x`
 - `sglang` MI355X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi350x`
 
@@ -383,7 +383,7 @@ Start a long-running container from the repo root, mounting it at the same path
 so `.env`, logs, and session artifacts stay valid:
 
 ```bash
-export HYPERLOOM_IMAGE=docker.io/rocm/hyperloom:vllm-v0.24.0-rocm7.2.0
+export HYPERLOOM_IMAGE=docker.io/rocm/hyperloom:vllm-v0.27.1-rocm7.2.3
 export REPO_ROOT="$(pwd -P)"
 docker run -d \
   --name "${HYPERLOOM_CONTAINER_NAME:-hyperloom-local}" \

--- a/examples/hyperloom-custom-advanced/SKILL.md
+++ b/examples/hyperloom-custom-advanced/SKILL.md
@@ -37,7 +37,7 @@ In docker mode:
 
 Suggested Docker images:
 
-- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.24.0-rocm7.2.0`
+- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.27.1-rocm7.2.3`
 - `sglang` MI300X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x`
 - `sglang` MI355X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi350x`
 

--- a/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
+++ b/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
@@ -27,7 +27,7 @@ In docker mode:
 
 Suggested Docker images:
 
-- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.24.0-rocm7.2.0`
+- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.27.1-rocm7.2.3`
 - `sglang` MI300X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x`
 - `sglang` MI355X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi350x`
 

--- a/examples/hyperloom-qwen3-8b-3h/SKILL.md
+++ b/examples/hyperloom-qwen3-8b-3h/SKILL.md
@@ -27,7 +27,7 @@ In docker mode:
 
 Suggested Docker images:
 
-- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.24.0-rocm7.2.0`
+- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.27.1-rocm7.2.3`
 - `sglang` MI300X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x`
 - `sglang` MI355X: `docker.io/rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi350x`
 

--- a/src/hyperloom/agents/kernel/scripts/install.sh
+++ b/src/hyperloom/agents/kernel/scripts/install.sh
@@ -596,8 +596,9 @@ ensure_python() {
 #     Still tolerates whitespace and single-line drift, the common
 #     point-release case the fuzzy fallback was designed for.
 #
-# Stripped runtime images (`lmsysorg/sglang:v0.5.9-rocm700-mi30x` and the
-# minimal vLLM serving images) sometimes ship without one or both binaries.
+# Stripped upstream runtime images (minimal SGLang/vLLM serving images, as
+# opposed to the `rocm/hyperloom` ones) sometimes ship without one or both
+# binaries.
 # `_server_patcher` fail-softs in that case → `--enable-shape-discovery-
 # for-cuda-graph-profile` is silently never injected → graph-replayed
 # kernels stay opaque, exactly what #194 §5 was trying to fix.
@@ -646,14 +647,15 @@ ensure_patch_tools() {
 # `cmd 2>&1 | ts '[%H:%M:%S]'` shim the optimizer fork-execs) doesn't blow
 # up with `ts: command not found`.
 #
-# Background: stripped runtime images (e.g. `lmsysorg/sglang:v0.5.9-rocm700-mi30x`
-# and the minimal vLLM serving images) ship without moreutils. When a wrapper
-# pipes its stdout/stderr through `ts` for per-line timestamps and `ts` is
-# missing, bash propagates exit code 127 up through the pipeline. The driving
-# inference_optimizer validate_stack executor sees `subprocess_nonzero`,
-# classifies the run as a baseline failure, and loops — burning minutes per
-# iteration on a one-line apt fix. moreutils itself is a tiny perl-only
-# package (<1 MB with deps), so this is a strict win over the retry cost.
+# Background: stripped upstream runtime images (minimal SGLang/vLLM serving
+# images, as opposed to the `rocm/hyperloom` ones) ship without moreutils.
+# When a wrapper pipes its stdout/stderr through `ts` for per-line timestamps
+# and `ts` is missing, bash propagates exit code 127 up through the pipeline.
+# The driving inference_optimizer validate_stack executor sees
+# `subprocess_nonzero`, classifies the run as a baseline failure, and loops —
+# burning minutes per iteration on a one-line apt fix. moreutils itself is a
+# tiny perl-only package (<1 MB with deps), so this is a strict win over the
+# retry cost.
 #
 # Same shape as ensure_patch_tools(): cheap apt-install with dry-run /
 # check-only / no-apt-get fail-soft semantics. fail-soft on install error

--- a/src/hyperloom/agents/kernel/tests/test_live_source_stack.py
+++ b/src/hyperloom/agents/kernel/tests/test_live_source_stack.py
@@ -8,7 +8,7 @@
 """Opt-in LIVE integration test for the v2 source-resolver stack.
 
 Runs the three real modules against the *actually installed* framework tree
-inside a real vLLM ROCm container (e.g. ``vllm/vllm-openai-rocm:v0.26.0``) --
+inside a real vLLM ROCm container (e.g. ``rocm/hyperloom:vllm-v0.27.1-rocm7.2.3``) --
 no fakes, no GPU needed (this only scans source):
 
 1. ``source_env``            -> discover_frameworks() dictionaries + metadata,

--- a/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
+++ b/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
@@ -47,9 +47,9 @@ _FRAMEWORK_ENV_WAS_SET="${FRAMEWORK_ENV+x}"
 FRAMEWORK_ENV="${FRAMEWORK_ENV:-shared}"
 SGLANG_REPO="${SGLANG_REPO:-https://github.com/sgl-project/sglang.git}"
 # Framework versions track docs/compatibility.rst (SGLang v0.5.16, ROCm 7.2).
-# vLLM installs 0.24.0+rocm723 from the wheels.vllm.ai pip index, matching the
-# v0.24.0 Docker image version. The pip index publishes 0.24.0 only as the
-# rocm723 variant (ROCm 7.2.3), so the ROCm layer is 7.2.3. AITER_REF
+# vLLM installs 0.27.1+rocm723 from the wheels.vllm.ai pip index, matching the
+# vllm-v0.27.1-rocm7.2.3 Docker image. The rocm723 variant puts the vLLM ROCm
+# layer at 7.2.3, one patch level above the SGLang stack. AITER_REF
 # can pin ROCm/aiter to a released tag; when unset, the installer selects the
 # newest tag compatible with the already-installed ROCm torch/triton stack.
 SGLANG_REF="${SGLANG_REF:-v0.5.16}"
@@ -65,7 +65,7 @@ fi
 SGLANG_ROCM_PYPI_VERSION="${SGLANG_ROCM_PYPI_VERSION:-7.2.0}"
 AITER_REPO="${AITER_REPO:-https://github.com/ROCm/aiter.git}"
 AITER_REF="${AITER_REF:-}"
-VLLM_VERSION="${VLLM_VERSION:-0.24.0}"
+VLLM_VERSION="${VLLM_VERSION:-0.27.1}"
 VLLM_ROCM_VARIANT="${VLLM_ROCM_VARIANT:-rocm723}"
 VLLM_ROCM_INDEX="${VLLM_ROCM_INDEX:-https://wheels.vllm.ai/rocm/${VLLM_VERSION}/${VLLM_ROCM_VARIANT}}"
 VLLM_VENV_ROOT="${VLLM_VENV_ROOT:-/opt/hyperloom/vllm-venv}"

--- a/src/hyperloom/inference_optimizer/assets/slurm/models.tsv
+++ b/src/hyperloom/inference_optimizer/assets/slurm/models.tsv
@@ -2,5 +2,5 @@
 # Example registry consumed by submit.sh. Replace repo_id / image / gpu_type
 # with your own published models and container images before running.
 deepseek_r1_sglang	deepseek-ai/DeepSeek-R1	sglang	MI300X	rocm/hyperloom:sglang-v0.5.16-rocm7.2.0-mi300x	8	fp8	1024	1024	64	moe_mla	6	10
-deepseek_r1_vllm	deepseek-ai/DeepSeek-R1	vllm	MI300X	vllm/vllm-openai-rocm:v0.24.0	8	fp8	1024	1024	64	moe_mla	6	10
-gptoss_vllm	openai/gpt-oss-120b	vllm	MI300X	vllm/vllm-openai-rocm:v0.24.0	8	fp4	1024	1024	64	moe_swa	6	10
+deepseek_r1_vllm	deepseek-ai/DeepSeek-R1	vllm	MI300X	rocm/hyperloom:vllm-v0.27.1-rocm7.2.3	8	fp8	1024	1024	64	moe_mla	6	10
+gptoss_vllm	openai/gpt-oss-120b	vllm	MI300X	rocm/hyperloom:vllm-v0.27.1-rocm7.2.3	8	fp4	1024	1024	64	moe_swa	6	10

--- a/src/hyperloom/inference_optimizer/tests/test_baremetal_doc_version_consistency.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baremetal_doc_version_consistency.py
@@ -27,12 +27,12 @@ def test_baremetal_defaults_match_compat_doc():
     sh = INSTALLER.read_text(encoding="utf-8")
     doc = COMPAT.read_text(encoding="utf-8")
 
-    vllm_version = _default("VLLM_VERSION", sh)        # e.g. 0.24.0
+    vllm_version = _default("VLLM_VERSION", sh)        # e.g. 0.27.1
     vllm_variant = _default("VLLM_ROCM_VARIANT", sh)   # e.g. rocm723
     sglang_ref = _default("SGLANG_REF", sh)            # e.g. v0.5.16
 
-    # compatibility.rst documents e.g. "v0.24.0 (rocm723)" and the pip spec
-    # "vllm==0.24.0+rocm723"; keep both in lockstep with the script defaults.
+    # compatibility.rst documents e.g. "v0.27.1 (rocm723)" and the pip spec
+    # "vllm==0.27.1+rocm723"; keep both in lockstep with the script defaults.
     assert "v%s (%s)" % (vllm_version, vllm_variant) in doc, (
         "docs/compatibility.rst must document vLLM 'v%s (%s)' to match "
         "install_baremetal.sh defaults" % (vllm_version, vllm_variant)

--- a/src/hyperloom/inference_optimizer/tests/test_bypass_backend.py
+++ b/src/hyperloom/inference_optimizer/tests/test_bypass_backend.py
@@ -591,10 +591,10 @@ def test_bypass_eval_limit_absent_is_none(tmp_path, monkeypatch):
 
 
 def test_vllm_server_command_enables_torch_profiler():
-    """vllm 0.24 needs --profiler-config flags to enable the torch profiler.
+    """vLLM needs --profiler-config flags to enable the torch profiler.
 
-    Regression: setting only VLLM_TORCH_PROFILER_DIR env is ignored by vllm
-    0.24 (Unknown env var), so /start_profile returns 404 and no trace lands.
+    Regression: setting only VLLM_TORCH_PROFILER_DIR env is ignored by vLLM
+    (Unknown env var), so /start_profile returns 404 and no trace lands.
     """
     cmd = bypass_engine.build_server_command(
         framework="vllm",

--- a/src/hyperloom/orchestrator/actions/executors/bypass_engine.py
+++ b/src/hyperloom/orchestrator/actions/executors/bypass_engine.py
@@ -141,7 +141,7 @@ def build_server_command(
         if max_model_len:
             cmd += ["--max-model-len", str(max_model_len)]
         if profile_dir:
-            # vllm 0.24 enables the torch profiler via --profiler-config
+            # vLLM enables the torch profiler via --profiler-config
             # (the legacy VLLM_TORCH_PROFILER_DIR env is ignored), without
             # which /start_profile returns 404 and no trace is written.
             cmd += [


### PR DESCRIPTION
## Summary

Moves the recommended vLLM stack from 0.24.0 to 0.27.1 and consolidates every container image reference onto the `rocm/hyperloom` repository.

- **Image**: `rocm/hyperloom:vllm-v0.24.0-rocm7.2.0` -> `rocm/hyperloom:vllm-v0.27.1-rocm7.2.3`
- **Bare metal**: `VLLM_VERSION` default `0.24.0` -> `0.27.1`; `VLLM_ROCM_VARIANT` stays `rocm723`
- **SGLang**: unchanged, since `sglang-v0.5.16-rocm7.2.0-mi300x` / `-mi350x` are still the newest published tags

The slurm example registry also moves off the upstream `vllm/vllm-openai-rocm:v0.24.0` image, so every image documented in the repo is now a `rocm/hyperloom` ref.

### Why the doc narrative changed

Before this PR the vLLM Docker image was ROCm 7.2.0 while bare metal resolved to 7.2.3, and `compatibility.rst` carried a paragraph explaining that mismatch. The new tag is itself 7.2.3, which lines up with the unchanged `rocm723` wheel variant, so the two setup modes now agree and that paragraph is rewritten to say each framework's bare-metal ROCm layer matches its image.

### No production code change

vLLM >= 0.26 ships `capture_torch_profiler` and `detailed_trace_annotation` upstream, so the native-profiler gate added in #1157 (`_VLLM_NATIVE_PROFILER_MIN_VERSION = (0, 26)`) already skips the TraceLens patch set for 0.27.1. The only non-doc edits are comments that had gone stale: `bypass_engine.py` and its test described `--profiler-config` as a "vllm 0.24" mechanism, and the kernel `install.sh` named a stripped `lmsysorg/sglang` v0.5.9 / rocm700 image as its example of a runtime lacking `git` / `patch` / `moreutils`. The former lose the version anchor because the interface is unchanged through 0.27.1; the latter now describes upstream stripped images generically, since naming a `rocm/hyperloom` tag there would wrongly imply our own images ship without those binaries.

## Verification

Checked against the real artifacts rather than assumed:

- `rocm/hyperloom:vllm-v0.27.1-rocm7.2.3` exists on Docker Hub (pushed 2026-08-15) and is the newest vLLM tag there; both SGLang tags exist and v0.5.16 is the newest SGLang.
- `vllm-0.27.1+rocm723-cp312-cp312-manylinux_2_34_x86_64.whl` exists under `wheels.vllm.ai/rocm/0.27.1/rocm723/`, so the raised bare-metal default resolves.
- Cross-checked v0.27.1's `vllm/config/profiler.py`: all seven fields this repo injects (`profiler`, `torch_profiler_dir`, `capture_torch_profiler`, `detailed_trace_annotation`, `ignore_frontend`, `delay_iterations`, `max_iterations`) are present, and `max_iterations=0` still means "no limit", so the `_profiler_bound_holds` guard keeps its meaning.
- That same file is what `_server_patcher`'s native path greps for its two sentinels, so `ensure_vllm_patched_for_tracelens` returns True on 0.27.1 and the two annotation flags are still injected. No silent profile degradation.

Note that this jumps three vLLM minor versions and one ROCm patch level at once: 0.27.1 is the first `rocm/hyperloom` image on ROCm 7.2.3, every earlier vLLM tag there is 7.2.0.

## Test plan

- [x] `test_baremetal_doc_version_consistency.py` passes. It locks `install_baremetal.sh` defaults to the `compatibility.rst` strings, which is the easiest thing to get wrong here.
- [x] `test_bypass_backend.py` profiler cases pass; the file's failure count is identical to `main` locally (the local box is Windows and lacks process-group support).
- [ ] CI on Linux.
- [ ] Optional follow-up on a GPU host: `docker run` the new image and confirm a profile round trip produces a torch trace plus the `capture_traces` sidecar.
