### PR TITLE
fix(budget): stamp one absolute deadline so a resume cannot reissue the budget

### DIFF
--- a/src/hyperloom/agents/robustness/role/envelope.py
+++ b/src/hyperloom/agents/robustness/role/envelope.py
@@ -113,6 +113,7 @@ CORE_STATE_FIELDS: frozenset[str] = frozenset(
         "start_ts",
         "resumed_ts",
         "max_minutes",
+        "deadline_unix",
         "closing_grace_sec",
         "optimization_stack",
         "gain_per_stack_entry",

--- a/src/hyperloom/inference_optimizer/cli/__init__.py
+++ b/src/hyperloom/inference_optimizer/cli/__init__.py
@@ -91,7 +91,7 @@ from ..protocol.action_surfaces import ACTION_CATALOGUE, ActionMetadata
 from hyperloom.orchestrator.loop.coordinator import Coordinator
 from hyperloom.orchestrator.framework.paths import resolve_source_file_allowlist
 from hyperloom.orchestrator.state.objective import Objective, build_objective
-from hyperloom.orchestrator.state.shared_state import SharedState
+from hyperloom.orchestrator.state.shared_state import SharedState, timed_teardown_step
 from hyperloom.orchestrator.prompts.prompt_builder import (
     TRANSPORT_TOOLS,
     build_orchestration_prompt,
@@ -2316,28 +2316,28 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             closing_grace_sec=args.closing_grace_sec,
         )
     finally:
-        await coordinator.stop()
+        state = coordinator.shared_state
+        with timed_teardown_step(state, "coordinator_stop"):
+            await coordinator.stop()
         # Drop the single-optimizer session lock once the
         # coordinator has released its leases. The OS would drop it on process
         # exit anyway; this just frees it promptly for an intentional resume.
-        session_lock.release()
+        with timed_teardown_step(state, "session_lock"):
+            session_lock.release()
         # Crash-safe reports/final.json. Runs unconditionally and first so a
         # machine-readable summary always exists even when the CLOSE sequencer
         # never ran. Idempotent: a no-op when ReportExecutor already wrote it.
         try:
             from ..breakdown import write_minimal_final_json
 
-            final_json = write_minimal_final_json(session_dir)
+            with timed_teardown_step(state, "final_json"):
+                final_json = write_minimal_final_json(session_dir)
             print(f"Final summary     : {final_json}")
         except Exception:  # noqa: BLE001 — safety net must never mask stop_reason
             log.exception("crash-safe final.json write failed (non-fatal)")
         # End-of-session safety net: always materialize session_breakdown.json (best-effort; never mask stop_reason).
         # Skip when the CLOSE sequencer already wrote it (close_sequence_done is locked in CORE_STATE_FIELDS).
-        sequencer_done = getattr(
-            coordinator.shared_state,
-            "close_sequence_done",
-            False,
-        )
+        sequencer_done = getattr(state, "close_sequence_done", False)
         if sequencer_done:
             print(
                 "Session breakdown : (already written by CLOSE phase sequencer; skipping cli.finally safety-net write)"
@@ -2349,18 +2349,20 @@ async def _run_optimize(args: argparse.Namespace) -> int:
                     record_session_breakdown,
                 )
 
-                flush_session(session_dir)
-                from ..breakdown import patch_breakdown_langfuse
+                with timed_teardown_step(state, "langfuse"):
+                    flush_session(session_dir)
+                    from ..breakdown import patch_breakdown_langfuse
 
-                patch_breakdown_langfuse(session_dir)
-                record_session_breakdown(session_dir)
+                    patch_breakdown_langfuse(session_dir)
+                    record_session_breakdown(session_dir)
             except Exception:  # noqa: BLE001
                 log.debug("langfuse flush_session (post-sequencer) failed", exc_info=True)
         else:
             try:
                 from ..breakdown import write_breakdown_json
 
-                breakdown_path = write_breakdown_json(session_dir)
+                with timed_teardown_step(state, "session_breakdown"):
+                    breakdown_path = write_breakdown_json(session_dir)
                 print(f"Session breakdown : {breakdown_path}")
             except Exception:  # noqa: BLE001
                 log.exception("session_breakdown finalize failed (non-fatal)")
@@ -2368,7 +2370,8 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             try:
                 from ..breakdown import write_minimal_final_report
 
-                final_md = write_minimal_final_report(session_dir)
+                with timed_teardown_step(state, "final_md"):
+                    final_md = write_minimal_final_report(session_dir)
                 print(f"Final report      : {final_md}")
             except Exception:  # noqa: BLE001
                 log.exception("emergency final report write failed (non-fatal)")
@@ -2383,11 +2386,12 @@ async def _run_optimize(args: argparse.Namespace) -> int:
                     record_session_breakdown,
                 )
 
-                flush_session(session_dir)
-                from ..breakdown import patch_breakdown_langfuse
+                with timed_teardown_step(state, "langfuse"):
+                    flush_session(session_dir)
+                    from ..breakdown import patch_breakdown_langfuse
 
-                patch_breakdown_langfuse(session_dir)
-                record_session_breakdown(session_dir)
+                    patch_breakdown_langfuse(session_dir)
+                    record_session_breakdown(session_dir)
             except Exception:  # noqa: BLE001
                 log.debug("langfuse flush_session failed (non-fatal)", exc_info=True)
 
@@ -2398,16 +2402,19 @@ async def _run_optimize(args: argparse.Namespace) -> int:
         try:
             from ..breakdown import package_session_artifacts
 
-            pkg_path = package_session_artifacts(
-                session_dir,
-                session_id=str(
-                    getattr(coordinator.shared_state, "session_id", "") or "",
-                ),
-            )
+            with timed_teardown_step(state, "artifact_package"):
+                pkg_path = package_session_artifacts(
+                    session_dir,
+                    session_id=str(getattr(state, "session_id", "") or ""),
+                )
             if pkg_path is not None:
                 print(f"Artifact package  : {pkg_path}")
         except Exception:  # noqa: BLE001
             log.exception("session artifact package failed (non-fatal)")
+        try:
+            state.save(session_dir)
+        except Exception:  # noqa: BLE001
+            log.exception("failed to persist teardown timings (non-fatal)")
 
     _reconcile_crash_count(coordinator.shared_state, session_dir)
     # NOTE: conc_sweep is now a SWEEP-phase action auto-enqueued by the Coordinator, not a post-hook here.

