### PR TITLE
Fix baremetal SGLang install for v0.5.17 kernel layout

### DIFF
--- a/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
+++ b/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
@@ -110,7 +110,7 @@ DEEPSEEK_* values are migrated automatically.
 Env overrides honored: REPO_ROOT,
 USER_DATA_PATH, HYPERLOOM_DEPS_ROOT / HYPERLOOM_CACHE_DIR,
 PYTHON, INFERENCE_OPTIMIZER_FORCE_PYTHON,
-SGLANG_REPO, SGLANG_REF, SGLANG_ROOT, SGLANG_ROCM_PYPI_VERSION,
+SGLANG_REPO, SGLANG_REF, SGLANG_ROOT, SGLANG_KERNEL_VERSION, SGLANG_ROCM_PYPI_VERSION,
 SGLANG_ROCM_EXTRA, AITER_REPO, AITER_REF, AITER_ROOT, ROCM_PATH, HIP_PATH,
 LD_LIBRARY_PATH, VLLM_VERSION, VLLM_ROCM_VARIANT, VLLM_ROCM_INDEX,
 VLLM_VENV_ROOT.
@@ -482,6 +482,45 @@ PY
   fi
 }
 
+# SGLang v0.5.17+ ships sglang-kernel as a separate PyPI package; older tags
+# still carry an in-tree sgl-kernel/ tree built via setup_rocm.py.
+resolve_sglang_kernel_pip_version() {
+  local sglang_root="$1" pyproject="${1}/python/pyproject.toml" ver=""
+  ver="${SGLANG_KERNEL_VERSION:-}"
+  if [ -n "$ver" ]; then
+    printf '%s' "$ver"
+    return 0
+  fi
+  if [ -f "$pyproject" ]; then
+    ver="$(grep -E '^\s*"sglang-kernel==' "$pyproject" | head -1 \
+      | sed -E 's/.*"sglang-kernel==([^"]+)".*/\1/')"
+    if [ -n "$ver" ]; then
+      printf '%s' "$ver"
+      return 0
+    fi
+  fi
+  printf '%s' "0.4.5"
+}
+
+install_sglang_kernel_rocm() {
+  local py="$1" sglang_root="$2" arch="$3" kernel_ver constraint_file
+  if [ -f "${sglang_root}/sgl-kernel/setup_rocm.py" ]; then
+    log "building in-tree sgl-kernel from ${sglang_root}/sgl-kernel (legacy layout, arch=${arch})"
+    (cd "${sglang_root}/sgl-kernel" && AMDGPU_TARGET="$arch" "$py" setup_rocm.py install)
+    return $?
+  fi
+
+  kernel_ver="$(resolve_sglang_kernel_pip_version "$sglang_root")"
+  log "SGLang ${SGLANG_REF}: no in-tree sgl-kernel/; installing sglang-kernel==${kernel_ver} from PyPI"
+  constraint_file="$(mktemp)"
+  write_rocm_torch_constraints "$py" "$constraint_file"
+  "$py" -m pip install --constraint "$constraint_file" "sglang-kernel==${kernel_ver}" \
+    || { rm -f "$constraint_file"; return 1; }
+  rm -f "$constraint_file"
+  "$py" -c "import sgl_kernel" >/dev/null \
+    || die "sglang-kernel==${kernel_ver} installed but sgl_kernel is not importable"
+}
+
 # Install SGLang from source for Python versions not supported by AMD wheels.
 install_sglang_from_source() {
   local py="$1" deps_root="$2" sglang_root arch constraint_file
@@ -501,7 +540,7 @@ install_sglang_from_source() {
   fi
 
   "$py" -m pip install --upgrade pip wheel setuptools
-  (cd "${sglang_root}/sgl-kernel" && AMDGPU_TARGET="$arch" "$py" setup_rocm.py install)
+  install_sglang_kernel_rocm "$py" "$sglang_root" "$arch"
   if [ -f "${sglang_root}/python/pyproject_other.toml" ]; then
     cp "${sglang_root}/python/pyproject_other.toml" "${sglang_root}/python/pyproject.toml"
   fi
@@ -637,6 +676,11 @@ PY
       log "would run: ${py} -m pip install 'amd-sglang[all-hip,${SGLANG_ROCM_EXTRA}]' -i https://pypi.amd.com/rocm-${SGLANG_ROCM_PYPI_VERSION}/simple --extra-index-url https://pypi.org/simple"
     else
       log "would clone/build SGLang source ${SGLANG_REPO}@${SGLANG_REF} under ${SGLANG_ROOT:-${deps_root}/sglang}"
+      if [ -f "${SGLANG_ROOT:-${deps_root}/sglang}/sgl-kernel/setup_rocm.py" ]; then
+        log "would build in-tree sgl-kernel via setup_rocm.py (legacy layout)"
+      else
+        log "would install sglang-kernel from PyPI (v0.5.17+ layout; no in-tree sgl-kernel/)"
+      fi
       log "would install SGLang source with [srt_hip] runtime dependencies under current torch/triton constraints"
     fi
     if [ -n "$AITER_REF" ]; then

--- a/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
+++ b/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
@@ -110,7 +110,7 @@ DEEPSEEK_* values are migrated automatically.
 Env overrides honored: REPO_ROOT,
 USER_DATA_PATH, HYPERLOOM_DEPS_ROOT / HYPERLOOM_CACHE_DIR,
 PYTHON, INFERENCE_OPTIMIZER_FORCE_PYTHON,
-SGLANG_REPO, SGLANG_REF, SGLANG_ROOT, SGLANG_KERNEL_VERSION, SGLANG_ROCM_PYPI_VERSION,
+SGLANG_REPO, SGLANG_REF, SGLANG_ROOT, SGLANG_ROCM_PYPI_VERSION,
 SGLANG_ROCM_EXTRA, AITER_REPO, AITER_REF, AITER_ROOT, ROCM_PATH, HIP_PATH,
 LD_LIBRARY_PATH, VLLM_VERSION, VLLM_ROCM_VARIANT, VLLM_ROCM_INDEX,
 VLLM_VENV_ROOT.
@@ -482,43 +482,28 @@ PY
   fi
 }
 
-# SGLang v0.5.17+ ships sglang-kernel as a separate PyPI package; older tags
-# still carry an in-tree sgl-kernel/ tree built via setup_rocm.py.
-resolve_sglang_kernel_pip_version() {
-  local sglang_root="$1" pyproject="${1}/python/pyproject.toml" ver=""
-  ver="${SGLANG_KERNEL_VERSION:-}"
-  if [ -n "$ver" ]; then
-    printf '%s' "$ver"
+# Resolve the in-tree ROCm kernel build directory for a SGLang checkout.
+# Legacy tags (<= v0.5.16): sgl-kernel/setup_rocm.py
+# v0.5.17+ tags: python/sglang/kernels/aot/setup_rocm.py
+sglang_kernel_rocm_build_dir() {
+  local sglang_root="$1"
+  if [ -f "${sglang_root}/sgl-kernel/setup_rocm.py" ]; then
+    printf '%s' "${sglang_root}/sgl-kernel"
     return 0
   fi
-  if [ -f "$pyproject" ]; then
-    ver="$(grep -E '^\s*"sglang-kernel==' "$pyproject" | head -1 \
-      | sed -E 's/.*"sglang-kernel==([^"]+)".*/\1/')"
-    if [ -n "$ver" ]; then
-      printf '%s' "$ver"
-      return 0
-    fi
+  if [ -f "${sglang_root}/python/sglang/kernels/aot/setup_rocm.py" ]; then
+    printf '%s' "${sglang_root}/python/sglang/kernels/aot"
+    return 0
   fi
-  printf '%s' "0.4.5"
+  return 1
 }
 
 install_sglang_kernel_rocm() {
-  local py="$1" sglang_root="$2" arch="$3" kernel_ver constraint_file
-  if [ -f "${sglang_root}/sgl-kernel/setup_rocm.py" ]; then
-    log "building in-tree sgl-kernel from ${sglang_root}/sgl-kernel (legacy layout, arch=${arch})"
-    (cd "${sglang_root}/sgl-kernel" && AMDGPU_TARGET="$arch" "$py" setup_rocm.py install)
-    return $?
-  fi
-
-  kernel_ver="$(resolve_sglang_kernel_pip_version "$sglang_root")"
-  log "SGLang ${SGLANG_REF}: no in-tree sgl-kernel/; installing sglang-kernel==${kernel_ver} from PyPI"
-  constraint_file="$(mktemp)"
-  write_rocm_torch_constraints "$py" "$constraint_file"
-  "$py" -m pip install --constraint "$constraint_file" "sglang-kernel==${kernel_ver}" \
-    || { rm -f "$constraint_file"; return 1; }
-  rm -f "$constraint_file"
-  "$py" -c "import sgl_kernel" >/dev/null \
-    || die "sglang-kernel==${kernel_ver} installed but sgl_kernel is not importable"
+  local py="$1" sglang_root="$2" arch="$3" kernel_dir=""
+  kernel_dir="$(sglang_kernel_rocm_build_dir "$sglang_root")" \
+    || die "no in-tree ROCm sglang-kernel build path under ${sglang_root} (checked sgl-kernel/ and python/sglang/kernels/aot/)"
+  log "building in-tree ROCm kernel from ${kernel_dir} (arch=${arch})"
+  (cd "$kernel_dir" && AMDGPU_TARGET="$arch" "$py" setup_rocm.py install)
 }
 
 # Install SGLang from source for Python versions not supported by AMD wheels.
