### PR TITLE
Fix GEAK kernel adoption gates and pin docs CI to Sphinx 8.x

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,7 +54,9 @@ jobs:
       - name: Install documentation dependencies
         run: |
           pip install --upgrade pip
-          pip install -r docs/requirements.txt
+          # Match Read the Docs: the lockfile pins Sphinx 8.x. The short
+          # docs/requirements.txt cap is for local installs only.
+          pip install -r docs/sphinx/requirements.txt
 
       - name: Build HTML
         # conf.py mocks the heavy runtime imports (torch, triton, ray, ...), so

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,11 @@
 # Documentation build dependencies for the Hyperloom Sphinx site.
-# Install with:  pip install -r docs/requirements.txt
+#
+# Reproducible builds (CI, Read the Docs): pip install -r docs/sphinx/requirements.txt
+# Quick local install: pip install -r docs/requirements.txt
 rocm-docs-core[api_reference]
 myst-parser>=2.0
 linkify-it-py>=2.0
 # Pin transitive dep above CVE-2026-45409 (affects idna 3.9.0).
 idna>=3.10
+# sphinx-book-theme 1.1.x crashes on Sphinx 9 (add_source_buttons unpacks None).
+sphinx>=8.1,<9

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/geak.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/geak.py
@@ -24,6 +24,47 @@ from ._common import (
 )
 
 
