### PR TITLE
feat(kb): record the roofline on every recipe

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_kb_roofline_persistence.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kb_roofline_persistence.py
@@ -12,12 +12,21 @@ part worth keeping.
 
 from __future__ import annotations
 
+from dataclasses import fields
 from pathlib import Path
 from typing import Any
 
+from hyperloom.orchestrator.kernel.roofline_ceiling import (
+    OpBreakdown,
+    PerfModelBreakdown,
+)
 from hyperloom.orchestrator.kernel.roofline_snapshot import (
     MAX_RECIPE_PERFMODEL_OPS,
+    _RECIPE_PERFMODEL_KEYS,
+    _RECIPE_PERFMODEL_OP_KEYS,
+    _RECIPE_SNAPSHOT_KEYS,
     build_recipe_roofline,
+    build_roofline_snapshot,
 )
 from hyperloom.orchestrator.knowledge.recipe_kb import (
     LocalRecipeStore,
@@ -30,6 +39,18 @@ from hyperloom.orchestrator.roles.mock_backend import (
     MockBackend,
     MockTurn,
     ScriptedPlan,
+)
+
+#: Snapshot fields deliberately left out of the recipe projection. ``top_kernel``
+#: is nested and projected by hand; the other two are session-local — the report
+#: layer owns ``framework``, and ``kernel_roofline_path`` points into a session
+#: directory that no longer exists by the time a recipe is read.
+_SNAPSHOT_KEYS_NOT_IN_RECIPE = frozenset(
+    {
+        "framework",
+        "kernel_roofline_path",
+        "top_kernel",
+    }
 )
 
 _MODEL = "qwen3-30b-a3b"
@@ -161,13 +182,17 @@ def test_projection_carries_both_ceilings_and_the_per_op_breakdown() -> None:
 
 
 def test_projection_records_the_latest_snapshot() -> None:
-    """``snapshots[-1]`` wins, matching ``SharedState.current_top_bottleneck``."""
+    """``snapshots[-1]`` wins, matching ``SharedState.current_top_bottleneck``.
+
+    ``snapshot_id`` says which snapshot was projected; nothing describes the
+    writing session, whose history the recipe does not carry.
+    """
     first = _snapshot(snapshot_id=1, within_roofline_pct=2.08)
     second = _snapshot(snapshot_id=2, within_roofline_pct=41.5)
     out = build_recipe_roofline([first, second])
     assert out["snapshot_id"] == 2
     assert out["within_roofline_pct"] == 41.5
-    assert out["snapshot_count"] == 2
+    assert "snapshot_count" not in out
 
 
 def test_a_snapshot_without_a_perfmodel_still_projects() -> None:
@@ -189,6 +214,45 @@ def test_the_per_op_array_is_capped() -> None:
     pm = build_recipe_roofline([snap])["perfmodel_breakdown"]
     assert len(pm["ops"]) == MAX_RECIPE_PERFMODEL_OPS
     assert pm["ops_truncated_from"] == MAX_RECIPE_PERFMODEL_OPS + 10
+
+
+def test_ops_that_all_project_to_nothing_leave_no_truncation_marker() -> None:
+    """An over-cap op list that stores no rows must not claim it capped any.
+
+    ``ops_truncated_from`` reads as "there were N, we kept the cap"; without a
+    stored ``ops`` array there is nothing for it to qualify.
+    """
+    empty_ops = [{} for _ in range(MAX_RECIPE_PERFMODEL_OPS + 5)]
+    assert build_recipe_roofline([{"ts": "t", "perfmodel_breakdown": {"ops": empty_ops}}]) == {"ts": "t"}
+    # Scalars still project; only the op array and its marker drop out.
+    kept = build_recipe_roofline([_snapshot(perfmodel_breakdown={"bound_kind": "memory", "ops": empty_ops})])
+    assert kept["perfmodel_breakdown"] == {"bound_kind": "memory"}
+
+
+def test_every_snapshot_field_is_projected_or_deliberately_dropped() -> None:
+    """The allowlist must account for every field ``build_roofline_snapshot`` emits.
+
+    The snapshot builder populates all of its keys unconditionally, so its
+    output is the source of truth for what a new field would have to be
+    triaged into — rather than silently never reaching the recipe.
+    """
+    emitted = set(build_roofline_snapshot(snapshot_id=1, ts="2026-08-17T00:00:00+00:00", analysis_md_path="").keys())
+    assert emitted - set(_RECIPE_SNAPSHOT_KEYS) == _SNAPSHOT_KEYS_NOT_IN_RECIPE
+    assert set(_RECIPE_SNAPSHOT_KEYS) <= emitted, "allowlist names a field the snapshot no longer emits"
+
+
+def test_every_perfmodel_field_is_projected_or_deliberately_dropped() -> None:
+    """The PerfModel allowlists must track the breakdown dataclasses.
+
+    ``attach_perfmodel_breakdown`` serialises :class:`PerfModelBreakdown` and
+    :class:`OpBreakdown` field for field, so their fields are the source of
+    truth for what the snapshot can carry. ``ops`` is the nested array, handled
+    by ``_RECIPE_PERFMODEL_OP_KEYS`` instead.
+    """
+    pm_fields = {f.name for f in fields(PerfModelBreakdown)}
+    assert pm_fields - set(_RECIPE_PERFMODEL_KEYS) == {"ops"}
+    assert set(_RECIPE_PERFMODEL_KEYS) <= pm_fields
+    assert {f.name for f in fields(OpBreakdown)} == set(_RECIPE_PERFMODEL_OP_KEYS)
 
 
 def test_close_stores_the_roofline_without_a_validated_win(tmp_path: Path) -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_kb_roofline_persistence.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kb_roofline_persistence.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the roofline projection stored on a recipe.
+
+The roofline records where a session finished against its ceiling. It rides the
+``extras`` channel so it is written on every CLOSE, independent of the
+``has_validated_win`` gate that guards ``best_config`` — a session that improved
+nothing still measured a distance to the roofline, and that measurement is the
+part worth keeping.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from hyperloom.orchestrator.kernel.roofline_snapshot import (
+    MAX_RECIPE_PERFMODEL_OPS,
+    build_recipe_roofline,
+)
+from hyperloom.orchestrator.knowledge.recipe_kb import (
+    LocalRecipeStore,
+    RecipeKB,
+    recipe_canonical_id,
+)
+from hyperloom.orchestrator.loop.coordinator import Coordinator
+from hyperloom.orchestrator.roles.agent_role import default_role_registry
+from hyperloom.orchestrator.roles.mock_backend import (
+    MockBackend,
+    MockTurn,
+    ScriptedPlan,
+)
+
+_MODEL = "qwen3-30b-a3b"
+_HW = "mi300x"
+_FW = "sglang"
+_FWV = "0.4.5"
+_PREC = "fp8"
+
+
+def _snapshot(**overrides: Any) -> dict[str, Any]:
+    """Build a roofline snapshot shaped like ``build_roofline_snapshot`` output."""
+    snap: dict[str, Any] = {
+        "snapshot_id": 1,
+        "ts": "2026-08-17T04:05:19.522322+00:00",
+        "throughput_unit": "tok/s",
+        "theoretical_peak_tok_per_sec": 11573.63,
+        "roofline_mem_ceiling_tok_per_sec": 11573.63,
+        "roofline_cmp_ceiling_tok_per_sec": 172038.66,
+        "roofline_bound_kind": "memory",
+        "achieved_tok_per_sec": 240.5,
+        "within_roofline_pct": 2.08,
+        "gap_to_roofline_pct": 97.92,
+        "compute_pct": 17.54,
+        "idle_pct": 0.14,
+        "comm_pct": 81.88,
+        "top_bottleneck": "InferenceAttention",
+        "top_kernel": {
+            "name": "vllm::unified_attention_with_output",
+            "gpu_pct": 2.13,
+            "efficiency_pct": 1.11,
+            "bound_type": "memory",
+        },
+        "roofline_provenance": {
+            "formula": "perfmodel",
+            "compute_peak_tflops": 1686.0,
+            "compute_peak_convention": "achievable",
+            "runtime_tp": 8,
+        },
+        "perfmodel_breakdown": {
+            "bound_kind": "memory",
+            "hbm_bw_gbps": 28480.0,
+            "peak_achievable_tflops": 6744.0,
+            "ops": [
+                {
+                    "name": "q_proj",
+                    "flops": 9.66e10,
+                    "bytes_moved": 6.07e9,
+                    "ai": 15.9,
+                    "time_s": 0.0002,
+                    "bound": "memory",
+                    "pct_time": 0.2,
+                },
+                {
+                    "name": "k_proj",
+                    "flops": 6.04e9,
+                    "bytes_moved": 3.9e8,
+                    "ai": 15.5,
+                    "time_s": 0.00001,
+                    "bound": "memory",
+                    "pct_time": 0.0,
+                },
+            ],
+        },
+    }
+    snap.update(overrides)
+    return snap
+
+
+def _make_coordinator(tmp_path: Path) -> Coordinator:
+    """Build a Coordinator backed by a real on-disk local recipe store."""
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    idle = ScriptedPlan(turns=[MockTurn(intents=[])])
+    backends = {
+        "orchestration": MockBackend(idle),
+        "critic": MockBackend(idle),
+        "robustness": MockBackend(idle),
+    }
+    kb = RecipeKB(local=LocalRecipeStore(root=tmp_path / "kb"))
+    coord = Coordinator(
+        session_dir=session_dir,
+        backends=backends,
+        role_registry=default_role_registry(),
+        recipe_kb=kb,
+        knowledge_plane=None,
+    )
+    ss = coord.shared_state
+    ss.model_name = _MODEL
+    ss.gpu_type = _HW
+    ss.framework = _FW
+    ss.framework_version = _FWV
+    ss.precision = _PREC
+    return coord
+
+
+def _expected_cid() -> str:
+    return recipe_canonical_id(
+        model=_MODEL,
+        hardware=_HW,
+        framework_name=_FW,
+        framework_version=_FWV,
+        precision=_PREC,
+    )
+
+
+def test_no_snapshots_project_to_nothing() -> None:
+    """A session that never ran a roofline yields no payload at all."""
+    assert build_recipe_roofline(None) == {}
+    assert build_recipe_roofline([]) == {}
+    assert build_recipe_roofline(["not-a-dict"]) == {}  # type: ignore[list-item]
+
+
+def test_projection_carries_both_ceilings_and_the_per_op_breakdown() -> None:
+    """Ceilings, the trace mix, provenance, and per-op rows all survive."""
+    out = build_recipe_roofline([_snapshot()])
+    assert out["roofline_mem_ceiling_tok_per_sec"] == 11573.63
+    assert out["roofline_cmp_ceiling_tok_per_sec"] == 172038.66
+    assert out["roofline_bound_kind"] == "memory"
+    assert out["within_roofline_pct"] == 2.08
+    assert out["comm_pct"] == 81.88
+    assert out["top_kernel"]["name"] == "vllm::unified_attention_with_output"
+    assert out["roofline_provenance"]["compute_peak_tflops"] == 1686.0
+    pm = out["perfmodel_breakdown"]
+    assert pm["hbm_bw_gbps"] == 28480.0
+    assert pm["peak_achievable_tflops"] == 6744.0
+    assert [op["name"] for op in pm["ops"]] == ["q_proj", "k_proj"]
+    assert pm["ops"][0]["ai"] == 15.9
+    assert pm["ops"][0]["bytes_moved"] == 6.07e9
+
+
+def test_projection_records_the_latest_snapshot() -> None:
+    """``snapshots[-1]`` wins, matching ``SharedState.current_top_bottleneck``."""
+    first = _snapshot(snapshot_id=1, within_roofline_pct=2.08)
+    second = _snapshot(snapshot_id=2, within_roofline_pct=41.5)
+    out = build_recipe_roofline([first, second])
+    assert out["snapshot_id"] == 2
+    assert out["within_roofline_pct"] == 41.5
+    assert out["snapshot_count"] == 2
+
+
+def test_a_snapshot_without_a_perfmodel_still_projects() -> None:
+    """The PerfModel is best-effort; its absence must not drop the ceilings."""
+    snap = _snapshot()
+    snap.pop("perfmodel_breakdown")
+    out = build_recipe_roofline([snap])
+    assert "perfmodel_breakdown" not in out
+    assert out["roofline_mem_ceiling_tok_per_sec"] == 11573.63
+
+
+def test_the_per_op_array_is_capped() -> None:
+    """A pathological op count is truncated, and the original size recorded."""
+    ops = [
+        {"name": f"op{i}", "flops": float(i), "bytes_moved": 1.0, "ai": 1.0, "bound": "memory"}
+        for i in range(MAX_RECIPE_PERFMODEL_OPS + 10)
+    ]
+    snap = _snapshot(perfmodel_breakdown={"bound_kind": "memory", "ops": ops})
+    pm = build_recipe_roofline([snap])["perfmodel_breakdown"]
+    assert len(pm["ops"]) == MAX_RECIPE_PERFMODEL_OPS
+    assert pm["ops_truncated_from"] == MAX_RECIPE_PERFMODEL_OPS + 10
+
+
+def test_close_stores_the_roofline_without_a_validated_win(tmp_path: Path) -> None:
+    """The roofline lands even when nothing beat the incumbent config.
+
+    This is the whole point of routing it outside the champion gate: every
+    recipe on this host has sessions but no ``best_config``, so a
+    win-gated roofline would never be written.
+    """
+    coord = _make_coordinator(tmp_path)
+    ss = coord.shared_state
+    ss.roofline_snapshots = [_snapshot()]
+    # No optimization stack, no validated gain, no current_best: has_validated_win is False.
+    ss.optimization_stack = []
+    ss.cumulative_gain_validated = 0.0
+    ss.current_best = {}
+    coord.finalize_recipe_and_journal()
+    row = coord.recipe_kb.get_recipe(canonical_id=_expected_cid())
+    assert row is not None, "finalize wrote no recipe at all"
+    assert not row.get("best_config"), "precondition broken: a champion was written"
+    roofline = row.get("roofline")
+    assert roofline, "roofline was gated behind the champion write"
+    assert roofline["roofline_bound_kind"] == "memory"
+    assert roofline["perfmodel_breakdown"]["ops"][0]["name"] == "q_proj"
+
+
+def test_a_session_without_a_roofline_keeps_the_previous_one(tmp_path: Path) -> None:
+    """Omitting the key preserves a prior roofline instead of erasing it."""
+    coord = _make_coordinator(tmp_path)
+    cid = _expected_cid()
+    coord.recipe_kb.put_recipe(
+        canonical_id=cid,
+        model=_MODEL,
+        hardware=_HW,
+        framework_name=_FW,
+        framework_version=_FWV,
+        precision=_PREC,
+        extras={"roofline": {"roofline_bound_kind": "compute", "within_roofline_pct": 88.0}},
+    )
+    coord.shared_state.roofline_snapshots = []
+    coord.finalize_recipe_and_journal()
+    row = coord.recipe_kb.get_recipe(canonical_id=cid)
+    assert row is not None
+    assert row["roofline"]["roofline_bound_kind"] == "compute"
+    assert row["roofline"]["within_roofline_pct"] == 88.0

--- a/src/hyperloom/orchestrator/kernel/roofline_snapshot.py
+++ b/src/hyperloom/orchestrator/kernel/roofline_snapshot.py
@@ -476,6 +476,128 @@ def build_roofline_comparison_from_history(
     return out
 
 
+#: Snapshot keys carried verbatim into the recipe projection. Scalars only —
+#: nested shapes (top_kernel, provenance, PerfModel) are projected separately.
+_RECIPE_SNAPSHOT_KEYS: tuple[str, ...] = (
+    "ts",
+    "snapshot_id",
+    "throughput_unit",
+    "theoretical_peak_tok_per_sec",
+    "roofline_mem_ceiling_tok_per_sec",
+    "roofline_cmp_ceiling_tok_per_sec",
+    "roofline_bound_kind",
+    "achieved_tok_per_sec",
+    "within_roofline_pct",
+    "gap_to_roofline_pct",
+    "e2e_mean_ms",
+    "roofline_ideal_ms",
+    "compute_pct",
+    "idle_pct",
+    "comm_pct",
+    "top_bottleneck",
+)
+
+#: PerfModel scalars carried into the recipe projection.
+_RECIPE_PERFMODEL_KEYS: tuple[str, ...] = (
+    "bound_kind",
+    "hbm_bw_gbps",
+    "peak_achievable_tflops",
+    "decode_tok_per_s",
+    "prefill_tok_per_s",
+    "decode_mem_tok_per_s",
+    "decode_cmp_tok_per_s",
+)
+
+#: Per-op PerfModel fields carried into the recipe projection.
+_RECIPE_PERFMODEL_OP_KEYS: tuple[str, ...] = (
+    "name",
+    "flops",
+    "bytes_moved",
+    "ai",
+    "time_s",
+    "bound",
+    "pct_time",
+)
+
+#: Cap on projected per-op rows. The breakdown is one row per op class (single
+#: digits in practice); the cap only bounds recipe growth for a pathological model.
+MAX_RECIPE_PERFMODEL_OPS: int = 64
+
+
+def _project_perfmodel_breakdown(breakdown: Any) -> dict[str, Any]:
+    """Project a ``perfmodel_breakdown`` into its recipe-storable subset.
+
+    Args:
+        breakdown: The snapshot's ``perfmodel_breakdown`` value, which is absent
+            whenever the PerfModel could not resolve the model metadata.
+
+    Returns:
+        dict[str, Any]: The projected breakdown, or ``{}`` when there is nothing
+            usable to store.
+    """
+    if not isinstance(breakdown, dict) or not breakdown:
+        return {}
+    out: dict[str, Any] = {}
+    for key in _RECIPE_PERFMODEL_KEYS:
+        val = breakdown.get(key)
+        if val is None or val == "":
+            continue
+        out[key] = val
+    ops = [op for op in (breakdown.get("ops") or []) if isinstance(op, dict)]
+    projected_ops: list[dict[str, Any]] = []
+    for op in ops[:MAX_RECIPE_PERFMODEL_OPS]:
+        row = {key: op[key] for key in _RECIPE_PERFMODEL_OP_KEYS if op.get(key) is not None}
+        if row:
+            projected_ops.append(row)
+    if projected_ops:
+        out["ops"] = projected_ops
+    if len(ops) > MAX_RECIPE_PERFMODEL_OPS:
+        out["ops_truncated_from"] = len(ops)
+    return out
+
+
+def build_recipe_roofline(snapshots: list[dict[str, Any]] | None) -> dict[str, Any]:
+    """Project the latest roofline snapshot into the shape stored on a recipe.
+
+    Follows the ``latest = snapshots[-1]`` convention shared with
+    :meth:`SharedState.current_top_bottleneck`, so the recipe records where the
+    session finished rather than where it started; the per-snapshot history stays
+    in the session's ``state.json``.
+
+    Args:
+        snapshots: The append-only ``SharedState.roofline_snapshots`` history, or
+            ``None`` when the session never ran a roofline.
+
+    Returns:
+        dict[str, Any]: The projected roofline, or ``{}`` when no snapshot
+            carries anything usable — callers omit the key entirely rather than
+            storing an empty shell over a previously recorded roofline.
+    """
+    snaps = [snap for snap in (snapshots or []) if isinstance(snap, dict)]
+    if not snaps:
+        return {}
+    latest = snaps[-1]
+    out: dict[str, Any] = {}
+    for key in _RECIPE_SNAPSHOT_KEYS:
+        val = latest.get(key)
+        if val is None or val == "":
+            continue
+        out[key] = val
+    top_kernel = latest.get("top_kernel")
+    if isinstance(top_kernel, dict) and top_kernel:
+        out["top_kernel"] = dict(top_kernel)
+    provenance = latest.get("roofline_provenance")
+    if isinstance(provenance, dict) and provenance:
+        out["roofline_provenance"] = dict(provenance)
+    breakdown = _project_perfmodel_breakdown(latest.get("perfmodel_breakdown"))
+    if breakdown:
+        out["perfmodel_breakdown"] = breakdown
+    if not out:
+        return {}
+    out["snapshot_count"] = len(snaps)
+    return out
+
+
 def _fmt_delta(val: float | None) -> str:
     """Format a signed delta cell with one decimal place.
 

--- a/src/hyperloom/orchestrator/kernel/roofline_snapshot.py
+++ b/src/hyperloom/orchestrator/kernel/roofline_snapshot.py
@@ -533,7 +533,9 @@ def _project_perfmodel_breakdown(breakdown: Any) -> dict[str, Any]:
 
     Returns:
         dict[str, Any]: The projected breakdown, or ``{}`` when there is nothing
-            usable to store.
+            usable to store. ``ops_truncated_from`` only rides alongside a
+            non-empty ``ops``, so the count never describes rows that were
+            dropped for being empty rather than for exceeding the cap.
     """
     if not isinstance(breakdown, dict) or not breakdown:
         return {}
@@ -551,8 +553,8 @@ def _project_perfmodel_breakdown(breakdown: Any) -> dict[str, Any]:
             projected_ops.append(row)
     if projected_ops:
         out["ops"] = projected_ops
-    if len(ops) > MAX_RECIPE_PERFMODEL_OPS:
-        out["ops_truncated_from"] = len(ops)
+        if len(ops) > MAX_RECIPE_PERFMODEL_OPS:
+            out["ops_truncated_from"] = len(ops)
     return out
 
 
@@ -562,7 +564,14 @@ def build_recipe_roofline(snapshots: list[dict[str, Any]] | None) -> dict[str, A
     Follows the ``latest = snapshots[-1]`` convention shared with
     :meth:`SharedState.current_top_bottleneck`, so the recipe records where the
     session finished rather than where it started; the per-snapshot history stays
-    in the session's ``state.json``.
+    in the session's ``state.json``. Every field describes that one snapshot —
+    nothing here counts or aggregates the writing session.
+
+    The sole caller is
+    :meth:`WritebackCollaborator.finalize_recipe_and_journal`
+    (``orchestrator/loop/writeback.py``), which stores the result under
+    ``extras["roofline"]``. Local mode only, and write-only: no reader consumes
+    the stored value yet.
 
     Args:
         snapshots: The append-only ``SharedState.roofline_snapshots`` history, or
@@ -592,9 +601,6 @@ def build_recipe_roofline(snapshots: list[dict[str, Any]] | None) -> dict[str, A
     breakdown = _project_perfmodel_breakdown(latest.get("perfmodel_breakdown"))
     if breakdown:
         out["perfmodel_breakdown"] = breakdown
-    if not out:
-        return {}
-    out["snapshot_count"] = len(snaps)
     return out
 
 

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -57,6 +57,7 @@ from ..actions.executors._accuracy_gate import (
     accuracy_meets_floor,
 )
 from ..knowledge.agent_kb import ExploreAgentKB, FrameworkAgentKB
+from ..kernel.roofline_snapshot import build_recipe_roofline
 
 from .coordinator import (
     _AUDIT_ACTIONS,
@@ -2101,6 +2102,12 @@ class WritebackCollaborator:
             extras_payload = dict(workload_tags or {})
             if merged_kopts:
                 extras_payload["kernel_optimizations"] = merged_kopts
+            # Where the session landed against its ceiling is worth keeping even
+            # when nothing beat the incumbent, so the roofline rides extras
+            # outside the has_validated_win gate below.
+            roofline_payload = build_recipe_roofline(getattr(ss, "roofline_snapshots", None))
+            if roofline_payload:
+                extras_payload["roofline"] = roofline_payload
 
             overrides: dict[str, Any] = {
                 "what_worked": attrs["what_worked"],


### PR DESCRIPTION
A recipe only kept what beat the incumbent, so a session that improved nothing left behind session rows and no measurement. The distance to the roofline is worth keeping either way: it says whether the run was near its ceiling or nowhere close, and which side bound it.

Project the latest roofline snapshot onto the recipe through extras, so the write sits outside the has_validated_win gate that guards best_config. Extras merge with the prior row, so a later session without a roofline preserves the earlier one rather than erasing it.

Local mode only. The remote publisher still filters roofline actions out of its new-KEEP test, and nothing reads the stored value back yet.