@@ -675,11 +660,12 @@ PY
     if [ "$py_mm" = "3.10" ]; then
       log "would run: ${py} -m pip install 'amd-sglang[all-hip,${SGLANG_ROCM_EXTRA}]' -i https://pypi.amd.com/rocm-${SGLANG_ROCM_PYPI_VERSION}/simple --extra-index-url https://pypi.org/simple"
     else
-      log "would clone/build SGLang source ${SGLANG_REPO}@${SGLANG_REF} under ${SGLANG_ROOT:-${deps_root}/sglang}"
-      if [ -f "${SGLANG_ROOT:-${deps_root}/sglang}/sgl-kernel/setup_rocm.py" ]; then
-        log "would build in-tree sgl-kernel via setup_rocm.py (legacy layout)"
+      local sglang_root="${SGLANG_ROOT:-${deps_root}/sglang}" kernel_dir=""
+      log "would clone/build SGLang source ${SGLANG_REPO}@${SGLANG_REF} under ${sglang_root}"
+      if kernel_dir="$(sglang_kernel_rocm_build_dir "$sglang_root" 2>/dev/null)"; then
+        log "would build in-tree ROCm kernel via ${kernel_dir}/setup_rocm.py"
       else
-        log "would install sglang-kernel from PyPI (v0.5.17+ layout; no in-tree sgl-kernel/)"
+        log "would build in-tree ROCm kernel via setup_rocm.py after clone (sgl-kernel/ legacy or python/sglang/kernels/aot/ for v0.5.17+)"
       fi
       log "would install SGLang source with [srt_hip] runtime dependencies under current torch/triton constraints"
     fi

