### PR TITLE
fix(explore): stop recommending `--no-enable-prefix-caching` as a serving config

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner_helpers_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner_helpers_coverage_unit.py
@@ -405,6 +405,27 @@ def test_compose_server_args_replace_still_applies_remove_args() -> None:
     assert out == "--also-bad 2 --keep 4"
 
 
+def test_compose_server_args_strips_denylisted_harness_flag_from_every_layer() -> None:
+    out = gr.compose_server_args(
+        inherited_args="--no-enable-prefix-caching --block-size 128",
+        base_extra_args="--no-enable-prefix-caching",
+        variant_extra_args="--kv-cache-dtype fp8 --no-enable-prefix-caching",
+    )
+    assert "--no-enable-prefix-caching" not in out
+    assert "--block-size 128" in out
+    assert "--kv-cache-dtype fp8" in out
+
+
+def test_compose_server_args_strips_denylisted_flag_in_replace_mode() -> None:
+    out = gr.compose_server_args(
+        inherited_args="--ignored",
+        base_extra_args="--no-enable-prefix-caching --max-num-seqs 256",
+        variant_extra_args="--kv-cache-dtype fp8",
+        args_mode="replace",
+    )
+    assert out == "--max-num-seqs 256 --kv-cache-dtype fp8"
+
+
 def test_remove_server_args_accepts_multi_flag_string() -> None:
     out = gr.remove_server_args(
         "--flag-a --flag-b --flag-c 3 --keep 4",

--- a/src/hyperloom/inference_optimizer/tests/test_promote_shared_state_lock.py
+++ b/src/hyperloom/inference_optimizer/tests/test_promote_shared_state_lock.py
@@ -1257,14 +1257,7 @@ def test_lift_is_the_only_writer_so_an_ablated_env_stays_gone(session_dir):
 
 
 def test_lift_strips_a_harness_flag_inherited_from_the_previous_current_best(session_dir):
-    """Issue #1192: the previous current_best is re-merged onto the winner.
-
-    ``compose_server_args`` already keeps the flag out of what explore launches
-    and publishes, but the composed stack collapses to exactly the candidate
-    delta when the only inherited flag is the denylisted one. That sends
-    ``_merge_cumulative_extra_server_args`` down its ``base + candidate`` branch
-    and the flag reappears from a base that never composed (here: warm replay).
-    """
+    """Issue #1192: the flag came back through the previous current_best re-merge."""
     coord = _coord(session_dir)
     s = coord.shared_state
     s.baseline_tput = 6137.0

--- a/src/hyperloom/inference_optimizer/tests/test_promote_shared_state_lock.py
+++ b/src/hyperloom/inference_optimizer/tests/test_promote_shared_state_lock.py
@@ -1256,6 +1256,71 @@ def test_lift_is_the_only_writer_so_an_ablated_env_stays_gone(session_dir):
     assert [e["variant_name"] for e in s.optimization_stack] == ["adds-env", "drops-env"]
 
 
+def test_lift_strips_a_harness_flag_inherited_from_the_previous_current_best(session_dir):
+    """Issue #1192: the previous current_best is re-merged onto the winner.
+
+    ``compose_server_args`` already keeps the flag out of what explore launches
+    and publishes, but the composed stack collapses to exactly the candidate
+    delta when the only inherited flag is the denylisted one. That sends
+    ``_merge_cumulative_extra_server_args`` down its ``base + candidate`` branch
+    and the flag reappears from a base that never composed (here: warm replay).
+    """
+    coord = _coord(session_dir)
+    s = coord.shared_state
+    s.baseline_tput = 6137.0
+    s.current_best = {
+        "action": "replay_warm_recipe",
+        "tput": 6165.0,
+        "extra_server_args": "--no-enable-prefix-caching",
+        "extra_envs": {},
+    }
+
+    coord._lift_to_current_best(
+        "explore",
+        8063.0,
+        {
+            "name": "aiter-fp8-kv-cache",
+            "candidate_extra_server_args": "--kv-cache-dtype fp8",
+            "extra_server_args": "--kv-cache-dtype fp8",
+            "effective_extra_server_args": "--no-enable-prefix-caching --kv-cache-dtype fp8",
+            "extra_envs": {"VLLM_ROCM_USE_AITER": "1"},
+        },
+    )
+
+    assert s.current_best["extra_server_args"] == "--kv-cache-dtype fp8"
+    assert s.current_best["effective_extra_server_args"] == "--kv-cache-dtype fp8"
+    top = s.optimization_stack[-1]
+    assert top["extra_server_args"] == "--kv-cache-dtype fp8"
+    assert top["candidate_extra_server_args"] == "--kv-cache-dtype fp8"
+
+
+def test_lift_strips_a_harness_flag_a_winner_proposed_directly(session_dir):
+    """A winner whose own delta is the harness flag publishes no serving change."""
+    coord = _coord(session_dir)
+    s = coord.shared_state
+    s.baseline_tput = 1000.0
+    s.current_best = {
+        "action": "explore",
+        "tput": 1100.0,
+        "extra_server_args": "--max-num-seqs 256",
+        "extra_envs": {},
+    }
+
+    coord._lift_to_current_best(
+        "explore",
+        1200.0,
+        {
+            "name": "no-prefix-cache",
+            "candidate_extra_server_args": "--no-enable-prefix-caching",
+            "extra_server_args": "--max-num-seqs 256 --no-enable-prefix-caching",
+            "extra_envs": {},
+        },
+    )
+
+    assert s.current_best["extra_server_args"] == "--max-num-seqs 256"
+    assert s.optimization_stack[-1]["candidate_extra_server_args"] == ""
+
+
 def test_lift_refuses_a_winner_that_does_not_beat_the_anchor(session_dir):
     """A measurement below current_best must leave config and stack untouched."""
     coord = _coord(session_dir)

--- a/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
@@ -168,11 +168,15 @@ def remove_server_args(server_args: str | None, remove_args: Any) -> str:
     return _reserialize_json_blobs(" ".join(out))
 
 
-# Serving-ineligible harness flags. Enroll here; compose_server_args strips
-# them after merge so they cannot KEEP into EXTRA_*_ARGS / current_best.
-_BENCHMARK_HARNESS_FLAG_DENYLIST: tuple[str, ...] = (
-    "--no-enable-prefix-caching",
-)
+# Serving-ineligible harness flags. Enroll here; two sites strip the set —
+# compose_server_args (what a grid launches) and _lift_to_current_best (what a
+# KEEP persists) — so neither the benchmark nor the recommendation carries them.
+_BENCHMARK_HARNESS_FLAG_DENYLIST: tuple[str, ...] = ("--no-enable-prefix-caching",)
+
+
+def strip_benchmark_harness_flags(server_args: str | None) -> str:
+    """Drop every :data:`_BENCHMARK_HARNESS_FLAG_DENYLIST` entry from ``server_args``."""
+    return remove_server_args(server_args, _BENCHMARK_HARNESS_FLAG_DENYLIST)
 
 
 def compose_server_args(
@@ -185,7 +189,7 @@ def compose_server_args(
 ) -> str:
     """Compose inherited/base/variant args with optional remove/replace semantics.
 
-    Always strips :data:`_BENCHMARK_HARNESS_FLAG_DENYLIST` from the result.
+    Always applies :func:`strip_benchmark_harness_flags` to the result.
     """
     mode = str(args_mode or "append").strip().lower()
     if mode == "replace":
@@ -196,8 +200,7 @@ def compose_server_args(
         combined_base = merge_server_args(inherited_args, base_extra_args)
         pruned = remove_server_args(combined_base, remove_args)
         composed = merge_server_args(pruned, variant_extra_args)
-    return remove_server_args(composed, _BENCHMARK_HARNESS_FLAG_DENYLIST)
-
+    return strip_benchmark_harness_flags(composed)
 
 
 # A JSON "bareword": an identifier-like token that appears where a double-quoted

--- a/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
@@ -168,9 +168,8 @@ def remove_server_args(server_args: str | None, remove_args: Any) -> str:
     return _reserialize_json_blobs(" ".join(out))
 
 
-# Serving-ineligible harness flags. Enroll here; two sites strip the set —
-# compose_server_args (what a grid launches) and _lift_to_current_best (what a
-# KEEP persists) — so neither the benchmark nor the recommendation carries them.
+# Serving-ineligible harness flags. Enroll here; compose_server_args strips them
+# from what a grid launches and _lift_to_current_best from what a KEEP persists.
 _BENCHMARK_HARNESS_FLAG_DENYLIST: tuple[str, ...] = ("--no-enable-prefix-caching",)
 
 

--- a/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
@@ -168,6 +168,13 @@ def remove_server_args(server_args: str | None, remove_args: Any) -> str:
     return _reserialize_json_blobs(" ".join(out))
 
 
+# Serving-ineligible harness flags. Enroll here; compose_server_args strips
+# them after merge so they cannot KEEP into EXTRA_*_ARGS / current_best.
+_BENCHMARK_HARNESS_FLAG_DENYLIST: tuple[str, ...] = (
+    "--no-enable-prefix-caching",
+)
+
+
 def compose_server_args(
     *,
     inherited_args: str | None = "",
@@ -176,15 +183,20 @@ def compose_server_args(
     remove_args: Any = None,
     args_mode: str = "append",
 ) -> str:
-    """Compose inherited/base/variant args with optional remove/replace semantics."""
+    """Compose inherited/base/variant args with optional remove/replace semantics.
+
+    Always strips :data:`_BENCHMARK_HARNESS_FLAG_DENYLIST` from the result.
+    """
     mode = str(args_mode or "append").strip().lower()
     if mode == "replace":
         pruned_base = remove_server_args(base_extra_args, remove_args)
         pruned_variant = remove_server_args(variant_extra_args, remove_args)
-        return merge_server_args(pruned_base, pruned_variant)
-    combined_base = merge_server_args(inherited_args, base_extra_args)
-    pruned = remove_server_args(combined_base, remove_args)
-    return merge_server_args(pruned, variant_extra_args)
+        composed = merge_server_args(pruned_base, pruned_variant)
+    else:
+        combined_base = merge_server_args(inherited_args, base_extra_args)
+        pruned = remove_server_args(combined_base, remove_args)
+        composed = merge_server_args(pruned, variant_extra_args)
+    return remove_server_args(composed, _BENCHMARK_HARNESS_FLAG_DENYLIST)
 
 
 

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -27,6 +27,7 @@ from ..state.optimization_journal import (
     summarize_change,
 )
 from ..actions.executors._accuracy_gate import ENABLEMENT_REVALIDATION_REASON
+from ..actions.executors._grid_server_args import strip_benchmark_harness_flags
 from ..actions.stop_attribution import stopped_by_the_run_class
 from ..state.shared_state import SharedState, resolve_grading_anchor_tput
 from hyperloom.inference_optimizer.protocol.intent import Intent
@@ -2542,6 +2543,12 @@ class WritebackCollaborator:
         applied, keyed by ``(action, variant_name)`` or by ``fingerprint``, so a
         rerun of an already-stacked config cannot double-apply it.
 
+        Every args string read here passes through
+        :func:`strip_benchmark_harness_flags`, including the previous
+        ``current_best`` — it is re-merged onto the winner, so a harness flag
+        left there by a layer that never composed (baseline, warm replay) would
+        otherwise reappear in the published config.
+
         Args:
             task_kind: The action kind that produced the winner (stamped on the
                 stack entry / current_best).
@@ -2568,17 +2575,19 @@ class WritebackCollaborator:
         previous = self.shared_state.current_best or {}
         base_args = ""
         if isinstance(previous, dict):
-            base_args = str(previous.get("extra_server_args") or "").strip()
+            base_args = strip_benchmark_harness_flags(previous.get("extra_server_args"))
         # An authored-kernel overlay stays active until another KEEP replaces it.
         _overlay = str((bv.get("final_overlay") if isinstance(bv, dict) else "") or "").strip()
         if not _overlay and isinstance(previous, dict):
             _overlay = str(previous.get("final_overlay") or "").strip()
         candidate_args = ""
         if isinstance(bv, dict):
-            candidate_args = str(bv.get("candidate_extra_server_args") or bv.get("extra_server_args") or "").strip()
+            candidate_args = strip_benchmark_harness_flags(
+                bv.get("candidate_extra_server_args") or bv.get("extra_server_args")
+            )
         full_args = ""
         if isinstance(bv, dict):
-            full_args = str(bv.get("extra_server_args") or "").strip()
+            full_args = strip_benchmark_harness_flags(bv.get("extra_server_args"))
         controls_effective = bool(
             isinstance(bv, dict)
             and (
@@ -2673,7 +2682,7 @@ class WritebackCollaborator:
                         stack_entry["task_id"] = str(bv.get("task_id"))
                     if bv.get("effective_extra_server_args"):
                         stack_entry["effective_extra_server_args"] = _dedupe_extra_server_args(
-                            str(bv.get("effective_extra_server_args") or "")
+                            strip_benchmark_harness_flags(bv.get("effective_extra_server_args"))
                         )
                 # Stable filter label for "what kind of optimization" (backend /
                 # param / env), so the stack can be sliced like the timeline.
@@ -2756,7 +2765,7 @@ class WritebackCollaborator:
                     current_best[_ctrl_key] = bv.get(_ctrl_key)
             if bv.get("effective_extra_server_args"):
                 current_best["effective_extra_server_args"] = _dedupe_extra_server_args(
-                    str(bv.get("effective_extra_server_args") or "")
+                    strip_benchmark_harness_flags(bv.get("effective_extra_server_args"))
                 )
             if (bv.get("remove_args") or bv.get("unset_envs")) and not current_best.get("args_mode"):
                 current_best["args_mode"] = "replace"

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -2544,10 +2544,8 @@ class WritebackCollaborator:
         rerun of an already-stacked config cannot double-apply it.
 
         Every args string read here passes through
-        :func:`strip_benchmark_harness_flags`, including the previous
-        ``current_best`` — it is re-merged onto the winner, so a harness flag
-        left there by a layer that never composed (baseline, warm replay) would
-        otherwise reappear in the published config.
+        :func:`strip_benchmark_harness_flags`, the previous ``current_best``
+        included since it is re-merged onto the winner.
 
         Args:
             task_kind: The action kind that produced the winner (stamped on the


### PR DESCRIPTION


> Branch `fix/zgong/arg-remove` → `main` · 4 files · +111 / −11 · 3 commits
> merge-base `c92784cbf` · Closes #1192 

## Problem

`--no-enable-prefix-caching` exists to measure uncached TTFT. Nothing stopped it
from reaching `current_best`, so `final.json` handed operators a config that
disables a serving default — the artifact in #1192 recommends
`"--no-enable-prefix-caching --kv-cache-dtype fp8"` when the only thing EXPLORE
actually optimized was fp8 KV cache. The flag was inherited from a PRELUDE warm
replay and never dropped.

Two independent leaks, both needed:

1. **What a grid launches and publishes.** `compose_server_args` is the shared
   merge point for `_build_variant_yaml` (the `EXTRA_*_ARGS` a variant is
   benchmarked with) and for explore's KEEP payload. It merged inherited, base
   and variant layers verbatim.

2. **What a KEEP persists.** `_lift_to_current_best` re-merges the previous
   `current_best` onto the winner. When the composed stack collapses to exactly
   the candidate delta — which is what happens when the only inherited flag is
   the denylisted one — `_merge_cumulative_extra_server_args` takes its
   `base + candidate` branch and the flag returns from a layer that never
   composed. Fixing only (1) still reproduces #1192.

## Change

One enrollment point in `_grid_server_args.py`:

```python
_BENCHMARK_HARNESS_FLAG_DENYLIST: tuple[str, ...] = ("--no-enable-prefix-caching",)


def strip_benchmark_harness_flags(server_args: str | None) -> str: ...
```

Applied at the two sites above. `compose_server_args` strips after
merge/remove, on both the append and replace paths. `_lift_to_current_best`
strips every args string it reads — the previous `current_best`, the winner's
`extra_server_args` and `candidate_extra_server_args`, and
`effective_extra_server_args` on both the stack entry and `current_best` — so
the published config, the optimization stack, and the KB `best_config` (which
reads `candidate_extra_server_args`) are all clean.

No new module, no fallback path: the strip reuses the existing
`remove_server_args`, which already handles valueless flags and re-serializes
JSON-valued siblings.

| File | Change |
|---|---|
| `orchestrator/actions/executors/_grid_server_args.py` | denylist + `strip_benchmark_harness_flags`; `compose_server_args` applies it |
| `orchestrator/loop/writeback.py` | `_lift_to_current_best` strips all five args reads |
| `tests/test_grid_runner_helpers_coverage_unit.py` | 2 tests: every layer, and replace mode |
| `tests/test_promote_shared_state_lock.py` | 2 tests: the #1192 warm-replay inheritance, and a winner proposing the flag directly |

## Verification

- 4 new tests; the #1192 one is built from the issue's own `aiter-fp8-kv-cache`
  payload and asserts `current_best`, `effective_extra_server_args` and the
  stack entry are all clean.
- CI-filtered suite (`-m "not critic_agent_e2e and not robustness_agent_e2e and
  not targeted_build_e2e"`): **14297 passed**. 28 failures are pre-existing and
  environment-dependent (credentials / model probing / isolated venv) — the same
  28 fail identically on the merge-base.
- `ruff check` and `pylint --errors-only` clean on the changed modules.

## Deliberately out of scope

- **SGLang's equivalent is not enrolled.** #1192 notes SGLang has a similar
  flag, but `--disable-radix-cache` is a real serving trade-off there and
  `SKILL.md` currently lists it as a candidate family. Needs the reporter's
  call before it becomes a denylist entry.
- **Baseline still launches with the flag.** `_workload_envs` does not compose,
  so a reference script or warm replay carrying the flag benchmarks the baseline
  with prefix caching off while every candidate now runs with it on. This PR
  fixes what is published, not the measurement asymmetry — the first KEEP's gain
  still absorbs re-enabling prefix caching.
- **No pre-run variant filter.** Fingerprints are computed on the raw candidate
  delta, so a variant whose only delta is the flag still gets a full benchmark
  round against a config now byte-identical to its base. It can no longer
  pollute the published artifact, but it does waste GPU time.
