### PR TITLE
fix(writeback): stack every applied explore winner, not just the best…

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_promote_shared_state_lock.py
+++ b/src/hyperloom/inference_optimizer/tests/test_promote_shared_state_lock.py
@@ -1616,3 +1616,43 @@ async def test_integrate_keep_lets_a_tuning_env_delta_win(session_dir):
     )
 
     assert s.current_best["extra_envs"] == {"KEEP_ME": "1", "TUNED": "new"}
+
+
+@pytest.mark.asyncio
+async def test_promote_explore_stacks_every_applied_winner(session_dir):
+    """Every winner applied in a round must reach optimization_stack.
+
+    Winners in one round are applied cumulatively: ``running_base_tput``
+    advances with each in-batch KEEP, so the second variant is stack-rebenched
+    on top of the first and the round's ``output_throughput`` reflects both.
+    Recording only ``best_variant`` therefore credits the round's cumulative
+    throughput to a config that is missing the other winners' args.
+    """
+    coord = _coord(session_dir)
+    s = coord.shared_state
+    s.baseline_tput = 100.0
+    w1 = {"name": "v1", "fingerprint": "f1", "tput": 120.0, "extra_server_args": "--flag-a"}
+    w2 = {"name": "v2", "fingerprint": "f2", "tput": 130.0, "extra_server_args": "--flag-b"}
+
+    await coord._promote_to_shared_state(
+        "explore",
+        {
+            "explore_search_update": {},
+            "winners": [w1, w2],
+            "round_id": "r1",
+            "best_variant": w1,
+            "output_throughput": 130.0,
+            "best_gain_pct": 20.0,
+        },
+        task=_task("explore"),
+    )
+
+    accepted = s.explore_search.get("accepted") if isinstance(s.explore_search, dict) else None
+    assert isinstance(accepted, list) and len(accepted) == 2
+
+    stacked_args = " ".join(str(e.get("extra_server_args") or "") for e in s.optimization_stack)
+    assert "--flag-a" in stacked_args
+    assert "--flag-b" in stacked_args, (
+        f"winner v2 was applied and counted in output_throughput but its args are "
+        f"missing from optimization_stack: {s.optimization_stack}"
+    )

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -3765,20 +3765,41 @@ class WritebackCollaborator:
                             prov,
                         )
                 changed = True
-            # 4. Lift the best winner into current_best / optimization_stack.
-            if isinstance(best_winner, dict) and isinstance(best_tput, (int, float)) and best_tput > 0:
-                best_winner = dict(best_winner)
+            # 4. Lift every applied winner into current_best / optimization_stack.
+            # Winners in a round are applied cumulatively -- ``running_base_tput``
+            # advances with each in-batch KEEP and ``output_throughput`` is the
+            # resulting final stack -- so lifting only ``best_variant`` credited
+            # the round's cumulative throughput to a config missing the other
+            # winners' args, and those args never reached the stack at all.
+            # Each entry carries its own post-apply ``tput`` (explore overwrites
+            # it with the stack rebench result), which rises with the running
+            # base, so the anchor check clears them in application order.
+            explore_gap_cid = (
+                str((task.params or {}).get("gap_canonical_id") or "").strip() if task is not None else ""
+            )
+            for winner in winners:
+                if not isinstance(winner, dict):
+                    continue
+                entry = dict(winner)
                 if task is not None:
-                    best_winner["task_id"] = str(task.task_id or "")
-                explore_gap_cid = (
-                    str((task.params or {}).get("gap_canonical_id") or "").strip() if task is not None else ""
-                )
-                promoted = self._lift_to_current_best(
+                    entry["task_id"] = str(task.task_id or "")
+                entry_tput = entry.get("tput")
+                if not isinstance(entry_tput, (int, float)) or float(entry_tput) <= 0:
+                    # A payload without a per-winner tput (older executors, and
+                    # some test doubles) only carries the round throughput; fall
+                    # back to it so the single-winner path is unchanged. With
+                    # several such winners the anchor check keeps the first one,
+                    # which is the pre-existing behaviour.
+                    entry_tput = best_tput
+                if not isinstance(entry_tput, (int, float)) or float(entry_tput) <= 0:
+                    continue
+                if self._lift_to_current_best(
                     "explore",
-                    float(best_tput),
-                    best_winner,
+                    float(entry_tput),
+                    entry,
                     gap_canonical_id=explore_gap_cid,
-                )
+                ):
+                    promoted = True
                 changed = True
         try:
             self.shared_state.note_explore_outcome(promoted=promoted)