--- a/src/hyperloom/inference_optimizer/cli/__init__.py
+++ b/src/hyperloom/inference_optimizer/cli/__init__.py
@@ -53,6 +53,7 @@ from ..model_config_utils import (
 )
 from .bootstrap import (
     _begin_resume_leg,
+    _clean_stop_resume_budget_lines,
     _print_final_summary,
     _print_session_skeleton,
     _reconcile_crash_count,
@@ -1756,22 +1757,11 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             print(f"  → cleared stop_reason and reset crash_count (was {prior_crash}) for fresh resume{override_note}")
             print(f"  → reset start_ts to {state.start_ts} (resume budget)")
         else:
-            # A clean stop (no stop_reason, crash_count < 3) keeps start_ts, so
-            # --max-hours is measured from the ORIGINAL session start and the
-            # earlier legs' wall-clock is already spent. Say so: an operator who
-            # stops a run by hand reads --max-hours as "from now".
-            elapsed_h = state.elapsed_minutes() / 60.0
-            budget_h = float(getattr(args, "max_hours", 0) or 0)
-            print(
-                f"  → start_ts kept at {state.start_ts} (clean stop, no stop_reason): "
-                f"--max-hours counts from the original session start"
-            )
-            print(f"  → budget: {elapsed_h:.2f}h already elapsed of {budget_h:.2f}h → {budget_h - elapsed_h:.2f}h left")
-            if budget_h and elapsed_h >= budget_h:
-                print(
-                    "  → WARNING: this budget is already exhausted; raise --max-hours "
-                    "or start a fresh session, or the run stops almost immediately"
-                )
+            for line in _clean_stop_resume_budget_lines(
+                state,
+                max_hours=float(getattr(args, "max_hours", 0) or 0),
+            ):
+                print(line)
         # Re-bootstrap the recipe KB client (recreates client + reruns T0 warm-start); skipped when --degraded-kb.
         recipe_kb_client = _bootstrap_recipe_kb(
             args,

--- a/src/hyperloom/inference_optimizer/cli/bootstrap.py
+++ b/src/hyperloom/inference_optimizer/cli/bootstrap.py
@@ -478,10 +478,11 @@ def _begin_resume_leg(state: SharedState, *, reanchor_budget: bool) -> str:
     ``deadline_unix`` so ``Coordinator.run`` can stamp a new one from the
     reset ``start_ts``; keeping the spent stamp would make ``--force-resume``
     after ``time_exhausted`` stop immediately. After a clean stop ``start_ts``
-    and the stamp are deliberately kept, so ``--max-hours`` still counts from
-    the original session start and the earlier legs' wall-clock stays spent.
-    The phase clock moves on either branch: the two answer different
-    questions, and neither answer includes time nothing was running.
+    and the stamp are deliberately kept, so remaining wall-clock is the
+    persisted deadline, not this invocation's ``--max-hours``. Raising that
+    flag on this path does not extend the stamp. The phase clock moves on
+    either branch: the two answer different questions, and neither answer
+    includes time nothing was running.
 
     Args:
         state (SharedState): The loaded session state, mutated in place.
@@ -509,6 +510,53 @@ def _begin_resume_leg(state: SharedState, *, reanchor_budget: bool) -> str:
         state.deadline_unix = 0.0
         state.teardown_timings_sec = {}
     return state.resumed_ts
+
+
+def _clean_stop_resume_budget_lines(state: SharedState, *, max_hours: float) -> list[str]:
+    """Operator-facing resume notes when the wall-clock stamp is kept.
+
+    Remaining time is :meth:`SharedState.remaining_minutes` (the stamp), not
+    this invocation's ``--max-hours``. Raising that flag here does not extend
+    the deadline.
+
+    Args:
+        state: Loaded session state after :func:`_begin_resume_leg`.
+        max_hours: This invocation's ``--max-hours``.
+
+    Returns:
+        Lines to print, each already prefixed with ``  → ``.
+    """
+    elapsed_h = state.elapsed_minutes() / 60.0
+    remaining_min = state.remaining_minutes()
+    lines = [
+        f"  → start_ts kept at {state.start_ts} (clean stop, no stop_reason): "
+        f"the persisted deadline is kept",
+    ]
+    if remaining_min is None:
+        lines.append(f"  → {elapsed_h:.2f}h elapsed; no persisted deadline")
+        return lines
+    remaining_h = remaining_min / 60.0
+    lines.append(
+        f"  → budget: {elapsed_h:.2f}h elapsed, {remaining_h:.2f}h left on the persisted stamp"
+    )
+    cli_hours = float(max_hours or 0.0)
+    if remaining_min <= 0.0:
+        lines.append(
+            "  → WARNING: the stamped deadline is already spent; start a fresh "
+            "session, or the run stops almost immediately"
+        )
+        lines.append(
+            "  → raising --max-hours on a clean-stop resume does not extend the "
+            "stamp; a recorded stop_reason re-anchors the budget"
+        )
+    elif cli_hours > 0.0:
+        cli_left_min = cli_hours * 60.0 - elapsed_h * 60.0
+        if abs(cli_left_min - remaining_min) > 1.0:
+            lines.append(
+                f"  → this invocation's --max-hours {cli_hours:.2f} does not "
+                f"extend or shrink that stamp"
+            )
+    return lines
 
 
 def _reconcile_crash_count(state: SharedState, session_dir: Path) -> None:

--- a/src/hyperloom/inference_optimizer/cli/bootstrap.py
+++ b/src/hyperloom/inference_optimizer/cli/bootstrap.py
@@ -474,11 +474,14 @@ def _begin_resume_leg(state: SharedState, *, reanchor_budget: bool) -> str:
     two legs to whichever phase the session stopped in.
 
     Only a previous leg that stopped for a recorded reason, or crashed
-    repeatedly, re-anchors the wall-clock budget. After a clean stop
-    ``start_ts`` is deliberately kept, so ``--max-hours`` still counts from the
-    original session start and the earlier legs' wall-clock stays spent. The
-    phase clock moves on either branch: the two answer different questions, and
-    neither answer includes time nothing was running.
+    repeatedly, re-anchors the wall-clock budget. That also clears
+    ``deadline_unix`` so ``Coordinator.run`` can stamp a new one from the
+    reset ``start_ts``; keeping the spent stamp would make ``--force-resume``
+    after ``time_exhausted`` stop immediately. After a clean stop ``start_ts``
+    and the stamp are deliberately kept, so ``--max-hours`` still counts from
+    the original session start and the earlier legs' wall-clock stays spent.
+    The phase clock moves on either branch: the two answer different
+    questions, and neither answer includes time nothing was running.
 
     Args:
         state (SharedState): The loaded session state, mutated in place.
@@ -501,6 +504,10 @@ def _begin_resume_leg(state: SharedState, *, reanchor_budget: bool) -> str:
         state.crash_count = 0
         # Reset start_ts to now so resume budget isn't seen as already-over-budget by the LLM.
         state.start_ts = state.resumed_ts
+        # The stamp is the loop's budget. Leaving a spent one in place after
+        # resetting start_ts would make this leg look already exhausted.
+        state.deadline_unix = 0.0
+        state.teardown_timings_sec = {}
     return state.resumed_ts
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_cli_bootstrap.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_bootstrap.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -63,6 +64,14 @@ def _args(**overrides):
     )
     base.update(overrides)
     return argparse.Namespace(**base)
+
+
+def _state_with_stamp(*, elapsed_h: float, remaining_h: float) -> SharedState:
+    now = time.time()
+    start = datetime.fromtimestamp(now - elapsed_h * 3600.0, tz=timezone.utc).isoformat()
+    state = SharedState(session_id="s", start_ts=start, max_minutes=int((elapsed_h + remaining_h) * 60))
+    state.deadline_unix = now + remaining_h * 3600.0
+    return state
 
 
 def test_seed_shared_state_populates_geak_and_cli_overrides(
@@ -432,6 +441,41 @@ def test_a_clean_stop_resume_records_where_the_new_leg_began() -> None:
     assert state.crash_count == 1
     assert state.deadline_unix == 1_700_000_000.0
     assert state.teardown_timings_sec == {"total": 1.5}
+
+
+def test_clean_stop_resume_notes_follow_the_stamp_not_a_larger_cli_budget() -> None:
+    """Raising --max-hours on a clean-stop resume must not be reported as time left."""
+    state = _state_with_stamp(elapsed_h=2.0, remaining_h=1.0)
+    lines = cb._clean_stop_resume_budget_lines(state, max_hours=8.0)
+    text = "\n".join(lines)
+    match = re.search(r"budget: ([0-9.]+)h elapsed, ([0-9.]+)h left on the persisted stamp", text)
+    assert match is not None
+    assert abs(float(match.group(1)) - 2.0) < 0.05
+    assert abs(float(match.group(2)) - 1.0) < 0.05
+    assert "this invocation's --max-hours 8.00 does not extend or shrink that stamp" in text
+    assert "raise --max-hours or start a fresh session" not in text
+
+
+def test_clean_stop_resume_notes_do_not_tell_the_operator_to_raise_max_hours() -> None:
+    state = _state_with_stamp(elapsed_h=3.5, remaining_h=-0.5)
+    lines = cb._clean_stop_resume_budget_lines(state, max_hours=8.0)
+    text = "\n".join(lines)
+    match = re.search(r"budget: ([0-9.]+)h elapsed, ([0-9.]+)h left on the persisted stamp", text)
+    assert match is not None
+    assert abs(float(match.group(1)) - 3.5) < 0.05
+    assert abs(float(match.group(2)) - 0.0) < 0.05
+    assert "WARNING: the stamped deadline is already spent" in text
+    assert "start a fresh session" in text
+    assert "does not extend the stamp" in text
+    assert "raise --max-hours or start a fresh session" not in text
+
+
+def test_clean_stop_resume_notes_omit_the_cli_mismatch_when_hours_match_the_stamp() -> None:
+    state = _state_with_stamp(elapsed_h=1.0, remaining_h=2.0)
+    lines = cb._clean_stop_resume_budget_lines(state, max_hours=3.0)
+    text = "\n".join(lines)
+    assert "does not extend or shrink that stamp" not in text
+    assert "WARNING:" not in text
 
 
 def test_a_resume_after_a_stop_re_anchors_the_budget_on_the_new_leg() -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_cli_bootstrap.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_bootstrap.py
@@ -10,8 +10,8 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from types import SimpleNamespace
 
+from hyperloom.common.coerce import to_unix
 from hyperloom.inference_optimizer.cli import bootstrap as cb
 from hyperloom.orchestrator.state.shared_state import SharedState
 
@@ -422,18 +422,24 @@ def test_snapshot_skeleton_and_session_dir_helpers(
 def test_a_clean_stop_resume_records_where_the_new_leg_began() -> None:
     """start_ts stays the budget anchor, so the resume timestamp is the only leg boundary."""
     state = SharedState(session_id="s", start_ts="2026-08-01T00:00:00+00:00", crash_count=1)
+    state.deadline_unix = 1_700_000_000.0
+    state.teardown_timings_sec = {"total": 1.5}
 
     cb._begin_resume_leg(state, reanchor_budget=False)
 
     assert state.start_ts == "2026-08-01T00:00:00+00:00"
     assert state.resumed_ts > state.start_ts
     assert state.crash_count == 1
+    assert state.deadline_unix == 1_700_000_000.0
+    assert state.teardown_timings_sec == {"total": 1.5}
 
 
 def test_a_resume_after_a_stop_re_anchors_the_budget_on_the_new_leg() -> None:
     state = SharedState(session_id="s", start_ts="2026-08-01T00:00:00+00:00", crash_count=4)
     state.set_stop_reason("time_exhausted")
     state.closing_phase = True
+    state.deadline_unix = 1_700_000_000.0
+    state.teardown_timings_sec = {"close_backends": 0.2, "total": 0.2}
 
     cb._begin_resume_leg(state, reanchor_budget=True)
 
@@ -442,6 +448,11 @@ def test_a_resume_after_a_stop_re_anchors_the_budget_on_the_new_leg() -> None:
     assert state.stop_ts == ""
     assert state.closing_phase is False
     assert state.crash_count == 0
+    assert state.deadline_unix == 0.0
+    assert state.teardown_timings_sec == {}
+    stamped = state.stamp_deadline_unix(budget_minutes=60)
+    start = to_unix(state.start_ts)
+    assert abs(stamped - (start + 3600.0)) < 2.0
 
 
 def test_a_resume_banks_what_the_stopped_leg_spent_in_its_phase() -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_close_phase_sequencer.py
+++ b/src/hyperloom/inference_optimizer/tests/test_close_phase_sequencer.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -429,6 +430,47 @@ async def test_a_running_task_that_never_lands_is_reported_not_waited_on_forever
 
     assert state == "running"
     assert coord.sub.run_calls == []
+
+
+class _HangsUntilCancelled(_StubSubAgentRunner):
+    """A report writer that never returns unless the waiter cancels it."""
+
+    def __init__(self):
+        super().__init__()
+        self.cancelled = False
+
+    async def run_task(self, task, *args, **kwargs):
+        self.run_calls.append(task)
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+        return _StubSubResult(state="succeeded")
+
+
+@pytest.mark.asyncio
+async def test_a_fresh_report_that_never_lands_is_not_awaited_forever(coord):
+    """The in-flight wait had a bound; a newly started report must too."""
+    coord.sub = _HangsUntilCancelled()
+    coord.shared_state.max_minutes = 60
+    coord.phase_close._close_step_wait_sec = lambda _task: 0.05  # type: ignore[method-assign]
+    queued = _StubTaskRow(
+        task_id="fresh-report",
+        kind="report",
+        state="queued",
+        params={},
+        idempotency_key="internal-report-close_phase_entry",
+    )
+
+    started = time.monotonic()
+    state = await coord._run_close_task(queued, step="1 (report)")
+    elapsed = time.monotonic() - started
+
+    assert state == "running"
+    assert elapsed < 2.0
+    assert coord.sub.run_calls == [queued]
+    assert coord.sub.cancelled is True
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/inference_optimizer/tests/test_machine_state.py
+++ b/src/hyperloom/inference_optimizer/tests/test_machine_state.py
@@ -131,6 +131,13 @@ def test_session_remaining_seconds() -> None:
         SimpleNamespace(max_minutes=60, start_ts=now_iso),
     )
     assert rem is not None and 0.0 < rem <= 3600.0
+    assert (
+        ps.session_remaining_seconds(
+            SimpleNamespace(max_minutes=60, start_ts=now_iso, deadline_unix=1000.0),
+            now_unix=400.0,
+        )
+        == 600.0
+    )
 
 
 def test_post_prelude_target() -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_machine_state.py
+++ b/src/hyperloom/inference_optimizer/tests/test_machine_state.py
@@ -138,6 +138,13 @@ def test_session_remaining_seconds() -> None:
         )
         == 600.0
     )
