### PR TITLE
fix(loop): keep approved variants when a sibling is rejected

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_critic_verdict_map.py
+++ b/src/hyperloom/inference_optimizer/tests/test_critic_verdict_map.py
@@ -25,7 +25,9 @@ from hyperloom.inference_optimizer.protocol.intent import (
     validate_envelope,
 )
 from hyperloom.orchestrator.loop.coordinator_helpers import (
+    collapse_verdict_map,
     collapse_verdicts,
+    proceedable_variant_names,
     verdict_held_to_its_rule,
     verdict_map_entry_grounds,
     verdict_map_entry_held_to_its_rule,
@@ -350,7 +352,7 @@ async def test_legacy_single_verdict_still_materialises_whole_proposal(coord):
 
 @pytest.mark.asyncio
 async def test_verdict_map_collapses_to_summary_single_verdict(coord):
-    """A ``verdict_map`` collapses to a summary verdict (approve if any variant approved); whole proposal materialised."""
+    """A mixed map proceeds on the approved subset, not the whole grid."""
     pending = _seed_explore_proposal(coord)
     intent = Intent(
         type=IntentType.REVIEW_VERDICT,
@@ -366,9 +368,9 @@ async def test_verdict_map_collapses_to_summary_single_verdict(coord):
     )
     await coord._handle_review_verdict("critic", intent)
     assert pending.decided is True
-    assert pending.verdict == "approve"  # any approve → summary approve
+    assert pending.verdict == "approve"
     assert len(coord._materialise_calls) == 1
-    assert coord._materialise_calls[0][1] is None
+    assert coord._materialise_calls[0][1] == {"v_a"}
     bus_msgs = [m for m in coord.bus.messages if m.topic == "review_verdict"]
     assert len(bus_msgs) == 1
     assert bus_msgs[0].payload["verdict"] == "approve"
@@ -377,9 +379,7 @@ async def test_verdict_map_collapses_to_summary_single_verdict(coord):
 
 @pytest.mark.asyncio
 async def test_verdict_map_mixed_collapse_logs_audit(coord, caplog):
-    # Defensive audit (log-only): a verdict_map that collapses to approve must
-    # STILL materialise the whole proposal (behaviour unchanged) AND emit a
-    # log-only audit record for traceability.
+    """A mixed map still logs the collapse, and materialises only the proceedable names."""
     import logging
 
     pending = _seed_explore_proposal(coord)
@@ -395,10 +395,9 @@ async def test_verdict_map_mixed_collapse_logs_audit(coord, caplog):
     )
     with caplog.at_level(logging.WARNING, logger="hyperloom.orchestrator.loop.intent_router"):
         await coord._handle_review_verdict("critic", intent)
-    # behaviour unchanged: any approve -> summary approve -> whole proposal materialised
     assert pending.verdict == "approve"
     assert len(coord._materialise_calls) == 1
-    # log-only audit fired
+    assert coord._materialise_calls[0][1] == {"v_a"}
     assert any("review_verdict collapse" in r.getMessage() for r in caplog.records)
 
 
@@ -420,6 +419,27 @@ async def test_verdict_map_all_rejected_collapses_to_reject(coord):
     await coord._handle_review_verdict("critic", intent)
     assert pending.verdict == "reject"
     assert coord._materialise_calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_genuine_reject_does_not_sink_advised_siblings(coord):
+    """A substantive reject on one variant must not discard siblings the Critic advised through."""
+    pending = _seed_explore_proposal(coord, msg_id="msg-partial", variants=["v_a", "v_b", "v_c"])
+    intent = Intent(
+        type=IntentType.REVIEW_VERDICT,
+        payload={
+            "target_proposal_msg_id": pending.proposal_msg_id,
+            "verdict_map": {
+                "v_a": {"verdict": "advise", "rationale": "worth a look"},
+                "v_b": {"verdict": "reject", "rationale": "kb says no"},
+                "v_c": {"verdict": "approve"},
+            },
+        },
+    )
+    await coord._handle_review_verdict("critic", intent)
+    assert pending.verdict == "approve"
+    assert len(coord._materialise_calls) == 1
+    assert coord._materialise_calls[0][1] == {"v_a", "v_c"}
 
 
 @pytest.mark.asyncio