### PR DESCRIPTION
# fix(writeback): stack every applied explore winner, not just the best one

## Problem

When one explore round produces several winners, they are all applied and all counted in the round's throughput, but only `best_variant` reaches `optimization_stack`. The other winners' args are dropped, so the reported final config cannot reproduce the throughput the report claims.

From a real 3h run:

```
explore_search.accepted        3 entries
optimization_stack             2 entries      <- one lost
final.extra_server_args        "--attention-backend ROCM_AITER_FA --kv-cache-dtype fp8"
                                              <- missing --async-scheduling ...
gain_per_stack_entry[0]        23.32%         <- 6638.2 x 1.2332 = 8186.4
stack[0].tput                  8186.4         <- the *second* winner's throughput
stack[0].extra_server_args     "--attention-backend ROCM_AITER_FA"   <- only the first
```

The second winner's throughput was credited to the first winner's config, and its own args vanished. `winners_count` per round confirms it: the round with 2 winners contributed 1 stack entry, the round with 1 winner contributed 1.

## Root cause

`_promote_explore` records every winner as accepted, but lifts only one:

```python
for winner in winners:
    self.shared_state.record_explore_accepted(accepted)   # every winner

# 4. Lift the best winner into current_best / optimization_stack.
if isinstance(best_winner, dict) and ...:
    promoted = self._lift_to_current_best("explore", float(best_tput), best_winner, ...)
```

The two arguments come from different things: `best_tput` is `result["output_throughput"]` — the whole round's cumulative throughput — while `best_winner` is `max(winners, key=gain_pct)`, a single variant.

Winners in a round are cumulative, not alternatives. In `explore.py`:

```python
keep_entry["tput"] = stack_rebench_tput    # 1780, overwritten after a stable KEEP
running_base_tput = stack_rebench_tput     # 1778, base advances with it
output_throughput = float(running_base_tput)   # 2016
# comment: "Each KEEP advances running_base_tput, so this is the final stack."
```

The second variant is stack-rebenched on top of the first, so the round's throughput reflects both. Crediting it to one variant's config is what breaks the report.

## Fix

Lift every winner, each with its own post-apply `tput`:

```python
for winner in winners:
    entry = dict(winner)
    entry_tput = entry.get("tput")
    if not valid(entry_tput):
        entry_tput = best_tput      # payloads without a per-winner tput
    if self._lift_to_current_best("explore", float(entry_tput), entry, ...):
        promoted = True
```

Since `keep_entry["tput"]` tracks `running_base_tput`, the per-winner values rise in application order, so each one clears the anchor check in `_lift_to_current_best` (`if anchor > 0 and best_tput <= anchor: return False`). `_lift_to_current_best` already accumulates `extra_server_args` from the previous `current_best`, so stack entries compose into the full config on their own.

The fallback keeps older payloads unchanged: with one such winner the behaviour is identical to before, and with several the anchor check keeps the first — the pre-existing outcome. `best_tput` is still used for `_update_cumulative_gain_validated`, which correctly wants the round's final stack throughput.

## Verification

**Unit test.** `test_promote_explore_stacks_every_applied_winner` feeds two winners whose args must both land in the stack. Reverting only the implementation confirms it catches the bug:

```
without fix:  FAILED  assert '--flag-b' in '--flag-a'
              stack: [{'variant_name': 'v1', 'extra_server_args': '--flag-a', 'tput': 130.0}]
              (tput is the cumulative value, args are one variant's)
with fix:     PASSED
```

**Full suite.** `9 failed, 14360 passed, 32 skipped` — the same 9 pre-existing failures as `main`; passing count goes 14359 -> 14360 (the new test).


