### PR TITLE
Upgrade Magpie to v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- The default Magpie benchmark dependency is upgraded from v0.1.0 to v0.2.0.
+  Both the installer and runtime preflight remain pinned to the immutable
+  v0.2.0 release commit for reproducible installs.
+
 - **Remote Recipe knowledge now uses one current KB Store contract.** Remote
   mode reads one identity-addressed inference Recipe containing replay config,
   the ordered patch timeline, and nested kernel columns, then publishes one

--- a/src/hyperloom/inference_optimizer/assets/install.sh
+++ b/src/hyperloom/inference_optimizer/assets/install.sh
@@ -217,7 +217,7 @@ EOF
 MAGPIE_REPO="${MAGPIE_REPO:-https://github.com/AMD-AGI/Magpie.git}"
 # Pin Magpie to a release commit/tag instead of the default branch. Operators can
 # re-pin with MAGPIE_REF=<tag|sha>.
-MAGPIE_REF="${MAGPIE_REF:-0171222c532db6fc5cb174667db66e34f1d9dd98}"
+MAGPIE_REF="${MAGPIE_REF:-e6833b8183c6c41adf6038252337550876ca0433}"
 MAGPIE_PACKAGE_SPEC="${MAGPIE_PACKAGE_SPEC:-magpie-eval @ git+${MAGPIE_REPO}@${MAGPIE_REF}}"
 
 # aiperf (SemiAnalysis AgentX benchmark client) — pinned to an immutable commit

--- a/src/hyperloom/inference_optimizer/cli/preflight.py
+++ b/src/hyperloom/inference_optimizer/cli/preflight.py
@@ -2046,7 +2046,7 @@ def _preflight(
         check = subprocess.run([magpie_python, "-c", "import Magpie"], capture_output=True)
     if _magpie_backend_active and check is not None and check.returncode != 0:
         magpie_repo = os.environ.get("MAGPIE_REPO", "https://github.com/AMD-AGI/Magpie.git")
-        magpie_ref = os.environ.get("MAGPIE_REF", "0171222c532db6fc5cb174667db66e34f1d9dd98")
+        magpie_ref = os.environ.get("MAGPIE_REF", "e6833b8183c6c41adf6038252337550876ca0433")
         magpie_spec = os.environ.get(
             "MAGPIE_PACKAGE_SPEC",
             f"magpie-eval @ git+{magpie_repo}@{magpie_ref}",

--- a/src/hyperloom/inference_optimizer/tests/test_install_magpie_idempotent.py
+++ b/src/hyperloom/inference_optimizer/tests/test_install_magpie_idempotent.py
@@ -19,6 +19,9 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 IO_INSTALL = REPO_ROOT / "src" / "hyperloom" / "inference_optimizer" / "assets" / "install.sh"
+PREFLIGHT = REPO_ROOT / "src" / "hyperloom" / "inference_optimizer" / "cli" / "preflight.py"
+
+MAGPIE_V020_COMMIT = "e6833b8183c6c41adf6038252337550876ca0433"
 
 PIP_MARKER = "pip-install-called"
 
@@ -135,3 +138,11 @@ def test_io_install_magpie_reinstall_is_idempotent_guarded() -> None:
     assert "Magpie already importable; skipping pip install" in body
     assert "MAGPIE_PACKAGE_SPEC" in body
     assert "pip install" in body, "reinstall path must still exist for the miss case"
+
+
+def test_default_magpie_pin_is_v020_and_consistent() -> None:
+    install_text = IO_INSTALL.read_text(encoding="utf-8")
+    preflight_text = PREFLIGHT.read_text(encoding="utf-8")
+
+    assert f'MAGPIE_REF="${{MAGPIE_REF:-{MAGPIE_V020_COMMIT}}}"' in install_text
+    assert f'os.environ.get("MAGPIE_REF", "{MAGPIE_V020_COMMIT}")' in preflight_text


### PR DESCRIPTION
## Summary
- upgrade the default Magpie pin from v0.1.0 to the immutable v0.2.0 release commit, ROCm 10 is using v0.2.0.
- keep install.sh and runtime preflight defaults aligned
- add a regression test for pin consistency and document the upgrade

## Testing
- uv run --native-tls --extra test pytest -q src/hyperloom/inference_optimizer/tests/test_install_magpie_idempotent.py::test_default_magpie_pin_is_v020_and_consistent
- uv run --native-tls --with ruff ruff check src/hyperloom/inference_optimizer/cli/preflight.py src/hyperloom/inference_optimizer/tests/test_install_magpie_idempotent.py
- git diff --check