### PR TITLE
fix(coordinator): route target_reached through CLOSE so the close seq…

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
@@ -2520,5 +2520,8 @@ async def test_target_reached_routes_through_close_phase(session_dir):
         )
         assert reason == "target_reached"
         assert (c.shared_state.phase or "").upper() == "CLOSE"
+        # The close sequencer actually ran; this is what separates a real close
+        # from the cli safety-net path.
+        assert c.shared_state.close_sequence_done is True
     finally:
         await c.stop()

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
@@ -5,10 +5,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from unittest import mock
 
 import pytest
 
@@ -2589,4 +2592,87 @@ async def test_target_reached_closes_despite_a_failed_state_save(session_dir):
         assert c.shared_state.close_sequence_done is True
     finally:
         c.shared_state.save = real_save  # type: ignore[method-assign]
+        await c.stop()
+
+
+@pytest.mark.asyncio
+async def test_target_reached_close_still_runs_the_post_opt_roofline(session_dir):
+    """A met target must not be treated as a wall-clock rescue.
+
+    ``_maybe_run_close_post_opt_roofline`` returns early on ``closing_phase``,
+    which means "the wall clock ran out, shed expensive work". Routing a success
+    terminal through that flag would drop the post-opt snapshot the
+    optimization-progress chart reads -- one of the artifacts skipping CLOSE
+    loses in the first place.
+    """
+    _write_marker_target_baseline(session_dir)
+    c = Coordinator(session_dir, backends=_silent_backends())
+    c.sub.register_executor("report", report_executor)
+    c.shared_state.baseline_tput = 100.0
+    c.shared_state.cumulative_gain_validated = 50.0
+    # A kernel-level optimization landed, so the roofline step applies.
+    c.shared_state.optimization_stack = [{"action": "integrate", "tput": 150.0}]
+    c.shared_state.save(session_dir)
+
+    ran: list[str] = []
+
+    async def _record_roofline() -> None:
+        ran.append(str(c.shared_state.closing_phase))
+
+    c.phase_close._maybe_run_close_post_opt_roofline = _record_roofline  # type: ignore[method-assign]
+    try:
+        reason = await c.run(
+            objective=TargetGainObjective(target_gain_pct=10.0),
+            max_minutes=0.0001,
+            max_ticks=6,
+        )
+        assert reason == "target_reached"
+        assert ran == ["False"], f"post-opt roofline saw closing_phase={ran}"
+    finally:
+        await c.stop()
+
+
+@pytest.mark.asyncio
+async def test_target_reached_close_is_not_cancelled_by_an_outer_bound(session_dir):
+    """The sequencer's own per-step timeouts are the budget, not an outer one.
+
+    ``CLOSE_POST_OPT_ROOFLINE_TIMEOUT_SEC`` alone allows 600s, so any outer
+    bound short enough to matter would cancel the step mid-flight and drop the
+    run onto the safety net -- the outcome this routing exists to avoid. With
+    the session bound already elapsed, an awaited step would be skipped outright
+    unless the terminal close lifts it.
+    """
+    _write_marker_target_baseline(session_dir)
+    c = Coordinator(session_dir, backends=_silent_backends())
+    c.sub.register_executor("report", report_executor)
+    c.shared_state.baseline_tput = 100.0
+    c.shared_state.cumulative_gain_validated = 50.0
+    c.shared_state.save(session_dir)
+
+    # The bound is armed and elapsed; the terminal close must ignore it.
+    c._run_deadline = time.monotonic() - 1.0
+    assert c._seconds_until_session_bound() is not None
+    c._terminal_closing = True
+    assert c._seconds_until_session_bound() is None, "terminal close must be unbounded"
+    c._terminal_closing = False
+
+    real_advance = c.phase_machine._advance_phase_if_needed
+    completed: list[bool] = []
+
+    async def _slow_advance() -> None:
+        # Any await at all is cancelled or skipped by an elapsed outer bound.
+        await asyncio.sleep(0.3)
+        await real_advance()
+        completed.append(True)
+
+    try:
+        with mock.patch.object(c.phase_machine, "_advance_phase_if_needed", _slow_advance):
+            reason = await c.run(
+                objective=TargetGainObjective(target_gain_pct=10.0),
+                max_minutes=0.0001,
+                max_ticks=2,
+            )
+        assert reason == "target_reached"
+        assert completed, "the close step was skipped or cancelled by an outer bound"
+    finally:
         await c.stop()

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
@@ -29,6 +29,7 @@ from hyperloom.orchestrator.loop.coordinator_helpers import (
 )
 from hyperloom.orchestrator.loop.proposals import ProposalsCollaborator
 from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
