### PR TITLE
fix(roofline): reduce the profile's sandbox-rebuild exposure, and record pod ownership

### DIFF
--- a/src/hyperloom/inference_optimizer/SKILL.md
+++ b/src/hyperloom/inference_optimizer/SKILL.md
@@ -1098,7 +1098,21 @@ guess). Edit the example before copying if defaults need to change.
 
 ## Monitoring
 
-Poll at most every 5 minutes unless debugging a startup failure.
+Each poll is one fast read of persisted state, and you poll only when you are
+next invoked. **Never block to reach the next poll**: no `sleep`, no wait loop,
+no `tail -f`. The only sanctioned wait is the one-shot `sleep 30` health check
+right after launch. Recurring 5-minute polling is the Robustness Monitor's job
+and already runs in its own `setsid nohup` process (see above) — do not
+reimplement it here.
+
+**Why this is load-bearing, not style.** A blocking call holds the sandbox
+connection open for its whole duration. Overlap it with a `roofline` trace flush
+— 8 ranks serialising torch traces to NFS, which takes minutes on a large TP=8
+MoE — and the connection can drop; the agent harness reads that as an
+unreachable sandbox and rebuilds it, which kills the optimizer and the in-flight
+profile with it. Session `Kimi-K3_20260818T062936Z_a62853e5` lost 3/3 rooflines,
+its `analysis.md`, and its whole KERNEL phase to a `sleep 110; sleep 110;
+sleep 80` progress loop. Launch, check once, hand off to the monitor, report.
 
 Resolve `$SESSION` the same way the Robustness Monitor does — never from
 `$USER_DATA_PATH`, which is the workspace root, not the session dir.

--- a/src/hyperloom/inference_optimizer/references/troubleshooting.md
+++ b/src/hyperloom/inference_optimizer/references/troubleshooting.md
@@ -103,3 +103,14 @@ Bypass with `--critic-mock` for offline / smoke runs. See
   family). Do not hand-edit `state.json`.
 - `stop_reason=time_exhausted`: resume same session (`--resume-from`); do not
   start fresh.
+- `dead_holder_reaped` (lease reclaimed because the holder pid vanished): the
+  optimizer process died without unwinding, which on a sandboxed runtime usually
+  means the pod itself went away mid-task. Read
+  `runtime/pod_history.jsonl` — one append-only line per optimizer-lock
+  acquisition (`acquired_at` / `hostname` / `pid`), so more than one line means
+  the session was rebuilt and each entry marks a takeover. Prefer it over
+  `manifest.json` (pins only the *first* owner) and over `runtime/optimizer.lock`
+  (holds only the *current* one); a multi-rebuild session reads as single-pod
+  from those two alone. Correlate the takeover timestamps with the task that
+  failed — a roofline reclaimed here typically leaves a partial `torch_trace/`
+  and no `analysis.md`.

--- a/src/hyperloom/inference_optimizer/session/lock.py
+++ b/src/hyperloom/inference_optimizer/session/lock.py
@@ -25,12 +25,19 @@ The lock file is intentionally never unlinked on release: unlinking a flock'd
 path races a concurrent acquirer (it would flock a now-unlinked inode while a
 newcomer creates and flocks a fresh file). A stale body is harmless — the next
 acquirer flocks the same inode and overwrites it.