+    assert (
+        ps.session_remaining_seconds(
+            SimpleNamespace(max_minutes=0, deadline_unix=2000.0),
+            now_unix=1400.0,
+        )
+        == 600.0
+    )
 
 
 def test_post_prelude_target() -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_phase_state_framework_agent.py
+++ b/src/hyperloom/inference_optimizer/tests/test_phase_state_framework_agent.py
@@ -439,6 +439,19 @@ def test_compute_next_phase_prelude_to_framework_when_enabled():
     assert reason == "prelude_done"
 
 
+def test_compute_next_phase_closing_phase_goes_to_close_not_framework():
+    """A spent wall-clock must not start FRAMEWORK; that allowlist drops ``report``."""
+    state = _State(phase=phase_state.PHASE_PRELUDE, baseline_tput=1500.0)
+    state.closing_phase = True
+    out = phase_state.compute_next_phase(state, framework_agent_phase_enabled=True)
+    assert out is not None
+    next_phase, reason, ev = out
+    assert next_phase == phase_state.PHASE_CLOSE
+    assert reason == "time_exhausted"
+    assert ev.get("terminal") is True
+    assert ev.get("reason_origin") == "closing_phase"
+
+
 def test_compute_next_phase_prelude_to_explore_when_disabled_keeps_prelude_done_reason():
     """``framework_agent_phase_enabled=False`` preserves the historical ``prelude_done`` reason."""
     state = _State(phase=phase_state.PHASE_PRELUDE, baseline_tput=1500.0)

--- a/src/hyperloom/inference_optimizer/tests/test_phase_state_helpers_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_phase_state_helpers_coverage_unit.py
@@ -131,6 +131,11 @@ def test_session_remaining_seconds() -> None:
         SimpleNamespace(max_minutes=60, start_ts=now_iso),
     )
     assert rem is not None and 0.0 < rem <= 3600.0