@@ -1169,6 +1189,7 @@ async def test_one_variant_held_to_advise_does_not_out_rank_its_siblings(coord):
     # Without the per-entry hold, reject out-ranks advise and the set is lost.
     assert pending.verdict == "advise"
     assert len(coord._materialise_calls) == 1
+    assert coord._materialise_calls[0][1] == {"v_a", "v_b"}
 
 
 @pytest.mark.asyncio
@@ -1194,6 +1215,7 @@ async def test_a_variant_citing_its_rule_in_the_key_the_entry_carries_is_held(co
 
     assert pending.verdict == "advise"
     assert len(coord._materialise_calls) == 1
+    assert coord._materialise_calls[0][1] == {"v_b"}
 
 
 @pytest.mark.asyncio
@@ -1211,6 +1233,7 @@ async def test_a_grid_rejected_only_on_advisory_rules_survives(coord):
     await coord._handle_review_verdict("critic", intent)
     assert pending.verdict == "advise"
     assert len(coord._materialise_calls) == 1
+    assert coord._materialise_calls[0][1] == {"v_a", "v_b"}
 
 
 @pytest.mark.asyncio
@@ -1696,6 +1719,30 @@ def test_the_collapse_keeps_its_priority_order(verdicts, expected):
     assert collapse_verdicts(verdicts) == expected
 
 
+def test_proceedable_names_drop_rejects_and_blank_keys():
+    assert proceedable_variant_names(
+        {"v_a": "approve", "v_b": "reject", "": "advise", "v_c": "advise", "v_d": "needs_review"}
+    ) == {"v_a", "v_c"}
+
+
+def test_collapse_verdict_map_keeps_proceedable_siblings():
+    summary, names = collapse_verdict_map({"v_a": "advise", "v_b": "reject", "v_c": "approve"})
+    assert summary == "approve"
+    assert names == {"v_a", "v_c"}
+
+
+def test_collapse_verdict_map_advise_survives_a_sibling_reject():
+    summary, names = collapse_verdict_map({"v_a": "advise", "v_b": "reject"})
+    assert summary == "advise"
+    assert names == {"v_a"}
+
+
+def test_collapse_verdict_map_with_no_proceedable_variant_stays_reject():
+    summary, names = collapse_verdict_map({"v_a": "reject", "v_b": "needs_review"})
+    assert summary == "reject"
+    assert names is None
+
+
 # 4. _materialize_approved_proposal — filter semantics (unit)
 @pytest.mark.asyncio
 async def test_materialize_filter_drops_rejected_variants(tmp_path: Path):
@@ -1750,6 +1797,40 @@ async def test_materialize_filter_drops_rejected_variants(tmp_path: Path):
     names = [v["name"] for v in grid]
     assert names == ["v_a", "v_c"]
     assert create_calls[0]["params"]["critic_filtered_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_materialize_filter_skips_when_no_variant_survives(tmp_path: Path):
+    """A filter that matches nothing must not enqueue an empty explore grid."""
+    coord = Coordinator.__new__(Coordinator)
+    coord.session_dir = tmp_path
+    coord.state = CoordinatorState()
+    coord.recipe_kb = _StubRecipeKB()
+    coord.bus = _StubBus()
+    coord._record_observation = AsyncMock()  # type: ignore[method-assign]
+    create_calls: list[dict[str, Any]] = []
+
+    class _StubTaskRegistry:
+        async def create_or_return_existing(self, **kwargs: Any):  # noqa: ANN401
+            create_calls.append(dict(kwargs))
+            raise AssertionError("empty filtered grid must not create a task")
+
+    coord.tasks = _StubTaskRegistry()
+    pending = _seed_explore_proposal(coord, variants=["v_a", "v_b"])
+
+    class _MoreState(_BareSharedState):
+        baseline_config_path: str = ""
+        baseline_tput: float = 1000.0
+        synergy_attempted: list[str] = field(default_factory=list)
+        backends_search: dict = field(default_factory=dict)
+        params_search: dict = field(default_factory=dict)
+        current_best: dict = field(default_factory=dict)
+
+    coord.shared_state = _MoreState()
+    await coord._materialize_approved_proposal(pending, approved_variant_names={"no-such-variant"})
+    assert create_calls == []
+    kinds = [call.args[2].get("kind") for call in coord._record_observation.await_args_list]
+    assert "proposal_materialize_skipped" in kinds
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_reauthor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_reauthor.py
@@ -249,7 +249,7 @@ async def test_advise_verdict_does_not_reauthor(coord: Coordinator) -> None:
     calls = _record_reauthor_calls(coord)
     materialized: list[Any] = []
 
-    async def _fake_materialize(pending: Any) -> None:
+    async def _fake_materialize(pending: Any, *, approved_variant_names: set[str] | None = None) -> None:
         materialized.append(pending)
 
     coord._materialize_approved_proposal = _fake_materialize  # type: ignore[method-assign]

--- a/src/hyperloom/orchestrator/loop/coordinator_helpers.py
+++ b/src/hyperloom/orchestrator/loop/coordinator_helpers.py
@@ -15,7 +15,7 @@ import logging
 import os
 import re
 import shlex
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -640,8 +640,11 @@ def cited_advisory_reason_code(entry: dict[str, Any]) -> str:
 
 # Priority a batch of per-variant verdicts collapses by: one approved variant
 # carries the proposal, otherwise one reject sinks it, and advice outranks a
-# request for more review.
+# request for more review. :func:`collapse_verdict_map` applies this to the
+# proceedable subset first so a genuine reject cannot sink siblings that may
+# still run.
 _VERDICT_COLLAPSE_ORDER: tuple[str, ...] = ("approve", _REJECT_VERDICT, ADVISE_VERDICT, "needs_review")
+_PROCEEDABLE_VERDICTS: frozenset[str] = frozenset({"approve", ADVISE_VERDICT})
 
 
 def collapse_verdicts(verdicts: Iterable[str]) -> str:
@@ -659,6 +662,48 @@ def collapse_verdicts(verdicts: Iterable[str]) -> str:
         if candidate in present:
             return candidate
     return "needs_review"
+
+
+def proceedable_variant_names(held_by_name: Mapping[str, str]) -> set[str]:
+    """Return variant names whose held verdict lets them reach a benchmark.
+
+    ``approve`` and ``advise`` both mean dispatch may proceed; ``reject`` and
+    ``needs_review`` do not. Blank names cannot match a grid slot and are
+    dropped.
+
+    Args:
+        held_by_name: Per-variant verdicts after any hold-to-rule.
+
+    Returns:
+        The non-blank names whose verdict is proceedable.
+    """
+    return {
+        name
+        for name, verdict in held_by_name.items()
+        if verdict in _PROCEEDABLE_VERDICTS and str(name).strip()
+    }
+
+
+def collapse_verdict_map(held_by_name: Mapping[str, str]) -> tuple[str, set[str] | None]:
+    """Collapse a held ``verdict_map`` and name the variants that may run.
+
+    A genuine reject on one variant must not sink siblings the Critic approved
+    or advised through. When any variant is proceedable, the summary is the
+    collapse of *those* verdicts and the set is the materialize filter.
+    Otherwise the summary is the collapse of the whole map and the filter is
+    ``None`` (nothing to dispatch).
+
+    Args:
+        held_by_name: Per-variant verdicts after any hold-to-rule.
+
+    Returns:
+        ``(summary_verdict, approved_variant_names)``. The set is ``None``
+        when no variant is proceedable.
+    """
+    proceedable = proceedable_variant_names(held_by_name)
+    if proceedable:
+        return collapse_verdicts(held_by_name[name] for name in proceedable), proceedable
+    return collapse_verdicts(held_by_name.values()), None
 
 
 def _states_findings(value: Any) -> bool:

--- a/src/hyperloom/orchestrator/loop/intent_router.py
+++ b/src/hyperloom/orchestrator/loop/intent_router.py
@@ -26,6 +26,7 @@ from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
 from .coordinator_helpers import (
     _parse_iso_unix,
     coerce_needs_gpu,
+    collapse_verdict_map,
     collapse_verdicts,
     format_exc_brief,
     serialize_verdict_advisory,
@@ -191,7 +192,12 @@ class IntentRouter:
         self.state.pending_proposals[msg.msg_id] = pending
 
     async def _handle_review_verdict(self, source: str, intent: Intent) -> None:
-        """Apply a Critic ``review_verdict`` to its target proposal; verdicts collapse by priority (approve > reject > needs_review).
+        """Apply a Critic ``review_verdict`` to its target proposal.
+
+        A ``verdict_map`` is held per entry, then collapsed on the proceedable
+        subset (``approve`` / ``advise``) so a genuine reject cannot discard
+        siblings that may still run. Those names are passed through as the
+        materialize filter.
 
         Args:
             source: The agent (Critic) emitting the verdict.
@@ -219,36 +225,19 @@ class IntentRouter:
             target=target,
         )
         authored = str(single_verdict or "").strip()
+        approved_variant_names: set[str] | None = None
         if not verdict and isinstance(verdict_map, dict) and verdict_map:
-            # Per entry before the collapse below: a variant rejected on an
-            # advisory-only rule must not out-rank its siblings' advice. Each
-            # entry is read against the findings the payload states for the
-            # batch, which hold every reject in the set.
-            sub_verdicts = [
-                await self._record_verdict_hold(
-                    verdict_map_entry_held_to_its_rule(entry, intent.payload, action_name=pending.action_name),
-                    target=target,
-                    variant=str(name),
-                )
-                for name, entry in verdict_map.items()
-            ]
-            verdict = collapse_verdicts(sub_verdicts)
+            held_by_name = await self._held_verdict_map(
+                verdict_map,
+                target=target,
+                action_name=pending.action_name,
+                payload=intent.payload,
+            )
+            verdict, approved_variant_names = collapse_verdict_map(held_by_name)
             authored = collapse_verdicts(
                 str((entry or {}).get("verdict") or "").strip() for entry in verdict_map.values()
             )
-
-            # Defensive audit (log-only): record verdict_map collapse
-            # outcomes for traceability. Behaviour is unchanged.
-            try:
-                if verdict in ("approve", "advise") and any(sv in ("reject", "needs_review") for sv in sub_verdicts):
-                    log.warning(
-                        "review_verdict collapse: target=%s collapsed to %r (sub_verdicts=%r)",
-                        target,
-                        verdict,
-                        sub_verdicts,
-                    )
-            except Exception:  # noqa: BLE001 - audit log must never affect flow
-                pass
+            self._log_mixed_verdict_map_collapse(target, verdict, held_by_name)
         await self._coord._handle_single_verdict(
             source=source,
             pending=pending,
@@ -256,7 +245,61 @@ class IntentRouter:
             authored_verdict=authored,
             reasoning=str(intent.payload.get("reasoning") or ""),
             advisory=serialize_verdict_advisory(intent.payload),
+            approved_variant_names=approved_variant_names,
         )
+
+    async def _held_verdict_map(
+        self,
+        verdict_map: dict[str, Any],
+        *,
+        target: str,
+        action_name: str,
+        payload: dict[str, Any],
+    ) -> dict[str, str]:
+        """Hold each ``verdict_map`` entry to its cited rule.
+
+        Args:
+            verdict_map: Per-variant verdict entries from the Critic payload.
+            target: The target proposal msg_id, for the audit record.
+            action_name: The proposal's action, forwarded to the hold.
+            payload: The full verdict payload; batch-level findings live here.
+
+        Returns:
+            ``{variant_name: held_verdict}`` after any advisory-only downgrade.
+        """
+        held_by_name: dict[str, str] = {}
+        for name, entry in verdict_map.items():
+            held_by_name[str(name)] = await self._record_verdict_hold(
+                verdict_map_entry_held_to_its_rule(entry, payload, action_name=action_name),
+                target=target,
+                variant=str(name),
+            )
+        return held_by_name
+
+    def _log_mixed_verdict_map_collapse(
+        self,
+        target: str,
+        verdict: str,
+        held_by_name: dict[str, str],
+    ) -> None:
+        """Log when a mixed map still proceeds, for traceability.
+
+        Args:
+            target: The target proposal msg_id.
+            verdict: The collapsed summary after the proceedable-subset rule.
+            held_by_name: Per-variant held verdicts.
+        """
+        try:
+            sub_verdicts = list(held_by_name.values())
+            if verdict in ("approve", "advise") and any(sv in ("reject", "needs_review") for sv in sub_verdicts):
+                log.warning(
+                    "review_verdict collapse: target=%s collapsed to %r (sub_verdicts=%r)",
+                    target,
+                    verdict,
+                    sub_verdicts,
+                )
+        except Exception:  # noqa: BLE001 - audit log must never affect flow
+            pass
 
     async def _record_verdict_hold(
         self,
@@ -317,8 +360,9 @@ class IntentRouter:
         reasoning: str,
         authored_verdict: str = "",
         advisory: dict[str, Any] | None = None,
+        approved_variant_names: set[str] | None = None,
     ) -> None:
-        """Single-verdict handler (approve/advise materialises proposal as-is); mirrors integrate_patch/specialist verdicts onto specialist_patch_verdicts for PolicyGate.
+        """Apply one collapsed verdict: approve/advise materialise, reject may rearm.
 
         Args:
             source: The agent emitting the verdict.
@@ -333,6 +377,9 @@ class IntentRouter:
                 ``notes`` / ``kb_evidence`` / ``packet_evidence``) to carry on
                 the rebroadcast payload so the full Critic context reaches the
                 orchestration inbox and downstream consumers.
+            approved_variant_names: When a ``verdict_map`` named proceedable
+                variants, restrict an explore grid to those names; ``None``
+                keeps the full proposal.
         """
         pending.decided = True
         pending.verdict = verdict
@@ -398,7 +445,10 @@ class IntentRouter:
         # Both `approve` and `advise` mean "dispatch may proceed"; treat them
         # identically for materialization.
         if verdict in ("approve", "advise"):
-            await self._materialize_approved_proposal(pending)
+            await self._materialize_approved_proposal(
+                pending,
+                approved_variant_names=approved_variant_names,
+            )
         elif verdict == "reject" and pending.action_name == "framework_agent":
             # Record the critic_denied row so the framework_agent pump advances.
             await self._coord._record_framework_agent_critic_denied(

--- a/src/hyperloom/orchestrator/loop/proposals.py
+++ b/src/hyperloom/orchestrator/loop/proposals.py
@@ -28,6 +28,43 @@ _TERMINAL_TASK_STATES: frozenset[str] = frozenset({"succeeded", "failed", "cance
 _MAX_IDEMPOTENCY_ATTEMPTS: int = 6
 
 
+def apply_critic_grid_filter(
+    params: dict[str, Any],
+    *,
+    original_grid: list[Any],
+    approved_variant_names: set[str] | None,
+) -> bool:
+    """Restrict ``params['grid']`` to Critic-approved variant names.
+
+    ``None`` leaves the grid untouched. Non-dict slots cannot carry a name:
+    they pass through only when there is no filter.
+
+    Args:
+        params: Task params mutated in place; must already hold ``grid``.
+        original_grid: The proposer's grid, used for the filter audit count.
+        approved_variant_names: Names that may run; ``None`` keeps the full grid.
+
+    Returns:
+        ``False`` when a filter was set and no variant survived; ``True`` otherwise.
+    """
+    stamped_grid: list[Any] = []
+    for variant in original_grid:
+        if not isinstance(variant, dict):
+            if approved_variant_names is None:
+                stamped_grid.append(variant)
+            continue
+        vname = str(variant.get("name") or "").strip()
+        if approved_variant_names is not None and vname not in approved_variant_names:
+            continue
+        stamped_grid.append(dict(variant))
+    params["grid"] = stamped_grid
+    if approved_variant_names is None:
+        return True
+    original_grid_len = len([v for v in original_grid if isinstance(v, dict)])
+    params["critic_filtered_count"] = max(0, original_grid_len - len(stamped_grid))
+    return bool(stamped_grid)
+
+
 def _extra_server_args(payload: Mapping[str, Any]) -> str:
     """Read canonical ``extra_server_args`` from a payload."""
     value = payload.get("extra_server_args")
@@ -418,28 +455,24 @@ class ProposalsCollaborator:
             )
         # Filter the grid to the Critic-approved subset.
         if pending.action_name == "explore" and isinstance(params.get("grid"), list):
-            stamped_grid: list[dict[str, Any]] = []
-            for variant in params["grid"]:
-                if not isinstance(variant, dict):
-                    # Non-dict slots can't carry a name: dropped under a filter, pass-through otherwise.
-                    if approved_variant_names is None:
-                        stamped_grid.append(variant)
-                    continue
-                vname = str(variant.get("name") or "").strip()
-                # Drop variants the Critic rejected before they hit the executor.
-                if approved_variant_names is not None and vname not in approved_variant_names:
-                    continue
-                stamped_grid.append(dict(variant))
-            params["grid"] = stamped_grid
-            # Audit hint: how many variants the Critic filtered.
-            if approved_variant_names is not None:
-                original_grid_len = len(
-                    [v for v in (pending.payload.get("params") or {}).get("grid", []) if isinstance(v, dict)]
+            original_grid = list(params["grid"])
+            if not apply_critic_grid_filter(
+                params,
+                original_grid=original_grid,
+                approved_variant_names=approved_variant_names,
+            ):
+                await self._record_observation(
+                    "coordinator",
+                    "observation",
+                    {
+                        "kind": "proposal_materialize_skipped",
+                        "reason": "critic_filter_empty_grid",
+                        "proposal_msg_id": pending.proposal_msg_id,
+                        "action_name": pending.action_name,
+                        "from_agent": pending.from_agent,
+                    },
                 )
-                params["critic_filtered_count"] = max(
-                    0,
-                    original_grid_len - len(approved_variant_names),
-                )
+                return
         if pending.action_name == "profile":
             # Stamp the server config that produced this trace.
             inject_stack_base_params(params, self.shared_state)


### PR DESCRIPTION
Closes #1143. Follow-up to #1161.

#1161's agreed fix had two halves. (a) strip the forbidden fields at source —
landed. (b) pass `approved_variant_names` so a partial reject stops discarding
every variant — this PR. With both halves on the tree, the reported failure
cannot reject a format slip, and one genuine reject cannot sink siblings the
Critic still let through.

A mixed `verdict_map` used to collapse `reject` over `advise` and then
materialise the whole grid. One genuine reject therefore threw away every
sibling the Critic had approved or advised through. The filter on
`_materialize_approved_proposal` already existed; the live verdict path never
passed it.

### What changes

- After the per-entry hold, collapse the **proceedable** subset (`approve` /
  `advise`) first. The summary is that subset's collapse, and those names are
  the materialize filter.
- A map with no proceedable variant still collapses the whole map (`reject` /
  `needs_review`) and does not dispatch.
- An explore grid that the filter empties is skipped rather than enqueued empty.
- Single-verdict paths, all-reject maps, and all-advisory-hold maps are
  unchanged.

Not in this PR, and not required to close #1143: one automatic format-class
resubmit, and a shared pydantic proposal model (`reason` / `rationale` / `note`).
Those remain optional follow-ups if wanted later.

### Test plan

- [x] `test_a_genuine_reject_does_not_sink_advised_siblings`: advise + reject +
      approve materialises `{v_a, v_c}` under summary `approve`.
- [x] Mixed maps pass only proceedable names; advisory-only holds still keep
      the held variants; all-reject still rejects.
- [x] `collapse_verdict_map` unit: proceedable subset, advise surviving a
      sibling reject, no-proceedable stays reject.
- [x] Empty filter does not enqueue an explore task.
- [x] 247 passed across `test_critic_verdict_map.py`,
      `test_framework_agent_reauthor.py`, `test_coordinator_async_batch2_unit.py`.

Made with [Cursor](https://cursor.com)