+
+That overwrite keeps only the *current* owner, so each acquisition is also
+appended to ``<session_dir>/runtime/pod_history.jsonl``. A session whose sandbox
+is rebuilt mid-run otherwise records only its first owner (in
+``manifest.json``) and its last (in the lock body), and reads like a single-pod
+session in post-mortem.
 """
 
 from __future__ import annotations
 
 import errno
 import json
+import logging
 import os
 import socket
 from contextlib import suppress
@@ -40,6 +47,8 @@ from typing import Any
 from hyperloom.common.timeutil import now_iso
 
 from . import session_paths
+
+log = logging.getLogger(__name__)
 
 try:  # POSIX runtime (Linux): authoritative flock-based exclusion.
     import fcntl
@@ -177,7 +186,9 @@ class SessionLock:
                 os.close(fd)
                 raise SessionAlreadyRunning(self.session_dir, owner)
         self._fd = fd
-        self._write_owner(self._now_owner(started_at=now_iso(timespec="seconds")))
+        owner = self._now_owner(started_at=now_iso(timespec="seconds"))
+        self._write_owner(owner)
+        self._append_pod_history(owner)
         return self
 
     def heartbeat(self) -> None:
@@ -208,6 +219,30 @@ class SessionLock:
             "started_at": self._started_at,
             "heartbeat_at": now,
         }
+
+    def _append_pod_history(self, owner: dict[str, Any]) -> None:
+        """Append this acquisition to the pod-ownership ledger (never raises).
+
+        One line per acquire, so a session whose sandbox is rebuilt mid-run keeps
+        the full owner chain instead of just the first (``manifest.json``) and
+        last (``optimizer.lock``) pod. Purely observational: a failure here must
+        never stop an optimizer that already holds the lock.
+
+        Args:
+            owner (dict): The owner document just written to the lock body.
+        """
+        record = {
+            "acquired_at": owner.get("started_at"),
+            "hostname": owner.get("hostname"),
+            "pid": owner.get("pid"),
+        }
+        try:
+            path = session_paths.pod_history_path(self.session_dir)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, sort_keys=True) + "\n")
+        except OSError:
+            log.debug("session lock: pod history append failed", exc_info=True)
 
     def _write_owner(self, owner: dict[str, Any]) -> None:
         """Atomically rewrite the lock body (truncate + write while holding it)."""

--- a/src/hyperloom/inference_optimizer/session/session_paths.py
+++ b/src/hyperloom/inference_optimizer/session/session_paths.py
@@ -57,6 +57,25 @@ def optimizer_lock_path(session_dir: Path) -> Path:
     return Path(session_dir) / "runtime" / "optimizer.lock"
 
 
+def pod_history_path(session_dir: Path) -> Path:
+    """Compute ``<sd>/runtime/pod_history.jsonl`` — the optimizer-owner ledger.
+
+    ``optimizer.lock`` holds only the *current* owner: each acquirer truncates
+    and rewrites it, so a session whose sandbox was rebuilt mid-run keeps no
+    record of the pods that came before. ``manifest.json`` pins the first owner
+    and the lock pins the last, which makes a multi-rebuild session read like a
+    single-pod one in post-mortem. This append-only ledger records one line per
+    acquisition so the whole ownership chain survives.
+
+    Args:
+        session_dir (Path): The session root directory.
+
+    Returns:
+        Path: The absolute path to ``<session_dir>/runtime/pod_history.jsonl``.
+    """
+    return Path(session_dir) / "runtime" / "pod_history.jsonl"
+
+
 # Phases (from the catalogue ``pipeline_phase`` field) whose executors own
 # a per-task ``runs/<action>/<task_id>/`` workspace.
 _RUNS_WORKSPACE_PHASES: frozenset[str] = frozenset(

--- a/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -1061,6 +1061,118 @@ def test_materialize_profile_sglang_omits_shape_discovery_when_patch_fails(
     assert "shape-discovery" not in extra, extra
 
 
+def test_materialize_profile_sglang_drops_annotations_when_patch_fails(
+    tmp_path,
+    monkeypatch,
+):
+    """A failed patch also clears the annotation-only capture options.
+
+    Without the server-side patch the trace carries no ``kernel_shape_profiler``
+    events, so requesting shape discovery / detailed annotations only pays the
+    capture cost. The vLLM branch already drops its equivalent flag."""
+    import json
+
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=False, sglang=False)
+    src = _profile_yaml(tmp_path, "sglang", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(src, tmp_path)
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    assert envs["HYPERLOOM_PROFILE_DEGRADED_REASON"] == "tracelens_runtime_patch_unavailable"
+    body = json.loads(envs["PROFILE_EXTRA_BODY"])
+    assert body["shape_discovery"] is False, body
+    assert body["detailed_annotations"] is False, body
+
+
+def test_materialize_profile_sglang_keeps_annotations_when_patch_succeeds(
+    tmp_path,
+    monkeypatch,
+):
+    """The healthy path is untouched: annotations stay on when the patch lands."""
+    import json
+
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=False, sglang=True)
+    src = _profile_yaml(tmp_path, "sglang", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(src, tmp_path)
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    assert "HYPERLOOM_PROFILE_DEGRADED_REASON" not in envs
+    body = json.loads(envs["PROFILE_EXTRA_BODY"])
+    assert body["shape_discovery"] is True, body
+    assert body["detailed_annotations"] is True, body
+
+
+def test_materialize_profile_sglang_keeps_annotations_when_patch_not_attempted(
+    tmp_path,
+    monkeypatch,
+):
+    """HYPERLOOM_ENABLE_PATCH=0 must not degrade the capture options.
+
+    Patching disabled is not the same as patching failed: the image may ship the
+    TraceLens patch already applied, in which case the annotations still work."""
+    import json
+
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    monkeypatch.setenv("HYPERLOOM_ENABLE_PATCH", "0")
+    counts = _mock_patchers(monkeypatch, vllm=False, sglang=False)
+    src = _profile_yaml(tmp_path, "sglang", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(src, tmp_path)
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    assert counts == {"vllm": 0, "sglang": 0}, counts
+    assert "HYPERLOOM_PROFILE_DEGRADED_REASON" not in envs
+    body = json.loads(envs["PROFILE_EXTRA_BODY"])
+    assert body["shape_discovery"] is True, body
+    assert body["detailed_annotations"] is True, body
+
+
+def test_materialize_profile_sglang_drops_graph_capture_flag_when_eager(
+    tmp_path,
+    monkeypatch,
+):
+    """``--disable-cuda-graph`` and ``--enable-profile-cuda-graph`` contradict.
+
+    The eager flag arrives via ``extra_server_args`` while the graph-capture
+    profiling flag comes from the profile YAML, so the two only meet after the
+    merges. An eager server captures no graph, leaving nothing to profile."""
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=False, sglang=True)
+    src = _profile_yaml(
+        tmp_path,
+        "sglang",
+        {"CONC": 32, "ISL": 256, "OSL": 1024, "EXTRA_SGLANG_ARGS": "--enable-profile-cuda-graph"},
+    )
+    out = _materialize_config_with_envs(src, tmp_path, extra_server_args="--disable-cuda-graph")
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_SGLANG_ARGS"]
+    assert "--disable-cuda-graph" in extra.split(), extra
+    assert "--enable-profile-cuda-graph" not in extra.split(), extra
+
+
+def test_materialize_profile_sglang_keeps_graph_capture_flag_without_eager(
+    tmp_path,
+    monkeypatch,
+):
+    """Graph-mode profiling keeps the capture flag (the healthy path)."""
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=False, sglang=True)
+    src = _profile_yaml(
+        tmp_path,
+        "sglang",
+        {"CONC": 32, "ISL": 256, "OSL": 1024, "EXTRA_SGLANG_ARGS": "--enable-profile-cuda-graph"},
+    )
+    out = _materialize_config_with_envs(src, tmp_path)
+    extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_SGLANG_ARGS"]
+    assert "--enable-profile-cuda-graph" in extra.split(), extra
+
+
 def test_materialize_profile_kill_switch_skips_patcher_entirely(
     tmp_path,
     monkeypatch,

--- a/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -1070,8 +1070,6 @@ def test_materialize_profile_sglang_drops_annotations_when_patch_fails(
     Without the server-side patch the trace carries no ``kernel_shape_profiler``
     events, so requesting shape discovery / detailed annotations only pays the
     capture cost. The vLLM branch already drops its equivalent flag."""
