### PR TITLE
Fix fusion smoke handoff and timeout salvage

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_forge_fusion.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_fusion.py
@@ -84,6 +84,17 @@ def test_build_cmd_maps_core_options(tmp_path):
     assert cmd[cmd.index("--agent-sandbox-mode") + 1] == "workspace-write"
     assert cmd[cmd.index("--max-turns") + 1] == "7"
     assert "--fuse-all-confirmed" in cmd
+    assert "--tp" not in cmd
+    assert "--block-size" not in cmd
+
+
+def test_build_cmd_forwards_session_serve_args(tmp_path):
+    payload = _payload(tmp_path)
+    payload.update({"tp": 8, "block_size": 128, "max_model_len": 13312})
+    cmd = forge_fusion._build_cmd(payload)
+    assert cmd[cmd.index("--tp") + 1] == "8"
+    assert cmd[cmd.index("--block-size") + 1] == "128"
+    assert cmd[cmd.index("--max-model-len") + 1] == "13312"
 
 
 def test_inject_author_gateway_env_adds_stability_defaults(monkeypatch):
@@ -274,6 +285,79 @@ def test_main_timeout_emits_revert_result(tmp_path, monkeypatch, capsys):
     assert result["kept"] is False
     assert result["requires_e2e_validation"] is False
     assert json.loads((output_dir / "result.json").read_text(encoding="utf-8")) == result
