### PR TITLE
Prove fused MoE candidate dispatch

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_fmoe_ck_coverage.py
+++ b/src/hyperloom/inference_optimizer/tests/test_fmoe_ck_coverage.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Regression tests for fmoe_ck E2E coverage and apply verification (#101821/#101810).
+
+Dense BF16 GEMM lookups must not be treated as fmoe_ck evidence. When a MoE
+model also runs dense linears, the server log carries bf16_tuned_gemm.csv misses
+alongside fused-MoE dispatch lines; mis-reading the former produced
+``artifact_table_not_consulted`` and ``not_merged`` false positives.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from hyperloom.orchestrator.loop.coordinator import Coordinator
+from hyperloom.orchestrator.phases.kernel import KernelPhase
+from hyperloom.orchestrator.state.shared_state import SharedState
+
+# Observed on gpt-oss-120b-style MoE runs: dense lm_head misses while MoE dispatches.
+AITER_BF16_MISS = (
+    "(EngineCore pid=1) [aiter] shape is M:1024, N:151936, K:5120 dtype='torch.bfloat16' "
+    "otype='torch.bfloat16' bias=False, scaleAB=False, bpreshuffle=False, not found tuned "
+    "config in /tmp/aiter_configs/bf16_tuned_gemm.csv, will use default config! "
+    "using torch solution:0"
+)
+
+FMOE_DISPATCH = (
+    "(Worker_TP0 pid=1) [aiter] [fused_moe] using 2stage ck for "
+    "(256, 64, 7168, 2048, 128, 8, 'ActivationType.Swiglu', 'torch.bfloat16', "
+    "'torch.float8_e4m3fn', 'torch.float8_e4m3fn', 'QuantType.per_1x128', True, False)"
+)
+
+FMOE_DISPATCH_UNCOVERED = (
+    "(Worker_TP0 pid=1) [aiter] [fused_moe] using 2stage ck for "
+    "(256, 128, 7168, 2048, 128, 8, 'ActivationType.Swiglu', 'torch.bfloat16', "
+    "'torch.float8_e4m3fn', 'torch.float8_e4m3fn', 'QuantType.per_1x128', True, False)"
+)
+
+_FMOE_TUNED_HEADER = (
+    "gfx,cu_num,token,model_dim,inter_dim,expert,topk,act_type,dtype,"
+    "q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1,kernelId,us,kernelName\n"
+)
+_FMOE_TUNED_ROW = (
+    "gfx950,256,64,7168,2048,128,8,Silu,bf16,"
+    "torch.float8_e4m3fn,torch.float8_e4m3fn,QuantType.per_1x128,1,0,1,10.0,tuned\n"
+)
+
+
+def _phase(tmp_path: Path) -> KernelPhase:
+    coord = Coordinator.__new__(Coordinator)
+    coord.session_dir = tmp_path
+    coord.shared_state = SharedState(
+        model_path=str(tmp_path / "model"),
+        tp=1,
+        framework="sglang",
+        baseline_tput=100.0,
+    )
+    return KernelPhase(coord)
+
+
+def _integrate_log(tmp_path: Path, text: str) -> Path:
+    run_dir = (
+        tmp_path
+        / "runs"
+        / "integrate"
+        / "integrate-gemm_tune_fmoe_ck"
+        / "attempt-1"
+    )
+    run_dir.mkdir(parents=True)
+    log_path = run_dir / "server.log"
+    log_path.write_text(text, encoding="utf-8")
+    return log_path
+
+
+def _fmoe_csv(tmp_path: Path) -> Path:
+    path = tmp_path / "candidate_fmoe.csv"
+    path.write_text(_FMOE_TUNED_HEADER + _FMOE_TUNED_ROW, encoding="utf-8")
+    return path
+
+
+def _envs(csv_path: Path) -> dict[str, str]:
+    return {"AITER_CONFIG_FMOE": str(csv_path), "AITER_LOG_TUNED_CONFIG": "1"}
+
+
+@pytest.fixture
+def stub_forge_parser(monkeypatch):
+    """Minimal forge parser so apply verification runs without forge installed."""
+
+    def _fake_parse_log_file(path):
+        text = Path(path).read_text(encoding="utf-8", errors="replace")
+        hits = misses = 0
+        merged: list[str] = []
+        consulted: set[str] = set()
+        for line in text.splitlines():
+            if "merge tuned file" in line:
+                merged.extend(p for p in line.split()[-1].split(":") if p)
+            elif "not found tuned config in" in line:
+                misses += 1
+                consulted.add(line.split("not found tuned config in")[1].split(",")[0].strip())
+            elif "found padded_M" in line:
+                hits += 1
+        return {
+            "apply_verdict": {"hit": hits, "miss": misses},
+            "merged_tables": sorted(set(merged)),
+            "consulted_tables": sorted(consulted),
+        }
+
+    fake = types.ModuleType("forge_gemm_tune")
+    fake_ev = types.ModuleType("forge_gemm_tune.evidence")
+    fake_ev.parse_log_file = _fake_parse_log_file  # type: ignore[attr-defined]
+    fake.evidence = fake_ev  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "forge_gemm_tune", fake)
+    monkeypatch.setitem(sys.modules, "forge_gemm_tune.evidence", fake_ev)
+
+
+class TestFmoeCoverageGate:
+    def test_dense_bf16_miss_plus_matching_fmoe_dispatch_is_not_table_not_consulted(
+        self, tmp_path
+    ):
+        _integrate_log(tmp_path, "\n".join([AITER_BF16_MISS, FMOE_DISPATCH]))
+        csv_path = _fmoe_csv(tmp_path)
+        phase = _phase(tmp_path)
+
+        report = phase._gemm_tuned_config_coverage("fmoe_ck", _envs(csv_path))
+
+        assert report is not None
+        assert report["artifact_applied"] is True
+        assert report.get("not_applied_reason") != "artifact_table_not_consulted"
+
+    def test_log_without_fused_moe_dispatch_blocks(self, tmp_path):
+        _integrate_log(tmp_path, AITER_BF16_MISS)
+        csv_path = _fmoe_csv(tmp_path)
+        phase = _phase(tmp_path)
+
+        report = phase._gemm_tuned_config_coverage("fmoe_ck", _envs(csv_path))
+
+        assert report is not None
+        assert report["artifact_applied"] is False
+        assert report.get("not_applied_reason") == "no_fused_moe_dispatch"
+
+    def test_uncovered_fmoe_dispatch_blocks(self, tmp_path):
+        _integrate_log(tmp_path, FMOE_DISPATCH_UNCOVERED)
+        csv_path = _fmoe_csv(tmp_path)
+        phase = _phase(tmp_path)
+
+        report = phase._gemm_tuned_config_coverage("fmoe_ck", _envs(csv_path))
+
+        assert report is not None
+        assert report["artifact_applied"] is False
+        assert report.get("not_applied_reason") == "no_shape_key_matched"
+
+    def test_missing_server_log_stays_inconclusive(self, tmp_path):
+        csv_path = _fmoe_csv(tmp_path)
+        phase = _phase(tmp_path)
+
+        report = phase._gemm_tuned_config_coverage("fmoe_ck", _envs(csv_path))
+
+        assert report is None
+
+
+class TestFmoeApplyVerdict:
+    def test_dense_consulted_tables_do_not_block_fmoe(self, tmp_path, stub_forge_parser):
+        _integrate_log(tmp_path, "\n".join([AITER_BF16_MISS, FMOE_DISPATCH]))
+        csv_path = _fmoe_csv(tmp_path)
+        phase = _phase(tmp_path)
+
+        verdict = phase._gemm_apply_verdict("fmoe_ck", _envs(csv_path))
+
+        assert verdict is not None
+        assert verdict.get("blocks_keep") is False
+        assert verdict.get("verdict") != "not_merged"
+
+    def test_no_fused_moe_dispatch_blocks_apply(self, tmp_path, stub_forge_parser):
+        _integrate_log(tmp_path, AITER_BF16_MISS)
+        csv_path = _fmoe_csv(tmp_path)
+        phase = _phase(tmp_path)
+
+        verdict = phase._gemm_apply_verdict("fmoe_ck", _envs(csv_path))
+
+        assert verdict is not None
+        assert verdict.get("blocks_keep") is True
+        assert verdict.get("verdict") == "no_fused_moe_dispatch"

--- a/src/hyperloom/inference_optimizer/tests/test_fmoe_ck_coverage.py
+++ b/src/hyperloom/inference_optimizer/tests/test_fmoe_ck_coverage.py
@@ -92,23 +92,10 @@ _MINIMAX_SHAPE_ROW = (
     "bundled_kernel1,bundled_kernel2\n"
 )
 
-MINIMAX_SESSION_LOG = Path(
-    "/shared_nfs/hyperloom-claw/MiniMax-M3-MXFP4/20260818T071552Z/runs/integrate/"
-    "integrate-gemm_tune_fmoe_ck/warmup_round/benchmark_sglang_20260818_181234/"
-    "server.log"
-)
-MINIMAX_CANDIDATE = Path(
-    "/shared_nfs/hyperloom-claw/MiniMax-M3-MXFP4/20260818T071552Z/runs/gemm_tuning/"
-    "kernel_entry_gemm_tuning/tuners/fmoe_ck/candidate_fmoe.csv"
-)
-GLM_SESSION_LOG = Path(
-    "/shared_nfs/hyperloom-claw/GLM-5.2-MXFP4/20260818T062821Z/runs/integrate/"
-    "integrate-gemm_tune_fmoe_ck/warmup_round/benchmark_sglang_20260818_153638/"
-    "server.log"
-)
-GLM_CANDIDATE = Path(
-    "/shared_nfs/hyperloom-claw/GLM-5.2-MXFP4/20260818T062821Z/runs/gemm_tuning/"
-    "kernel_entry_gemm_tuning/tuners/fmoe_ck/candidate_fmoe.csv"
+# Malformed fused-MoE line: marker present but tuple does not parse.
+UNPARSEABLE_FMOE_MARKER = (
+    "(Worker_TP0 pid=1) [aiter] [fused_moe] using 2stage "
+    "(kernelName1='broken') for (incomplete tuple"
 )
 
 
@@ -283,6 +270,52 @@ class TestFmoeCoverageGate:
         assert report["not_applied_reason"] == "candidate_csv_missing"
         assert report.get("conclusive") is False
 
+    def test_merged_tuned_fmoe_resolves_bare_sibling(self, tmp_path):
+        _integrate_log(tmp_path, SYNTHETIC_SERVED)
+        bare = tmp_path / "tuned_fmoe.csv"
+        bare.write_text(_FMOE_HEADER + _CANDIDATE_ROW, encoding="utf-8")
+        merged = tmp_path / "merged_tuned_fmoe.csv"
+        merged.write_text(_FMOE_HEADER + _CANDIDATE_ROW, encoding="utf-8")
+        phase = _phase(tmp_path)
+
+        report = phase._gemm_tuned_config_coverage(
+            "fmoe_ck",
+            {"AITER_CONFIG_FMOE": str(merged), "AITER_LOG_TUNED_CONFIG": "1"},
+        )
+
+        assert report is not None
+        assert report["artifact_applied"] is True
+        assert report["candidate_csv"] == str(bare)
+
+    def test_fused_moe_marker_without_parse_is_inconclusive(self, tmp_path):
+        _integrate_log(tmp_path, UNPARSEABLE_FMOE_MARKER)
+        csv_path = _candidate_csv(tmp_path)
+        phase = _phase(tmp_path)
+
+        report = phase._gemm_tuned_config_coverage("fmoe_ck", _envs(csv_path))
+
+        assert report is not None
+        assert report["artifact_applied"] is False
+        assert report["not_applied_reason"] == "fused_moe_parse_inconclusive"
+        assert report.get("conclusive") is False
+
+    def test_minimax_default_embedded_replay_blocks(self, tmp_path):
+        from hyperloom.orchestrator.kernel.gemm_shape_coverage import (
+            fmoe_tuned_config_coverage,
+            parse_aiter_fused_moe_dispatches,
+            tuned_fmoe_csv_rows,
+        )
+
+        candidate = tmp_path / "candidate_fmoe.csv"
+        candidate.write_text(_FMOE_HEADER + _MINIMAX_SHAPE_ROW, encoding="utf-8")
+        dispatches = parse_aiter_fused_moe_dispatches(MINIMAX_DEFAULT)
+        assert dispatches
+        assert all(d["descriptor"] == "default" for d in dispatches)
+
+        report = fmoe_tuned_config_coverage(tuned_fmoe_csv_rows(candidate), dispatches)
+        assert report["covered"] == 0
+        assert report["runtime_default"] >= 1
+
 
 class TestFmoeApplyVerdict:
     def test_dense_consulted_tables_do_not_block_fmoe(self, tmp_path, stub_forge_parser):
@@ -318,7 +351,7 @@ class TestFmoeApplyVerdict:
         assert verdict.get("blocks_keep") is True
         assert verdict.get("verdict") == "no_fused_moe_dispatch"
 
-    def test_merged_without_bare_candidate_blocks_inconclusively(self, tmp_path):
+    def test_merged_without_bare_candidate_does_not_block_keep(self, tmp_path):
         _integrate_log(tmp_path, SYNTHETIC_SERVED)
         merged = tmp_path / "merged_candidate_fmoe.csv"
         merged.write_text(_FMOE_HEADER + _CANDIDATE_ROW, encoding="utf-8")
@@ -330,49 +363,51 @@ class TestFmoeApplyVerdict:
         )
 
         assert verdict is not None