+def _geak_result_kernel_specs(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return authored kernel specs from ``result.json``, both lanes, env excluded."""
+    try:
+        from hyperloom.orchestrator.loop.coordinator_helpers import (
+            _geak_accepted_kernel_specs,
+        )
+
+        return _geak_accepted_kernel_specs(result)
+    except Exception:  # pragma: no cover - offline replay without orchestrator
+        out: list[dict[str, Any]] = []
+        kernels = result.get("accepted_kernels") or []
+        heads = result.get("accepted_heads") or []
+        if not isinstance(kernels, list):
+            kernels = []
+        if not isinstance(heads, list):
+            heads = []
+        for lane in kernels + heads:
+            if not isinstance(lane, dict):
+                continue
+            if str(lane.get("kind") or "").strip().lower() == "env":
+                continue
+            try:
+                delta = float(lane.get("e2e_delta_pct") or 0.0)
+            except (TypeError, ValueError):
+                continue
+            if delta <= 0.0:
+                continue
+            out.append(lane)
+        return out
+
+
+def _legacy_string_accepted_kernels(result: dict[str, Any]) -> list[str]:
+    """Preserve pre-schema bare-string ``accepted_kernels`` lists."""
+    raw = result.get("accepted_kernels") or []
+    if not isinstance(raw, list) or not raw:
+        return []
+    if not all(isinstance(item, str) for item in raw):
+        return []
+    return [str(item).strip() for item in raw if str(item).strip()]
+
+
 def _journey_paths(result: dict[str, Any]) -> list[Path]:
     """Every ``kernel_journey.json`` belonging to a GEAK session, pointer first.
 
@@ -300,6 +341,27 @@ def _journey_row_symbol(row: dict[str, Any]) -> str:
     return str(row.get("name") or row.get("kernel_id") or "").strip()
 
 
+def _is_alias_twin_group(group: list[dict[str, Any]], is_cand_tag: Any) -> bool:
+    """Return True only when a group is a slot-tag + symbol alias pair.
+
+    Two unrelated kernels can share a run-level gain and the measured/unmeasured
+    gpu_pct split; collapsing on gain alone would drop one of them.
+    """
+    measured = [r for r in group if r.get("gpu_pct") is not None]
+    unmeasured = [r for r in group if r.get("gpu_pct") is None]
+    if not measured or not unmeasured:
+        return False
+    names: list[str] = []
+    for row in group:
+        for field in ("name", "kernel_id"):
+            text = str(row.get(field) or "").strip()
+            if text and text not in names:
+                names.append(text)
+    has_tag = any(is_cand_tag(n) for n in names)
+    has_symbol = any(not is_cand_tag(n) for n in names)
+    return has_tag and has_symbol
+
+
 def _collapse_journey_aliases(accepted: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Collapse the twin rows GEAK writes for one accepted kernel.
 
@@ -345,7 +407,11 @@ def _collapse_journey_aliases(accepted: list[dict[str, Any]]) -> list[dict[str, 
     groups: dict[Any, list[dict[str, Any]]] = {}
     for row in accepted:
         gain = row.get("e2e_gain_pct")
-        key = round(gain, 3) if isinstance(gain, (int, float)) else ("_", id(row))
+        op_kind = str(row.get("op_kind") or "")
+        if isinstance(gain, (int, float)):
+            key: Any = (op_kind, round(float(gain), 3))
+        else:
+            key = (op_kind, "_", id(row))
         groups.setdefault(key, []).append(row)
 
     collapsed: list[dict[str, Any]] = []
@@ -353,10 +419,10 @@ def _collapse_journey_aliases(accepted: list[dict[str, Any]]) -> list[dict[str, 
     for group in groups.values():
         if len(group) < 2:
             continue
+        if not _is_alias_twin_group(group, is_cand_tag):
+            continue
         measured = [r for r in group if r.get("gpu_pct") is not None]
         unmeasured = [r for r in group if r.get("gpu_pct") is None]
-        if not measured or not unmeasured:
-            continue
         primary = measured[0]
 
         # The unmeasured twin is the resolved symbol, by construction. When
@@ -922,26 +988,36 @@ def collect_geak(
     if not isinstance(accepted_heads, list):
         accepted_heads = []
 
-    # Back-fill per-kernel attribution from ``kernel_journey.json`` when
-    # ``result.json`` shipped the aggregate win but an empty ``accepted_kernels``.
-    # Fires on any run that completed and returned a workflow result with an
-    # empty list; a producer-populated list is always preserved verbatim.
-    #
-    # ``no_gain`` must be included. ``status`` is derived from
-    # ``throughput_speedup``, which GEAK reports on the run's headline basis --
-    # frequently ``cold``. A run can therefore be stamped ``no_gain`` on the cold
-    # basis while ``alignment_metrics.hot_geak_speedup`` records a large measured
-    # hot win and the journey holds genuine KEEP rows. Gating attribution on
-    # ``status == "ok"`` discarded those rows entirely. ``error`` / ``timeout``
-    # stay excluded: those runs never produced a trustworthy workflow return.
-    accepted_kernels_source = "result" if accepted_kernels else None
-    if not accepted_kernels and status in ("ok", "no_gain"):
-        backfilled = _geak_accepted_kernels_from_journey(
-            result, warnings, state.get("optimization_stack")
-        )
-        if backfilled:
-            accepted_kernels = backfilled
-            accepted_kernels_source = "kernel_journey_backfill"
+    normalized_result = {
+        **result,
+        "accepted_kernels": accepted_kernels,
+        "accepted_heads": accepted_heads,
+    }
+
+    # Normalize the direct result path through the same admission rules as the
+    # orchestrator ledger: both lanes, env selections excluded, alias twins
+    # collapsed. Journey backfill runs only when this yields nothing.
+    accepted_kernels_source: str | None = None
+    specs = _geak_result_kernel_specs(normalized_result)
+    if specs:
+        accepted_kernels = specs
+        accepted_kernels_source = "result"
+    else:
+        legacy_strings = _legacy_string_accepted_kernels(normalized_result)
+        if legacy_strings:
+            accepted_kernels = legacy_strings
+            accepted_kernels_source = "result"
+        elif status in ("ok", "no_gain"):
+            backfilled = _geak_accepted_kernels_from_journey(
+                result, warnings, state.get("optimization_stack")
+            )
+            if backfilled:
+                accepted_kernels = backfilled
+                accepted_kernels_source = "kernel_journey_backfill"
+            else:
+                accepted_kernels = []
+        else:
+            accepted_kernels = []
 
     section: dict[str, Any] = {
         "engaged": True,

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/geak.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/geak.py
@@ -342,24 +342,16 @@ def _journey_row_symbol(row: dict[str, Any]) -> str:
 
 
 def _is_alias_twin_group(group: list[dict[str, Any]], is_cand_tag: Any) -> bool:
-    """Return True only when a group is a slot-tag + symbol alias pair.
-
-    Two unrelated kernels can share a run-level gain and the measured/unmeasured
-    gpu_pct split; collapsing on gain alone would drop one of them.
-    """
+    """Return True only for a one-to-one slot-tag + symbol alias pair."""
+    if len(group) != 2:
+        return False
     measured = [r for r in group if r.get("gpu_pct") is not None]
     unmeasured = [r for r in group if r.get("gpu_pct") is None]
-    if not measured or not unmeasured:
+    if len(measured) != 1 or len(unmeasured) != 1:
         return False
-    names: list[str] = []
-    for row in group:
-        for field in ("name", "kernel_id"):
-            text = str(row.get(field) or "").strip()
-            if text and text not in names:
-                names.append(text)
-    has_tag = any(is_cand_tag(n) for n in names)
-    has_symbol = any(not is_cand_tag(n) for n in names)
-    return has_tag and has_symbol
+    tag_id = _journey_row_symbol(measured[0])
+    sym_id = _journey_row_symbol(unmeasured[0])
+    return bool(tag_id) and bool(sym_id) and is_cand_tag(tag_id) and not is_cand_tag(sym_id)
 
 
 def _collapse_journey_aliases(accepted: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -517,10 +509,17 @@ def _geak_accepted_kernels_from_journey(
         verification = br.get("verification") if isinstance(br.get("verification"), dict) else {}
         dispatch = k.get("dispatch") if isinstance(k.get("dispatch"), dict) else {}
         backend = str(verification.get("best_backend") or (dispatch.get("backends") or [None])[0] or "")
+        op_kind = str(
+            k.get("op_kind")
+            or dispatch.get("op_kind")
+            or e2e.get("op_kind")
+            or ""
+        )
         accepted.append(
             {
                 "kernel_id": kid,
                 "name": str(k.get("name") or kid),
+                "op_kind": op_kind,
                 "gpu_pct": _to_float(k.get("gpu_pct")),
                 "micro_speedup": _to_float(k.get("micro_speedup") or verification.get("micro_speedup")),
                 "e2e_gain_pct": _to_float(e2e.get("e2e_gain_pct")),

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
@@ -801,6 +801,10 @@ def _collect_adopted_kernels(state: dict[str, Any]) -> list[dict[str, Any]]:
                 continue
             if ent.get("last_decision") != "KEEP":
                 continue
+            # GEAK rows without a proven overlay stay in the ledger for audit
+            # but must not surface as adopted lifecycle entries.
+            if ent.get("validated") is False:
+                continue
             out.append(
                 {
                     "kernel_id": str(ent.get("kernel_id") or ""),

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
@@ -779,11 +779,33 @@ def _collect_optimized_kernels(
     return sorted(by_kid.values(), key=lambda e: e.get("kernel_id") or "")
 
 
+def _ledger_entry_is_adopted(ent: dict[str, Any]) -> bool:
+    """Report whether a ledger row represents an adopted kernel patch.
+
+    ``validated`` tracks single-kernel gain attribution, not adoption. GEAK
+    joint rebench rows and later failed revalidations can be ``validated=False``
+    while the kernel was still promoted with a proven overlay or an earlier
+    ``KEEP`` attempt.
+    """
+    if ent.get("last_decision") == "KEEP":
+        return True
+    source = str(ent.get("source") or "")
+    attempts = ent.get("attempts") or []
+    has_keep = any(
+        isinstance(a, dict) and a.get("decision") == "KEEP" for a in attempts
+    )
+    if source == "geak_e2e":
+        if ent.get("overlay_loaded") is True:
+            return True
+        return has_keep
+    return has_keep
+
+
 def _collect_adopted_kernels(state: dict[str, Any]) -> list[dict[str, Any]]:
     """Collect KEEP-promoted (adopted) kernel patch entries.
 
-    Reads ``state.kernel_integrate_attempts`` and keeps only entries whose
-    ``last_decision`` is ``"KEEP"``.
+    Reads ``state.kernel_integrate_attempts`` and keeps entries that were
+    promoted (``KEEP`` or proven GEAK overlay / historical ``KEEP``).
 
     Args:
         state (dict[str, Any]): Parsed ``state.json``.
@@ -799,11 +821,7 @@ def _collect_adopted_kernels(state: dict[str, Any]) -> list[dict[str, Any]]:
         for key, ent in integ.items():
             if not isinstance(ent, dict):
                 continue
-            if ent.get("last_decision") != "KEEP":
-                continue
-            # GEAK rows without a proven overlay stay in the ledger for audit
-            # but must not surface as adopted lifecycle entries.
-            if ent.get("validated") is False:
+            if not _ledger_entry_is_adopted(ent):
                 continue
             out.append(
                 {

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
@@ -790,14 +790,16 @@ def _ledger_entry_is_adopted(ent: dict[str, Any]) -> bool:
     if ent.get("last_decision") == "KEEP":
         return True
     source = str(ent.get("source") or "")
+    if source != "geak_e2e":
+        # Forge / integrate writers stamp REVERT on the entry itself; a prior
+        # KEEP attempt must not resurrect a kernel that was later rejected.
+        return False
     attempts = ent.get("attempts") or []
     has_keep = any(
         isinstance(a, dict) and a.get("decision") == "KEEP" for a in attempts
     )
-    if source == "geak_e2e":
-        if ent.get("overlay_loaded") is True:
-            return True
-        return has_keep
+    if ent.get("overlay_loaded") is True:
+        return True
     return has_keep
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_geak_acceptance_identity.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_acceptance_identity.py
@@ -210,6 +210,34 @@ def test_collapse_skips_unrelated_measured_unmeasured_pair_at_same_gain() -> Non
     assert sorted(r["name"] for r in out) == ["kernel_a", "kernel_b"]
 
 
+def test_collapse_skips_three_kernel_mixed_group_at_same_gain() -> None:
+    rows = [
+        {
+            "kernel_id": "c0_triton",
+            "name": "c0_triton",
+            "gpu_pct": 10.0,
+            "e2e_gain_pct": 5.0,
+            "op_kind": "prefill_attn",
+        },
+        {
+            "kernel_id": "sym_a",
+            "name": "sym_a",
+            "gpu_pct": None,
+            "e2e_gain_pct": 5.0,
+            "op_kind": "prefill_attn",
+        },
+        {
+            "kernel_id": "kernel_c",
+            "name": "kernel_c",
+            "gpu_pct": 8.0,
+            "e2e_gain_pct": 5.0,
+            "op_kind": "prefill_attn",
+        },
+    ]
+    out = _collapse_journey_aliases(rows)
+    assert len(out) == 3
+
+
 def test_collapse_keeps_two_unmeasured_rows_that_share_a_gain() -> None:
     rows = [
         {"kernel_id": "kernel_a", "name": "kernel_a", "gpu_pct": None, "e2e_gain_pct": 2.0},

--- a/src/hyperloom/inference_optimizer/tests/test_geak_acceptance_identity.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_acceptance_identity.py
@@ -34,11 +34,16 @@ from hyperloom.inference_optimizer.breakdown.collectors.geak import (
     _stamp_journey_kind,
 )
 from hyperloom.orchestrator.loop.coordinator_helpers import (
+    _geak_accepted_kernel_specs,
     geak_is_cand_tag,
     geak_spec_is_env,
     geak_spec_kind,
     geak_spec_name,
 )
+
+
+def _spec(name: str, delta: float, **extra: Any) -> dict[str, Any]:
+    return {"short_name": name, "e2e_delta_pct": delta, **extra}
 
 
 # --------------------------------------------------------------------------
@@ -171,8 +176,41 @@ def test_collapse_keeps_two_real_kernels_that_share_a_gain() -> None:
     assert sorted(r["name"] for r in out) == ["kernel_a", "kernel_b"]
 
 
+def test_specs_keeps_two_distinct_kernels_that_share_op_kind_and_gain() -> None:
+    result = {
+        "accepted_kernels": [
+            _spec("kernel_a", 12.31, op_kind="prefill_attn"),
+            _spec("kernel_b", 12.31, op_kind="prefill_attn"),
+        ]
+    }
+    assert [geak_spec_name(s) for s in _geak_accepted_kernel_specs(result)] == [
+        "kernel_a",
+        "kernel_b",
+    ]
+
+
+def test_collapse_skips_unrelated_measured_unmeasured_pair_at_same_gain() -> None:
+    rows = [
+        {
+            "kernel_id": "kernel_a",
+            "name": "kernel_a",
+            "gpu_pct": 10.0,
+            "e2e_gain_pct": 5.0,
+            "op_kind": "prefill_attn",
+        },
+        {
+            "kernel_id": "kernel_b",
+            "name": "kernel_b",
+            "gpu_pct": None,
+            "e2e_gain_pct": 5.0,
+            "op_kind": "prefill_attn",
+        },
+    ]
+    out = _collapse_journey_aliases(rows)
+    assert sorted(r["name"] for r in out) == ["kernel_a", "kernel_b"]
+
+
 def test_collapse_keeps_two_unmeasured_rows_that_share_a_gain() -> None:
-    # The mirror case: all-unmeasured is not a twin group either.
     rows = [
         {"kernel_id": "kernel_a", "name": "kernel_a", "gpu_pct": None, "e2e_gain_pct": 2.0},
         {"kernel_id": "kernel_b", "name": "kernel_b", "gpu_pct": None, "e2e_gain_pct": 2.0},

--- a/src/hyperloom/inference_optimizer/tests/test_geak_adoption_ledger.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_adoption_ledger.py
@@ -260,6 +260,24 @@ def test_historical_keep_survives_a_later_unproven_rebench() -> None:
     assert adopted[0]["validated"] is False
 
 
+def test_reverted_forge_kernel_with_prior_keep_is_not_adopted() -> None:
+    state = {
+        "kernel_integrate_attempts": {
+            "my_kernel": {
+                "kernel_id": "my_kernel",
+                "attempts": [
+                    {"decision": "KEEP", "gain_pct": 8.0},
+                    {"decision": "REVERT", "gain_pct": -2.0},
+                ],
+                "last_decision": "REVERT",
+                "best_gain_pct": 8.0,
+                "validated": True,
+            }
+        }
+    }
+    assert _collect_adopted_kernels(state) == []
+
+
 def test_two_kernels_on_one_rebench_share_no_invented_split() -> None:
     phase = _phase()
     result = {

--- a/src/hyperloom/inference_optimizer/tests/test_geak_adoption_ledger.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_adoption_ledger.py
@@ -22,6 +22,9 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+from hyperloom.inference_optimizer.breakdown.collectors.kernels import (
+    _collect_adopted_kernels,
+)
 from hyperloom.orchestrator.loop.coordinator_helpers import (
     _geak_accepted_kernel_specs,
     _geak_overlay_digest,
@@ -213,7 +216,23 @@ def test_an_unproven_overlay_records_the_row_without_a_gain() -> None:
     assert entry["validated"] is False
     assert entry["best_gain_pct"] is None
     assert entry["overlay_loaded"] is False
+    assert entry["last_decision"] == "UNATTRIBUTED"
+    assert entry["last_status"] == "unvalidated"
     assert entry["attempts"][0]["gain_pct"] is None
+    assert entry["attempts"][0]["decision"] == "UNATTRIBUTED"
+
+
+def test_unvalidated_geak_ledger_row_is_not_adopted() -> None:
+    phase = _phase()
+    _record(
+        phase,
+        {"accepted_kernels": [_spec("k", 5.0)]},
+        overlay_loaded=False,
+    )
+    adopted = _collect_adopted_kernels(
+        {"kernel_integrate_attempts": phase.shared_state.kernel_integrate_attempts}
+    )
+    assert adopted == []
 
 
 def test_two_kernels_on_one_rebench_share_no_invented_split() -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_geak_adoption_ledger.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_adoption_ledger.py
@@ -222,7 +222,7 @@ def test_an_unproven_overlay_records_the_row_without_a_gain() -> None:
     assert entry["attempts"][0]["decision"] == "UNATTRIBUTED"
 
 
-def test_unvalidated_geak_ledger_row_is_not_adopted() -> None:
+def test_unproven_overlay_geak_row_is_not_adopted() -> None:
     phase = _phase()
     _record(
         phase,
@@ -233,6 +233,31 @@ def test_unvalidated_geak_ledger_row_is_not_adopted() -> None:
         {"kernel_integrate_attempts": phase.shared_state.kernel_integrate_attempts}
     )
     assert adopted == []
+
+
+def test_joint_rebench_with_proven_overlay_is_still_adopted() -> None:
+    phase = _phase()
+    result = {"accepted_kernels": [_spec("k_one", 5.0), _spec("k_two", 7.0)]}
+    _record(phase, result)
+    adopted = _collect_adopted_kernels(
+        {"kernel_integrate_attempts": phase.shared_state.kernel_integrate_attempts}
+    )
+    assert {r["kernel_id"] for r in adopted} == {"k_one", "k_two"}
+    assert all(r["validated"] is False for r in adopted)
+
+
+def test_historical_keep_survives_a_later_unproven_rebench() -> None:
+    phase = _phase()
+    result = {"accepted_kernels": [_spec("k", 5.0)]}
+    _record(phase, result, measured_tput=150.0)
+    _record(phase, result, measured_tput=150.0, overlay_loaded=False)
+    adopted = _collect_adopted_kernels(
+        {"kernel_integrate_attempts": phase.shared_state.kernel_integrate_attempts}
+    )
+    assert len(adopted) == 1
+    assert adopted[0]["kernel_id"] == "k"
+    assert adopted[0]["e2e_gain_pct"] == 50.0
+    assert adopted[0]["validated"] is False
 
 
 def test_two_kernels_on_one_rebench_share_no_invented_split() -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_geak_breakdown_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_breakdown_unit.py
@@ -273,6 +273,47 @@ def test_collect_geak_full_success_maps_fields(tmp_path: Path) -> None:
     assert out["eval_dir"] == "runs/geak/eval"
 
 
+def test_collect_geak_result_reads_accepted_heads_lane(tmp_path: Path) -> None:
+    state = {
+        "kernel_optimizer": "geak",
+        "geak_result": {
+            "status": "ok",
+            "accepted_kernels": [],
+            "accepted_heads": [
+                {
+                    "short_name": "dsa_sparse_attn_prefill_main_kernel",
+                    "kind": "authored",
+                    "e2e_delta_pct": 12.5,
+                }
+            ],
+        },
+    }
+    out = collect_geak(tmp_path, state, [])
+    assert out["kernels_optimized"] == 1
+    assert out["accepted_kernels_source"] == "result"
+    assert out["accepted_kernels"][0]["short_name"] == "dsa_sparse_attn_prefill_main_kernel"
+
+
+def test_collect_geak_result_excludes_env_kind(tmp_path: Path) -> None:
+    state = {
+        "kernel_optimizer": "geak",
+        "geak_result": {
+            "status": "ok",
+            "accepted_kernels": [
+                {
+                    "short_name": "ck_gemm_selection",
+                    "kind": "env",
+                    "e2e_delta_pct": 8.0,
+                }
+            ],
+            "accepted_heads": [],
+        },
+    }
+    out = collect_geak(tmp_path, state, [])
+    assert out["kernels_optimized"] == 0
+    assert out["accepted_kernels"] == []
+
+
 def _write_kernel_journey(eval_dir: Path) -> Path:
     """Write a minimal kernel_journey.json with one integrated KEEP kernel."""
     eval_dir.mkdir(parents=True, exist_ok=True)

--- a/src/hyperloom/inference_optimizer/tests/test_geak_breakdown_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_breakdown_unit.py
@@ -22,7 +22,10 @@ import pytest
 
 from hyperloom.inference_optimizer.breakdown import collectors
 from hyperloom.inference_optimizer.breakdown.collectors import collect_geak
-from hyperloom.inference_optimizer.breakdown.collectors.geak import _geak_kind_index
+from hyperloom.inference_optimizer.breakdown.collectors.geak import (
+    _geak_accepted_kernels_from_journey,
+    _geak_kind_index,
+)
 from hyperloom.orchestrator.actions.executors._geak_sweep import (
     _parse_isl_osl,
     _serving_gpus,
@@ -772,7 +775,13 @@ def test_collect_geak_backfill_dedupes_repeated_kernel_across_cycles(tmp_path: P
     assert out["kernels_optimized"] == 1
 
 
-def _alias_journey(eval_dir: Path, *, primary_gain: float, twin_gain: float) -> None:
+def _alias_journey(
+    eval_dir: Path,
+    *,
+    primary_gain: float,
+    twin_gain: float,
+    op_kind: str = "sparse_attn",
+) -> None:
     """Journey holding one accepted kernel written twice (candidate + symbol)."""
     eval_dir.mkdir(parents=True, exist_ok=True)
     (eval_dir / "kernel_journey.json").write_text(
@@ -783,6 +792,7 @@ def _alias_journey(eval_dir: Path, *, primary_gain: float, twin_gain: float) -> 
                     {
                         "kernel_id": "c0_triton",
                         "name": "c0_triton",
+                        "op_kind": op_kind,
                         "gpu_pct": 20.2,
                         "micro_speedup": 2.2024,
                         "e2e": {"decision": "KEEP", "integrated": True, "e2e_gain_pct": primary_gain},
@@ -790,6 +800,7 @@ def _alias_journey(eval_dir: Path, *, primary_gain: float, twin_gain: float) -> 
                     {
                         "kernel_id": "dsa_sparse_attn_prefill_main_kernel",
                         "name": "dsa_sparse_attn_prefill_main_kernel",
+                        "op_kind": op_kind,
                         "gpu_pct": None,
                         "micro_speedup": 1.13,
                         "e2e": {"decision": "KEEP", "integrated": True, "e2e_gain_pct": twin_gain},
@@ -799,6 +810,66 @@ def _alias_journey(eval_dir: Path, *, primary_gain: float, twin_gain: float) -> 
         ),
         encoding="utf-8",
     )
+
+
+def test_journey_backfill_projects_op_kind(tmp_path: Path) -> None:
+    eval_dir = tmp_path / "geak" / "e2e_cycle0"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    (eval_dir / "kernel_journey.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kernels": [
+                    {
+                        "kernel_id": "k1",
+                        "name": "k1",
+                        "op_kind": "sparse_attn",
+                        "gpu_pct": 10.0,
+                        "e2e": {"decision": "KEEP", "integrated": True, "e2e_gain_pct": 12.0},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    rows = _geak_accepted_kernels_from_journey({"eval_dir": str(eval_dir)}, [])
+    assert rows[0]["op_kind"] == "sparse_attn"
+
+
+def test_journey_backfill_keeps_distinct_op_kinds_at_same_gain(tmp_path: Path) -> None:
+    eval_dir = tmp_path / "geak" / "e2e_cycle0"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    (eval_dir / "kernel_journey.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kernels": [
+                    {
+                        "kernel_id": "kernel_a",
+                        "name": "kernel_a",
+                        "op_kind": "prefill_attn",
+                        "gpu_pct": 10.0,
+                        "e2e": {"decision": "KEEP", "integrated": True, "e2e_gain_pct": 5.0},
+                    },
+                    {
+                        "kernel_id": "kernel_b",
+                        "name": "kernel_b",
+                        "op_kind": "decode_attn",
+                        "gpu_pct": 12.0,
+                        "e2e": {"decision": "KEEP", "integrated": True, "e2e_gain_pct": 5.0},
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    state = {
+        "kernel_optimizer": "geak",
+        "geak_result": {"status": "ok", "accepted_kernels": [], "eval_dir": str(eval_dir)},
+    }
+    out = collect_geak(tmp_path, state, [])
+    assert out["kernels_optimized"] == 2
+    assert {k["kernel_id"] for k in out["accepted_kernels"]} == {"kernel_a", "kernel_b"}
 
 
 def test_collect_geak_backfill_collapses_alias_twin(tmp_path: Path) -> None:

--- a/src/hyperloom/orchestrator/loop/coordinator_helpers.py
+++ b/src/hyperloom/orchestrator/loop/coordinator_helpers.py
@@ -1388,8 +1388,15 @@ def _geak_accepted_kernel_specs(result: Any) -> list[dict[str, Any]]:
             index[twin] = len(out)
             out.append(k)
             continue
-        if _GEAK_CAND_TAG_RE.match(_geak_spec_name(out[pos])) and not _GEAK_CAND_TAG_RE.match(name):
+        existing_name = _geak_spec_name(out[pos])
+        if _GEAK_CAND_TAG_RE.match(existing_name) and not _GEAK_CAND_TAG_RE.match(name):
             out[pos] = k
+            continue
+        if _GEAK_CAND_TAG_RE.match(name) and not _GEAK_CAND_TAG_RE.match(existing_name):
+            continue
+        if name == existing_name:
+            continue
+        out.append(k)
     return out
 
 

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -1559,10 +1559,12 @@ class KernelPhase(PhaseHandler):
             spec = row["spec"]
             entry = dict(ledger.get(kid) or {})
             attempts = list(entry.get("attempts") or [])
+            attempt_decision = "KEEP" if attributable else "UNATTRIBUTED"
+            attempt_status = "ok" if attributable else "unvalidated"
             attempts.append(
                 {
-                    "decision": "KEEP",
-                    "status": "ok",
+                    "decision": attempt_decision,
+                    "status": attempt_status,
                     "new_tput": measured_tput,
                     "gain_pct": rebench_gain if attributable else None,
                     "decision_reason": provenance,
@@ -1590,8 +1592,8 @@ class KernelPhase(PhaseHandler):
                     "attempts": attempts,
                     "attempt_count": len(attempts),
                     "best_gain_pct": max(gains) if gains else None,
-                    "last_decision": "KEEP",
-                    "last_status": "ok",
+                    "last_decision": attempt_decision,
+                    "last_status": attempt_status,
                     "validated": attributable,
                     "overlay_loaded": bool(overlay_loaded),
                     "basis": basis,


### PR DESCRIPTION
Only count overlay-proven kernels as adopted, route collect_geak through unified acceptance rules, and tighten alias dedup so unrelated kernels are not collapsed. Align GitHub Pages docs build with the RTD lockfile.