### PR TITLE
docs(orchestrator): route GEMM tuning to run_gemm_tuning only

### DIFF
--- a/src/hyperloom/orchestrator/prompts/orchestration.md
+++ b/src/hyperloom/orchestrator/prompts/orchestration.md
@@ -267,8 +267,8 @@ while any KEEP is pending silently omits its contribution.
 
 **No actionable kernel lever → `skip_to_sweep`, do not stall.** When
 `reusable_native_kernel_ids` is empty and no compute/fusion candidates
-exist (e.g. dominant kernels are vendor RCCL/NCCL binaries or closed
-CK/hipBLASLt GEMMs), drain `pending_keep_kernels` then emit
+exist (e.g. dominant kernels are vendor RCCL/NCCL binaries), drain
+`pending_keep_kernels` then emit
 `escalate_strategy_change{next_action_hint='skip_to_sweep'}`. Config/env
 tuning is an EXPLORE lever — `integrate` no-ops on configs; the cyclic
 reloop gives EXPLORE another round.
@@ -368,6 +368,11 @@ on the next tick.
   (PRELUDE bootstrap + every +10% watermark refresh) and never in the
   per-phase proposable set; any proposal/delegate is denied by R1
   `phase_incompatible`.
+* **Never propose or commission a tuned GEMM/BLAS table** —
+  `AITER_CONFIG_GEMM_*` / `PYTORCH_TUNABLEOP_*` / `VLLM_TUNED_CONFIG_FOLDER`
+  and the CSV/JSON they resolve to, or online tuning during a benchmark
+  (`PYTORCH_TUNABLEOP_TUNING=1`). That is `run_gemm_tuning`'s job in
+  KERNEL_AGENT; boolean GEMM-backend switches are unaffected.
 
 <!-- phase: KERNEL_AGENT -->
 ### Kernel request kinds

--- a/src/hyperloom/orchestrator/prompts/specialist_prompt_builder.py
+++ b/src/hyperloom/orchestrator/prompts/specialist_prompt_builder.py
@@ -2114,12 +2114,12 @@ def _section_output_protocol(inp: SpecialistPromptInputs) -> list[str]:
             "- ``artifacts_written`` lists any non-diff tuned artifacts to install",
             "  (e.g. an autotuned config JSON) as objects ``{source, target, kind,",
             "  description}``: ``source`` is a path inside your worktree, ``target``",
-            "  is the install path — PREFER a framework-relative path (e.g.",
-            "  ``configs/model_configs/foo.csv``); an absolute path is accepted only",
-            "  if it resolves inside an allowlisted framework root. ``integrate_patch``",
-            "  backs up the target, installs the artifact, runs the same E2E gate, and",
-            "  restores the backup on REVERT. A non-diff tuned artifact is a FULL",
-            "  result — set ``empty=false`` when ``artifacts_written`` is non-empty.",
+            "  is the install path — PREFER a framework-relative path; an absolute",
+            "  path is accepted only if it resolves inside an allowlisted framework",
+            "  root. ``integrate_patch`` backs up the target, installs the artifact,",
+            "  runs the same E2E gate, and restores the backup on REVERT. A non-diff",
+            "  tuned artifact is a FULL result — set ``empty=false`` when",
+            "  ``artifacts_written`` is non-empty.",
         ]
         no_output = "  AND no ``patches_written``/``artifacts_written``; in that case"
     else:


### PR DESCRIPTION
## What

Prompt-only change to keep GEMM/BLAS table tuning on a single lever.

- `orchestration.md`: new Iron Rule — Orchestration must **never** propose or commission a tuned GEMM/BLAS table (`AITER_CONFIG_GEMM_*`, `PYTORCH_TUNABLEOP_*`, `VLLM_TUNED_CONFIG_FOLDER` and the CSV/JSON they resolve to, or online tuning during a benchmark via `PYTORCH_TUNABLEOP_TUNING=1`). That is `run_gemm_tuning`'s job in KERNEL_AGENT. Boolean GEMM-backend switches are unaffected.
- `orchestration.md`: drop "closed CK/hipBLASLt GEMMs" from the *no actionable kernel lever → `skip_to_sweep`* example, since those are now explicitly routed to `run_gemm_tuning` rather than treated as a dead end.
- `specialist_prompt_builder.py`: generalize the `artifacts_written` target wording so it no longer holds up a GEMM config CSV as the canonical example.

## Why

Orchestration was free to reach for tuned-GEMM env vars and config tables as an EXPLORE-style config lever, which duplicates (and can race with) the dedicated `run_gemm_tuning` KERNEL_AGENT action and its gating. Making the boundary explicit in the prompt keeps one owner for that artifact.

## Test plan

Prompt text and docstring-style wording only — no executable code paths changed. CI lint/tests cover the touched Python module.
