### PR TITLE
Raise default enablement accuracy floor to 0.5

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_integrate_patch_executor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_integrate_patch_executor.py
@@ -895,7 +895,7 @@ async def test_enablement_reverts_when_still_not_runnable(tmp_path: Path, monkey
 @pytest.mark.asyncio
 async def test_enablement_keeps_verified_when_accuracy_above_floor(tmp_path: Path, monkeypatch):
     """Booted + eval accuracy above the absolute floor -> KEEP, non-provisional."""
-    result, repo = await _run_enablement_integrate(tmp_path, monkeypatch, booted=True, enablement_accuracy=0.42)
+    result, repo = await _run_enablement_integrate(tmp_path, monkeypatch, booted=True, enablement_accuracy=0.9)
     assert result["status"] == "kept"
     assert result["runnable"] is True
     assert result["correctness_verified"] is True

--- a/src/hyperloom/orchestrator/actions/executors/_accuracy_gate.py
+++ b/src/hyperloom/orchestrator/actions/executors/_accuracy_gate.py
@@ -33,9 +33,13 @@ ACCURACY_THRESHOLD = 0.05  # allowed deviation
 # enablement KEEP path. At 0.0 the gate degenerates to ``accuracy > 0``, which
 # admits a model that is answering essentially nothing: a real run KEPT a
 # candidate scoring gsm8k=0.00076 (0.08% of a 0.906 baseline) as "correct".
-# 0.05 is a floor of last resort -- it rejects the collapsed-output regime
-# without judging genuine quality.
-DEFAULT_ENABLEMENT_ACCURACY_FLOOR = 0.05
+#
+# 0.5 separates a working baseline from a broken one with a wide margin on both
+# sides. Across historical runs every healthy baseline scored >= 0.63 while the
+# two genuinely broken ones scored 0.196 (MiniMax-M3-MXFP4, a miscompiled MoE
+# kernel) and 0.000 (GLM-5.2-MXFP4). The previous 0.05 rejected only the fully
+# collapsed regime and admitted the 0.196 case as a usable baseline.
+DEFAULT_ENABLEMENT_ACCURACY_FLOOR = 0.5
 
 # Enablement admission, selected by the ``--enablement`` CLI flag. ``launch``
 # covers the boot-failure self-heal lane, ``eval`` the accuracy-failure lane.


### PR DESCRIPTION
## Summary

Raises `DEFAULT_ENABLEMENT_ACCURACY_FLOOR` from `0.05` to `0.5`.

This floor is the only correctness authority on the enablement KEEP path, and it is shared by the baseline eval-failure trigger and the enablement KEEP gate so the two cannot diverge. At `0.05` it rejected only the fully collapsed-output regime, so a baseline that was measurably broken but still emitting some correct answers was admitted as usable.

That is not hypothetical. A MiniMax-M3-MXFP4 baseline scoring `0.196` on gsm8k passed the gate and was treated as a valid baseline. The underlying defect was a miscompiled MXFP4 MoE kernel in the aiter backend, which the gate should have surfaced immediately instead of letting the run proceed on a broken baseline.

## Why 0.5

Historical runs separate cleanly into two groups with no values in between:

- Healthy baselines: all scored `>= 0.63` (lowest observed: Qwen3-0.6B on vLLM at `0.645`).
- Genuinely broken baselines: `0.196` (MiniMax-M3-MXFP4) and `0.000` (GLM-5.2-MXFP4).

`0.5` sits in the empty band between the two clusters, leaving wide margin on both sides. It is high enough to catch both known failures and low enough that no healthy baseline comes close to tripping it.

## Scope

Only the shared enablement floor changes. `ACCURACY_THRESHOLD` in the same module is a distinct knob (allowed patched-vs-baseline deviation, not an absolute floor) and is deliberately left at `0.05`.

Existing tests reference the constant symbolically rather than hardcoding `0.05`, so the relative assertions (a score at the floor passes, half the floor fails) continue to hold under the new value.

## Test plan

- [ ] `test_accuracy_gate_units.py`
- [ ] `test_baseline_eval_fallback.py`
- [ ] `test_integrate_patch_executor.py`
- [ ] `test_enablement_breakdown.py`