-    import json
-
     import yaml
 
     _clear_workload_env(monkeypatch)
@@ -1090,8 +1088,6 @@ def test_materialize_profile_sglang_keeps_annotations_when_patch_succeeds(
     monkeypatch,
 ):
     """The healthy path is untouched: annotations stay on when the patch lands."""
-    import json
-
     import yaml
 
     _clear_workload_env(monkeypatch)
@@ -1113,8 +1109,6 @@ def test_materialize_profile_sglang_keeps_annotations_when_patch_not_attempted(
 
     Patching disabled is not the same as patching failed: the image may ship the
     TraceLens patch already applied, in which case the annotations still work."""
-    import json
-
     import yaml
 
     _clear_workload_env(monkeypatch)

--- a/src/hyperloom/inference_optimizer/tests/test_session_lock.py
+++ b/src/hyperloom/inference_optimizer/tests/test_session_lock.py
@@ -11,6 +11,7 @@ spawn a duplicate optimizer that corrupts the shared leases / ``state.json``.
 from __future__ import annotations
 
 import errno
+import json
 import os
 import subprocess
 import sys
@@ -70,8 +71,6 @@ def test_acquire_appends_pod_history(tmp_path):
 
     ``optimizer.lock`` is truncated by every acquirer, so a session whose sandbox
     is rebuilt mid-run would otherwise keep no record of the earlier pods."""
-    import json
-
     first = SessionLock(tmp_path)
     first.acquire()
     first.release()

--- a/src/hyperloom/inference_optimizer/tests/test_session_lock.py
+++ b/src/hyperloom/inference_optimizer/tests/test_session_lock.py
@@ -60,6 +60,51 @@ def test_release_allows_reacquire(tmp_path):
     second.release()
 
 
+def test_pod_history_path_under_runtime(tmp_path):
+    """The ownership ledger lives at ``<session_dir>/runtime/pod_history.jsonl``."""
+    assert session_paths.pod_history_path(tmp_path) == tmp_path / "runtime" / "pod_history.jsonl"
+
+
+def test_acquire_appends_pod_history(tmp_path):
+    """Each acquisition appends one ledger line, so the owner chain survives.
+
+    ``optimizer.lock`` is truncated by every acquirer, so a session whose sandbox
+    is rebuilt mid-run would otherwise keep no record of the earlier pods."""
+    import json
+
+    first = SessionLock(tmp_path)
+    first.acquire()
+    first.release()
+    second = SessionLock(tmp_path)
+    second.acquire()
+    second.release()
+
+    lines = session_paths.pod_history_path(tmp_path).read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2, lines
+    for line in lines:
+        record = json.loads(line)
+        assert record["pid"] == os.getpid()
+        assert record["hostname"]
+        assert record["acquired_at"]
+
+
+def test_pod_history_failure_does_not_break_acquire(tmp_path):
+    """The ledger is observational: a write failure must not fail the acquire.
+
+    The ledger path is pre-created as a directory so the append raises
+    ``IsADirectoryError``; the lock must still be acquired and readable."""
+    ledger = session_paths.pod_history_path(tmp_path)
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    ledger.mkdir()
+
+    lock = SessionLock(tmp_path)
+    lock.acquire()  # must not raise
+    try:
+        assert session_lock.read_owner(tmp_path) is not None
+    finally:
+        lock.release()
+
+
 @pytest.mark.skipif(
     session_lock.fcntl is None,
     reason="flock-based mutual exclusion requires POSIX fcntl",

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -84,6 +84,16 @@ _DEFAULT_PROFILE_MAX_STEPS = 128
 # Default profile OSL ceiling when --profile-osl / PROFILE_OSL is unset: the
 # profile reuses min(served OSL, this) so its trace stays light.
 _PROFILE_DEFAULT_OSL = 1024
+# SGLang graph-capture profiling flag shipped by the profile YAML, and the
+# eager flag that makes it a no-op. Literals rather than an import from
+# ``baseline``: that module imports this one, so the dependency only goes one
+# way.
+_SGLANG_PROFILE_CUDA_GRAPH_FLAG = "--enable-profile-cuda-graph"
+_SGLANG_DISABLE_CUDA_GRAPH_FLAG = "--disable-cuda-graph"
+# ``HYPERLOOM_PROFILE_DEGRADED_REASON`` value meaning the TraceLens runtime patch
+# was attempted and did not apply. Distinct from "never attempted": patching can
+# be disabled for an image that already ships the patch.
+_TRACELENS_PATCH_UNAVAILABLE = "tracelens_runtime_patch_unavailable"
 _AGENTX_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 
 # Quality-reference env names, in resolution order. Every scriptable workload
@@ -1052,7 +1062,7 @@ def materialize_config_with_envs(
                 tracelens_patch_ok = ensure_sglang_patched_for_tracelens()
             if not tracelens_patch_ok:
                 envs["HYPERLOOM_TRACELENS_PATCH_STATUS"] = "unavailable"
-                envs["HYPERLOOM_PROFILE_DEGRADED_REASON"] = "tracelens_runtime_patch_unavailable"
+                envs["HYPERLOOM_PROFILE_DEGRADED_REASON"] = _TRACELENS_PATCH_UNAVAILABLE
                 log.warning(
                     "TraceLens runtime patch unavailable for framework=%s; "
                     "profile will omit annotation-only flags and roofline "
@@ -1137,8 +1147,21 @@ def materialize_config_with_envs(
                             "imprecise.",
                             _model,
                         )
+            # Both capture options are annotation-only and need TraceLens
+            # server-side support to land: without it the trace carries no
+            # ``kernel_shape_profiler`` events (trace-health check 5), so asking
+            # for them pays the capture cost for data nothing downstream reads.
+            # Keyed on the degraded *reason* rather than ``tracelens_patch_ok``:
+            # a patch that was never attempted (HYPERLOOM_ENABLE_PATCH=0) can
+            # still be baked into the image, and must keep the annotations.
+            _patch_degraded = envs.get("HYPERLOOM_PROFILE_DEGRADED_REASON") == _TRACELENS_PATCH_UNAVAILABLE
+            if _patch_degraded:
+                _shape_disc = False
             extra_body["shape_discovery"] = _shape_disc
-            extra_body.setdefault("detailed_annotations", True)
+            if _patch_degraded:
+                extra_body["detailed_annotations"] = False
+            else:
+                extra_body.setdefault("detailed_annotations", True)
             # NOTE: this write happens before the per-task ``extra_envs`` merge, so
             # an ``extra_envs`` entry for PROFILE_EXTRA_BODY can still drop
             # start_step/num_steps the way ``args_mode="replace"`` used to drop
@@ -1237,6 +1260,21 @@ def materialize_config_with_envs(
     _final_args = str(envs.get(framework_env, "")).strip()
     if _final_args:
         envs[framework_env] = dedup_vllm_server_args(_final_args, bench.get("framework"))
+    # An eager profile cannot capture a CUDA graph, so the profile YAML's
+    # ``--enable-profile-cuda-graph`` is dead weight the server still sets up
+    # for. The two flags reach the env from different layers -- the YAML
+    # template vs the eager fallback folded into ``extra_server_args`` -- and
+    # only meet here, after every merge above, so this is the first point that
+    # can see the contradiction.
+    if framework_env == "EXTRA_SGLANG_ARGS":
+        _sg_tokens = str(envs.get(framework_env, "")).split()
+        if _SGLANG_DISABLE_CUDA_GRAPH_FLAG in _sg_tokens and _SGLANG_PROFILE_CUDA_GRAPH_FLAG in _sg_tokens:
+            envs[framework_env] = " ".join(t for t in _sg_tokens if t != _SGLANG_PROFILE_CUDA_GRAPH_FLAG)
+            log.info(
+                "Dropping %s: %s is set, so there is no graph capture to profile.",
+                _SGLANG_PROFILE_CUDA_GRAPH_FLAG,
+                _SGLANG_DISABLE_CUDA_GRAPH_FLAG,
+            )
     # ── Quality-reference wiring (scriptable / server-less workloads) ──────
     # Magpie forwards only ``benchmark.envs`` to the wrapper subprocess, so
     # re-inject the quality reference here (the single scriptable choke point)

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -538,8 +538,19 @@ def _tracelens_patch_enabled() -> bool:
     """Read the ``HYPERLOOM_ENABLE_PATCH`` kill switch (default on).
 
     Set ``HYPERLOOM_ENABLE_PATCH=0`` to disable runtime patching of vLLM /
-    SGLang (keeps today's safe behaviour, no TraceLens-only flags injected).
-    Default on because the patches are backward-compatible.
+    SGLang. Default on because the patches are backward-compatible.
+
+    With the switch off, no *server flag* that only a patched build accepts is
+    injected (vLLM ``--profiler-config.detailed_trace_annotation``, SGLang
+    ``--enable-shape-discovery-for-cuda-graph-profile``), because an unpatched
+    argparse rejects them. The SGLang ``PROFILE_EXTRA_BODY`` annotations
+    (``shape_discovery`` / ``detailed_annotations``) are a different case and are
+    **kept**: they ride the ``/start_profile`` API, which an unpatched server
+    accepts, and the switch is also how a pre-patched image opts out of runtime
+    patching while still supporting them. Only a patch that was *attempted and
+    failed* clears them, which is why that gate reads
+    ``HYPERLOOM_PROFILE_DEGRADED_REASON`` (set solely on the attempted-and-failed
+    path) rather than ``tracelens_patch_ok``.
 
     Returns:
         True when runtime patching is enabled (default), else False.


### PR DESCRIPTION
## Context

Session `Kimi-K3_20260818T062936Z_a62853e5` lost 3/3 rooflines, never produced an `analysis.md`, and skipped its whole KERNEL phase. Root cause is **outside this repo**: the agent harness saw `UND_ERR_SOCKET` on an in-flight sandbox call, hit its rebuild path, and issued `POST /workloads/{id}/stop` — which kills the optimizer and the in-flight profile along with the pod. It ran across 4 pods / 3 rebuilds, each rebuild landing inside a roofline trace-flush window.

Hyperloom cannot fix that trigger (it owns no sandbox lifecycle and never calls any workload-stop API). What it can do is stop *inviting* the trigger, stop paying for capture it cannot use, and make a rebuild diagnosable after the fact. This PR does those three things.

## Changes

**1. Forbid blocking waits in the monitor loop** (`SKILL.md`, prompt-only)

`## Monitoring` asked for a 5-minute polling cadence without saying how to wait for it. An agent whose only waiting tool is a sandbox bash call implements that as `sleep 110; sleep 110; sleep 80` — which is what the 08-18 session did. That call holds the sandbox connection open for its whole duration, so overlapping it with a trace flush (8 ranks serialising torch traces to NFS, minutes on a 2.8T MoE) is what dropped the connection. The cadence was never this skill's job: the Robustness Monitor two sections up already polls every 5 minutes from its own `setsid nohup` process. The section now states the division of labour (launch, check once, hand off, report), forbids `sleep` / wait loops / `tail -f`, keeps the sanctioned one-shot `sleep 30` health check explicit, and records *why* so the next editor does not reintroduce a wait.

This is the only change here that reduces the trigger probability rather than the blast radius.

**2. Drop annotation-only capture options when the TraceLens patch failed** (`_workload_envs.py`)

Without the server-side patch the trace carries no `kernel_shape_profiler` events at all (trace-health check 5), yet SGLang still requested `shape_discovery` / `detailed_annotations` over `/start_profile` — full capture and serialization cost for data nothing downstream can read, and a longer flush window to be interrupted in. The vLLM branch already gated its equivalent `detailed_trace_annotation`; SGLang did not, and the existing `"profile will omit annotation-only flags"` warning described only the CLI flag, not the `extra_body` options.

Gated on the degraded **reason**, not on `tracelens_patch_ok`: "patching disabled" (`HYPERLOOM_ENABLE_PATCH=0`, which a pre-patched image legitimately uses) is not "patching failed" and must keep the annotations. That also leaves the healthy and kill-switch paths byte-identical, so the profile golden lock is unchanged.

**3. Resolve the CUDA-graph flag contradiction** (`_workload_envs.py`)

Eager profiles carried both `--enable-profile-cuda-graph` and `--disable-cuda-graph`. An eager server captures no graph, so the former is setup cost for a no-op. The two flags arrive from different layers — the profile YAML template versus the eager fallback folded into `extra_server_args` — and only meet after the reference/server-args merges, so the resolution lives there.

**4. Record pod ownership across rebuilds** (`lock.py`, `session_paths.py`)

Every acquirer truncates `optimizer.lock`, so a rebuilt session keeps only its first owner (`manifest.json`) and its last (the lock body). The 08-18 session ran on 4 pods but reads as single-pod from the session directory alone — which is how the first pass at triage undercounted it as 2. Each acquisition now appends to `runtime/pod_history.jsonl`; append-only and best-effort, since a write failure must never fail an optimizer that already holds the lock.

## Non-goals, and what still needs an owner

- **The rebuild trigger itself is not fixed here.** Filed separately for the harness team: all three rebuilds fired at `consecutive_errors=1` even though the threshold is configured as 3. That one check would neutralise every trigger path — long bash, short poll, health probe — and is higher leverage than anything in this PR.
- **Change 3 is hygiene, not a defence.** A sibling Kimi-K3 session (`Kimi-K3_20260818T064529Z_f059f91d`, vLLM) hit the same failure with CUDA graph *enabled* (`enforce_eager=False`), so shortening the eager flush window does not prevent it.
- **Partial-trace salvage was considered and rejected.** The 2/8 traces that survived rebuild #2 are truncated mid-write — `gzip` fails with `EOFError: Compressed file ended before the end-of-stream marker was reached`. Salvage would feed a corrupt trace to TraceLens, or reject it on validation and salvage nothing. Machinery for no benefit in the observed case.

## Test plan

- [x] 7 new tests: annotations dropped when degraded / kept when healthy / kept when patching was never attempted; graph-capture flag dropped when eager / kept in graph mode; pod ledger accumulates one line per acquire; ledger write failure does not break acquire.
- [x] `pytest` on the touched areas: 293 passed, plus the `SKILL.md` consumer (`test_dotenv_precedence_recipes.py`) green after the prompt edit.
- [x] Profile golden lock (`test_workload_envs_golden_lock.py`) unchanged — the healthy and kill-switch paths are byte-identical.
- [x] `ruff check` clean on changed files. Remaining `ruff format` drift verified pre-existing (identical on `main`); not reformatted, to keep the diff reviewable.
- [ ] Pre-existing unrelated failure in this environment: `test_trace_analyze_handler_dry_run_returns_structured_result` (`ModuleNotFoundError: No module named 'hyperloom'` in a subprocess — reproduces identically on `main` without `pip install -e .`).