+
+
+def test_main_timeout_salvages_micro_keep_and_patch(tmp_path, monkeypatch, capsys):
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    patch = output_dir / "fusion.patch"
+    input_json = tmp_path / "input.json"
+    payload = _payload(output_dir)
+    input_json.write_text(json.dumps(payload), encoding="utf-8")
+
+    def fake_run(cmd, timeout):
+        (output_dir / "kernel_keep_checkpoint.json").write_text(
+            json.dumps(
+                {
+                    "kept": True,
+                    "kernel_speedup": 2.69,
+                    "env_flag": "QWEN_FUSED",
+                    "source_file": "/fw/model.py",
+                    "repo_root": "/fw",
+                }
+            ),
+            encoding="utf-8",
+        )
+        patch.write_text("diff --git a/model.py b/model.py\n", encoding="utf-8")
+        raise subprocess.TimeoutExpired(cmd, timeout, output="", stderr="")
+
+    monkeypatch.setattr(forge_fusion, "_run_with_tree_timeout", fake_run)
+
+    rc = forge_fusion.main(["--input-json", str(input_json)])
+
+    out = capsys.readouterr()
+    assert rc == 124
+    result = _sentinel_payload(out.out)
+    assert result["kept"] is True
+    assert result["decision"] == "KEEP"
+    assert result["requires_e2e_validation"] is True
+    assert result["salvaged"] is True
+    assert result["patch"] == str(patch)
+    assert result["kernel_speedup"] == 2.69
+
+
+def test_main_timeout_does_not_salvage_stale_previous_run(tmp_path, monkeypatch, capsys):
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    (output_dir / "kernel_keep_checkpoint.json").write_text(
+        json.dumps(
+            {
+                "kept": True,
+                "kernel_speedup": 9.99,
+                "env_flag": "STALE_FUSED",
+                "source_file": "/fw/stale.py",
+                "repo_root": "/fw",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (output_dir / "fusion.patch").write_text(
+        "diff --git a/stale.py b/stale.py\n", encoding="utf-8"
+    )
+    input_json = tmp_path / "input.json"
+    input_json.write_text(json.dumps(_payload(output_dir)), encoding="utf-8")
+
+    def fake_run(cmd, timeout):
+        raise subprocess.TimeoutExpired(cmd, timeout, output="", stderr="")
+
+    monkeypatch.setattr(forge_fusion, "_run_with_tree_timeout", fake_run)
+
+    rc = forge_fusion.main(["--input-json", str(input_json)])
+
+    result = _sentinel_payload(capsys.readouterr().out)
+    assert rc == 124
+    assert result["kept"] is False
+    assert result["decision"] == "REVERT"
 
 
 def test_run_with_tree_timeout_captures_output():
@@ -721,6 +805,7 @@ def test_main_kept_manifest_emits_keep_result(tmp_path, monkeypatch, capsys):
 
     def fake_run(_cmd, _timeout):
         # The run writes its own manifest; main() clears any stale one first.
+        _patch_file(output_dir)
         (output_dir / "fusion_manifest.json").write_text(
             json.dumps(manifest), encoding="utf-8"
         )

--- a/src/hyperloom/agents/kernel/tools/forge_fusion.py
+++ b/src/hyperloom/agents/kernel/tools/forge_fusion.py
@@ -141,6 +141,9 @@ def _build_cmd(args: dict[str, Any]) -> list[str]:
     _add_opt(cmd, args, "ab_isl", "--ab-isl")
     _add_opt(cmd, args, "ab_osl", "--ab-osl")
     _add_opt(cmd, args, "framework_root", "--framework-root")
+    _add_opt(cmd, args, "tp", "--tp")
+    _add_opt(cmd, args, "block_size", "--block-size")
+    _add_opt(cmd, args, "max_model_len", "--max-model-len")
     # Author all source-confirmed patterns together by default; set
     # fuse_all_confirmed=false to author only the top recipe.
     if bool(args.get("fuse_all_confirmed", True)):
@@ -357,9 +360,86 @@ def _normalize_manifest(output_dir: str, rc: int) -> dict[str, Any]:
     return result
 
 
+def salvage_forge_fusion_from_workspace(output_dir: str) -> dict[str, Any] | None:
+    """Rebuild a KEEP result from pre-smoke checkpoint + patch after a kill.
+
+    ``forge-fuse`` is often SIGKILLed during serving smoke (default 7200s). The
+    micro KEEP and ``fusion.patch`` are written before smoke so Hyperloom can
+    still hand them to formal e2e integrate.
+    """
+    root = Path(output_dir or "")
+    if not root.is_dir():
+        return None
+    ckpt_path = root / "kernel_keep_checkpoint.json"
+    patch_path = root / "fusion.patch"
+    manifest_path = root / "fusion_manifest.json"
+    kept = False
+    speedup = None
+    env_flag = ""
+    source_file = ""
+    repo_root = ""
+    patch = None
+    if ckpt_path.is_file():
+        try:
+            ckpt = json.loads(ckpt_path.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, json.JSONDecodeError):
+            ckpt = {}
+        if isinstance(ckpt, dict) and ckpt.get("kept"):
+            kept = True
+            speedup = ckpt.get("kernel_speedup")
+            env_flag = str(ckpt.get("env_flag") or "")
+            source_file = str(ckpt.get("source_file") or "")
+            repo_root = str(ckpt.get("repo_root") or "")
+    if manifest_path.is_file():
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, json.JSONDecodeError):
+            manifest = {}
+        if isinstance(manifest, dict):
+            loop = manifest.get("fusion_loop") or {}
+            compile_pass = manifest.get("compile_pass") or {}
+            if loop.get("kept") or compile_pass.get("kept"):
+                kept = True
+            speedup = speedup or (loop.get("best") or {}).get("kernel_speedup") or compile_pass.get("speedup")
+            env_flag = env_flag or str(loop.get("best_env_flag") or "")
+            source_file = source_file or str((manifest.get("fusion") or {}).get("source_file") or "")
+            artifacts = manifest.get("artifacts") or {}
+            if artifacts.get("patch"):
+                patch = artifacts.get("patch")
+            repo_root = repo_root or str(artifacts.get("repo_root") or "")
+    if patch_path.is_file():
+        patch = str(patch_path)
+    if not kept or not patch or not Path(str(patch)).is_file():
+        return None
+    flags = [f for f in env_flag.split() if f]
+    return {
+        "status": "ok",
+        "engine": "forge_fusion",
+        "micro_decision": "candidate",
+        "decision": "KEEP",
+        "kept": True,
+        "kernel_speedup": speedup,
+        "env_flags": {f: "1" for f in flags},
+        "baseline_env_flags": {f: "0" for f in flags},
+        "artifact_files": [],
+        "patch": str(patch),
+        "source_file": source_file,
+        "kernel_repo": repo_root,
+        "requires_e2e_validation": True,
+        "salvaged": True,
+        "workspace": str(root),
+    }
+
+
 def _timeout_result(output_dir: str, timeout_sec: int, exc: subprocess.TimeoutExpired) -> dict[str, Any]:
-    """Shape a timed-out forge-fusion run as a normal REVERT result."""
+    """Shape a timed-out forge-fusion run; salvage a micro KEEP when present."""
+    salvaged = salvage_forge_fusion_from_workspace(output_dir)
     cmd_repr = " ".join(str(c) for c in (getattr(exc, "cmd", None) or []))
+    timeout_error = f"TimeoutExpired after {timeout_sec}s: {cmd_repr[:1500]}"
+    if salvaged:
+        salvaged["error_class"] = "subprocess_timeout"
+        salvaged["error"] = timeout_error
+        return salvaged
     return {
         "status": "failed",
         "engine": "forge_fusion",
@@ -374,7 +454,7 @@ def _timeout_result(output_dir: str, timeout_sec: int, exc: subprocess.TimeoutEx
         "requires_e2e_validation": False,
         "workspace": str(output_dir or ""),
         "error_class": "subprocess_timeout",
-        "error": f"TimeoutExpired after {timeout_sec}s: {cmd_repr[:1500]}",
+        "error": timeout_error,
     }
 
 
@@ -436,9 +516,15 @@ def main(argv: list[str] | None = None) -> int:
 
     _inject_author_gateway_env(str(payload.get("agent_backend") or ""))
     output_dir = str(payload.get("output_dir") or "")
-    # The output dir is keyed on the task, so a run that dies before writing a
-    # manifest would otherwise have the previous run's KEEP read back as its own.
-    (Path(output_dir or ".") / "fusion_manifest.json").unlink(missing_ok=True)
+    # The output dir is keyed on the task, so a run that dies before writing new
+    # artifacts must not salvage the previous run's KEEP as its own.
+    output_root = Path(output_dir or ".")
+    for stale_name in (
+        "fusion_manifest.json",
+        "kernel_keep_checkpoint.json",
+        "fusion.patch",
+    ):
+        (output_root / stale_name).unlink(missing_ok=True)
     timeout_sec = _timeout_sec(payload)
     try:
         proc = _run_with_tree_timeout(cmd, timeout_sec)

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -1201,7 +1201,7 @@ class TestForgeGemmHelperCoverage:
         ).save(tmp_path)
         _pin_fusion_provider_env(monkeypatch, _ANTHROPIC_ONLY_ENV)
         monkeypatch.setattr(krh, "_forge_fusion_available", lambda: True)
-        monkeypatch.setattr(krh, "_kernel_agent_tool_path", lambda name: Path(name))
+        monkeypatch.setattr(krh, "_kernel_agent_tool_path", Path)
 
         async def _fake_subprocess(cmd, *, timeout_sec):
             result = {"status": "complete", "decision": "REVERT", "kept": False}
@@ -1234,7 +1234,7 @@ class TestForgeGemmHelperCoverage:
         ).save(tmp_path)
         _pin_fusion_provider_env(monkeypatch, _ANTHROPIC_ONLY_ENV)
         monkeypatch.setattr(krh, "_forge_fusion_available", lambda: True)
-        monkeypatch.setattr(krh, "_kernel_agent_tool_path", lambda name: Path(name))
+        monkeypatch.setattr(krh, "_kernel_agent_tool_path", Path)
 
         async def _timeout(cmd, *, timeout_sec):
             workspace = tmp_path / "runs" / "fusion" / "kernel_entry_fusion"

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -1180,6 +1180,92 @@ class TestForgeGemmHelperCoverage:
         assert result["status"] == "failed"
         assert result["error_class"] == "subprocess_timeout"
         assert result["backend"] == "forge"
+        assert result["kept"] is False
+
+    @pytest.mark.asyncio
+    async def test_run_forge_fusion_passes_session_serve_args(self, tmp_path, monkeypatch):
+        model = tmp_path / "MiniMax-M3-MXFP4"
+        model.mkdir()
+        (model / "config.json").write_text(
+            json.dumps({"sparse_attention_config": {"sparse_block_size": 128}}),
+            encoding="utf-8",
+        )
+        trace = tmp_path / "trace.json.gz"
+        trace.write_text("{}", encoding="utf-8")
+        SharedState(
+            framework="vllm",
+            model_path=str(model),
+            last_profile_trace=str(trace),
+            tp=8,
+            max_model_len=13312,
+        ).save(tmp_path)
+        _pin_fusion_provider_env(monkeypatch, _ANTHROPIC_ONLY_ENV)
+        monkeypatch.setattr(krh, "_forge_fusion_available", lambda: True)
+        monkeypatch.setattr(krh, "_kernel_agent_tool_path", lambda name: Path(name))
+
+        async def _fake_subprocess(cmd, *, timeout_sec):
+            result = {"status": "complete", "decision": "REVERT", "kept": False}
+            return (
+                0,
+                "FORGE_FUSION_RESULT_BEGIN\n" + json.dumps(result) + "\nFORGE_FUSION_RESULT_END\n",
+                "",
+            )
+
+        monkeypatch.setattr(krh, "_run_subprocess", _fake_subprocess)
+
+        await krh._run_forge_fusion({"task_id": "fusion_task"}, session_dir=tmp_path)
+        input_payload = json.loads(
+            (tmp_path / "runs" / "fusion" / "fusion_task" / "forge_fusion_input.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert input_payload["tp"] == 8
+        assert input_payload["block_size"] == 128
+        assert input_payload["max_model_len"] == 13312
+
+    @pytest.mark.asyncio
+    async def test_run_forge_fusion_timeout_salvages_keep(self, tmp_path, monkeypatch):
+        trace = tmp_path / "trace.json.gz"
+        trace.write_text("{}", encoding="utf-8")
+        SharedState(
+            framework="sglang",
+            model_path="/models/zaya",
+            last_profile_trace=str(trace),
+        ).save(tmp_path)
+        _pin_fusion_provider_env(monkeypatch, _ANTHROPIC_ONLY_ENV)
+        monkeypatch.setattr(krh, "_forge_fusion_available", lambda: True)
+        monkeypatch.setattr(krh, "_kernel_agent_tool_path", lambda name: Path(name))
+
+        async def _timeout(cmd, *, timeout_sec):
+            workspace = tmp_path / "runs" / "fusion" / "kernel_entry_fusion"
+            (workspace / "kernel_keep_checkpoint.json").write_text(
+                json.dumps(
+                    {
+                        "kept": True,
+                        "kernel_speedup": 2.69,
+                        "env_flag": "QWEN_FUSED",
+                        "source_file": "/fw/model.py",
+                        "repo_root": "/fw",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (workspace / "fusion.patch").write_text(
+                "diff --git a/model.py b/model.py\n",
+                encoding="utf-8",
+            )
+            raise subprocess.TimeoutExpired(cmd, timeout_sec)
+
+        monkeypatch.setattr(krh, "_run_subprocess", _timeout)
+
+        result = await krh._run_forge_fusion({"timeout": 60}, session_dir=tmp_path)
+
+        assert result["kept"] is True
+        assert result["decision"] == "KEEP"
+        assert result["requires_e2e_validation"] is True
+        assert result["salvaged"] is True
+        assert result["error_class"] == "subprocess_timeout"
+        assert result["kernel_speedup"] == 2.69
 
     @pytest.mark.asyncio
     async def test_run_forge_gemm_tuning_requires_model_path(self, tmp_path, monkeypatch):

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -1753,6 +1753,43 @@ def _forge_fusion_wrapper_timeout_sec(timeout_sec: int) -> int:
     return max(1, int(timeout_sec)) + _FORGE_FUSION_WRAPPER_TIMEOUT_GRACE_SEC
 
 
+def _positive_int(value: object) -> int:
+    try:
+        parsed = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+    return parsed if parsed > 0 else 0
+
+
+def _fusion_session_serve_args(
+    state: object,
+    payload: dict,
+    *,
+    framework: str,
+    model_path: str,
+) -> dict[str, int]:
+    """TP / KV block size / max-model-len the serving smoke must match."""
+    tp = _positive_int(payload.get("tp") or getattr(state, "tp", 0))
+    max_model_len = _positive_int(
+        payload.get("max_model_len") or getattr(state, "max_model_len", 0)
+    )
+    block_size = _positive_int(payload.get("block_size"))
+    if block_size <= 0 and "vllm" in (framework or "").strip().lower():
+        from hyperloom.inference_optimizer.model_config_utils import (  # noqa: PLC0415
+            _sparse_kv_block_size,
+        )
+
+        block_size = _positive_int(_sparse_kv_block_size(model_path))
+    args: dict[str, int] = {}
+    if tp:
+        args["tp"] = tp
+    if block_size:
+        args["block_size"] = block_size
+    if max_model_len:
+        args["max_model_len"] = max_model_len
+    return args
+
+
 def _gemm_tuning_workspace(payload: dict, *, session_dir: Path) -> Path:
     """Resolve the workspace directory for a GEMM-tuning run.
 
@@ -4357,6 +4394,9 @@ async def _run_forge_fusion(payload: dict, *, session_dir: Path) -> HandlerResul
         "timeout": timeout,
         "fuse_all_confirmed": bool(payload.get("fuse_all_confirmed", True)),
         "verbose": bool(payload.get("verbose", False)),
+        **_fusion_session_serve_args(
+            state, payload, framework=framework, model_path=model_path
+        ),
     }
     input_json = workspace / "forge_fusion_input.json"
     input_json.write_text(json.dumps(input_payload, indent=2, sort_keys=True), encoding="utf-8")
@@ -4370,16 +4410,29 @@ async def _run_forge_fusion(payload: dict, *, session_dir: Path) -> HandlerResul
         if result is None:
             result = _shape_tool_result(rc, stdout, stderr)
     except subprocess.TimeoutExpired as exc:
+        from hyperloom.agents.kernel.tools.forge_fusion import (  # noqa: PLC0415
+            salvage_forge_fusion_from_workspace,
+        )
+
         cmd_repr = " ".join(str(c) for c in (getattr(exc, "cmd", None) or cmd))
-        result = {
-            "status": "failed",
-            "backend": "forge",
-            "engine": "forge_fusion",
-            "error_class": "subprocess_timeout",
-            "error": f"TimeoutExpired after {wrapper_timeout}s: {cmd_repr[:1500]}",
-            "decision": "REVERT",
-            "kept": False,
-        }
+        timeout_error = f"TimeoutExpired after {wrapper_timeout}s: {cmd_repr[:1500]}"
+        salvaged = salvage_forge_fusion_from_workspace(str(workspace))
+        if salvaged:
+            result = {
+                **salvaged,
+                "error_class": "subprocess_timeout",
+                "error": timeout_error,
+            }
+        else:
+            result = {
+                "status": "failed",
+                "backend": "forge",
+                "engine": "forge_fusion",
+                "error_class": "subprocess_timeout",
+                "error": timeout_error,
+                "decision": "REVERT",
+                "kept": False,
+            }
 
     result.setdefault("backend", "forge")
     result.setdefault("engine", "forge_fusion")


### PR DESCRIPTION
## Problem
- Fusion smoke launches without the session TP, sparse KV block size, or max model length, so valid kernels can be rejected by an incompatible server boot.
- A forge-fusion timeout discards a checkpointed microbenchmark KEEP, and stale workspace artifacts can be mistaken for the current run.

## Fix
- Forward the session serving arguments into KernelForge, deriving the required sparse vLLM block size from model config.
- Salvage only fresh checkpoint-plus-patch artifacts after timeout and hand them to formal e2e validation.