--- a/src/hyperloom/inference_optimizer/assets/test_sglang_kernel_layout.sh
+++ b/src/hyperloom/inference_optimizer/assets/test_sglang_kernel_layout.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# Regression: SGLang v0.5.17+ has no in-tree sgl-kernel/; installer must pick pip path.
+# Regression: baremetal ROCm kernel path selection for legacy vs v0.5.17+ layouts.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_SH="${SCRIPT_DIR}/install_baremetal.sh"
+FIXTURE_ROOT="${SCRIPT_DIR}/../tests/fixtures/sglang_kernel_layouts"
 
 fail() {
   echo "[test] FAIL: $*" >&2
@@ -14,30 +15,25 @@ pass() {
   echo "[test] PASS: $*"
 }
 
-eval "$(sed -n '/^resolve_sglang_kernel_pip_version()/,/^}/p' "$INSTALL_SH")"
+eval "$(sed -n '/^sglang_kernel_rocm_build_dir()/,/^}/p' "$INSTALL_SH")"
 
-if [ ! -d /tmp/sglang-517/.git ]; then
-  git clone --depth 1 --branch v0.5.17 https://github.com/sgl-project/sglang.git /tmp/sglang-517
-fi
-if [ ! -d /tmp/sglang-516/.git ]; then
-  git clone --depth 1 --branch v0.5.16 https://github.com/sgl-project/sglang.git /tmp/sglang-516
-fi
+legacy="${FIXTURE_ROOT}/legacy"
+aot="${FIXTURE_ROOT}/v0517_aot"
+empty="${FIXTURE_ROOT}/empty"
 
-[ -f /tmp/sglang-517/python/pyproject.toml ] || fail "v0.5.17 checkout missing pyproject.toml"
-[ ! -f /tmp/sglang-517/sgl-kernel/setup_rocm.py ] || fail "v0.5.17 should not have in-tree sgl-kernel"
-[ -f /tmp/sglang-516/sgl-kernel/setup_rocm.py ] || fail "v0.5.16 should have in-tree sgl-kernel"
+[ -f "${legacy}/sgl-kernel/setup_rocm.py" ] || fail "legacy fixture missing"
+[ -f "${aot}/python/sglang/kernels/aot/setup_rocm.py" ] || fail "aot fixture missing"
+[ ! -f "${empty}/sgl-kernel/setup_rocm.py" ] || fail "empty fixture should lack kernel"
 
-grep -q 'install_sglang_kernel_rocm' "$INSTALL_SH" || fail "install_sglang_kernel_rocm helper missing"
-grep -q 'no in-tree sgl-kernel/' "$INSTALL_SH" || fail "pip fallback log line missing"
+dir="$(sglang_kernel_rocm_build_dir "$legacy")"
+[ "$dir" = "${legacy}/sgl-kernel" ] || fail "legacy path got ${dir}"
+pass "legacy -> sgl-kernel/"
 
-ver="$(resolve_sglang_kernel_pip_version /tmp/sglang-517)"
-[ "$ver" = "0.4.5" ] || fail "expected sglang-kernel 0.4.5 for v0.5.17, got ${ver}"
-pass "resolve_sglang_kernel_pip_version v0.5.17 -> ${ver}"
+dir="$(sglang_kernel_rocm_build_dir "$aot")"
+[ "$dir" = "${aot}/python/sglang/kernels/aot" ] || fail "aot path got ${dir}"
+pass "v0.5.17+ -> python/sglang/kernels/aot/"
 
-export SGLANG_KERNEL_VERSION="9.9.9"
-ver="$(resolve_sglang_kernel_pip_version /tmp/sglang-517)"
-[ "$ver" = "9.9.9" ] || fail "SGLANG_KERNEL_VERSION override ignored"
-unset SGLANG_KERNEL_VERSION
-pass "SGLANG_KERNEL_VERSION override"
+sglang_kernel_rocm_build_dir "$empty" >/dev/null 2>&1 && fail "empty layout should fail"
+pass "missing layout returns non-zero"
 
 pass "sglang-kernel layout regression checks"

--- a/src/hyperloom/inference_optimizer/assets/test_sglang_kernel_layout.sh
+++ b/src/hyperloom/inference_optimizer/assets/test_sglang_kernel_layout.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Regression: SGLang v0.5.17+ has no in-tree sgl-kernel/; installer must pick pip path.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_SH="${SCRIPT_DIR}/install_baremetal.sh"
+
+fail() {
+  echo "[test] FAIL: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "[test] PASS: $*"
+}
+
+eval "$(sed -n '/^resolve_sglang_kernel_pip_version()/,/^}/p' "$INSTALL_SH")"
+
+if [ ! -d /tmp/sglang-517/.git ]; then
+  git clone --depth 1 --branch v0.5.17 https://github.com/sgl-project/sglang.git /tmp/sglang-517
+fi
+if [ ! -d /tmp/sglang-516/.git ]; then
+  git clone --depth 1 --branch v0.5.16 https://github.com/sgl-project/sglang.git /tmp/sglang-516
+fi
+
+[ -f /tmp/sglang-517/python/pyproject.toml ] || fail "v0.5.17 checkout missing pyproject.toml"
+[ ! -f /tmp/sglang-517/sgl-kernel/setup_rocm.py ] || fail "v0.5.17 should not have in-tree sgl-kernel"
+[ -f /tmp/sglang-516/sgl-kernel/setup_rocm.py ] || fail "v0.5.16 should have in-tree sgl-kernel"
+
+grep -q 'install_sglang_kernel_rocm' "$INSTALL_SH" || fail "install_sglang_kernel_rocm helper missing"
+grep -q 'no in-tree sgl-kernel/' "$INSTALL_SH" || fail "pip fallback log line missing"
+
+ver="$(resolve_sglang_kernel_pip_version /tmp/sglang-517)"
+[ "$ver" = "0.4.5" ] || fail "expected sglang-kernel 0.4.5 for v0.5.17, got ${ver}"
+pass "resolve_sglang_kernel_pip_version v0.5.17 -> ${ver}"
+
+export SGLANG_KERNEL_VERSION="9.9.9"
+ver="$(resolve_sglang_kernel_pip_version /tmp/sglang-517)"
+[ "$ver" = "9.9.9" ] || fail "SGLANG_KERNEL_VERSION override ignored"
+unset SGLANG_KERNEL_VERSION
+pass "SGLANG_KERNEL_VERSION override"
+
+pass "sglang-kernel layout regression checks"

--- a/src/hyperloom/inference_optimizer/tests/fixtures/sglang_kernel_layouts/legacy/sgl-kernel/setup_rocm.py
+++ b/src/hyperloom/inference_optimizer/tests/fixtures/sglang_kernel_layouts/legacy/sgl-kernel/setup_rocm.py
@@ -1,0 +1,1 @@
+# Fixture stub for legacy SGLang kernel layout tests.

--- a/src/hyperloom/inference_optimizer/tests/fixtures/sglang_kernel_layouts/v0517_aot/python/sglang/kernels/aot/setup_rocm.py
+++ b/src/hyperloom/inference_optimizer/tests/fixtures/sglang_kernel_layouts/v0517_aot/python/sglang/kernels/aot/setup_rocm.py
@@ -1,0 +1,1 @@
+# Fixture stub for SGLang v0.5.17+ AOT kernel layout tests.

--- a/src/hyperloom/inference_optimizer/tests/test_install_baremetal_sglang_kernel.py
+++ b/src/hyperloom/inference_optimizer/tests/test_install_baremetal_sglang_kernel.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_ASSETS = Path(__file__).resolve().parents[1] / "assets"
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "sglang_kernel_layouts"
+_INSTALL_SH = _ASSETS / "install_baremetal.sh"
+
+
+def _kernel_dir(checkout: Path) -> subprocess.CompletedProcess[str]:
+    fn_src = subprocess.run(
+        ["sed", "-n", "/^sglang_kernel_rocm_build_dir()/,/^}/p", str(_INSTALL_SH)],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    script = f"set -euo pipefail\n{fn_src}\nsglang_kernel_rocm_build_dir '{checkout}'\n"
+    return subprocess.run(
+        ["bash", "-lc", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "expected_suffix"),
+    [
+        ("legacy", "sgl-kernel"),
+        ("v0517_aot", "python/sglang/kernels/aot"),
+    ],
+)
+def test_sglang_kernel_rocm_build_dir_known_layouts(
+    fixture_name: str, expected_suffix: str
+) -> None:
+    checkout = _FIXTURES / fixture_name
+    result = _kernel_dir(checkout)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith(expected_suffix)
+
+
+def test_sglang_kernel_rocm_build_dir_missing_layout() -> None:
+    checkout = _FIXTURES / "empty"
+    result = _kernel_dir(checkout)
+    assert result.returncode != 0


### PR DESCRIPTION
## Problem

1. `install_baremetal.sh` defaults to `SGLANG_REF=v0.5.17` but only builds from legacy `sgl-kernel/setup_rocm.py`.
2. SGLang v0.5.17 moved the ROCm kernel build to `python/sglang/kernels/aot/setup_rocm.py`, so source install fails on Python 3.12 baremetal.
3. A PyPI `sglang-kernel` fallback is unsuitable for ROCm baremetal because those wheels target CUDA/torch 2.11, not the host ROCm torch 2.9.x stack.

## Fix

1. Add `sglang_kernel_rocm_build_dir()` to detect legacy and v0.5.17+ in-tree ROCm kernel layouts.
2. Build via `setup_rocm.py` from the detected directory; fail fast when neither layout exists.
3. Update dry-run messaging to reflect the selected in-tree kernel path.
4. Add hermetic layout tests (shell + pytest fixtures) for legacy, v0.5.17 AOT, and missing layouts.