### PR TITLE
docs: use official vllm/vllm-openai-rocm image for vLLM

### DIFF
--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -134,10 +134,10 @@ The following inference frameworks are supported:
 Container images
 ----------------
 
-Pick the image that matches your environment. Public Docker Hub refs
-(``rocm/hyperloom:<tag>``) are used on your own GPU machine. If your
-deployment uses a private registry mirror, set the registry prefix
-accordingly.
+Pick the image that matches your environment. Public Docker Hub refs are used
+on your own GPU machine: ``rocm/hyperloom:<tag>`` for SGLang and the official
+upstream ``vllm/vllm-openai-rocm:<tag>`` for vLLM. If your deployment uses a
+private registry mirror, set the registry prefix accordingly.
 
 .. list-table::
    :header-rows: 1
@@ -149,11 +149,16 @@ accordingly.
      - MI300X / MI325X
    * - ``rocm/hyperloom:sglang-v0.5.17-rocm7.2.0-mi350x``
      - MI355X
-   * - ``rocm/hyperloom:vllm-v0.27.1-rocm7.2.3``
+   * - ``vllm/vllm-openai-rocm:v0.27.1``
      - MI300X / MI325X / MI355X
 
+The vLLM image entrypoint is ``vllm serve``, so override it (for example
+``--entrypoint tail``) when starting a long-running Hyperloom container.
+
 Browse all available tags at
-`hub.docker.com/r/rocm/hyperloom/tags <https://hub.docker.com/r/rocm/hyperloom/tags>`_.
+`hub.docker.com/r/rocm/hyperloom/tags <https://hub.docker.com/r/rocm/hyperloom/tags>`_
+and
+`hub.docker.com/r/vllm/vllm-openai-rocm/tags <https://hub.docker.com/r/vllm/vllm-openai-rocm/tags>`_.
 
 Bare-metal recommended environment
 -----------------------------------
@@ -185,8 +190,8 @@ Hyperloom does not install ROCm or torch itself.
      - Installs ``vllm==0.27.1+rocm723`` from the wheels.vllm.ai pip index. vLLM's ROCm wheel pins its own torch, so it installs into a dedicated venv (``--framework-env isolated``, the default for vLLM) and never touches the host torch.
 
 Bare-metal ROCm patch levels differ per framework, and each one matches its
-``rocm/hyperloom`` image. The vLLM stack installs the ``rocm723`` variant (ROCm
-7.2.3), matching ``rocm/hyperloom:vllm-v0.27.1-rocm7.2.3``; the SGLang stack
+container image. The vLLM stack installs the ``rocm723`` variant (ROCm
+7.2.3), matching ``vllm/vllm-openai-rocm:v0.27.1``; the SGLang stack
 installs from the ROCm 7.2.0 AMD wheel index, matching the two
 ``sglang-v0.5.17-rocm7.2.0`` images. ``docker`` mode is still the preferred
 route for a pre-validated stack, since the images also pin the surrounding

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -374,7 +374,7 @@ It is recommended that you use a ROCm image that already ships the serving
 framework, so nothing needs to be installed inside the container beyond
 Hyperloom's runtime deps. The following images are recommended:
 
-- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.27.1-rocm7.2.3`
+- `vllm`: `docker.io/vllm/vllm-openai-rocm:v0.27.1`
 - `sglang` MI300X: `docker.io/rocm/hyperloom:sglang-v0.5.17-rocm7.2.0-mi300x`
 - `sglang` MI355X: `docker.io/rocm/hyperloom:sglang-v0.5.17-rocm7.2.0-mi350x`
 
@@ -382,7 +382,7 @@ Start a long-running container from the repo root, mounting it at the same path
 so `.env`, logs, and session artifacts stay valid:
 
 ```bash
-export HYPERLOOM_IMAGE=docker.io/rocm/hyperloom:vllm-v0.27.1-rocm7.2.3
+export HYPERLOOM_IMAGE=docker.io/vllm/vllm-openai-rocm:v0.27.1
 export REPO_ROOT="$(pwd -P)"
 docker run -d \
   --name "${HYPERLOOM_CONTAINER_NAME:-hyperloom-local}" \