-        assert verdict.get("blocks_keep") is True
+        assert verdict.get("blocks_keep") is False
         assert verdict.get("conclusive") is False
         assert verdict.get("verdict") == "candidate_csv_missing"
 
+    def test_fused_moe_marker_without_parse_does_not_block_keep(self, tmp_path):
+        _integrate_log(tmp_path, UNPARSEABLE_FMOE_MARKER)
+        csv_path = _candidate_csv(tmp_path)
+        phase = _phase(tmp_path)
 
-class TestSessionLogReplay:
-    def test_minimax_session_log_replay_blocks_on_default(self):
-        if not MINIMAX_SESSION_LOG.is_file() or not MINIMAX_CANDIDATE.is_file():
-            pytest.skip("MiniMax session artifacts not mounted")
+        verdict = phase._gemm_apply_verdict("fmoe_ck", _envs(csv_path))
+
+        assert verdict is not None
+        assert verdict.get("blocks_keep") is False
+        assert verdict.get("conclusive") is False
+        assert verdict.get("verdict") == "fused_moe_parse_inconclusive"
+
+    def test_logging_disabled_without_dispatch_is_inconclusive(self, tmp_path):
+        _integrate_log(tmp_path, AITER_BF16_MISS)
+        csv_path = _candidate_csv(tmp_path)
+        phase = _phase(tmp_path)
+
+        verdict = phase._gemm_apply_verdict(
+            "fmoe_ck",
+            {"AITER_CONFIG_FMOE": str(csv_path), "AITER_LOG_TUNED_CONFIG": "0"},
+        )
+
+        assert verdict is not None
+        assert verdict.get("blocks_keep") is False
+        assert verdict.get("conclusive") is False
+        assert verdict.get("verdict") == "fused_moe_logging_disabled"
+
+
+class TestFmoeEmbeddedReplay:
+    def test_glm_descriptor_embedded_replay_does_not_hit_candidate(self, tmp_path):
         from hyperloom.orchestrator.kernel.gemm_shape_coverage import (
             fmoe_tuned_config_coverage,
             parse_aiter_fused_moe_dispatches,
             tuned_fmoe_csv_rows,
         )
 
-        text = MINIMAX_SESSION_LOG.read_text(encoding="utf-8", errors="replace")
-        dispatches = parse_aiter_fused_moe_dispatches(text)
-        assert dispatches, "expected fused-MoE dispatch lines in session log"
-        assert all(d["descriptor"] == "default" for d in dispatches)
-        assert all(d["gfx"] == "gfx950" for d in dispatches)
-
-        report = fmoe_tuned_config_coverage(
-            tuned_fmoe_csv_rows(MINIMAX_CANDIDATE), dispatches
-        )
-        assert report["covered"] == 0
-        assert report["runtime_default"] >= 1
-
-    def test_glm_session_log_replay_does_not_attribute_bundled_hit_to_candidate(self):
-        if not GLM_SESSION_LOG.is_file() or not GLM_CANDIDATE.is_file():
-            pytest.skip("GLM session artifacts not mounted")
-        from hyperloom.orchestrator.kernel.gemm_shape_coverage import (
-            fmoe_tuned_config_coverage,
-            parse_aiter_fused_moe_dispatches,
-            tuned_fmoe_csv_rows,
-        )
-
-        text = GLM_SESSION_LOG.read_text(encoding="utf-8", errors="replace")
-        dispatches = parse_aiter_fused_moe_dispatches(text)
-        assert dispatches, "expected parenthesised fused-MoE descriptors"
+        candidate = tmp_path / "candidate_fmoe.csv"
+        candidate.write_text(_FMOE_HEADER + _CANDIDATE_ROW, encoding="utf-8")
+        dispatches = parse_aiter_fused_moe_dispatches(GLM_KERNEL_DESCRIPTOR)
+        assert dispatches
         assert all(d["descriptor"] != "default" for d in dispatches)
-        assert all(d["gfx"] == "gfx950" for d in dispatches)
 
-        report = fmoe_tuned_config_coverage(
-            tuned_fmoe_csv_rows(GLM_CANDIDATE), dispatches
-        )
+        report = fmoe_tuned_config_coverage(tuned_fmoe_csv_rows(candidate), dispatches)
         assert report["covered"] == 0

--- a/src/hyperloom/inference_optimizer/tests/test_fmoe_ck_coverage.py
+++ b/src/hyperloom/inference_optimizer/tests/test_fmoe_ck_coverage.py
@@ -3,10 +3,10 @@
 
 """Regression tests for fmoe_ck E2E coverage and apply verification (#101821/#101810).
 
-Dense BF16 GEMM lookups must not be treated as fmoe_ck evidence. When a MoE
-model also runs dense linears, the server log carries bf16_tuned_gemm.csv misses
-alongside fused-MoE dispatch lines; mis-reading the former produced
-``artifact_table_not_consulted`` and ``not_merged`` false positives.
+Dense BF16 GEMM lookups must not be treated as fmoe_ck evidence. Runtime
+attribution requires a non-default descriptor whose kernelName1/kernelName2
+pair matches the bare ``candidate_fmoe.csv`` row for the full fourteen-column
+``get_2stage_cfgs`` lookup key.
 """
 
 from __future__ import annotations
@@ -29,25 +29,86 @@ AITER_BF16_MISS = (
     "using torch solution:0"
 )
 