+    # A stamped unix deadline wins over start_ts, so a resume cannot reissue.
+    assert ps.session_remaining_seconds(
+        SimpleNamespace(max_minutes=60, start_ts=now_iso, deadline_unix=1_000.0),
+        now_unix=400.0,
+    ) == pytest.approx(600.0)
 
 
 def test_post_prelude_target() -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_phase_state_helpers_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_phase_state_helpers_coverage_unit.py
@@ -136,6 +136,11 @@ def test_session_remaining_seconds() -> None:
         SimpleNamespace(max_minutes=60, start_ts=now_iso, deadline_unix=1_000.0),
         now_unix=400.0,
     ) == pytest.approx(600.0)
+    # A stamp is enough even when persisted max_minutes was truncated to 0.
+    assert ps.session_remaining_seconds(
+        SimpleNamespace(max_minutes=0, deadline_unix=2_000.0),
+        now_unix=1_400.0,
+    ) == pytest.approx(600.0)
 
 
 def test_post_prelude_target() -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_session_time_budget.py
+++ b/src/hyperloom/inference_optimizer/tests/test_session_time_budget.py
@@ -1385,6 +1385,19 @@ class TestThePersistedDeadlineIsTheLoopDeadline:
         assert stamped == pytest.approx(start + 3600.0, abs=2.0)
 
     @pytest.mark.asyncio
+    async def test_run_stamps_a_fractional_budget_before_int_truncation(
+        self, coord: Coordinator
+    ):
+        from hyperloom.common.coerce import to_unix
+
+        try:
+            await coord.run(max_ticks=1, max_minutes=0.0001, closing_grace_sec=0.0)
+        finally:
+            await coord.stop()
+        start = to_unix(coord.shared_state.start_ts)
+        assert coord.shared_state.deadline_unix == pytest.approx(start + 0.006, abs=0.05)
+
+    @pytest.mark.asyncio
     async def test_run_keeps_a_deadline_stamped_before_this_process(self, coord: Coordinator):
         from datetime import datetime, timedelta, timezone
 

--- a/src/hyperloom/inference_optimizer/tests/test_session_time_budget.py
+++ b/src/hyperloom/inference_optimizer/tests/test_session_time_budget.py
@@ -1361,3 +1361,64 @@ class TestATickCannotOutliveTheSessionBound:
 
         await coord._await_within_session_bound(_ok, stage="close")
         assert started == [True]
+
+
+class TestThePersistedDeadlineIsTheLoopDeadline:
+    """Coordinator.run must not reissue a full max_minutes on a spent session.
+
+    The GPU CI e2e run is a smoke check, not a wall-clock assertion. This is
+    the in-process stand-in for #1146 item 5: a session whose deadline is
+    already in the past must stop as ``time_exhausted`` instead of running out
+    the remaining ticks against a freshly computed budget.
+    """
+
+    @pytest.mark.asyncio
+    async def test_run_stamps_deadline_unix_from_start_ts(self, coord: Coordinator):
+        from hyperloom.common.coerce import to_unix
+
+        try:
+            await coord.run(max_ticks=1, max_minutes=60, closing_grace_sec=0.0)
+        finally:
+            await coord.stop()
+        stamped = coord.shared_state.deadline_unix
+        start = to_unix(coord.shared_state.start_ts)
+        assert stamped == pytest.approx(start + 3600.0, abs=2.0)
+
+    @pytest.mark.asyncio
+    async def test_run_keeps_a_deadline_stamped_before_this_process(self, coord: Coordinator):
+        from datetime import datetime, timedelta, timezone
+
+        start = datetime.now(timezone.utc) - timedelta(hours=3)
+        original = start.timestamp() + 180 * 60.0
+        coord.shared_state.start_ts = start.isoformat()
+        coord.shared_state.max_minutes = 180
+        coord.shared_state.deadline_unix = original
+        try:
+            await coord.run(max_ticks=1, max_minutes=180, closing_grace_sec=0.0)
+        finally:
+            await coord.stop()
+        assert coord.shared_state.deadline_unix == pytest.approx(original)
+
+    @pytest.mark.asyncio
+    async def test_a_spent_session_stops_instead_of_reissuing_the_budget(
+        self, coord: Coordinator
+    ):
+        from datetime import datetime, timedelta, timezone
+
+        start = datetime.now(timezone.utc) - timedelta(hours=3)
+        coord.shared_state.start_ts = start.isoformat()
+        coord.shared_state.max_minutes = 180
+        coord.shared_state.deadline_unix = start.timestamp() + 180 * 60.0
+        started = time.monotonic()
+        try:
+            reason = await coord.run(
+                max_minutes=180,
+                closing_grace_sec=0.0,
+                max_ticks=8,
+            )
+        finally:
+            await coord.stop()
+        assert reason == "time_exhausted"
+        assert time.monotonic() - started < 15.0
+        assert "close_backends" in coord.shared_state.teardown_timings_sec
+        assert coord.shared_state.teardown_timings_sec["total"] >= 0.0

--- a/src/hyperloom/inference_optimizer/tests/test_shared_state_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_shared_state_units.py
@@ -177,6 +177,28 @@ class TestDeadlineUnix:
         now = datetime.fromtimestamp(500.0, tz=timezone.utc)
         assert state.remaining_minutes(now=now) == 0.0
 
+    def test_a_stamp_survives_a_max_minutes_truncated_to_zero(self):
+        from datetime import datetime, timezone
+
+        from hyperloom.common.coerce import to_unix
+
+        state = SharedState(session_id="s")
+        stamped = state.stamp_deadline_unix(budget_minutes=0.0001)
+        start = to_unix(state.start_ts)
+        assert stamped == pytest.approx(start + 0.006, abs=0.001)
+        assert state.remaining_minutes() == pytest.approx(0.0001, abs=0.00005)
+        state.max_minutes = 0
+        now = datetime.fromtimestamp(stamped - 6.0, tz=timezone.utc)
+        assert state.remaining_minutes(now=now) == pytest.approx(0.1)
+
+    def test_remaining_minutes_reads_a_stamp_when_max_minutes_is_zero(self):
+        from datetime import datetime, timezone
+
+        state = SharedState(session_id="s", max_minutes=0)
+        state.deadline_unix = 2_000.0
+        now = datetime.fromtimestamp(1_400.0, tz=timezone.utc)
+        assert state.remaining_minutes(now=now) == pytest.approx(10.0)
+
     def test_teardown_timings_accumulate_and_keep_a_total(self):
         state = SharedState(session_id="s")
         state.record_teardown_timing("final_json", 1.25)

--- a/src/hyperloom/inference_optimizer/tests/test_shared_state_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_shared_state_units.py
@@ -136,6 +136,67 @@ class TestGridSessionDeadline:
         assert s.grid_session_deadline_sec() == pytest.approx(500.0)
 
 