--- a/examples/hyperloom-custom-advanced/SKILL.md
+++ b/examples/hyperloom-custom-advanced/SKILL.md
@@ -37,7 +37,7 @@ In docker mode:
 
 Suggested Docker images:
 
-- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.27.1-rocm7.2.3`
+- `vllm`: `docker.io/vllm/vllm-openai-rocm:v0.27.1`
 - `sglang` MI300X: `docker.io/rocm/hyperloom:sglang-v0.5.17-rocm7.2.0-mi300x`
 - `sglang` MI355X: `docker.io/rocm/hyperloom:sglang-v0.5.17-rocm7.2.0-mi350x`
 

--- a/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
+++ b/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
@@ -27,7 +27,7 @@ In docker mode:
 
 Suggested Docker images:
 
-- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.27.1-rocm7.2.3`
+- `vllm`: `docker.io/vllm/vllm-openai-rocm:v0.27.1`
 - `sglang` MI300X: `docker.io/rocm/hyperloom:sglang-v0.5.17-rocm7.2.0-mi300x`
 - `sglang` MI355X: `docker.io/rocm/hyperloom:sglang-v0.5.17-rocm7.2.0-mi350x`
 

--- a/examples/hyperloom-qwen3-8b-3h/SKILL.md
+++ b/examples/hyperloom-qwen3-8b-3h/SKILL.md
@@ -27,7 +27,7 @@ In docker mode:
 
 Suggested Docker images:
 
-- `vllm`: `docker.io/rocm/hyperloom:vllm-v0.27.1-rocm7.2.3`
+- `vllm`: `docker.io/vllm/vllm-openai-rocm:v0.27.1`
 - `sglang` MI300X: `docker.io/rocm/hyperloom:sglang-v0.5.17-rocm7.2.0-mi300x`
 - `sglang` MI355X: `docker.io/rocm/hyperloom:sglang-v0.5.17-rocm7.2.0-mi350x`
 