-FMOE_DISPATCH = (
-    "(Worker_TP0 pid=1) [aiter] [fused_moe] using 2stage ck for "
-    "(256, 64, 7168, 2048, 128, 8, 'ActivationType.Swiglu', 'torch.bfloat16', "
-    "'torch.float8_e4m3fn', 'torch.float8_e4m3fn', 'QuantType.per_1x128', True, False)"
+# MiniMax-M3-MXFP4 baseline: runtime never selected a tuned row (#101821).
+MINIMAX_DEFAULT = (
+    "(Worker_TP0 pid=1) [aiter] [fused_moe] using 2stage default for "
+    "('gfx950', 256, 512, 6144, 512, 128, 4, 'ActivationType.Swiglu', "
+    "'torch.bfloat16', 'torch.float4_e2m1fn_x2', 'torch.float4_e2m1fn_x2', "
+    "'QuantType.per_1x32', True, False)"
 )
 
-FMOE_DISPATCH_UNCOVERED = (
-    "(Worker_TP0 pid=1) [aiter] [fused_moe] using 2stage ck for "
-    "(256, 128, 7168, 2048, 128, 8, 'ActivationType.Swiglu', 'torch.bfloat16', "
-    "'torch.float8_e4m3fn', 'torch.float8_e4m3fn', 'QuantType.per_1x128', True, False)"
+# GLM-style parenthesised descriptor: parses, but keys/kernel names must match candidate.
+GLM_KERNEL_DESCRIPTOR = (
+    "(Worker_TP0 pid=1) [aiter] [fused_moe] using 2stage "
+    "(kernelName1='flydsl_moe1_afp4_wfp4_bf16_t128x128x256_fp4', "
+    "kernelName2='flydsl_moe2_afp4_wfp4_bf16_t64x256x256_reduce_bnt2_persist_sbm128') "
+    "for ('gfx950', 256, 4096, 8192, 256, 512, 10, 'ActivationType.Silu', "
+    "'torch.bfloat16', 'torch.float4_e2m1fn_x2', 'torch.float4_e2m1fn_x2', "
+    "'QuantType.per_1x32', True, False)"
 )
 
-_FMOE_TUNED_HEADER = (
+SYNTHETIC_SERVED = (
+    "(Worker_TP0 pid=1) [aiter] [fused_moe] using 2stage "
+    "(kernelName1='ck_moe_stage1_tuned', kernelName2='ck_moe_stage2_tuned') "
+    "for ('gfx950', 256, 64, 7168, 2048, 128, 8, 'ActivationType.Swiglu', "
+    "'torch.bfloat16', 'torch.float8_e4m3fn', 'torch.float8_e4m3fn', "
+    "'QuantType.per_1x128', True, False)"
+)
+
+SYNTHETIC_WRONG_KERNEL = (
+    "(Worker_TP0 pid=1) [aiter] [fused_moe] using 2stage "
+    "(kernelName1='ck_moe_stage1_other', kernelName2='ck_moe_stage2_other') "
+    "for ('gfx950', 256, 64, 7168, 2048, 128, 8, 'ActivationType.Swiglu', "
+    "'torch.bfloat16', 'torch.float8_e4m3fn', 'torch.float8_e4m3fn', "
+    "'QuantType.per_1x128', True, False)"
+)
+
+SYNTHETIC_WRONG_TOKEN = (
+    "(Worker_TP0 pid=1) [aiter] [fused_moe] using 2stage "
+    "(kernelName1='ck_moe_stage1_tuned', kernelName2='ck_moe_stage2_tuned') "
+    "for ('gfx950', 256, 128, 7168, 2048, 128, 8, 'ActivationType.Swiglu', "
+    "'torch.bfloat16', 'torch.float8_e4m3fn', 'torch.float8_e4m3fn', "
+    "'QuantType.per_1x128', True, False)"
+)
+
+_FMOE_HEADER = (
     "gfx,cu_num,token,model_dim,inter_dim,expert,topk,act_type,dtype,"
-    "q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1,kernelId,us,kernelName\n"
+    "q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1,kernelId,us,"
+    "kernelName1,kernelName2\n"
 )
-_FMOE_TUNED_ROW = (
-    "gfx950,256,64,7168,2048,128,8,Silu,bf16,"
-    "torch.float8_e4m3fn,torch.float8_e4m3fn,QuantType.per_1x128,1,0,1,10.0,tuned\n"
+_CANDIDATE_ROW = (
+    "gfx950,256,64,7168,2048,128,8,Swiglu,bf16,"
+    "torch.float8_e4m3fn,torch.float8_e4m3fn,QuantType.per_1x128,1,0,1,10.0,"
+    "ck_moe_stage1_tuned,ck_moe_stage2_tuned\n"
+)
+_GLM_SHAPE_ROW = (
+    "gfx950,256,4096,8192,256,512,10,Silu,bf16,"
+    "torch.float4_e2m1fn_x2,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,1,10.0,"
+    "bundled_kernel1,bundled_kernel2\n"
+)
+_MINIMAX_SHAPE_ROW = (
+    "gfx950,256,512,6144,512,128,4,Swiglu,bf16,"
+    "torch.float4_e2m1fn_x2,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,1,10.0,"
+    "bundled_kernel1,bundled_kernel2\n"
+)
+
+MINIMAX_SESSION_LOG = Path(
+    "/shared_nfs/hyperloom-claw/MiniMax-M3-MXFP4/20260818T071552Z/runs/integrate/"
+    "integrate-gemm_tune_fmoe_ck/warmup_round/benchmark_sglang_20260818_181234/"
+    "server.log"
+)
+MINIMAX_CANDIDATE = Path(
+    "/shared_nfs/hyperloom-claw/MiniMax-M3-MXFP4/20260818T071552Z/runs/gemm_tuning/"
+    "kernel_entry_gemm_tuning/tuners/fmoe_ck/candidate_fmoe.csv"
+)
+GLM_SESSION_LOG = Path(
+    "/shared_nfs/hyperloom-claw/GLM-5.2-MXFP4/20260818T062821Z/runs/integrate/"
+    "integrate-gemm_tune_fmoe_ck/warmup_round/benchmark_sglang_20260818_153638/"
+    "server.log"
+)
+GLM_CANDIDATE = Path(
+    "/shared_nfs/hyperloom-claw/GLM-5.2-MXFP4/20260818T062821Z/runs/gemm_tuning/"
+    "kernel_entry_gemm_tuning/tuners/fmoe_ck/candidate_fmoe.csv"
 )
 
 
@@ -77,10 +138,17 @@ def _integrate_log(tmp_path: Path, text: str) -> Path:
     return log_path
 
 
-def _fmoe_csv(tmp_path: Path) -> Path:
+def _candidate_csv(tmp_path: Path, row: str = _CANDIDATE_ROW) -> Path:
     path = tmp_path / "candidate_fmoe.csv"
-    path.write_text(_FMOE_TUNED_HEADER + _FMOE_TUNED_ROW, encoding="utf-8")
+    path.write_text(_FMOE_HEADER + row, encoding="utf-8")
     return path
+
+
+def _merged_env(tmp_path: Path, *, candidate_row: str, merged_row: str) -> dict[str, str]:
+    candidate = _candidate_csv(tmp_path, candidate_row)
+    merged = tmp_path / "merged_candidate_fmoe.csv"
+    merged.write_text(_FMOE_HEADER + merged_row, encoding="utf-8")
+    return {"AITER_CONFIG_FMOE": str(merged), "AITER_LOG_TUNED_CONFIG": "1"}
 
 
 def _envs(csv_path: Path) -> dict[str, str]:
@@ -119,11 +187,9 @@ def stub_forge_parser(monkeypatch):
 
 
 class TestFmoeCoverageGate:
-    def test_dense_bf16_miss_plus_matching_fmoe_dispatch_is_not_table_not_consulted(
-        self, tmp_path
-    ):
-        _integrate_log(tmp_path, "\n".join([AITER_BF16_MISS, FMOE_DISPATCH]))
-        csv_path = _fmoe_csv(tmp_path)
+    def test_dense_bf16_miss_does_not_trigger_table_not_consulted(self, tmp_path):
+        _integrate_log(tmp_path, "\n".join([AITER_BF16_MISS, SYNTHETIC_SERVED]))
+        csv_path = _candidate_csv(tmp_path)
         phase = _phase(tmp_path)
 
         report = phase._gemm_tuned_config_coverage("fmoe_ck", _envs(csv_path))
@@ -132,9 +198,59 @@ class TestFmoeCoverageGate:
         assert report["artifact_applied"] is True
         assert report.get("not_applied_reason") != "artifact_table_not_consulted"
 
+    def test_minimax_default_blocks_even_when_merged_csv_has_shape(self, tmp_path):
+        _integrate_log(tmp_path, MINIMAX_DEFAULT)
+        env = _merged_env(tmp_path, candidate_row=_CANDIDATE_ROW, merged_row=_MINIMAX_SHAPE_ROW)
+        phase = _phase(tmp_path)
+
+        report = phase._gemm_tuned_config_coverage("fmoe_ck", env)
+
+        assert report is not None
+        assert report["artifact_applied"] is False
+        assert report["not_applied_reason"] == "runtime_default_config"
+
+    def test_glm_descriptor_parses_but_bare_candidate_mismatch_blocks(self, tmp_path):
+        _integrate_log(tmp_path, GLM_KERNEL_DESCRIPTOR)
+        env = _merged_env(tmp_path, candidate_row=_CANDIDATE_ROW, merged_row=_GLM_SHAPE_ROW)
+        phase = _phase(tmp_path)
+
+        report = phase._gemm_tuned_config_coverage("fmoe_ck", env)
+
+        assert report is not None
+        assert report["artifact_applied"] is False
+        assert report["not_applied_reason"] in {
+            "no_shape_key_matched",
+            "kernel_name_mismatch",
+        }
+
+    def test_exact_candidate_kernel_hit_is_served(self, tmp_path):
+        _integrate_log(tmp_path, SYNTHETIC_SERVED)
+        csv_path = _candidate_csv(tmp_path)
+        phase = _phase(tmp_path)
+
+        report = phase._gemm_tuned_config_coverage("fmoe_ck", _envs(csv_path))
+
+        assert report is not None
+        assert report["artifact_applied"] is True
+        assert report["covered"] == 1
+
+    def test_fourteen_col_key_or_kernel_mismatch_blocks(self, tmp_path):
+        _integrate_log(
+            tmp_path,
+            "\n".join([SYNTHETIC_WRONG_KERNEL, SYNTHETIC_WRONG_TOKEN]),
+        )
+        csv_path = _candidate_csv(tmp_path)
+        phase = _phase(tmp_path)
+
+        report = phase._gemm_tuned_config_coverage("fmoe_ck", _envs(csv_path))
+
+        assert report is not None
+        assert report["artifact_applied"] is False
+        assert report["covered"] == 0
+
     def test_log_without_fused_moe_dispatch_blocks(self, tmp_path):
         _integrate_log(tmp_path, AITER_BF16_MISS)
-        csv_path = _fmoe_csv(tmp_path)
+        csv_path = _candidate_csv(tmp_path)
         phase = _phase(tmp_path)
 
         report = phase._gemm_tuned_config_coverage("fmoe_ck", _envs(csv_path))
@@ -143,41 +259,57 @@ class TestFmoeCoverageGate:
         assert report["artifact_applied"] is False
         assert report.get("not_applied_reason") == "no_fused_moe_dispatch"
 
-    def test_uncovered_fmoe_dispatch_blocks(self, tmp_path):
-        _integrate_log(tmp_path, FMOE_DISPATCH_UNCOVERED)
-        csv_path = _fmoe_csv(tmp_path)
-        phase = _phase(tmp_path)
-
-        report = phase._gemm_tuned_config_coverage("fmoe_ck", _envs(csv_path))
-
-        assert report is not None
-        assert report["artifact_applied"] is False
-        assert report.get("not_applied_reason") == "no_shape_key_matched"
-
     def test_missing_server_log_stays_inconclusive(self, tmp_path):
-        csv_path = _fmoe_csv(tmp_path)
+        csv_path = _candidate_csv(tmp_path)
         phase = _phase(tmp_path)
 
         report = phase._gemm_tuned_config_coverage("fmoe_ck", _envs(csv_path))
 
         assert report is None
 
+    def test_merged_env_without_bare_candidate_is_inconclusive(self, tmp_path):
+        _integrate_log(tmp_path, SYNTHETIC_SERVED)
+        merged = tmp_path / "merged_candidate_fmoe.csv"
+        merged.write_text(_FMOE_HEADER + _CANDIDATE_ROW, encoding="utf-8")
+        phase = _phase(tmp_path)
+
+        report = phase._gemm_tuned_config_coverage(
+            "fmoe_ck",
+            {"AITER_CONFIG_FMOE": str(merged), "AITER_LOG_TUNED_CONFIG": "1"},
+        )
+
+        assert report is not None
+        assert report["artifact_applied"] is False
+        assert report["not_applied_reason"] == "candidate_csv_missing"
+        assert report.get("conclusive") is False
+
 
 class TestFmoeApplyVerdict:
     def test_dense_consulted_tables_do_not_block_fmoe(self, tmp_path, stub_forge_parser):
-        _integrate_log(tmp_path, "\n".join([AITER_BF16_MISS, FMOE_DISPATCH]))
-        csv_path = _fmoe_csv(tmp_path)
+        _integrate_log(tmp_path, "\n".join([AITER_BF16_MISS, SYNTHETIC_SERVED]))
+        csv_path = _candidate_csv(tmp_path)
         phase = _phase(tmp_path)
 
         verdict = phase._gemm_apply_verdict("fmoe_ck", _envs(csv_path))
 
         assert verdict is not None
         assert verdict.get("blocks_keep") is False
-        assert verdict.get("verdict") != "not_merged"
+        assert verdict.get("verdict") == "served"
+
+    def test_minimax_default_blocks_keep(self, tmp_path, stub_forge_parser):
+        _integrate_log(tmp_path, MINIMAX_DEFAULT)
+        env = _merged_env(tmp_path, candidate_row=_CANDIDATE_ROW, merged_row=_MINIMAX_SHAPE_ROW)
+        phase = _phase(tmp_path)
+
+        verdict = phase._gemm_apply_verdict("fmoe_ck", env)
+
+        assert verdict is not None
+        assert verdict.get("blocks_keep") is True
+        assert verdict.get("verdict") == "runtime_default_config"
 
     def test_no_fused_moe_dispatch_blocks_apply(self, tmp_path, stub_forge_parser):
         _integrate_log(tmp_path, AITER_BF16_MISS)
-        csv_path = _fmoe_csv(tmp_path)
+        csv_path = _candidate_csv(tmp_path)
         phase = _phase(tmp_path)
 
         verdict = phase._gemm_apply_verdict("fmoe_ck", _envs(csv_path))
@@ -185,3 +317,62 @@ class TestFmoeApplyVerdict:
         assert verdict is not None
         assert verdict.get("blocks_keep") is True
         assert verdict.get("verdict") == "no_fused_moe_dispatch"
+
+    def test_merged_without_bare_candidate_blocks_inconclusively(self, tmp_path):
+        _integrate_log(tmp_path, SYNTHETIC_SERVED)
+        merged = tmp_path / "merged_candidate_fmoe.csv"
+        merged.write_text(_FMOE_HEADER + _CANDIDATE_ROW, encoding="utf-8")
+        phase = _phase(tmp_path)
+
+        verdict = phase._gemm_apply_verdict(
+            "fmoe_ck",
+            {"AITER_CONFIG_FMOE": str(merged), "AITER_LOG_TUNED_CONFIG": "1"},
+        )
+
+        assert verdict is not None
+        assert verdict.get("blocks_keep") is True
+        assert verdict.get("conclusive") is False
+        assert verdict.get("verdict") == "candidate_csv_missing"
+
+
+class TestSessionLogReplay:
+    def test_minimax_session_log_replay_blocks_on_default(self):
+        if not MINIMAX_SESSION_LOG.is_file() or not MINIMAX_CANDIDATE.is_file():
+            pytest.skip("MiniMax session artifacts not mounted")
+        from hyperloom.orchestrator.kernel.gemm_shape_coverage import (
+            fmoe_tuned_config_coverage,
+            parse_aiter_fused_moe_dispatches,
+            tuned_fmoe_csv_rows,
+        )
+
+        text = MINIMAX_SESSION_LOG.read_text(encoding="utf-8", errors="replace")
+        dispatches = parse_aiter_fused_moe_dispatches(text)
+        assert dispatches, "expected fused-MoE dispatch lines in session log"
+        assert all(d["descriptor"] == "default" for d in dispatches)
+        assert all(d["gfx"] == "gfx950" for d in dispatches)
+
+        report = fmoe_tuned_config_coverage(
+            tuned_fmoe_csv_rows(MINIMAX_CANDIDATE), dispatches
+        )
+        assert report["covered"] == 0
+        assert report["runtime_default"] >= 1
+
+    def test_glm_session_log_replay_does_not_attribute_bundled_hit_to_candidate(self):
+        if not GLM_SESSION_LOG.is_file() or not GLM_CANDIDATE.is_file():
+            pytest.skip("GLM session artifacts not mounted")
+        from hyperloom.orchestrator.kernel.gemm_shape_coverage import (
+            fmoe_tuned_config_coverage,
+            parse_aiter_fused_moe_dispatches,
+            tuned_fmoe_csv_rows,
+        )
+
+        text = GLM_SESSION_LOG.read_text(encoding="utf-8", errors="replace")
+        dispatches = parse_aiter_fused_moe_dispatches(text)
+        assert dispatches, "expected parenthesised fused-MoE descriptors"
+        assert all(d["descriptor"] != "default" for d in dispatches)
+        assert all(d["gfx"] == "gfx950" for d in dispatches)
+
+        report = fmoe_tuned_config_coverage(
+            tuned_fmoe_csv_rows(GLM_CANDIDATE), dispatches
+        )
+        assert report["covered"] == 0

--- a/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
+++ b/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
@@ -12,7 +12,6 @@ from hyperloom.orchestrator.kernel.gemm_shape_coverage import (
     aiter_padded_m_coarse,
     aiter_padded_m_fine,
     align_shapes_to_aiter_keys,
-    fmoe_dispatch_lookup_key,
     fmoe_tuned_config_coverage,
     load_shapes_json,
     parse_aiter_consulted_tables,
@@ -21,9 +20,9 @@ from hyperloom.orchestrator.kernel.gemm_shape_coverage import (
     resolve_fmoe_candidate_csv,
     tuned_config_coverage,
     tuned_csv_shapes,
-    tuned_fmoe_csv_keys,
     tuned_fmoe_csv_rows,
     write_shapes_json,
+    _normalize_fmoe_q_dtype,
 )
 
 
@@ -247,7 +246,14 @@ class TestFmoeDispatchParsing:
         merged.write_text("gfx\n", encoding="utf-8")
         assert resolve_fmoe_candidate_csv(merged) == bare
 
-    def test_q_dtype_aliases_normalize_to_log_form(self, tmp_path):
+    def test_q_dtype_aliases_normalize_known_forms_only(self, tmp_path):
+        assert _normalize_fmoe_q_dtype("torch.float8_e4m3fn") == "torch.float8_e4m3fn"
+        assert _normalize_fmoe_q_dtype("torch.float8_e5m2") == "torch.float8_e5m2"
+        assert _normalize_fmoe_q_dtype("torch.float8_e4m3fnuz") == "torch.float8_e4m3fnuz"
+        assert _normalize_fmoe_q_dtype("torch.float4_e2m1fn_x2") == "torch.float4_e2m1fn_x2"
+        assert _normalize_fmoe_q_dtype("fp4") == "torch.float4_e2m1fn_x2"
+        assert _normalize_fmoe_q_dtype("torch.float8_e5m2fn") == "torch.float8_e5m2fn"
+
         path = tmp_path / "candidate_fmoe.csv"
         path.write_text(
             "gfx,cu_num,token,model_dim,inter_dim,expert,topk,act_type,dtype,"

--- a/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
+++ b/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
@@ -18,6 +18,7 @@ from hyperloom.orchestrator.kernel.gemm_shape_coverage import (
     parse_aiter_consulted_tables,
     parse_aiter_fused_moe_dispatches,
     parse_aiter_shape_lookups,
+    resolve_fmoe_candidate_csv,
     tuned_config_coverage,
     tuned_csv_shapes,
     tuned_fmoe_csv_keys,
@@ -231,6 +232,35 @@ class TestFmoeDispatchParsing:
         (record,) = parse_aiter_fused_moe_dispatches(self._DISPATCH)
         report = fmoe_tuned_config_coverage(tuned_fmoe_csv_rows(path), [record])
         assert report["covered"] == 0
+
+    def test_resolve_merged_candidate_fmoe_csv(self, tmp_path):
+        bare = tmp_path / "candidate_fmoe.csv"
+        bare.write_text("gfx\n", encoding="utf-8")
+        merged = tmp_path / "merged_candidate_fmoe.csv"
+        merged.write_text("gfx\n", encoding="utf-8")
+        assert resolve_fmoe_candidate_csv(merged) == bare
+
+    def test_resolve_merged_tuned_fmoe_csv(self, tmp_path):
+        bare = tmp_path / "tuned_fmoe.csv"
+        bare.write_text("gfx\n", encoding="utf-8")
+        merged = tmp_path / "merged_tuned_fmoe.csv"
+        merged.write_text("gfx\n", encoding="utf-8")
+        assert resolve_fmoe_candidate_csv(merged) == bare
+
+    def test_q_dtype_aliases_normalize_to_log_form(self, tmp_path):
+        path = tmp_path / "candidate_fmoe.csv"
+        path.write_text(
+            "gfx,cu_num,token,model_dim,inter_dim,expert,topk,act_type,dtype,"
+            "q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1,kernelId,us,"
+            "kernelName1,kernelName2\n"
+            "gfx950,256,64,7168,2048,128,8,Swiglu,bf16,"
+            "fp4,fp4,QuantType.per_1x128,1,0,1,10.0,"
+            "ck_moe_stage1_tuned,ck_moe_stage2_tuned\n",
+            encoding="utf-8",
+        )
+        rows = tuned_fmoe_csv_rows(path)
+        assert rows[0]["q_dtype_a"] == "torch.float4_e2m1fn_x2"
+        assert rows[0]["q_dtype_w"] == "torch.float4_e2m1fn_x2"
 
 
 class TestTunedCsvCoverage:

--- a/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
+++ b/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
@@ -12,11 +12,15 @@ from hyperloom.orchestrator.kernel.gemm_shape_coverage import (
     aiter_padded_m_coarse,
     aiter_padded_m_fine,
     align_shapes_to_aiter_keys,
+    fmoe_dispatch_lookup_key,
+    fmoe_tuned_config_coverage,
     load_shapes_json,
     parse_aiter_consulted_tables,
+    parse_aiter_fused_moe_dispatches,
     parse_aiter_shape_lookups,
     tuned_config_coverage,
     tuned_csv_shapes,
+    tuned_fmoe_csv_keys,
     write_shapes_json,
 )
 
@@ -148,6 +152,50 @@ class TestServerLogParsing:
 
     def test_consulted_tables_of_empty_log(self):
         assert parse_aiter_consulted_tables("") == set()
+
+
+class TestFmoeDispatchParsing:
+    _DISPATCH = (
+        "(Worker_TP0 pid=1) [aiter] [fused_moe] using 2stage ck for "
+        "(256, 64, 7168, 2048, 128, 8, 'ActivationType.Swiglu', 'torch.bfloat16', "
+        "'torch.float8_e4m3fn', 'torch.float8_e4m3fn', 'QuantType.per_1x128', True, False)"
+    )
+
+    def test_parses_dispatch_tuple(self):
+        (record,) = parse_aiter_fused_moe_dispatches(self._DISPATCH)
+        assert record["token"] == "64"
+        assert record["model_dim"] == "7168"
+        assert record["inter_dim"] == "2048"
+        assert record["expert"] == "128"
+        assert record["topk"] == "8"
+        assert record["q_type"] == "QuantType.per_1x128"
+
+    def test_csv_key_matches_dispatch(self, tmp_path):
+        path = tmp_path / "tuned_fmoe.csv"
+        path.write_text(
+            "gfx,cu_num,token,model_dim,inter_dim,expert,topk,act_type,dtype,"
+            "q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1,kernelId,us,kernelName\n"
+            "gfx950,256,64,7168,2048,128,8,Silu,bf16,"
+            "torch.float8_e4m3fn,torch.float8_e4m3fn,QuantType.per_1x128,1,0,1,10.0,tuned\n",
+            encoding="utf-8",
+        )
+        (record,) = parse_aiter_fused_moe_dispatches(self._DISPATCH)
+        assert fmoe_dispatch_lookup_key(record) in tuned_fmoe_csv_keys(path)
+        report = fmoe_tuned_config_coverage(tuned_fmoe_csv_keys(path), [record])
+        assert report["coverage_pct"] == 100.0
+
+    def test_csv_key_rejects_different_cu_count(self, tmp_path):
+        path = tmp_path / "tuned_fmoe.csv"
+        path.write_text(
+            "gfx,cu_num,token,model_dim,inter_dim,expert,topk,act_type,dtype,"
+            "q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1,kernelId,us,kernelName\n"
+            "gfx950,304,64,7168,2048,128,8,Silu,bf16,"
+            "torch.float8_e4m3fn,torch.float8_e4m3fn,QuantType.per_1x128,1,0,1,10.0,tuned\n",
+            encoding="utf-8",
+        )
+        (record,) = parse_aiter_fused_moe_dispatches(self._DISPATCH)
+        report = fmoe_tuned_config_coverage(tuned_fmoe_csv_keys(path), [record])
+        assert report["covered"] == 0
 
 
 class TestTunedCsvCoverage:

--- a/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
+++ b/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
@@ -21,6 +21,7 @@ from hyperloom.orchestrator.kernel.gemm_shape_coverage import (
     tuned_config_coverage,
     tuned_csv_shapes,
     tuned_fmoe_csv_keys,
+    tuned_fmoe_csv_rows,
     write_shapes_json,
 )
 
@@ -156,45 +157,79 @@ class TestServerLogParsing:
 
 class TestFmoeDispatchParsing:
     _DISPATCH = (
-        "(Worker_TP0 pid=1) [aiter] [fused_moe] using 2stage ck for "
-        "(256, 64, 7168, 2048, 128, 8, 'ActivationType.Swiglu', 'torch.bfloat16', "
-        "'torch.float8_e4m3fn', 'torch.float8_e4m3fn', 'QuantType.per_1x128', True, False)"
+        "(Worker_TP0 pid=1) [aiter] [fused_moe] using 2stage "
+        "(kernelName1='ck_moe_stage1_tuned', kernelName2='ck_moe_stage2_tuned') "
+        "for ('gfx950', 256, 64, 7168, 2048, 128, 8, 'ActivationType.Swiglu', "
+        "'torch.bfloat16', 'torch.float8_e4m3fn', 'torch.float8_e4m3fn', "
+        "'QuantType.per_1x128', True, False)"
+    )
+    _DEFAULT = (
+        "(Worker_TP0 pid=1) [aiter] [fused_moe] using 2stage default for "
+        "('gfx950', 256, 512, 6144, 512, 128, 4, 'ActivationType.Swiglu', "
+        "'torch.bfloat16', 'torch.float4_e2m1fn_x2', 'torch.float4_e2m1fn_x2', "
+        "'QuantType.per_1x32', True, False)"
     )
 
-    def test_parses_dispatch_tuple(self):
+    def test_parses_fourteen_column_tuple_with_gfx_first(self):
         (record,) = parse_aiter_fused_moe_dispatches(self._DISPATCH)
+        assert record["gfx"] == "gfx950"
+        assert record["cu_num"] == "256"
         assert record["token"] == "64"
-        assert record["model_dim"] == "7168"
-        assert record["inter_dim"] == "2048"
-        assert record["expert"] == "128"
-        assert record["topk"] == "8"
-        assert record["q_type"] == "QuantType.per_1x128"
+        assert record["kernelName1"] == "ck_moe_stage1_tuned"
+        assert record["kernelName2"] == "ck_moe_stage2_tuned"
+        assert record["descriptor"] != "default"
 
-    def test_csv_key_matches_dispatch(self, tmp_path):
-        path = tmp_path / "tuned_fmoe.csv"
+    def test_parses_default_descriptor(self):
+        (record,) = parse_aiter_fused_moe_dispatches(self._DEFAULT)
+        assert record["descriptor"] == "default"
+        assert record["kernelName1"] == ""
+        assert record["gfx"] == "gfx950"
+
+    def test_exact_candidate_kernel_hit(self, tmp_path):
+        path = tmp_path / "candidate_fmoe.csv"
         path.write_text(
             "gfx,cu_num,token,model_dim,inter_dim,expert,topk,act_type,dtype,"
-            "q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1,kernelId,us,kernelName\n"
-            "gfx950,256,64,7168,2048,128,8,Silu,bf16,"
-            "torch.float8_e4m3fn,torch.float8_e4m3fn,QuantType.per_1x128,1,0,1,10.0,tuned\n",
+            "q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1,kernelId,us,"
+            "kernelName1,kernelName2\n"
+            "gfx950,256,64,7168,2048,128,8,Swiglu,bf16,"
+            "torch.float8_e4m3fn,torch.float8_e4m3fn,QuantType.per_1x128,1,0,1,10.0,"
+            "ck_moe_stage1_tuned,ck_moe_stage2_tuned\n",
             encoding="utf-8",
         )
         (record,) = parse_aiter_fused_moe_dispatches(self._DISPATCH)
-        assert fmoe_dispatch_lookup_key(record) in tuned_fmoe_csv_keys(path)
-        report = fmoe_tuned_config_coverage(tuned_fmoe_csv_keys(path), [record])
+        rows = tuned_fmoe_csv_rows(path)
+        report = fmoe_tuned_config_coverage(rows, [record])
         assert report["coverage_pct"] == 100.0
 
-    def test_csv_key_rejects_different_cu_count(self, tmp_path):
-        path = tmp_path / "tuned_fmoe.csv"
+    def test_shape_overlap_without_kernel_match_is_not_served(self, tmp_path):
+        path = tmp_path / "candidate_fmoe.csv"
         path.write_text(
             "gfx,cu_num,token,model_dim,inter_dim,expert,topk,act_type,dtype,"
-            "q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1,kernelId,us,kernelName\n"
-            "gfx950,304,64,7168,2048,128,8,Silu,bf16,"
-            "torch.float8_e4m3fn,torch.float8_e4m3fn,QuantType.per_1x128,1,0,1,10.0,tuned\n",
+            "q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1,kernelId,us,"
+            "kernelName1,kernelName2\n"
+            "gfx950,256,64,7168,2048,128,8,Swiglu,bf16,"
+            "torch.float8_e4m3fn,torch.float8_e4m3fn,QuantType.per_1x128,1,0,1,10.0,"
+            "other_stage1,other_stage2\n",
             encoding="utf-8",
         )
         (record,) = parse_aiter_fused_moe_dispatches(self._DISPATCH)
-        report = fmoe_tuned_config_coverage(tuned_fmoe_csv_keys(path), [record])
+        report = fmoe_tuned_config_coverage(tuned_fmoe_csv_rows(path), [record])
+        assert report["covered"] == 0
+        assert report["kernel_name_mismatch"] == 1
+
+    def test_csv_key_rejects_different_gfx(self, tmp_path):
+        path = tmp_path / "tuned_fmoe.csv"
+        path.write_text(
+            "gfx,cu_num,token,model_dim,inter_dim,expert,topk,act_type,dtype,"
+            "q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1,kernelId,us,"
+            "kernelName1,kernelName2\n"
+            "gfx942,256,64,7168,2048,128,8,Swiglu,bf16,"
+            "torch.float8_e4m3fn,torch.float8_e4m3fn,QuantType.per_1x128,1,0,1,10.0,"
+            "ck_moe_stage1_tuned,ck_moe_stage2_tuned\n",
+            encoding="utf-8",
+        )
+        (record,) = parse_aiter_fused_moe_dispatches(self._DISPATCH)
+        report = fmoe_tuned_config_coverage(tuned_fmoe_csv_rows(path), [record])
         assert report["covered"] == 0
 
 

--- a/src/hyperloom/orchestrator/kernel/gemm_shape_coverage.py
+++ b/src/hyperloom/orchestrator/kernel/gemm_shape_coverage.py
@@ -44,6 +44,16 @@ _AITER_SHAPE_HIT_RE = re.compile(
 Shape = tuple[int, int, int]
 FmoeDispatchKey = tuple[str, ...]
 
+# Short aliases and canonical torch dtype strings seen in fused-MoE logs/CSVs.
+# Only listed forms are normalized; anything else is preserved for exact matching.
+_FMoe_Q_DTYPE_ALIASES: dict[str, str] = {
+    "fp4": "torch.float4_e2m1fn_x2",
+    "torch.float4_e2m1fn_x2": "torch.float4_e2m1fn_x2",
+    "torch.float8_e4m3fn": "torch.float8_e4m3fn",
+    "torch.float8_e4m3fnuz": "torch.float8_e4m3fnuz",
+    "torch.float8_e5m2": "torch.float8_e5m2",
+}
+
 # ``get_2stage_cfgs`` indexes tuned rows on all fourteen columns below (see
 # ``aiter/fused_moe.py::_INDEX_COLS``). Runtime logs the same tuple after gfx
 # was added; the descriptor between ``using 2stage`` and ``for`` is either
@@ -257,6 +267,19 @@ def _split_fmoe_tuple(raw: str) -> list[str]:
     return parts
 
 
+def _normalize_fmoe_q_dtype(value: str) -> str:
+    """Map known q-dtype aliases to the canonical string aiter logs."""
+    text = str(value or "").strip().strip("'\"")
+    if not text:
+        return text
+    if text in _FMoe_Q_DTYPE_ALIASES:
+        return _FMoe_Q_DTYPE_ALIASES[text]
+    lowered = text.lower()
+    if lowered in _FMoe_Q_DTYPE_ALIASES:
+        return _FMoe_Q_DTYPE_ALIASES[lowered]
+    return text
+
+
 def _normalize_fmoe_field(name: str, value: str) -> str:
     text = str(value or "").strip().strip("'\"")
     if name == "gfx":
@@ -271,21 +294,13 @@ def _normalize_fmoe_field(name: str, value: str) -> str:
         if lowered.startswith("torch.float16"):
             return "fp16"
     if name in ("q_dtype_a", "q_dtype_w"):
-        lowered = text.lower()
-        if "float4" in lowered or "fp4" in lowered or "e2m1" in lowered:
-            return "torch.float4_e2m1fn_x2"
-        if "float8" in lowered or "fp8" in lowered or "e4m3" in lowered:
-            if "fnuz" in lowered:
-                return "torch.float8_e4m3fnuz"
-            return "torch.float8_e4m3fn"
+        return _normalize_fmoe_q_dtype(text)
     if name in ("use_g1u1", "doweight_stage1"):
         lowered = text.lower()
         if lowered in ("true", "1"):
             return "1"
         if lowered in ("false", "0"):
             return "0"
-    if name == "q_type" and text.startswith("QuantType."):
-        return text
     return text
 
 
@@ -325,11 +340,7 @@ def _parse_fused_moe_dispatch_line(line: str) -> dict[str, str] | None:
     descriptor = "default"
     kernel_name1 = ""
     kernel_name2 = ""
-    if stage_desc.endswith(" default"):
-        pass
-    elif stage_desc.endswith("default"):
-        pass
-    else:
+    if not stage_desc.endswith("default"):
         desc_open = stage_desc.rfind("(")
         if desc_open < 0:
             return None
@@ -468,11 +479,6 @@ def tuned_fmoe_csv_rows(path: str | Path) -> list[dict[str, str]]:
             record["kernelName2"] = cols[kn2_idx].strip()
         out.append(record)
     return out
-
-
-def tuned_fmoe_csv_keys(path: str | Path) -> set[FmoeDispatchKey]:
-    """Return dispatch lookup keys present in a ``tuned_fmoe.csv``."""
-    return {fmoe_dispatch_lookup_key(row) for row in tuned_fmoe_csv_rows(path)}
 
 
 def _fmoe_candidate_row_for_dispatch(

--- a/src/hyperloom/orchestrator/kernel/gemm_shape_coverage.py
+++ b/src/hyperloom/orchestrator/kernel/gemm_shape_coverage.py
@@ -270,6 +270,14 @@ def _normalize_fmoe_field(name: str, value: str) -> str:
             return "bf16"
         if lowered.startswith("torch.float16"):
             return "fp16"
+    if name in ("q_dtype_a", "q_dtype_w"):
+        lowered = text.lower()
+        if "float4" in lowered or "fp4" in lowered or "e2m1" in lowered:
+            return "torch.float4_e2m1fn_x2"
+        if "float8" in lowered or "fp8" in lowered or "e4m3" in lowered:
+            if "fnuz" in lowered:
+                return "torch.float8_e4m3fnuz"
+            return "torch.float8_e4m3fn"
     if name in ("use_g1u1", "doweight_stage1"):
         lowered = text.lower()
         if lowered in ("true", "1"):
@@ -381,17 +389,51 @@ def parse_aiter_fused_moe_dispatches(log_text: str) -> list[dict[str, str]]:
 def resolve_fmoe_candidate_csv(path: str | Path) -> Path | None:
     """Resolve the bare candidate CSV used for runtime attribution.
 
-    E2E envs often point at ``merged_candidate_fmoe.csv``. Attribution must use
-    the sibling ``candidate_fmoe.csv`` when it exists; the merged superset must
+    E2E envs often point at ``merged_<name>.csv`` (for example
+    ``merged_candidate_fmoe.csv`` or ``merged_tuned_fmoe.csv``). Attribution
+    must use the sibling bare file when it exists; the merged superset must
     not impersonate a candidate row the tuner never produced.
     """
     resolved = Path(path)
     if not resolved.is_file():
         return None
-    if resolved.name == "merged_candidate_fmoe.csv":
-        bare = resolved.parent / "candidate_fmoe.csv"
+    if resolved.name.startswith("merged_"):
+        bare = resolved.parent / resolved.name[len("merged_") :]
         return bare if bare.is_file() else None
     return resolved
+
+
+FMOE_INTEGRATE_RUN = "integrate-gemm_tune_fmoe_ck"
+
+
+def log_has_fused_moe_activity(log_text: str) -> bool:
+    """Return True when server.log shows fused-MoE activity we might parse."""
+    text = log_text or ""
+    return "[aiter] [fused_moe]" in text or "Mxfp4 MoE backend" in text
+
+
+def aiter_log_tuned_config_enabled(envs: dict[str, str]) -> bool:
+    """Mirror dense apply verification: dispatch attribution needs the flag."""
+    raw = str(envs.get("AITER_LOG_TUNED_CONFIG", "1")).strip().lower()
+    return raw not in ("", "0", "false", "no", "off")
+
+
+def read_latest_integrate_server_log(
+    session_dir: Path,
+    integrate_name: str = FMOE_INTEGRATE_RUN,
+) -> tuple[Path, str] | None:
+    """Return the newest ``server.log`` under an integrate run, if readable."""
+    run_dir = session_dir / "runs" / "integrate" / integrate_name
+    logs = sorted(
+        run_dir.rglob("server.log"),
+        key=lambda p: p.stat().st_mtime if p.exists() else 0,
+    )
+    if not logs:
+        return None
+    try:
+        return logs[-1], logs[-1].read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
 
 
 def tuned_fmoe_csv_rows(path: str | Path) -> list[dict[str, str]]:

--- a/src/hyperloom/orchestrator/kernel/gemm_shape_coverage.py
+++ b/src/hyperloom/orchestrator/kernel/gemm_shape_coverage.py
@@ -42,6 +42,25 @@ _AITER_SHAPE_HIT_RE = re.compile(
 )
 
 Shape = tuple[int, int, int]
+FmoeDispatchKey = tuple[str, ...]
+
+# aiter logs fused-MoE dispatch as
+# ``[fused_moe] using <stage> <tag> for (cu, token, model_dim, inter, expert, topk, ...)``.
+_AITER_FUSED_MOE_DISPATCH_RE = re.compile(
+    r"\[fused_moe\]\s+using\s+\S+\s+\S+\s+for\s+\((?P<tuple>[^)]*)\)"
+)
+
+# Minimum columns shared by dispatch tuples and ``tuned_fmoe.csv`` rows.
+FMOE_DISPATCH_MIN_FIELDS = (
+    "cu_num",
+    "token",
+    "model_dim",
+    "inter_dim",
+    "expert",
+    "topk",
+)
+# Quant signature columns that are stable in both log and CSV when present.
+FMOE_DISPATCH_STABLE_FIELDS = ("q_dtype_a", "q_dtype_w", "q_type")
 
 
 def aiter_padded_m_fine(m: int) -> int:
@@ -209,6 +228,165 @@ def parse_aiter_shape_lookups(log_text: str) -> tuple[set[Shape], set[Shape]]:
     missed = {(int(m), int(n), int(k)) for m, n, k, _table in _AITER_SHAPE_MISS_RE.findall(log_text or "")}
     hit = {(int(m), int(n), int(k)) for m, n, k, _padded in _AITER_SHAPE_HIT_RE.findall(log_text or "")}
     return missed, hit
+
+
+def _split_fmoe_tuple(raw: str) -> list[str]:
+    """Split a fused-MoE dispatch tuple, respecting single-quoted fields."""
+    parts: list[str] = []
+    current: list[str] = []
+    in_quote = False
+    for ch in raw:
+        if ch == "'":
+            in_quote = not in_quote
+            continue
+        if ch == "," and not in_quote:
+            parts.append("".join(current).strip())
+            current = []
+            continue
+        current.append(ch)
+    tail = "".join(current).strip()
+    if tail:
+        parts.append(tail)
+    return parts
+
+
+def _normalize_fmoe_field(name: str, value: str) -> str:
+    text = str(value or "").strip()
+    if name == "act_type" and "." in text:
+        # ``ActivationType.Swiglu`` in the log vs ``Silu`` in CSV: keep the suffix.
+        text = text.rsplit(".", 1)[-1]
+    if name == "dtype":
+        lowered = text.lower()
+        if lowered.startswith("torch.bfloat"):
+            return "bf16"
+        if lowered.startswith("torch.float16"):
+            return "fp16"
+    if name == "q_type" and text.startswith("QuantType."):
+        return text
+    return text
+
+
+def _fmoe_dispatch_record(parts: list[str]) -> dict[str, str] | None:
+    """Map a fused-MoE dispatch tuple to the CSV dispatch-schema columns."""
+    if len(parts) < 6:
+        return None
+    names = (
+        "cu_num",
+        "token",
+        "model_dim",
+        "inter_dim",
+        "expert",
+        "topk",
+        "act_type",
+        "dtype",
+        "q_dtype_a",
+        "q_dtype_w",
+        "q_type",
+        "use_g1u1",
+        "doweight_stage1",
+    )
+    record: dict[str, str] = {}
+    for idx, name in enumerate(names):
+        if idx >= len(parts):
+            break
+        record[name] = _normalize_fmoe_field(name, parts[idx])
+    if not all(record.get(field) for field in FMOE_DISPATCH_MIN_FIELDS):
+        return None
+    return record
+
+
+def fmoe_dispatch_lookup_key(record: dict[str, str]) -> FmoeDispatchKey:
+    """Return the lookup key a ``tuned_fmoe.csv`` row must match."""
+    fields = list(FMOE_DISPATCH_MIN_FIELDS)
+    for name in FMOE_DISPATCH_STABLE_FIELDS:
+        if record.get(name):
+            fields.append(name)
+    return tuple(record[field] for field in fields)
+
+
+def parse_aiter_fused_moe_dispatches(log_text: str) -> list[dict[str, str]]:
+    """Return every fused-MoE dispatch the server logged."""
+    seen: set[FmoeDispatchKey] = set()
+    out: list[dict[str, str]] = []
+    for match in _AITER_FUSED_MOE_DISPATCH_RE.finditer(log_text or ""):
+        record = _fmoe_dispatch_record(_split_fmoe_tuple(match.group("tuple")))
+        if record is None:
+            continue
+        key = fmoe_dispatch_lookup_key(record)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(record)
+    return out
+
+
+def tuned_fmoe_csv_keys(path: str | Path) -> set[FmoeDispatchKey]:
+    """Return dispatch lookup keys present in a ``tuned_fmoe.csv``."""
+    out: set[FmoeDispatchKey] = set()
+    try:
+        lines = Path(path).read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return out
+    if not lines:
+        return out
+    header = [col.strip() for col in lines[0].split(",")]
+    try:
+        indices = {name: header.index(name) for name in FMOE_DISPATCH_MIN_FIELDS}
+        stable = {
+            name: header.index(name)
+            for name in FMOE_DISPATCH_STABLE_FIELDS
+            if name in header
+        }
+    except ValueError:
+        return out
+    for line in lines[1:]:
+        cols = line.split(",")
+        if len(cols) <= max(indices.values()):
+            continue
+        record = {
+            name: _normalize_fmoe_field(name, cols[index])
+            for name, index in indices.items()
+        }
+        for name, index in stable.items():
+            if index < len(cols) and cols[index].strip():
+                record[name] = _normalize_fmoe_field(name, cols[index])
+        if all(record.get(field) for field in FMOE_DISPATCH_MIN_FIELDS):
+            out.add(fmoe_dispatch_lookup_key(record))
+    return out
+
+
+def fmoe_tuned_config_coverage(
+    tuned_keys: Iterable[FmoeDispatchKey],
+    requested_dispatches: Iterable[dict[str, str]],
+) -> dict[str, Any]:
+    """Report how many logged fused-MoE dispatches the CSV can serve."""
+    tuned = {tuple(key) for key in tuned_keys}
+    requested = list(requested_dispatches)
+    if not requested:
+        return {
+            "requested": 0,
+            "covered": 0,
+            "coverage_pct": None,
+            "tuned_rows": len(tuned),
+        }
+    covered: list[dict[str, str]] = []
+    uncovered: list[dict[str, str]] = []
+    for record in requested:
+        if fmoe_dispatch_lookup_key(record) in tuned:
+            covered.append(record)
+        else:
+            uncovered.append(record)
+    total = len(requested)
+    return {
+        "requested": total,
+        "covered": len(covered),
+        "coverage_pct": round(100.0 * len(covered) / total, 2),
+        "tuned_rows": len(tuned),
+        "uncovered_sample": [
+            {field: record.get(field) for field in FMOE_DISPATCH_MIN_FIELDS}
+            for record in uncovered[:10]
+        ],
+    }
 
 
 def parse_aiter_consulted_tables(log_text: str) -> set[str]:

--- a/src/hyperloom/orchestrator/kernel/gemm_shape_coverage.py
+++ b/src/hyperloom/orchestrator/kernel/gemm_shape_coverage.py
@@ -44,23 +44,30 @@ _AITER_SHAPE_HIT_RE = re.compile(
 Shape = tuple[int, int, int]
 FmoeDispatchKey = tuple[str, ...]
 
-# aiter logs fused-MoE dispatch as
-# ``[fused_moe] using <stage> <tag> for (cu, token, model_dim, inter, expert, topk, ...)``.
-_AITER_FUSED_MOE_DISPATCH_RE = re.compile(
-    r"\[fused_moe\]\s+using\s+\S+\s+\S+\s+for\s+\((?P<tuple>[^)]*)\)"
-)
-
-# Minimum columns shared by dispatch tuples and ``tuned_fmoe.csv`` rows.
-FMOE_DISPATCH_MIN_FIELDS = (
+# ``get_2stage_cfgs`` indexes tuned rows on all fourteen columns below (see
+# ``aiter/fused_moe.py::_INDEX_COLS``). Runtime logs the same tuple after gfx
+# was added; the descriptor between ``using 2stage`` and ``for`` is either
+# ``default`` or ``(kernelName1='…', kernelName2='…')``.
+FMOE_INDEX_COLS = (
+    "gfx",
     "cu_num",
     "token",
     "model_dim",
     "inter_dim",
     "expert",
     "topk",
+    "act_type",
+    "dtype",
+    "q_dtype_a",
+    "q_dtype_w",
+    "q_type",
+    "use_g1u1",
+    "doweight_stage1",
 )
-# Quant signature columns that are stable in both log and CSV when present.
-FMOE_DISPATCH_STABLE_FIELDS = ("q_dtype_a", "q_dtype_w", "q_type")
+
+_KERNEL_DESCRIPTOR_RE = re.compile(
+    r"kernelName1='(?P<kn1>[^']*)'.*?kernelName2='(?P<kn2>[^']*)'"
+)
 
 
 def aiter_padded_m_fine(m: int) -> int:
@@ -251,9 +258,11 @@ def _split_fmoe_tuple(raw: str) -> list[str]:
 
 
 def _normalize_fmoe_field(name: str, value: str) -> str:
-    text = str(value or "").strip()
+    text = str(value or "").strip().strip("'\"")
+    if name == "gfx":
+        return text
     if name == "act_type" and "." in text:
-        # ``ActivationType.Swiglu`` in the log vs ``Silu`` in CSV: keep the suffix.
+        # Runtime logs ``ActivationType.Swiglu``; CSVs may store the suffix.
         text = text.rsplit(".", 1)[-1]
     if name == "dtype":
         lowered = text.lower()
@@ -261,68 +270,133 @@ def _normalize_fmoe_field(name: str, value: str) -> str:
             return "bf16"
         if lowered.startswith("torch.float16"):
             return "fp16"
+    if name in ("use_g1u1", "doweight_stage1"):
+        lowered = text.lower()
+        if lowered in ("true", "1"):
+            return "1"
+        if lowered in ("false", "0"):
+            return "0"
     if name == "q_type" and text.startswith("QuantType."):
         return text
     return text
 
 
-def _fmoe_dispatch_record(parts: list[str]) -> dict[str, str] | None:
-    """Map a fused-MoE dispatch tuple to the CSV dispatch-schema columns."""
-    if len(parts) < 6:
+def _extract_paren_group(text: str, start: int) -> str | None:
+    """Return the parenthesised group starting at ``start``, or ``None``."""
+    if start >= len(text) or text[start] != "(":
         return None
-    names = (
-        "cu_num",
-        "token",
-        "model_dim",
-        "inter_dim",
-        "expert",
-        "topk",
-        "act_type",
-        "dtype",
-        "q_dtype_a",
-        "q_dtype_w",
-        "q_type",
-        "use_g1u1",
-        "doweight_stage1",
-    )
+    depth = 0
+    for idx in range(start, len(text)):
+        ch = text[idx]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return text[start + 1 : idx]
+    return None
+
+
+def _parse_fused_moe_dispatch_line(line: str) -> dict[str, str] | None:
+    """Parse one ``[fused_moe] using … for (…)`` line."""
+    marker = "[fused_moe] using "
+    pos = line.find(marker)
+    if pos < 0:
+        return None
+    rest = line[pos + len(marker) :]
+    for_sep = " for ("
+    for_pos = rest.find(for_sep)
+    if for_pos < 0:
+        return None
+
+    stage_desc = rest[:for_pos].strip()
+    keys_raw = _extract_paren_group(rest, for_pos + len(" for "))
+    if keys_raw is None:
+        return None
+
+    descriptor = "default"
+    kernel_name1 = ""
+    kernel_name2 = ""
+    if stage_desc.endswith(" default"):
+        pass
+    elif stage_desc.endswith("default"):
+        pass
+    else:
+        desc_open = stage_desc.rfind("(")
+        if desc_open < 0:
+            return None
+        descriptor = stage_desc[desc_open:].strip()
+        kn_match = _KERNEL_DESCRIPTOR_RE.search(descriptor)
+        if kn_match is None:
+            return None
+        kernel_name1 = kn_match.group("kn1")
+        kernel_name2 = kn_match.group("kn2")
+
+    record = _fmoe_dispatch_record(_split_fmoe_tuple(keys_raw))
+    if record is None:
+        return None
+    record["descriptor"] = descriptor
+    record["kernelName1"] = kernel_name1
+    record["kernelName2"] = kernel_name2
+    return record
+
+
+def _fmoe_dispatch_record(parts: list[str]) -> dict[str, str] | None:
+    """Map a fused-MoE dispatch tuple to the fourteen-column lookup schema."""
+    if len(parts) < len(FMOE_INDEX_COLS):
+        return None
     record: dict[str, str] = {}
-    for idx, name in enumerate(names):
-        if idx >= len(parts):
-            break
+    for idx, name in enumerate(FMOE_INDEX_COLS):
         record[name] = _normalize_fmoe_field(name, parts[idx])
-    if not all(record.get(field) for field in FMOE_DISPATCH_MIN_FIELDS):
+    if not all(record.get(field) for field in FMOE_INDEX_COLS[:7]):
         return None
     return record
 
 
 def fmoe_dispatch_lookup_key(record: dict[str, str]) -> FmoeDispatchKey:
-    """Return the lookup key a ``tuned_fmoe.csv`` row must match."""
-    fields = list(FMOE_DISPATCH_MIN_FIELDS)
-    for name in FMOE_DISPATCH_STABLE_FIELDS:
-        if record.get(name):
-            fields.append(name)
-    return tuple(record[field] for field in fields)
+    """Return the fourteen-column lookup key ``get_2stage_cfgs`` uses."""
+    return tuple(record[field] for field in FMOE_INDEX_COLS)
 
 
 def parse_aiter_fused_moe_dispatches(log_text: str) -> list[dict[str, str]]:
     """Return every fused-MoE dispatch the server logged."""
-    seen: set[FmoeDispatchKey] = set()
+    seen: set[tuple[str, str, FmoeDispatchKey]] = set()
     out: list[dict[str, str]] = []
-    for match in _AITER_FUSED_MOE_DISPATCH_RE.finditer(log_text or ""):
-        record = _fmoe_dispatch_record(_split_fmoe_tuple(match.group("tuple")))
+    for line in (log_text or "").splitlines():
+        record = _parse_fused_moe_dispatch_line(line)
         if record is None:
             continue
-        key = fmoe_dispatch_lookup_key(record)
-        if key in seen:
+        dedupe = (
+            record.get("descriptor") or "",
+            record.get("kernelName1") or "",
+            fmoe_dispatch_lookup_key(record),
+        )
+        if dedupe in seen:
             continue
-        seen.add(key)
+        seen.add(dedupe)
         out.append(record)
     return out
 
 
-def tuned_fmoe_csv_keys(path: str | Path) -> set[FmoeDispatchKey]:
-    """Return dispatch lookup keys present in a ``tuned_fmoe.csv``."""
-    out: set[FmoeDispatchKey] = set()
+def resolve_fmoe_candidate_csv(path: str | Path) -> Path | None:
+    """Resolve the bare candidate CSV used for runtime attribution.
+
+    E2E envs often point at ``merged_candidate_fmoe.csv``. Attribution must use
+    the sibling ``candidate_fmoe.csv`` when it exists; the merged superset must
+    not impersonate a candidate row the tuner never produced.
+    """
+    resolved = Path(path)
+    if not resolved.is_file():
+        return None
+    if resolved.name == "merged_candidate_fmoe.csv":
+        bare = resolved.parent / "candidate_fmoe.csv"
+        return bare if bare.is_file() else None
+    return resolved
+
+
+def tuned_fmoe_csv_rows(path: str | Path) -> list[dict[str, str]]:
+    """Return candidate rows with lookup keys and kernel names."""
+    out: list[dict[str, str]] = []
     try:
         lines = Path(path).read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError:
@@ -331,14 +405,11 @@ def tuned_fmoe_csv_keys(path: str | Path) -> set[FmoeDispatchKey]:
         return out
     header = [col.strip() for col in lines[0].split(",")]
     try:
-        indices = {name: header.index(name) for name in FMOE_DISPATCH_MIN_FIELDS}
-        stable = {
-            name: header.index(name)
-            for name in FMOE_DISPATCH_STABLE_FIELDS
-            if name in header
-        }
+        indices = {name: header.index(name) for name in FMOE_INDEX_COLS}
     except ValueError:
         return out
+    kn1_idx = header.index("kernelName1") if "kernelName1" in header else None
+    kn2_idx = header.index("kernelName2") if "kernelName2" in header else None
     for line in lines[1:]:
         cols = line.split(",")
         if len(cols) <= max(indices.values()):
@@ -347,43 +418,79 @@ def tuned_fmoe_csv_keys(path: str | Path) -> set[FmoeDispatchKey]:
             name: _normalize_fmoe_field(name, cols[index])
             for name, index in indices.items()
         }
-        for name, index in stable.items():
-            if index < len(cols) and cols[index].strip():
-                record[name] = _normalize_fmoe_field(name, cols[index])
-        if all(record.get(field) for field in FMOE_DISPATCH_MIN_FIELDS):
-            out.add(fmoe_dispatch_lookup_key(record))
+        if not all(record.get(field) for field in FMOE_INDEX_COLS[:7]):
+            continue
+        if kn1_idx is not None and kn1_idx < len(cols):
+            record["kernelName1"] = cols[kn1_idx].strip()
+        if kn2_idx is not None and kn2_idx < len(cols):
+            record["kernelName2"] = cols[kn2_idx].strip()
+        out.append(record)
     return out
 
 
+def tuned_fmoe_csv_keys(path: str | Path) -> set[FmoeDispatchKey]:
+    """Return dispatch lookup keys present in a ``tuned_fmoe.csv``."""
+    return {fmoe_dispatch_lookup_key(row) for row in tuned_fmoe_csv_rows(path)}
+
+
+def _fmoe_candidate_row_for_dispatch(
+    record: dict[str, str],
+    candidate_rows: dict[FmoeDispatchKey, dict[str, str]],
+) -> dict[str, str] | None:
+    return candidate_rows.get(fmoe_dispatch_lookup_key(record))
+
+
 def fmoe_tuned_config_coverage(
-    tuned_keys: Iterable[FmoeDispatchKey],
+    candidate_rows: Iterable[dict[str, str]],
     requested_dispatches: Iterable[dict[str, str]],
 ) -> dict[str, Any]:
-    """Report how many logged fused-MoE dispatches the CSV can serve."""
-    tuned = {tuple(key) for key in tuned_keys}
+    """Report how many logged dispatches hit a candidate row *and* kernel pair."""
+    by_key = {fmoe_dispatch_lookup_key(row): row for row in candidate_rows}
     requested = list(requested_dispatches)
     if not requested:
         return {
             "requested": 0,
             "covered": 0,
             "coverage_pct": None,
-            "tuned_rows": len(tuned),
+            "tuned_rows": len(by_key),
         }
     covered: list[dict[str, str]] = []
     uncovered: list[dict[str, str]] = []
+    default_count = 0
+    kernel_mismatch = 0
     for record in requested:
-        if fmoe_dispatch_lookup_key(record) in tuned:
+        if record.get("descriptor") == "default":
+            default_count += 1
+            uncovered.append(record)
+            continue
+        row = _fmoe_candidate_row_for_dispatch(record, by_key)
+        if row is None:
+            uncovered.append(record)
+            continue
+        if (
+            record.get("kernelName1") == row.get("kernelName1")
+            and record.get("kernelName2") == row.get("kernelName2")
+        ):
             covered.append(record)
         else:
+            kernel_mismatch += 1
             uncovered.append(record)
     total = len(requested)
     return {
         "requested": total,
         "covered": len(covered),
-        "coverage_pct": round(100.0 * len(covered) / total, 2),
-        "tuned_rows": len(tuned),
+        "coverage_pct": round(100.0 * len(covered) / total, 2) if total else None,
+        "tuned_rows": len(by_key),
+        "runtime_default": default_count,
+        "kernel_name_mismatch": kernel_mismatch,
         "uncovered_sample": [
-            {field: record.get(field) for field in FMOE_DISPATCH_MIN_FIELDS}
+            {
+                "gfx": record.get("gfx"),
+                "token": record.get("token"),
+                "descriptor": record.get("descriptor"),
+                "kernelName1": record.get("kernelName1"),
+                "kernelName2": record.get("kernelName2"),
+            }
             for record in uncovered[:10]
         ],
     }

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -1834,6 +1834,8 @@ class KernelPhase(PhaseHandler):
         the real cause -- an artifact the runtime never applied -- stays invisible.
         Replaying the lookup against the round's ``server.log`` separates the two.
         """
+        if tuner_name == "fmoe_ck":
+            return self._fmoe_tuned_config_coverage(envs)
         from ..kernel.gemm_shape_coverage import (
             parse_aiter_consulted_tables,
             parse_aiter_shape_lookups,
@@ -1873,6 +1875,56 @@ class KernelPhase(PhaseHandler):
             report["artifact_applied"] = False
             report["not_applied_reason"] = "artifact_table_not_consulted"
         elif not report["artifact_applied"]:
+            report["not_applied_reason"] = "no_shape_key_matched"
+        return report
+
+    def _fmoe_tuned_config_coverage(
+        self,
+        envs: dict[str, str],
+    ) -> dict[str, Any] | None:
+        """Report whether a ``tuned_fmoe.csv`` covers logged fused-MoE dispatches.
+
+        Dense BF16 GEMM lookups in the same log are ignored: they belong to
+        linears the ``fmoe_ck`` tuner never wrote, and treating
+        ``bf16_tuned_gemm.csv`` as evidence produced false
+        ``artifact_table_not_consulted`` blockers on MoE models.
+        """
+        from ..kernel.gemm_shape_coverage import (
+            fmoe_tuned_config_coverage,
+            parse_aiter_fused_moe_dispatches,
+            tuned_fmoe_csv_keys,
+        )
+
+        csv_paths = [value for key, value in envs.items() if key.startswith("AITER_CONFIG")]
+        if not csv_paths:
+            return None
+        run_dir = self.session_dir / "runs" / "integrate" / "integrate-gemm_tune_fmoe_ck"
+        logs = sorted(run_dir.rglob("server.log"), key=lambda p: p.stat().st_mtime if p.exists() else 0)
+        if not logs:
+            return None
+        try:
+            log_text = logs[-1].read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return None
+        dispatches = parse_aiter_fused_moe_dispatches(log_text)
+        report: dict[str, Any] = {
+            "server_log": str(logs[-1]),
+            "requested": len(dispatches),
+        }
+        if not dispatches:
+            report["artifact_applied"] = False
+            report["not_applied_reason"] = "no_fused_moe_dispatch"
+            report["runtime_lookup_miss"] = 0
+            report["runtime_lookup_hit"] = 0
+            return report
+        tuned: set[tuple[str, ...]] = set()
+        for path in csv_paths:
+            tuned |= tuned_fmoe_csv_keys(path)
+        report.update(fmoe_tuned_config_coverage(tuned, dispatches))
+        report["artifact_applied"] = bool(report.get("covered"))
+        report["runtime_lookup_miss"] = report.get("requested", 0) - report.get("covered", 0)
+        report["runtime_lookup_hit"] = report.get("covered", 0)
+        if not report["artifact_applied"]:
             report["not_applied_reason"] = "no_shape_key_matched"
         return report
 
@@ -1967,6 +2019,8 @@ class KernelPhase(PhaseHandler):
         arrived and the server loaded its bundled default instead, because the
         CSV on our disk still contains the right rows either way.
         """
+        if tuner_name == "fmoe_ck":
+            return self._fmoe_apply_verdict(envs)
         from ..measurement.apply_verification import verify_applied
 
         csv_paths = [value for key, value in envs.items() if key.startswith("AITER_CONFIG")]
@@ -2009,6 +2063,88 @@ class KernelPhase(PhaseHandler):
         except Exception:  # noqa: BLE001 - verification must never fail the run
             log.warning("apply verification failed for %s", tuner_name, exc_info=True)
             return None
+
+    def _fmoe_apply_verdict(
+        self,
+        envs: dict[str, str],
+    ) -> dict[str, Any] | None:
+        """Apply verdict for ``fmoe_ck`` based on fused-MoE dispatch, not dense GEMM.
+
+        Dense ``bf16_tuned_gemm.csv`` consulted-table lines in the same log must
+        not drive ``not_merged`` for a tuner that only deploys ``tuned_fmoe.csv``.
+        """
+        from ..kernel.gemm_shape_coverage import (
+            fmoe_tuned_config_coverage,
+            parse_aiter_fused_moe_dispatches,
+            tuned_fmoe_csv_keys,
+        )
+
+        csv_paths = [value for key, value in envs.items() if key.startswith("AITER_CONFIG")]
+        if not csv_paths:
+            return None
+        run_dir = self.session_dir / "runs" / "integrate" / "integrate-gemm_tune_fmoe_ck"
+        logs = sorted(
+            run_dir.rglob("server.log"),
+            key=lambda p: p.stat().st_mtime if p.exists() else 0,
+        )
+        if not logs:
+            log.warning(
+                "forge gemm E2E: no server.log under %s; apply verification "
+                "cannot run for fmoe_ck", run_dir,
+            )
+            return None
+        try:
+            log_text = logs[-1].read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return None
+
+        dispatches = parse_aiter_fused_moe_dispatches(log_text)
+        if not dispatches:
+            return {
+                "verdict": "no_fused_moe_dispatch",
+                "hits": 0,
+                "misses": 0,
+                "blocks_keep": True,
+                "conclusive": True,
+                "merged_tables": [],
+                "unmerged_artifacts": list(csv_paths),
+                "detail": (
+                    "server.log exists but contains no [aiter] [fused_moe] "
+                    "dispatch lines"
+                ),
+            }
+
+        tuned: set[tuple[str, ...]] = set()
+        for path in csv_paths:
+            tuned |= tuned_fmoe_csv_keys(path)
+        coverage = fmoe_tuned_config_coverage(tuned, dispatches)
+        covered = int(coverage.get("covered") or 0)
+        requested = int(coverage.get("requested") or 0)
+        if covered > 0:
+            return {
+                "verdict": "served",
+                "hits": covered,
+                "misses": requested - covered,
+                "blocks_keep": False,
+                "conclusive": True,
+                "merged_tables": [],
+                "unmerged_artifacts": [],
+                "detail": (
+                    f"{covered} fused-MoE dispatch(es) match tuned_fmoe.csv keys"
+                ),
+            }
+        return {
+            "verdict": "no_shape_key_matched",
+            "hits": 0,
+            "misses": requested,
+            "blocks_keep": True,
+            "conclusive": True,
+            "merged_tables": [],
+            "unmerged_artifacts": [],
+            "detail": (
+                f"0 of {requested} fused-MoE dispatch(es) resolve to a tuned row"
+            ),
+        }
 
     def _merge_gemm_candidate_with_runtime(
         self, env_var: str, candidate_csv_path: str

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -1892,12 +1892,14 @@ class KernelPhase(PhaseHandler):
         from ..kernel.gemm_shape_coverage import (
             fmoe_tuned_config_coverage,
             parse_aiter_fused_moe_dispatches,
-            tuned_fmoe_csv_keys,
+            resolve_fmoe_candidate_csv,
+            tuned_fmoe_csv_rows,
         )
 
         csv_paths = [value for key, value in envs.items() if key.startswith("AITER_CONFIG")]
         if not csv_paths:
             return None
+        candidate_path = resolve_fmoe_candidate_csv(csv_paths[0])
         run_dir = self.session_dir / "runs" / "integrate" / "integrate-gemm_tune_fmoe_ck"
         logs = sorted(run_dir.rglob("server.log"), key=lambda p: p.stat().st_mtime if p.exists() else 0)
         if not logs:
@@ -1917,15 +1919,26 @@ class KernelPhase(PhaseHandler):
             report["runtime_lookup_miss"] = 0
             report["runtime_lookup_hit"] = 0
             return report
-        tuned: set[tuple[str, ...]] = set()
-        for path in csv_paths:
-            tuned |= tuned_fmoe_csv_keys(path)
-        report.update(fmoe_tuned_config_coverage(tuned, dispatches))
+        if candidate_path is None:
+            report["artifact_applied"] = False
+            report["not_applied_reason"] = "candidate_csv_missing"
+            report["runtime_lookup_miss"] = len(dispatches)
+            report["runtime_lookup_hit"] = 0
+            report["conclusive"] = False
+            return report
+        candidate_rows = tuned_fmoe_csv_rows(candidate_path)
+        report["candidate_csv"] = str(candidate_path)
+        report.update(fmoe_tuned_config_coverage(candidate_rows, dispatches))
         report["artifact_applied"] = bool(report.get("covered"))
         report["runtime_lookup_miss"] = report.get("requested", 0) - report.get("covered", 0)
         report["runtime_lookup_hit"] = report.get("covered", 0)
         if not report["artifact_applied"]:
-            report["not_applied_reason"] = "no_shape_key_matched"
+            if report.get("runtime_default"):
+                report["not_applied_reason"] = "runtime_default_config"
+            elif report.get("kernel_name_mismatch"):
+                report["not_applied_reason"] = "kernel_name_mismatch"
+            else:
+                report["not_applied_reason"] = "no_shape_key_matched"
         return report
 
     async def _confirm_gemm_gain_paired(
@@ -2076,12 +2089,14 @@ class KernelPhase(PhaseHandler):
         from ..kernel.gemm_shape_coverage import (
             fmoe_tuned_config_coverage,
             parse_aiter_fused_moe_dispatches,
-            tuned_fmoe_csv_keys,
+            resolve_fmoe_candidate_csv,
+            tuned_fmoe_csv_rows,
         )
 
         csv_paths = [value for key, value in envs.items() if key.startswith("AITER_CONFIG")]
         if not csv_paths:
             return None
+        candidate_path = resolve_fmoe_candidate_csv(csv_paths[0])
         run_dir = self.session_dir / "runs" / "integrate" / "integrate-gemm_tune_fmoe_ck"
         logs = sorted(
             run_dir.rglob("server.log"),
@@ -2114,10 +2129,24 @@ class KernelPhase(PhaseHandler):
                 ),
             }
 
-        tuned: set[tuple[str, ...]] = set()
-        for path in csv_paths:
-            tuned |= tuned_fmoe_csv_keys(path)
-        coverage = fmoe_tuned_config_coverage(tuned, dispatches)
+        if candidate_path is None:
+            return {
+                "verdict": "candidate_csv_missing",
+                "hits": 0,
+                "misses": len(dispatches),
+                "blocks_keep": True,
+                "conclusive": False,
+                "merged_tables": [],
+                "unmerged_artifacts": list(csv_paths),
+                "detail": (
+                    "env points at merged_candidate_fmoe.csv but sibling "
+                    "candidate_fmoe.csv is absent; cannot attribute runtime "
+                    "kernel names to the tuner candidate"
+                ),
+            }
+
+        candidate_rows = tuned_fmoe_csv_rows(candidate_path)
+        coverage = fmoe_tuned_config_coverage(candidate_rows, dispatches)
         covered = int(coverage.get("covered") or 0)
         requested = int(coverage.get("requested") or 0)
         if covered > 0:
@@ -2130,7 +2159,36 @@ class KernelPhase(PhaseHandler):
                 "merged_tables": [],
                 "unmerged_artifacts": [],
                 "detail": (
-                    f"{covered} fused-MoE dispatch(es) match tuned_fmoe.csv keys"
+                    f"{covered} fused-MoE dispatch(es) match candidate "
+                    f"kernelName1/kernelName2 in {candidate_path.name}"
+                ),
+            }
+        if coverage.get("runtime_default"):
+            return {
+                "verdict": "runtime_default_config",
+                "hits": 0,
+                "misses": requested,
+                "blocks_keep": True,
+                "conclusive": True,
+                "merged_tables": [],
+                "unmerged_artifacts": [],
+                "detail": (
+                    "runtime served default heuristics; tuned candidate "
+                    "kernels were not selected"
+                ),
+            }
+        if coverage.get("kernel_name_mismatch"):
+            return {
+                "verdict": "kernel_name_mismatch",
+                "hits": 0,
+                "misses": requested,
+                "blocks_keep": True,
+                "conclusive": True,
+                "merged_tables": [],
+                "unmerged_artifacts": [],
+                "detail": (
+                    "lookup key matched bundled rows but runtime kernelName1/"
+                    "kernelName2 differ from candidate_fmoe.csv"
                 ),
             }
         return {
@@ -2142,7 +2200,7 @@ class KernelPhase(PhaseHandler):
             "merged_tables": [],
             "unmerged_artifacts": [],
             "detail": (
-                f"0 of {requested} fused-MoE dispatch(es) resolve to a tuned row"
+                f"0 of {requested} fused-MoE dispatch(es) resolve to a candidate row"
             ),
         }
 

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -1833,6 +1833,10 @@ class KernelPhase(PhaseHandler):
         still boots and benchmarks fine, so the gate sees an honest "no gain" and
         the real cause -- an artifact the runtime never applied -- stays invisible.
         Replaying the lookup against the round's ``server.log`` separates the two.
+
+        For ``fmoe_ck``, delegates to ``_fmoe_tuned_config_coverage``, which
+        matches fused-MoE dispatch lines against ``candidate_fmoe.csv`` rather
+        than dense ``(M, N, K)`` GEMM lookups.
         """
         if tuner_name == "fmoe_ck":
             return self._fmoe_tuned_config_coverage(envs)
@@ -1890,8 +1894,11 @@ class KernelPhase(PhaseHandler):
         ``artifact_table_not_consulted`` blockers on MoE models.
         """
         from ..kernel.gemm_shape_coverage import (
+            aiter_log_tuned_config_enabled,
             fmoe_tuned_config_coverage,
+            log_has_fused_moe_activity,
             parse_aiter_fused_moe_dispatches,
+            read_latest_integrate_server_log,
             resolve_fmoe_candidate_csv,
             tuned_fmoe_csv_rows,
         )
@@ -1899,23 +1906,30 @@ class KernelPhase(PhaseHandler):
         csv_paths = [value for key, value in envs.items() if key.startswith("AITER_CONFIG")]
         if not csv_paths:
             return None
+        loaded = read_latest_integrate_server_log(self.session_dir)
+        if loaded is None:
+            return None
+        log_path, log_text = loaded
         candidate_path = resolve_fmoe_candidate_csv(csv_paths[0])
-        run_dir = self.session_dir / "runs" / "integrate" / "integrate-gemm_tune_fmoe_ck"
-        logs = sorted(run_dir.rglob("server.log"), key=lambda p: p.stat().st_mtime if p.exists() else 0)
-        if not logs:
-            return None
-        try:
-            log_text = logs[-1].read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            return None
         dispatches = parse_aiter_fused_moe_dispatches(log_text)
+        hit_logging = aiter_log_tuned_config_enabled(envs)
         report: dict[str, Any] = {
-            "server_log": str(logs[-1]),
+            "server_log": str(log_path),
             "requested": len(dispatches),
         }
         if not dispatches:
-            report["artifact_applied"] = False
-            report["not_applied_reason"] = "no_fused_moe_dispatch"
+            if log_has_fused_moe_activity(log_text):
+                report["artifact_applied"] = False
+                report["not_applied_reason"] = "fused_moe_parse_inconclusive"
+                report["conclusive"] = False
+            elif not hit_logging:
+                report["artifact_applied"] = False
+                report["not_applied_reason"] = "fused_moe_logging_disabled"
+                report["conclusive"] = False
+            else:
+                report["artifact_applied"] = False
+                report["not_applied_reason"] = "no_fused_moe_dispatch"
+                report["conclusive"] = True
             report["runtime_lookup_miss"] = 0
             report["runtime_lookup_hit"] = 0
             return report
@@ -1930,6 +1944,7 @@ class KernelPhase(PhaseHandler):
         report["candidate_csv"] = str(candidate_path)
         report.update(fmoe_tuned_config_coverage(candidate_rows, dispatches))
         report["artifact_applied"] = bool(report.get("covered"))
+        report["conclusive"] = True
         report["runtime_lookup_miss"] = report.get("requested", 0) - report.get("covered", 0)
         report["runtime_lookup_hit"] = report.get("covered", 0)
         if not report["artifact_applied"]:
@@ -2031,6 +2046,10 @@ class KernelPhase(PhaseHandler):
         served the requests"; it cannot see the case where the table never
         arrived and the server loaded its bundled default instead, because the
         CSV on our disk still contains the right rows either way.
+
+        For ``fmoe_ck``, delegates to ``_fmoe_apply_verdict``, which attributes
+        fused-MoE kernel pairs from dispatch lines instead of dense merge/hit
+        logging.
         """
         if tuner_name == "fmoe_ck":
             return self._fmoe_apply_verdict(envs)
@@ -2087,8 +2106,11 @@ class KernelPhase(PhaseHandler):
         not drive ``not_merged`` for a tuner that only deploys ``tuned_fmoe.csv``.
         """
         from ..kernel.gemm_shape_coverage import (
+            aiter_log_tuned_config_enabled,
             fmoe_tuned_config_coverage,
+            log_has_fused_moe_activity,
             parse_aiter_fused_moe_dispatches,
+            read_latest_integrate_server_log,
             resolve_fmoe_candidate_csv,
             tuned_fmoe_csv_rows,
         )
@@ -2096,25 +2118,47 @@ class KernelPhase(PhaseHandler):
         csv_paths = [value for key, value in envs.items() if key.startswith("AITER_CONFIG")]
         if not csv_paths:
             return None
-        candidate_path = resolve_fmoe_candidate_csv(csv_paths[0])
-        run_dir = self.session_dir / "runs" / "integrate" / "integrate-gemm_tune_fmoe_ck"
-        logs = sorted(
-            run_dir.rglob("server.log"),
-            key=lambda p: p.stat().st_mtime if p.exists() else 0,
-        )
-        if not logs:
+        loaded = read_latest_integrate_server_log(self.session_dir)
+        if loaded is None:
+            run_dir = self.session_dir / "runs" / "integrate" / "integrate-gemm_tune_fmoe_ck"
             log.warning(
                 "forge gemm E2E: no server.log under %s; apply verification "
                 "cannot run for fmoe_ck", run_dir,
             )
             return None
-        try:
-            log_text = logs[-1].read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            return None
-
+        log_path, log_text = loaded
+        hit_logging = aiter_log_tuned_config_enabled(envs)
+        candidate_path = resolve_fmoe_candidate_csv(csv_paths[0])
         dispatches = parse_aiter_fused_moe_dispatches(log_text)
         if not dispatches:
+            if log_has_fused_moe_activity(log_text):
+                return {
+                    "verdict": "fused_moe_parse_inconclusive",
+                    "hits": 0,
+                    "misses": 0,
+                    "blocks_keep": False,
+                    "conclusive": False,
+                    "merged_tables": [],
+                    "unmerged_artifacts": list(csv_paths),
+                    "detail": (
+                        "server.log contains fused-MoE activity but no dispatch "
+                        "lines could be parsed"
+                    ),
+                }
+            if not hit_logging:
+                return {
+                    "verdict": "fused_moe_logging_disabled",
+                    "hits": 0,
+                    "misses": 0,
+                    "blocks_keep": False,
+                    "conclusive": False,
+                    "merged_tables": [],
+                    "unmerged_artifacts": list(csv_paths),
+                    "detail": (
+                        "AITER_LOG_TUNED_CONFIG is off; fused-MoE dispatch "
+                        "attribution cannot run"
+                    ),
+                }
             return {
                 "verdict": "no_fused_moe_dispatch",
                 "hits": 0,
@@ -2134,13 +2178,13 @@ class KernelPhase(PhaseHandler):
                 "verdict": "candidate_csv_missing",
                 "hits": 0,
                 "misses": len(dispatches),
-                "blocks_keep": True,
+                "blocks_keep": False,
                 "conclusive": False,
                 "merged_tables": [],
                 "unmerged_artifacts": list(csv_paths),
                 "detail": (
-                    "env points at merged_candidate_fmoe.csv but sibling "
-                    "candidate_fmoe.csv is absent; cannot attribute runtime "
+                    "env points at a merged fmoe CSV but the sibling bare "
+                    "candidate file is absent; cannot attribute runtime "
                     "kernel names to the tuner candidate"
                 ),
             }
@@ -2960,7 +3004,7 @@ class KernelPhase(PhaseHandler):
             coverage = self._gemm_tuned_config_coverage(tuner_name, env)
             if coverage is not None:
                 cand = {**cand, "tuned_config_coverage": coverage}
-                if not coverage.get("artifact_applied"):
+                if not coverage.get("artifact_applied") and coverage.get("conclusive", True):
                     apply_blockers.append(
                         str(coverage.get("not_applied_reason") or "no_shape_key_matched")
                     )
@@ -2971,6 +3015,12 @@ class KernelPhase(PhaseHandler):
                         tuner_name,
                         coverage.get("requested") or 0,
                         gain_pct,
+                    )
+                elif not coverage.get("artifact_applied"):
+                    log.info(
+                        "gemm E2E: tuner=%s tuned-config coverage inconclusive — %s",
+                        tuner_name,
+                        coverage.get("not_applied_reason"),
                     )
                 else:
                     log.info(


### PR DESCRIPTION
## Problem
FMOE E2E validation reused dense GEMM M/N/K logs and could also mistake a default or bundled fused-MoE config for the tuner candidate. The production aiter lookup uses a fourteen-column key and reports the selected kernel pair in the dispatch log.

## Fix
Parse the production fused-MoE descriptor and full lookup key, then require `kernelName1` and `kernelName2` to match the bare candidate CSV before allowing KEEP. Ignore dense BF16 lookups, and block default, bundled, missing-candidate, or unmatched dispatches.