+class TestDeadlineUnix:
+    """The persisted unix deadline is the one remaining-time check."""
+
+    def test_an_unbounded_session_does_not_stamp_a_deadline(self):
+        state = SharedState(session_id="s")
+        assert state.stamp_deadline_unix() == 0.0
+        assert state.deadline_unix == 0.0
+        assert state.remaining_minutes() is None
+
+    def test_the_first_stamp_is_start_plus_the_budget(self):
+        from hyperloom.common.coerce import to_unix
+
+        state = SharedState(session_id="s", max_minutes=60)
+        stamped = state.stamp_deadline_unix()
+        start = to_unix(state.start_ts)
+        assert stamped == pytest.approx(start + 3600.0, abs=1.0)
+        assert state.remaining_minutes() == pytest.approx(60.0, abs=0.1)
+
+    def test_a_second_stamp_does_not_reissue_the_budget(self):
+        state = SharedState(session_id="s", max_minutes=60)
+        first = state.stamp_deadline_unix(now_unix=1_000.0)
+        state.start_ts = "2099-01-01T00:00:00+00:00"
+        assert state.stamp_deadline_unix(now_unix=9_000.0) == first
+        assert state.deadline_unix == first
+
+    def test_remaining_minutes_reads_the_stamp_not_elapsed(self):
+        from datetime import datetime, timezone
+
+        state = SharedState(session_id="s", max_minutes=60)
+        state.deadline_unix = 2_000.0
+        now = datetime.fromtimestamp(1_400.0, tz=timezone.utc)
+        assert state.remaining_minutes(now=now) == pytest.approx(10.0)
+
+    def test_a_spent_stamp_reads_as_zero_not_negative(self):
+        from datetime import datetime, timezone
+
+        state = SharedState(session_id="s", max_minutes=60)
+        state.deadline_unix = 100.0
+        now = datetime.fromtimestamp(500.0, tz=timezone.utc)
+        assert state.remaining_minutes(now=now) == 0.0
+
+    def test_teardown_timings_accumulate_and_keep_a_total(self):
+        state = SharedState(session_id="s")
+        state.record_teardown_timing("final_json", 1.25)
+        state.record_teardown_timing("langfuse", 0.5)
+        assert state.teardown_timings_sec["final_json"] == 1.25
+        assert state.teardown_timings_sec["langfuse"] == 0.5
+        assert state.teardown_timings_sec["total"] == pytest.approx(1.75)
+
+    def test_timed_teardown_step_records_the_elapsed_wall(self, monkeypatch):
+        from hyperloom.orchestrator.state import shared_state as ss_mod
+        from hyperloom.orchestrator.state.shared_state import timed_teardown_step
+
+        clock = {"t": 0.0}
+        monkeypatch.setattr(ss_mod.time, "monotonic", lambda: clock["t"])
+        state = SharedState(session_id="s")
+        with timed_teardown_step(state, "final_md"):
+            clock["t"] = 2.5
+        assert state.teardown_timings_sec["final_md"] == 2.5
+
+
 class TestProfileWorkloadContext:
     def test_normalizes_state_and_payload_overrides(self):
         state = SharedState(

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -1466,10 +1466,12 @@ class Coordinator(metaclass=_CoordinatorMeta):
         grace_sec = effective_closing_grace_sec(max_minutes, closing_grace_sec)
         self.shared_state.closing_grace_sec = closing_grace_sec
         max_minutes_value = max_minutes if max_minutes is not None else 0
-        if max_minutes is not None:
-            self.shared_state.max_minutes = int(max_minutes)
         if max_minutes:
-            self.shared_state.stamp_deadline_unix()
+            # Stamp from the float budget before persisting ``int(max_minutes)``.
+            # ``int(0.0001)`` is 0, and stamping after that truncation used to
+            # leave ``deadline_unix`` unset so remaining-time checks read unbounded.
+            self.shared_state.stamp_deadline_unix(budget_minutes=float(max_minutes))
+            self.shared_state.max_minutes = int(max_minutes)
             self.shared_state.save(self.session_dir)
             deadline = self.shared_state.monotonic_session_deadline_sec()
             if deadline is None:
@@ -1477,6 +1479,7 @@ class Coordinator(metaclass=_CoordinatorMeta):
         else:
             self.shared_state.deadline_unix = 0.0
             if max_minutes is not None:
+                self.shared_state.max_minutes = int(max_minutes)
                 self.shared_state.save(self.session_dir)
             deadline = time.monotonic() + _phase_state.DEFAULT_LONGRUN_MAX_MINUTES * 60.0
         self._run_started_monotonic = time.monotonic()

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -77,7 +77,7 @@ from ..bus.resource_lock import (
     ResourceLockManager,
     SqliteLeaseBackend,
 )
-from ..state.shared_state import SharedState, effective_closing_grace_sec
+from ..state.shared_state import SharedState, effective_closing_grace_sec, timed_teardown_step
 from .intent_router import IntentRouter
 from .sub_agent_runner import SubAgentRunner
 from ..state.task_registry import TaskRegistry
@@ -1443,6 +1443,46 @@ class Coordinator(metaclass=_CoordinatorMeta):
         await self._recipe_kb_t4_hook()
         self.db.close()
 
+    def _bind_session_deadline(
+        self,
+        *,
+        max_minutes: float | None,
+        closing_grace_sec: float | None,
+    ) -> tuple[float, float, float]:
+        """Stamp the persisted deadline once and size this process's loop clock.
+
+        Bounded sessions persist ``deadline_unix`` from ``start_ts + budget`` on
+        the first ``run()`` and keep it on resume, so this process cannot
+        reissue a full ``max_minutes``. Unbounded sessions keep the container
+        cap as a local monotonic deadline and do not persist one.
+
+        Args:
+            max_minutes: Operator wall-clock budget, or ``None``/0 for unbounded.
+            closing_grace_sec: Operator CLOSE window; ``None`` derives a default.
+
+        Returns:
+            ``(grace_sec, monotonic_deadline, max_minutes_value)``.
+        """
+        grace_sec = effective_closing_grace_sec(max_minutes, closing_grace_sec)
+        self.shared_state.closing_grace_sec = closing_grace_sec
+        max_minutes_value = max_minutes if max_minutes is not None else 0
+        if max_minutes is not None:
+            self.shared_state.max_minutes = int(max_minutes)
+        if max_minutes:
+            self.shared_state.stamp_deadline_unix()
+            self.shared_state.save(self.session_dir)
+            deadline = self.shared_state.monotonic_session_deadline_sec()
+            if deadline is None:
+                deadline = time.monotonic()
+        else:
+            self.shared_state.deadline_unix = 0.0
+            if max_minutes is not None:
+                self.shared_state.save(self.session_dir)
+            deadline = time.monotonic() + _phase_state.DEFAULT_LONGRUN_MAX_MINUTES * 60.0
+        self._run_started_monotonic = time.monotonic()
+        self._run_deadline = deadline
+        return grace_sec, deadline, float(max_minutes_value)
+
     async def _recipe_kb_t4_hook(self) -> None:
         """Finalize or retry on graceful teardown/Ctrl-C.
 
@@ -1664,27 +1704,11 @@ class Coordinator(metaclass=_CoordinatorMeta):
         objective = objective or TimeOnlyObjective()
         # Stash so _compose_prompt can update target_gap_pct.
         self._current_objective = objective
-        grace_sec = effective_closing_grace_sec(max_minutes, closing_grace_sec)
-        # Unbounded runs are capped at the container lifetime; bounded runs keep
-        # their explicit deadline.
-        effective_minutes = max_minutes if max_minutes else _phase_state.DEFAULT_LONGRUN_MAX_MINUTES
-        deadline = time.monotonic() + effective_minutes * 60.0
-        self._run_started_monotonic = time.monotonic()
-        self._run_deadline = deadline
         # Capture the live loop for the inline fast-action context tool.
         try:
             self._coordinator_loop = asyncio.get_running_loop()
         except RuntimeError:
             self._coordinator_loop = None
-        # The reserve every unit of work holds back IS this window, so the
-        # admission gate has to see the operator's choice too, not only the
-        # closing phase that spends it.
-        self.shared_state.closing_grace_sec = closing_grace_sec
-        max_minutes_value = max_minutes if max_minutes is not None else 0
-        # Persist budget so prompts and Resume can see it.
-        if max_minutes is not None:
-            self.shared_state.max_minutes = int(max_minutes)
-            self.shared_state.save(self.session_dir)
 
         previous_handlers: dict[int, Any] = {}
         if install_signal_handlers:
@@ -1700,6 +1724,10 @@ class Coordinator(metaclass=_CoordinatorMeta):
                 previous_handlers = {}
 
         await self._replay_resume_if_needed()
+        grace_sec, deadline, max_minutes_value = self._bind_session_deadline(
+            max_minutes=max_minutes,
+            closing_grace_sec=closing_grace_sec,
+        )
 
         tick_n = 0
         stop_reason = ""
@@ -1880,7 +1908,9 @@ class Coordinator(metaclass=_CoordinatorMeta):
                 except (NotImplementedError, RuntimeError):
                     # Teardown is best-effort; signal handlers may be unsupported.
                     pass
-            await self._close_backends()
+            with timed_teardown_step(self.shared_state, "close_backends"):
+                await self._close_backends()
+            self.shared_state.save(self.session_dir)
         return self.shared_state.stop_reason
 
     async def _close_backends(self) -> None:

--- a/src/hyperloom/orchestrator/phases/close.py
+++ b/src/hyperloom/orchestrator/phases/close.py
@@ -524,19 +524,19 @@ class ClosePhase(PhaseHandler):
         )
 
     def _close_step_wait_sec(self, task: Task) -> float:
-        """How long to wait for a close-step task that is already running.
+        """How long CLOSE waits for a close-step task to reach a terminal state.
 
         The bound is the step's own expected runtime, clamped into
         ``[_CLOSE_STEP_WAIT_FLOOR_SEC, _CLOSE_STEP_WAIT_CEILING_SEC]``. This is
         deliberately not the closing reserve: the reserve answers "how much of
         the session do we hold back for CLOSE", which scales with the session
         and is a handful of seconds for a short one, while this answers "how
-        long is it reasonable to wait for work that is already under way",
-        which scales with the work. Bounding a two-minute report by a
-        twelve-second reserve is a wait only on paper.
+        long is it reasonable to wait for the work", which scales with the
+        work. Bounding a two-minute report by a twelve-second reserve is a wait
+        only on paper.
 
         Args:
-            task: The close-step task found in ``running``.
+            task: The close-step task, already running or about to start.
 
         Returns:
             The bound in seconds.
@@ -649,7 +649,40 @@ class ClosePhase(PhaseHandler):
             return state
         if state == _TASK_STATE_RUNNING:
             return await self._await_running_close_task(task, step=step)
-        result = await self.sub.run_task(task)
+        return await self._run_fresh_close_task(task, step=step)
+
+    async def _run_fresh_close_task(self, task: Task, *, step: str) -> str:
+        """Run a queued close-step task, bounded by the same wait as an in-flight one.
+
+        A fresh report used to be awaited with no timeout, so a wedged writer
+        held the process open after the session budget was already gone. The
+        bound is the step's typical cost, not the closing reserve.
+
+        Args:
+            task: The queued (or otherwise runnable) close-step task.
+            step: Close-step label, for logging.
+
+        Returns:
+            The state the task ended in, or ``running`` when the bound elapsed
+            first.
+        """
+        bound_sec = self._close_step_wait_sec(task)
+        log.info(
+            "CLOSE step %s: task_id=%s starting; waiting up to %.0fs for it",
+            step,
+            task.task_id,
+            bound_sec,
+        )
+        try:
+            result = await asyncio.wait_for(self.sub.run_task(task), timeout=bound_sec)
+        except asyncio.TimeoutError:
+            log.warning(
+                "CLOSE step %s: task_id=%s still running after %.0fs; recording the step as failed",
+                step,
+                task.task_id,
+                bound_sec,
+            )
+            return _TASK_STATE_RUNNING
         return result.state
 
     async def _record_close_step(

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -13,6 +13,7 @@ Any phase → CLOSE on terminal/abort; ``recover`` is phase-orthogonal.
 from __future__ import annotations
 
 import math
+import time
 from typing import Any
 
 from hyperloom.common.coerce import to_unix
@@ -1308,11 +1309,16 @@ def session_remaining_seconds(
 ) -> float | None:
     """Total wall-clock seconds remaining for the session (``None`` when ``max_minutes`` 0 or ``start_ts`` unparseable).
 
+    Prefers a stamped ``deadline_unix`` when present so this agrees with
+    admission and the Coordinator loop. Falls back to ``start_ts + max_minutes``
+    for sessions that predate the stamp.
+
     Args:
         state (Any): Frozen SharedState view exposing ``max_minutes`` and
             ``start_ts``.
-        now_unix (float | None): Accepted for signature parity; the deadline is
-            computed against the current UTC time.
+        now_unix (float | None): Override for the current time; the deadline is
+            subtracted from this when stamped, otherwise compared against
+            ``start_ts``.
 
     Returns:
         float | None: Non-negative seconds left in the session, or ``None``
@@ -1321,6 +1327,13 @@ def session_remaining_seconds(
     mm = _max_minutes(state)
     if mm <= 0:
         return None
+    try:
+        deadline = float(getattr(state, "deadline_unix", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        deadline = 0.0
+    if deadline > 0.0:
+        now = float(now_unix) if now_unix is not None else time.time()
+        return max(0.0, deadline - now)
     start_ts = str(getattr(state, "start_ts", "") or "").strip()
     if not start_ts:
         return None

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -1307,11 +1307,12 @@ def session_remaining_seconds(
     *,
     now_unix: float | None = None,
 ) -> float | None:
-    """Total wall-clock seconds remaining for the session (``None`` when ``max_minutes`` 0 or ``start_ts`` unparseable).
+    """Total wall-clock seconds remaining for the session (``None`` when unbounded).
 
     Prefers a stamped ``deadline_unix`` when present so this agrees with
-    admission and the Coordinator loop. Falls back to ``start_ts + max_minutes``
-    for sessions that predate the stamp.
+    admission and the Coordinator loop, even when persisted ``max_minutes``
+    was truncated to 0. Falls back to ``start_ts + max_minutes`` for sessions
+    that predate the stamp.
 
     Args:
         state (Any): Frozen SharedState view exposing ``max_minutes`` and
@@ -1322,11 +1323,9 @@ def session_remaining_seconds(
 
     Returns:
         float | None: Non-negative seconds left in the session, or ``None``
-        when ``max_minutes`` is 0 or ``start_ts`` is missing/unparseable.
+        when unbounded (no stamp and ``max_minutes`` is 0) or ``start_ts`` is
+        missing/unparseable.
     """
-    mm = _max_minutes(state)
-    if mm <= 0:
-        return None
     try:
         deadline = float(getattr(state, "deadline_unix", 0.0) or 0.0)
     except (TypeError, ValueError):
@@ -1334,6 +1333,9 @@ def session_remaining_seconds(
     if deadline > 0.0:
         now = float(now_unix) if now_unix is not None else time.time()
         return max(0.0, deadline - now)
+    mm = _max_minutes(state)
+    if mm <= 0:
+        return None
     start_ts = str(getattr(state, "start_ts", "") or "").strip()
     if not start_ts:
         return None
@@ -1672,6 +1674,25 @@ def _global_terminal(state: Any) -> tuple[str, dict[str, Any]] | None:
             return sr, {"reason_origin": "shared_state.stop_reason", "vocab": "unknown"}
         return sr, {"reason_origin": "shared_state.stop_reason"}
     return None
+
+
+def _closing_phase_terminal(state: Any) -> tuple[str, dict[str, Any]] | None:
+    """Return a CLOSE stop when the wall-clock path has entered the closing phase.
+
+    PRELUDE with a baseline otherwise advances to FRAMEWORK_AGENT, whose
+    allowlist does not include ``report``. That transition would cancel the
+    closing report ``_enter_closing_phase`` just enqueued.
+
+    Args:
+        state (Any): Frozen SharedState view exposing ``closing_phase``.
+
+    Returns:
+        tuple[str, dict[str, Any]] | None: ``("time_exhausted", evidence)``
+        when the closing phase is active, else ``None``.
+    """
+    if not bool(getattr(state, "closing_phase", False)):
+        return None
+    return "time_exhausted", {"reason_origin": "closing_phase"}
 
 
 # per-phase judgments
@@ -2956,7 +2977,8 @@ def compute_next_phase(
 ) -> tuple[str, str, dict[str, Any]] | None:
     """Return ``(next_phase, reason, evidence)`` or ``None``.
 
-    Priority (Inv-8.2): global terminal first, then exit_terminal > exit_normal.
+    Priority (Inv-8.2): global terminal first, then the wall-clock closing
+    phase, then exit_terminal > exit_normal.
 
     Args:
         state (Any): Frozen SharedState view exposing the current ``phase``.
@@ -2979,6 +3001,11 @@ def compute_next_phase(
     terminal = _global_terminal(state)
     if terminal is not None and current != PHASE_CLOSE:
         reason, evidence = terminal
+        return PHASE_CLOSE, reason, {"terminal": True, **evidence}
+
+    closing = _closing_phase_terminal(state)
+    if closing is not None and current != PHASE_CLOSE:
+        reason, evidence = closing
         return PHASE_CLOSE, reason, {"terminal": True, **evidence}
 
     if current == PHASE_PRELUDE:

--- a/src/hyperloom/orchestrator/policy/gate.py
+++ b/src/hyperloom/orchestrator/policy/gate.py
@@ -555,6 +555,9 @@ CORE_STATE_FIELDS: frozenset[str] = frozenset(
         # leg's CLOSE transition back the right to speak for this one.
         "resumed_ts",
         "max_minutes",
+        # Absolute session deadline. Forging it is the same as forging the
+        # budget: a value in the future reissues time the session already spent.
+        "deadline_unix",
         # Sizes the closing reserve, so it decides how much of ``max_minutes``
         # is still usable: locking the budget without locking this one leaves
         # the same forgery one field over -- a large value spends the session

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -3669,36 +3669,53 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
         delta = (now_dt - start).total_seconds() / 60.0
         return max(0.0, delta)
 
-    def stamp_deadline_unix(self, *, now_unix: float | None = None) -> float:
+    def stamp_deadline_unix(
+        self,
+        *,
+        now_unix: float | None = None,
+        budget_minutes: float | None = None,
+    ) -> float:
         """Persist the absolute session deadline if a bounded session has none.
 
         A resume must not reissue a full ``max_minutes`` from the moment
         ``Coordinator.run`` is entered. The first stamp — ``start_ts`` plus the
         budget — is what every remaining-time check reads.
 
+        ``budget_minutes`` is the run() argument before it is stored as
+        ``int(max_minutes)``. Tests pass fractional minutes; truncating first
+        would make this a no-op and leave the loop with no persisted deadline.
+
         Args:
             now_unix: Clock used only when ``start_ts`` cannot be parsed;
                 defaults to ``time.time()``.
+            budget_minutes: Minutes to add to ``start_ts``; ``None`` uses
+                :attr:`max_minutes`.
 
         Returns:
             The unix deadline, or ``0.0`` when the session is unbounded.
         """
-        if not self.max_minutes:
+        minutes = float(self.max_minutes or 0) if budget_minutes is None else float(budget_minutes)
+        existing = float(self.deadline_unix or 0.0)
+        if minutes <= 0:
+            # A truncated stored budget must not erase a stamp this process or
+            # an earlier one already wrote.
+            if existing > 0.0:
+                return existing
             self.deadline_unix = 0.0
             return 0.0
-        existing = float(self.deadline_unix or 0.0)
         if existing > 0.0:
             return existing
         start = to_unix(self.start_ts, None)
         origin = float(start) if start else float(now_unix if now_unix is not None else time.time())
-        self.deadline_unix = origin + float(self.max_minutes) * 60.0
+        self.deadline_unix = origin + minutes * 60.0
         return self.deadline_unix
 
     def remaining_minutes(self, *, now: datetime | None = None) -> float | None:
-        """Minutes left in the wall-clock budget; ``None`` when ``max_minutes`` unset (unbounded), else clamped at 0.
+        """Minutes left in the wall-clock budget; ``None`` when unbounded, else clamped at 0.
 
         When :attr:`deadline_unix` is stamped, remaining time is derived from
-        it so the Coordinator loop, admission, and the grid cannot disagree.
+        it so the Coordinator loop, admission, and the grid cannot disagree —
+        including when the persisted ``max_minutes`` was truncated to 0.
         Otherwise this falls back to ``max_minutes - elapsed`` so tests that
         inject elapsed without a stamp keep working.
 
@@ -3708,16 +3725,16 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
 
         Returns:
             float | None: Minutes remaining in the budget (clamped at 0.0), or
-                ``None`` when ``max_minutes`` is unset.
+                ``None`` when the session is unbounded.
         """
-        if not self.max_minutes:
-            return None
         deadline = float(self.deadline_unix or 0.0)
         if deadline > 0.0:
             now_dt = now or datetime.now(timezone.utc)
             if now_dt.tzinfo is None:
                 now_dt = now_dt.replace(tzinfo=timezone.utc)
             return max(0.0, (deadline - now_dt.timestamp()) / 60.0)
+        if not self.max_minutes:
+            return None
         return max(0.0, float(self.max_minutes) - self.elapsed_minutes(now=now))
 
     def monotonic_session_deadline_sec(self) -> float | None:

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -36,6 +36,7 @@ Fields::
     pruned_families     list[str]  — set by Robustness via PRUNE_BRANCH
     start_ts            str   — ISO timestamp
     max_minutes         int   — wall-clock budget (0 = unlimited)
+    deadline_unix       float — absolute session deadline (0 = unset/unbounded)
     last_profile_trace  str   — set by Coordinator when `profile` returns a
                                 trace path; consumed by Orch to populate
                                 `trace_analyze` REQUEST `trace_input` param
@@ -52,13 +53,14 @@ import math
 import os
 import shlex
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from hyperloom.common.coerce import to_str_list
+from hyperloom.common.coerce import to_str_list, to_unix
 from hyperloom.common.env_safety import redact_secret_values
 from hyperloom.common.io import atomic_write_json
 from hyperloom.common.profile_args import sanitize_profile_server_args
@@ -365,6 +367,27 @@ def effective_closing_grace_sec(
     if closing_grace_sec is not None:
         return float(closing_grace_sec)
     return min(120.0, (max_minutes or 0.0) * 60.0 * 0.02)
+
+
+@contextmanager
+def timed_teardown_step(state: Any, name: str) -> Iterator[None]:
+    """Record how long one post-deadline teardown step took on ``state``.
+
+    The session's own record never said what the unbudgeted tail cost. A step
+    that cannot be timed is the same gap as a step that never ran.
+
+    Args:
+        state: Object exposing :meth:`SharedState.record_teardown_timing`;
+            missing the method is a no-op so tests can pass a stub.
+        name: Step key stored on ``teardown_timings_sec``.
+    """
+    started = time.monotonic()
+    try:
+        yield
+    finally:
+        recorder = getattr(state, "record_teardown_timing", None)
+        if callable(recorder):
+            recorder(name, time.monotonic() - started)
 
 
 def _cap_tested_ledger(tested: dict[str, Any]) -> dict[str, Any]:
@@ -683,6 +706,12 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
     pruned_families: list[str] = field(default_factory=list)
     start_ts: str = field(default_factory=_now_iso)
     max_minutes: int = 0
+    # Absolute unix deadline for a bounded session. Stamped once from
+    # ``start_ts + max_minutes`` so a resume cannot reissue a full budget.
+    # ``0.0`` means unset or unbounded.
+    deadline_unix: float = 0.0
+    # Wall-clock seconds spent in post-deadline teardown, keyed by step.
+    teardown_timings_sec: dict[str, float] = field(default_factory=dict)
     # Operator's ``--closing-grace-sec``; ``None`` derives it from max_minutes.
     closing_grace_sec: float | None = None
     last_profile_trace: str = ""
@@ -3640,8 +3669,38 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
         delta = (now_dt - start).total_seconds() / 60.0
         return max(0.0, delta)
 
+    def stamp_deadline_unix(self, *, now_unix: float | None = None) -> float:
+        """Persist the absolute session deadline if a bounded session has none.
+
+        A resume must not reissue a full ``max_minutes`` from the moment
+        ``Coordinator.run`` is entered. The first stamp — ``start_ts`` plus the
+        budget — is what every remaining-time check reads.
+
+        Args:
+            now_unix: Clock used only when ``start_ts`` cannot be parsed;
+                defaults to ``time.time()``.
+
+        Returns:
+            The unix deadline, or ``0.0`` when the session is unbounded.
+        """
+        if not self.max_minutes:
+            self.deadline_unix = 0.0
+            return 0.0
+        existing = float(self.deadline_unix or 0.0)
+        if existing > 0.0:
+            return existing
+        start = to_unix(self.start_ts, None)
+        origin = float(start) if start else float(now_unix if now_unix is not None else time.time())
+        self.deadline_unix = origin + float(self.max_minutes) * 60.0
+        return self.deadline_unix
+
     def remaining_minutes(self, *, now: datetime | None = None) -> float | None:
         """Minutes left in the wall-clock budget; ``None`` when ``max_minutes`` unset (unbounded), else clamped at 0.
+
+        When :attr:`deadline_unix` is stamped, remaining time is derived from
+        it so the Coordinator loop, admission, and the grid cannot disagree.
+        Otherwise this falls back to ``max_minutes - elapsed`` so tests that
+        inject elapsed without a stamp keep working.
 
         Args:
             now (datetime | None): Reference time; defaults to the current UTC
@@ -3653,7 +3712,45 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
         """
         if not self.max_minutes:
             return None
+        deadline = float(self.deadline_unix or 0.0)
+        if deadline > 0.0:
+            now_dt = now or datetime.now(timezone.utc)
+            if now_dt.tzinfo is None:
+                now_dt = now_dt.replace(tzinfo=timezone.utc)
+            return max(0.0, (deadline - now_dt.timestamp()) / 60.0)
         return max(0.0, float(self.max_minutes) - self.elapsed_minutes(now=now))
+
+    def monotonic_session_deadline_sec(self) -> float | None:
+        """``time.monotonic()`` instant the session budget is spent, or ``None`` if unbounded.
+
+        Converts the persisted unix deadline into the clock the Coordinator
+        loop already consults, so a resume cannot pick a fresh full budget.
+
+        Returns:
+            A monotonic deadline, or ``None`` when ``max_minutes`` is unset.
+        """
+        remaining = self.remaining_minutes()
+        if remaining is None:
+            return None
+        return time.monotonic() + remaining * 60.0
+
+    def record_teardown_timing(self, step: str, elapsed_sec: float) -> None:
+        """Record one post-deadline teardown step's duration.
+
+        Args:
+            step: Name of the teardown step (``coordinator_stop``,
+                ``final_json``, ...).
+            elapsed_sec: Wall-clock seconds the step took.
+        """
+        name = str(step or "").strip()
+        if not name:
+            return
+        timings = self.teardown_timings_sec
+        if not isinstance(timings, dict):
+            self.teardown_timings_sec = {}
+            timings = self.teardown_timings_sec
+        timings[name] = round(max(0.0, float(elapsed_sec)), 3)
+        timings["total"] = round(sum(v for k, v in timings.items() if k != "total"), 3)
 
     def closing_reserve_sec(self) -> float:
         """Seconds held back from every unit of work so CLOSE can still report.
@@ -3733,4 +3830,4 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
         return len(self.optimization_stack) > int(self.cumulative_gain_validated_stack_len)
 
 
-__all__ = ["SharedState", "render_model_arch_compact"]
+__all__ = ["SharedState", "render_model_arch_compact", "timed_teardown_step"]


### PR DESCRIPTION
Closes #1146. Follow-up to #1171.

#1171 made a bounded session stop on time (admission, timeout clamps, session reaper, in-flight cancel, PRELUDE spend policy). What it left was a loop deadline recomputed on every `Coordinator.run()` entry — a resume kept `start_ts` and then reissued a full `max_minutes` — plus an untimed CLOSE report and an unmeasured teardown tail.

Together with #1171 this is the remaining code for the five items on #1146. The GPU CI e2e job is still a smoke run, not a `wall_clock <= max_hours + grace` assert; that is a CI follow-up, not a product gap that should keep the issue open.

### Changes

- **`deadline_unix`** — stamped once from `start_ts + max_minutes` (the float budget, before `int(max_minutes)` truncates it) and kept on resume. `remaining_minutes`, `session_remaining_seconds`, and the Coordinator loop deadline all derive from it. Locked in `CORE_STATE_FIELDS`.
- **Closing phase goes to CLOSE** — a spent session with a baseline must not advance PRELUDE → FRAMEWORK_AGENT; that allowlist cancelled the closing report.
- **Fresh report hard timeout** — a newly started CLOSE report uses the same wait bound as an already-running one (typical runtime, floor 60s / ceiling 600s).
- **Teardown timings** — `teardown_timings_sec` records `close_backends`, `coordinator_stop`, `final_json`, `session_breakdown`, `final_md`, `langfuse`, `artifact_package`, plus `total`.
- **Wall-clock assertion** — a session whose deadline is already in the past stops as `time_exhausted` instead of running `max_ticks` against a freshly computed budget.

### #1146 item map

| Item | Where |
| --- | --- |
| 1. One absolute `deadline_unix` | this PR |
| 2. Deadline reaches the work (clamp / admit / reap) | #1171; this PR is the single clock those layers read |
| 3. Cancel in-flight work at deadline + grace | #1171 |
| 4. Bound the report; size CLOSE from the same grace; measure teardown | #1171 (reserve) + this PR (report wait + `teardown_timings_sec`) |
| 5. Assert the session does not outlive the budget | this PR, in-process. GPU CI e2e remains smoke |

Does not close #1143, #1144, #1145, or #1168.

### Test plan

- [x] `test_shared_state_units.py::TestDeadlineUnix` — stamp once, remaining time reads the stamp, a truncated `max_minutes` does not wipe it, teardown timings accumulate
- [x] `test_session_time_budget.py::TestThePersistedDeadlineIsTheLoopDeadline` — resume does not reissue; a spent session stops as `time_exhausted`; a fractional `max_minutes` still stamps
- [x] `test_session_time_budget.py::TestATickCannotOutliveTheSessionBound` — still passes after rebase onto #1171
- [x] `test_close_phase_sequencer.py` — a fresh report that never lands is cancelled, not awaited forever
- [x] `test_objective.py::test_run_closing_phase_writes_report_on_time_exhausted` — closing still writes `final.md` when `int(max_minutes)` is 0
- [x] `test_phase_state_framework_agent.py` — `closing_phase` routes to CLOSE, not FRAMEWORK_AGENT
- [x] `session_remaining_seconds` prefers `deadline_unix` when stamped

Made with [Cursor](https://cursor.com)