--- a/src/hyperloom/agents/kernel/tests/test_live_source_stack.py
+++ b/src/hyperloom/agents/kernel/tests/test_live_source_stack.py
@@ -8,7 +8,7 @@
 """Opt-in LIVE integration test for the v2 source-resolver stack.
 
 Runs the three real modules against the *actually installed* framework tree
-inside a real vLLM ROCm container (e.g. ``rocm/hyperloom:vllm-v0.27.1-rocm7.2.3``) --
+inside a real vLLM ROCm container (e.g. ``vllm/vllm-openai-rocm:v0.27.1``) --
 no fakes, no GPU needed (this only scans source):
 
 1. ``source_env``            -> discover_frameworks() dictionaries + metadata,

--- a/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
+++ b/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
@@ -42,8 +42,8 @@ FRAMEWORK_ENV="${FRAMEWORK_ENV:-shared}"
 SGLANG_REPO="${SGLANG_REPO:-https://github.com/sgl-project/sglang.git}"
 # Framework versions track docs/compatibility.rst (SGLang v0.5.17, ROCm 7.2).
 # vLLM installs 0.27.1+rocm723 from the wheels.vllm.ai pip index, matching the
-# vllm-v0.27.1-rocm7.2.3 Docker image. The rocm723 variant puts the vLLM ROCm
-# layer at 7.2.3, one patch level above the SGLang stack. AITER_REF
+# vllm/vllm-openai-rocm:v0.27.1 Docker image. The rocm723 variant puts the
+# vLLM ROCm layer at 7.2.3, one patch level above the SGLang stack. AITER_REF
 # can pin ROCm/aiter to a released tag; when unset, the installer selects the
 # newest tag compatible with the already-installed ROCm torch/triton stack.
 SGLANG_REF="${SGLANG_REF:-v0.5.17}"
@@ -158,8 +158,9 @@ warn() { echo "[install-baremetal WARN] $*" >&2; }
 die() { echo "[install-baremetal ERROR] $*" >&2; exit 1; }
 
 IMAGE_HINT="Provision the ROCm framework base first (run inside an AMD ROCm \
-SGLang/vLLM image such as rocm/hyperloom:sglang-*-rocm7.2.0-mi300x|mi350x, or \
-install an equivalent ROCm torch + framework stack), then re-run."
+SGLang/vLLM image such as rocm/hyperloom:sglang-*-rocm7.2.0-mi300x|mi350x or \
+vllm/vllm-openai-rocm:v0.27.1, or install an equivalent ROCm torch + \
+framework stack), then re-run."
 
 is_interactive() { [ "$ASSUME_YES" -eq 0 ] && [ -t 0 ] && [ -t 1 ]; }
 

--- a/src/hyperloom/inference_optimizer/assets/slurm/models.tsv
+++ b/src/hyperloom/inference_optimizer/assets/slurm/models.tsv
@@ -2,5 +2,5 @@
 # Example registry consumed by submit.sh. Replace repo_id / image / gpu_type
 # with your own published models and container images before running.
 deepseek_r1_sglang	deepseek-ai/DeepSeek-R1	sglang	MI300X	rocm/hyperloom:sglang-v0.5.17-rocm7.2.0-mi300x	8	fp8	1024	1024	64	moe_mla	6	10
-deepseek_r1_vllm	deepseek-ai/DeepSeek-R1	vllm	MI300X	rocm/hyperloom:vllm-v0.27.1-rocm7.2.3	8	fp8	1024	1024	64	moe_mla	6	10
-gptoss_vllm	openai/gpt-oss-120b	vllm	MI300X	rocm/hyperloom:vllm-v0.27.1-rocm7.2.3	8	fp4	1024	1024	64	moe_swa	6	10
+deepseek_r1_vllm	deepseek-ai/DeepSeek-R1	vllm	MI300X	vllm/vllm-openai-rocm:v0.27.1	8	fp8	1024	1024	64	moe_mla	6	10
+gptoss_vllm	openai/gpt-oss-120b	vllm	MI300X	vllm/vllm-openai-rocm:v0.27.1	8	fp4	1024	1024	64	moe_swa	6	10


### PR DESCRIPTION
## Summary

- Replace every vLLM container image reference `rocm/hyperloom:vllm-v0.27.1-rocm7.2.3` with the official upstream image `vllm/vllm-openai-rocm:v0.27.1`. AMD deprecated `rocm/vllm` / `rocm/vllm-dev` in favor of the upstream vLLM Docker Hub repo, and ROCm docs now point at `vllm/vllm-openai-rocm`.
- SGLang images are untouched: upstream publishes no SGLang image, so `rocm/hyperloom:sglang-*` stays.
- Note the entrypoint difference in `docs/compatibility.rst`: the official image entrypoint is `vllm serve`, so it must be overridden (`--entrypoint tail`) for a long-running Hyperloom container. All `docker run` snippets in the repo already do this, so no launch command changed.

## Why the tag is a 1:1 replacement

Pulled the image config from the Docker Hub registry for `vllm/vllm-openai-rocm:v0.27.1`:

- build history sets `ROCM_VERSION=7.2.3` on base `rocm/dev-ubuntu-22.04:7.2.3-complete` — same ROCm patch level as the old image and as the bare-metal `rocm723` wheel variant
- `PYTHON_VERSION=3.12`, matching the vLLM ROCm wheel requirement documented in `docs/compatibility.rst`
- `PYTORCH_ROCM_ARCH` includes `gfx942;gfx950`, covering MI300X / MI325X / MI355X
- vLLM is installed into the system interpreter (`uv pip install --system`), so there is no `/opt/venv`; `install.sh` / `install_baremetal.sh` `resolve_python()` falls through to `/usr/bin/python3`, which carries ROCm torch + vLLM, and pip in the image is new enough for the `--break-system-packages` path

## Files changed

- `docs/compatibility.rst`, `docs/install/install.md`
- `examples/hyperloom-qwen3-8b-3h/SKILL.md`, `examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md`, `examples/hyperloom-custom-advanced/SKILL.md`
- `src/hyperloom/inference_optimizer/assets/slurm/models.tsv`
- `src/hyperloom/inference_optimizer/assets/install_baremetal.sh` (comment + `IMAGE_HINT`)
- `src/hyperloom/agents/kernel/tests/test_live_source_stack.py` (docstring)