+from hyperloom.orchestrator.state.objective import TargetGainObjective
 from hyperloom.orchestrator.state.shared_state import SharedState
 from hyperloom.orchestrator.loop.sub_agent_runner import (
     SubAgentRunner,
@@ -2494,5 +2495,30 @@ async def test_dispatch_audit_skips_kernel_owned_kind_under_no_kernel(session_di
         assert evidence.get("reason") == "policy_denied"
         assert evidence.get("rule") == "kernel_owned_by_kernel_agent"
         assert not await c.tasks.by_state("failed")
+    finally:
+        await c.stop()
+
+
+@pytest.mark.asyncio
+async def test_target_reached_routes_through_close_phase(session_dir):
+    """A met objective transitions to CLOSE instead of breaking out of the loop.
+
+    ``machine_state`` registers ``target_reached`` as an "any phase -> CLOSE"
+    transition reason, so a met target must reach the close sequencer rather
+    than leaving the run with only the cli safety-net report.
+    """
+    _write_marker_target_baseline(session_dir)
+    c = Coordinator(session_dir, backends=_silent_backends())
+    c.sub.register_executor("report", report_executor)
+    c.shared_state.baseline_tput = 100.0
+    c.shared_state.cumulative_gain_validated = 50.0
+    c.shared_state.save(session_dir)
+    try:
+        reason = await c.run(
+            objective=TargetGainObjective(target_gain_pct=10.0),
+            max_ticks=6,
+        )
+        assert reason == "target_reached"
+        assert (c.shared_state.phase or "").upper() == "CLOSE"
     finally:
         await c.stop()

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
@@ -2525,3 +2525,68 @@ async def test_target_reached_routes_through_close_phase(session_dir):
         assert c.shared_state.close_sequence_done is True
     finally:
         await c.stop()
+
+
+@pytest.mark.asyncio
+async def test_target_reached_at_session_bound_still_closes(session_dir):
+    """A target met at/after the session bound must still reach the sequencer.
+
+    Every ``_advance_phase_if_needed`` in the tick body is wrapped in
+    ``_await_within_session_bound``, which skips the step once the bound has
+    elapsed. Deferring the CLOSE transition to the next tick therefore never
+    gets one, and the run falls back to the cli safety-net report -- the exact
+    outcome this fix exists to prevent.
+    """
+    _write_marker_target_baseline(session_dir)
+    c = Coordinator(session_dir, backends=_silent_backends())
+    c.sub.register_executor("report", report_executor)
+    c.shared_state.baseline_tput = 100.0
+    c.shared_state.cumulative_gain_validated = 50.0
+    c.shared_state.save(session_dir)
+    try:
+        reason = await c.run(
+            objective=TargetGainObjective(target_gain_pct=10.0),
+            max_minutes=0.0001,
+            max_ticks=6,
+        )
+        assert reason == "target_reached"
+        assert c.shared_state.close_sequence_done is True
+    finally:
+        await c.stop()
+
+
+@pytest.mark.asyncio
+async def test_target_reached_closes_despite_a_failed_state_save(session_dir):
+    """Persisting the terminal is best-effort; it must not gate the close.
+
+    The stop_reason is already set in memory, so a failed save leaves the run
+    with a met target and no close sequence -- the safety-net path again.
+    """
+    _write_marker_target_baseline(session_dir)
+    c = Coordinator(session_dir, backends=_silent_backends())
+    c.sub.register_executor("report", report_executor)
+    c.shared_state.baseline_tput = 100.0
+    c.shared_state.cumulative_gain_validated = 50.0
+    c.shared_state.save(session_dir)
+
+    real_save = c.shared_state.save
+    state = {"tripped": False}
+
+    def flaky_save(*args, **kwargs):
+        if c.shared_state.stop_reason == "target_reached" and not state["tripped"]:
+            state["tripped"] = True
+            raise OSError("simulated transient state-save failure")
+        return real_save(*args, **kwargs)
+
+    c.shared_state.save = flaky_save  # type: ignore[method-assign]
+    try:
+        reason = await c.run(
+            objective=TargetGainObjective(target_gain_pct=10.0),
+            max_ticks=6,
+        )
+        assert state["tripped"] is True
+        assert reason == "target_reached"
+        assert c.shared_state.close_sequence_done is True
+    finally:
+        c.shared_state.save = real_save  # type: ignore[method-assign]
+        await c.stop()

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -1815,7 +1815,21 @@ class Coordinator(metaclass=_CoordinatorMeta):
                     stop_reason = self.shared_state.stop_reason
                     break
                 if objective.reached(self.shared_state):
-                    stop_reason = "target_reached"
+                    # Route the terminal through CLOSE instead of breaking here.
+                    # ``machine_state`` registers ``target_reached`` as an
+                    # "any phase -> CLOSE" transition reason, but nothing ever
+                    # produced it, so a met target skipped the 7-step close
+                    # sequencer and left only the cli safety-net report.
+                    # Publishing the stop_reason lets ``_global_terminal`` drive
+                    # that transition on the next tick; the stop-condition check
+                    # above then exits once CLOSE has run. Bounded by design:
+                    # that check fires on the very next tick regardless of
+                    # whether CLOSE succeeded, so this cannot spin.
+                    if not self.shared_state.stop_reason:
+                        self.shared_state.set_stop_reason("target_reached")
+                        self.shared_state.save(self.session_dir)
+                        continue
+                    stop_reason = self.shared_state.stop_reason
                     break
                 if deadline is not None and time.monotonic() >= deadline and not in_closing:
                     if grace_sec <= 0:

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -37,6 +37,13 @@ MAINTENANCE_EVERY_TICKS: int = 50
 DEFAULT_CYCLE_HOURS: float = 24.0
 # Trailing window for the crash-rate emergency stop, in seconds.
 _CRASH_EMERGENCY_WINDOW_SEC: float = 24.0 * 3600.0
+
+# Window granted to the CLOSE sequencer when a terminal fires on the success
+# path. The post-deadline ``grace_sec`` cannot be reused as-is: it is 0 on an
+# unbounded run and whenever an operator disables the rescue window, which would
+# leave a met target with no time to produce its report at all. Matches the
+# ceiling ``effective_closing_grace_sec`` uses for bounded runs.
+_TERMINAL_CLOSE_WINDOW_SEC: float = 120.0
 # Combined baseline-failure backstop: fast-fail after this many TOTAL baseline failures.
 _BASELINE_MAX_TOTAL_FAILURES: int = 3
 # Enablement stall cap: consecutive enablement rounds that neither made the combo
@@ -1815,21 +1822,56 @@ class Coordinator(metaclass=_CoordinatorMeta):
                     stop_reason = self.shared_state.stop_reason
                     break
                 if objective.reached(self.shared_state):
-                    # Route the terminal through CLOSE instead of breaking here.
-                    # ``machine_state`` registers ``target_reached`` as an
-                    # "any phase -> CLOSE" transition reason, but nothing ever
-                    # produced it, so a met target skipped the 7-step close
-                    # sequencer and left only the cli safety-net report.
-                    # Publishing the stop_reason lets ``_global_terminal`` drive
-                    # that transition on the next tick; the stop-condition check
-                    # above then exits once CLOSE has run. Bounded by design:
-                    # that check fires on the very next tick regardless of
-                    # whether CLOSE succeeded, so this cannot spin.
+                    # Route the terminal through CLOSE. ``machine_state``
+                    # registers ``target_reached`` as an "any phase -> CLOSE"
+                    # transition reason, but nothing ever produced it, so a met
+                    # target skipped the 7-step close sequencer and left only
+                    # the cli safety-net report.
+                    #
+                    # The transition runs in THIS tick rather than the next one.
+                    # Every ``_advance_phase_if_needed`` in the tick body sits
+                    # behind ``_await_within_session_bound``, which skips the
+                    # step once the session bound has elapsed -- so a target met
+                    # at or after the deadline would never get another advance,
+                    # and deferring the close would silently fall back to the
+                    # safety net.
                     if not self.shared_state.stop_reason:
                         self.shared_state.set_stop_reason("target_reached")
-                        self.shared_state.save(self.session_dir)
-                        continue
-                    stop_reason = self.shared_state.stop_reason
+                        # Best-effort: the terminal is already set in memory and
+                        # CLOSE persists state itself, so a failed write must not
+                        # cost the run its close sequence.
+                        try:
+                            self.shared_state.save(self.session_dir)
+                        except Exception:  # noqa: BLE001
+                            log.exception(
+                                "Coordinator: persisting target_reached failed; closing anyway",
+                            )
+                        # Arm the closing bound before advancing: that swaps
+                        # ``_seconds_until_session_bound`` onto
+                        # ``_closing_deadline``, which is what keeps CLOSE work
+                        # from being skipped on an elapsed session bound, and
+                        # keeps the sequencer itself bounded.
+                        #
+                        # ``grace_sec`` is the post-deadline rescue window: 0 on
+                        # an unbounded run, and ``max_minutes * 60 * 0.02``
+                        # otherwise, so it shrinks with the budget. A met target
+                        # is not a rescue -- it is the success path -- and the
+                        # sequencer needs a workable window to render its report
+                        # whatever the budget was, hence a floor rather than a
+                        # zero-check.
+                        close_window = max(grace_sec, _TERMINAL_CLOSE_WINDOW_SEC)
+                        self.shared_state.closing_phase = True
+                        self._closing_deadline = time.monotonic() + close_window
+                        try:
+                            await self._await_within_session_bound(
+                                self._advance_phase_if_needed,
+                                stage="advance_phase_target_reached",
+                            )
+                        except Exception:  # noqa: BLE001
+                            log.exception(
+                                "Coordinator: close transition on target_reached failed",
+                            )
+                    stop_reason = self.shared_state.stop_reason or "target_reached"
                     break
                 if deadline is not None and time.monotonic() >= deadline and not in_closing:
                     if grace_sec <= 0:

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -1676,7 +1676,7 @@ class Coordinator(metaclass=_CoordinatorMeta):
         crash_emergency_threshold: int = 25,
         closing_grace_sec: float | None = None,
     ) -> str:
-        """Run reactor + dispatcher until a stop condition fires (priority order): signal, target_reached, time_exhausted (via closing phase), emergency, custom, max_ticks. Sets + saves + returns shared_state.stop_reason.
+        """Run reactor + dispatcher until a stop condition fires (priority order): signal, target_reached (via the CLOSE phase sequencer), time_exhausted (via closing phase), emergency, custom, max_ticks. Sets + saves + returns shared_state.stop_reason.
 
         Args:
             objective: Stop objective; ``None`` uses a :class:`TimeOnlyObjective`.

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -37,13 +37,6 @@ MAINTENANCE_EVERY_TICKS: int = 50
 DEFAULT_CYCLE_HOURS: float = 24.0
 # Trailing window for the crash-rate emergency stop, in seconds.
 _CRASH_EMERGENCY_WINDOW_SEC: float = 24.0 * 3600.0
-
-# Window granted to the CLOSE sequencer when a terminal fires on the success
-# path. The post-deadline ``grace_sec`` cannot be reused as-is: it is 0 on an
-# unbounded run and whenever an operator disables the rescue window, which would
-# leave a met target with no time to produce its report at all. Matches the
-# ceiling ``effective_closing_grace_sec`` uses for bounded runs.
-_TERMINAL_CLOSE_WINDOW_SEC: float = 120.0
 # Combined baseline-failure backstop: fast-fail after this many TOTAL baseline failures.
 _BASELINE_MAX_TOTAL_FAILURES: int = 3
 # Enablement stall cap: consecutive enablement rounds that neither made the combo
@@ -874,6 +867,12 @@ class Coordinator(metaclass=_CoordinatorMeta):
         # Closing-grace bound; used only while ``closing_phase`` is set so CLOSE
         # work is not skipped just because the session deadline has passed.
         self._closing_deadline: float | None = None
+        # Set while a success terminal (a met objective) is being routed into
+        # CLOSE. Distinct from ``closing_phase``, which means the wall clock ran
+        # out and the sequencer should shed expensive work; a met target has to
+        # produce the full set of artifacts. ``True`` lifts the session bound for
+        # that routing without claiming a rescue is under way.
+        self._terminal_closing: bool = False
         # Latest objective wired by run(); refreshes target_gap_pct each tick. None outside a run.
         self._current_objective: Objective | None = None
 
@@ -1629,9 +1628,17 @@ class Coordinator(metaclass=_CoordinatorMeta):
         During CLOSE the session deadline has already passed, so the bound
         switches to ``_closing_deadline`` and CLOSE work is not skipped.
 
+        A success terminal is unbounded here: the sequencer's own per-step
+        timeouts (``CLOSE_POST_OPT_ROOFLINE_TIMEOUT_SEC`` is 600s on its own)
+        are the budget. An outer bound short enough to matter would cancel the
+        step mid-flight and drop the run onto the safety net -- the very outcome
+        routing into CLOSE exists to avoid.
+
         Returns:
             Remaining seconds, or ``None`` when no bound is armed.
         """
+        if self._terminal_closing:
+            return None
         if bool(getattr(self.shared_state, "closing_phase", False)):
             bound = self._closing_deadline
         else:
@@ -1846,22 +1853,15 @@ class Coordinator(metaclass=_CoordinatorMeta):
                             log.exception(
                                 "Coordinator: persisting target_reached failed; closing anyway",
                             )
-                        # Arm the closing bound before advancing: that swaps
-                        # ``_seconds_until_session_bound`` onto
-                        # ``_closing_deadline``, which is what keeps CLOSE work
-                        # from being skipped on an elapsed session bound, and
-                        # keeps the sequencer itself bounded.
-                        #
-                        # ``grace_sec`` is the post-deadline rescue window: 0 on
-                        # an unbounded run, and ``max_minutes * 60 * 0.02``
-                        # otherwise, so it shrinks with the budget. A met target
-                        # is not a rescue -- it is the success path -- and the
-                        # sequencer needs a workable window to render its report
-                        # whatever the budget was, hence a floor rather than a
-                        # zero-check.
-                        close_window = max(grace_sec, _TERMINAL_CLOSE_WINDOW_SEC)
-                        self.shared_state.closing_phase = True
-                        self._closing_deadline = time.monotonic() + close_window
+                        # Lift the session bound for this one advance so the
+                        # elapsed run deadline cannot skip it. ``closing_phase``
+                        # is deliberately NOT set: that flag means the wall clock
+                        # ran out, and CLOSE reads it to shed expensive work --
+                        # ``_maybe_run_close_post_opt_roofline`` returns early on
+                        # it, which would drop the very artifact this routing
+                        # exists to produce. The sequencer's own per-step
+                        # timeouts bound the work.
+                        self._terminal_closing = True
                         try:
                             await self._await_within_session_bound(
                                 self._advance_phase_if_needed,
@@ -1871,6 +1871,8 @@ class Coordinator(metaclass=_CoordinatorMeta):
                             log.exception(
                                 "Coordinator: close transition on target_reached failed",
                             )
+                        finally:
+                            self._terminal_closing = False
                     stop_reason = self.shared_state.stop_reason or "target_reached"
                     break
                 if deadline is not None and time.monotonic() >= deadline and not in_closing:


### PR DESCRIPTION


## Problem

When a run meets its `--target-gain`, the coordinator breaks out of the tick loop immediately, so the CLOSE phase never runs and the 7-step close sequencer is skipped. The session ends with only the CLI safety-net report:

```json
{ "report_complete": false, "safety_net": true, "stop_reason": "target_reached" }
```

```markdown
# Inference Optimizer — emergency final report
> **Auto-generated safety-net.** The CLOSE phase 7-step sequencer did not run to
> completion (process exited before phase transition, or `report` executor failed).
```

A successful run therefore loses the real `report` output, the post-optimization roofline (CLOSE step 0), `kernel_optimization_summary.json`, `robustness_postmortem.md`, and the CLOSE segment in `session_breakdown.json`.

## Root cause

`machine_state.py:228` registers `target_reached` as an "any phase -> CLOSE" terminal transition reason, but **nothing ever produced that transition** — `compute_next_phase()` never returns it. The only producer was the tick loop, which used it as a local variable and broke:

```python
if objective.reached(self.shared_state):
    stop_reason = "target_reached"   # local variable only
    break                            # phase machine never runs again
```

`_advance_phase_if_needed()` lives in the tick body, so `break` removes any further chance to reach CLOSE — and `shared_state.stop_reason` is still empty at that point, since it is only written in the `finally` block.

This also made the two success terminals inconsistent: `time_exhausted` (also in `_SUCCESS_STOP_REASONS`) routes through a closing path, so a timeout closed cleanly while a met target did not.

## Fix

Publish the stop reason and let the existing state machine drive the transition:

```python
if objective.reached(self.shared_state):
    if not self.shared_state.stop_reason:
        self.shared_state.set_stop_reason("target_reached")
        self.shared_state.save(self.session_dir)
        continue
    stop_reason = self.shared_state.stop_reason
    break
```

`_global_terminal()` (`machine_state.py:1645`) already picks this up — its comment reads *"Coordinator-set stop_reason takes precedence over phase exits"*. That path had simply never been fed a value. No new mechanism is introduced.

Bounded: after `continue`, the `if self.shared_state.stop_reason and not in_closing` check necessarily fires on the next tick, so the loop runs at most one extra tick and cannot spin regardless of whether CLOSE succeeded. The `else` branch preserves the previous behaviour when a stop reason is already published, leaving the timeout path untouched.

## Verification

**Unit test.** `test_target_reached_routes_through_close_phase` builds a run that necessarily meets its objective and asserts the phase reaches CLOSE. Reverting only the implementation confirms it catches the bug:

```
without fix:  FAILED  assert 'FRAMEWORK_AGENT' == 'CLOSE'
with fix:     PASSED
```

**Full suite.** `9 failed, 14360 passed, 32 skipped` — the same 9 pre-existing failures as `main`; passing count goes 14359 -> 14360 (the new test).

**End-to-end.** A real run (MI355X, vLLM 0.24.0, Qwen3-8B, TP=1, conc=64, ISL=OSL=1024, bf16, `--target-gain 15`) ending in `target_reached`:

```
close_sequence_done:       True
cumulative_gain_validated: 28.12%   (baseline 6736.07 tok/s/GPU)

PRELUDE   from=-         reason=prelude_done
EXPLORE   from=PRELUDE   reason=target_reached
CLOSE     from=EXPLORE   reason=(current)
```

`reason=target_reached` on the EXPLORE segment is the vocab entry that previously had no producer.

| | before | after |
|---|---|---|
| `final.md` heading | `— emergency final report` | `Inference Optimizer Report — <id>` |
| `final.json` | 2,869 B | 59,898 B |
| `report_complete` / `safety_net` | `false` / `true` | absent |
| CLOSE phase segment | missing | present |
| `kernel_optimization_summary.json` | missing | written |
| `robustness_postmortem.md` | missing | written |
