### PR TITLE
fix(kernel-agent): reject a capture-only trace input before analysis

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -2344,6 +2344,130 @@ def test_analysis_input_is_left_alone_when_the_first_candidate_has_kernels(tmp_p
     assert str(first) in [str(p) for p in splitter]
 
 
+def _capture_sidecar(path: Path, kernels: int = 2) -> Path:
+    """Write a CUDA-graph capture sidecar in its production shape.
+
+    ``kernels`` defaults to 2 on purpose. A capture records the graph being
+    built, so a couple of launches still reach the device while the rest of the
+    file is host-side call tree — the run this guards against had 2 kernels in
+    1.49M events. A sidecar with *zero* kernels would already be stopped by the
+    CPU-only preflight; two is the count that gets through it.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return _rank_trace(path, kernels=kernels, cpu_events=200)
+
+
+def test_capture_only_input_is_rejected_before_the_splitter(tmp_path, capsys):
+    """A directory holding nothing but graph-capture sidecars must not analyse.
+
+    The sidecars carry kernels, so the CPU-only preflight passes them and the
+    splitter is handed a file with no iteration loop in it. It then reports
+    ``trace_split_no_steady_state``, which reads as "the profiled window was too
+    short" and sends the next person to lengthen a capture that was never a
+    workload timeline. The rejection has to name the real cause instead.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    capture = trace_dir / "capture_traces"
+    for bs in (2, 4, 8):
+        for rank in (0, 1):
+            _capture_sidecar(capture / f"bs_{bs}_rank{rank}.json.gz")
+
+    # Precondition: this is exactly the shape the old check waved through.
+    _kind, traces = tla.discover_trace_inputs(trace_dir)
+    assert len(traces) == 6
+    assert tla._count_kernels_if_readable(traces[0])[1] > 0
+
+    captured = _drive_main_over_capture_dir(tmp_path, trace_dir)
+
+    assert _find_splitter_cmd(captured) is None, "the splitter must never be invoked"
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "failed"
+    assert "trace_input_capture_only" in result["error"]
+    # The message has to point at the profile, not at the splitter or the window.
+    assert "re-profile" in result["error"]
+
+
+def test_capture_sidecars_beside_a_real_trace_still_analyse(tmp_path):
+    """The healthy layout must be unaffected.
+
+    A normal profile writes its annotated trace *beside* the capture sidecars,
+    which is why the rejection tests ``all`` and not ``any``. Getting this
+    backwards would disable roofline for every well-formed profile.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    real = _rank_trace(trace_dir / "rank_0.trace.json.gz", kernels=12)
+    _capture_sidecar(trace_dir / "capture_traces" / "bs_2_rank0.json.gz")
+
+    captured = _drive_main_over_capture_dir(tmp_path, trace_dir)
+
+    splitter = _find_splitter_cmd(captured)
+    assert splitter is not None, "a real trace beside sidecars must still analyse"
+    assert str(real) in [str(p) for p in splitter]
+
+
+def test_lone_capture_sidecar_file_is_rejected_by_name(tmp_path, capsys):
+    """``--trace-input`` pointed straight at one sidecar is the same mistake."""
+    sidecar = _capture_sidecar(tmp_path / "torch_trace" / "bs_16_rank3.json.gz")
+
+    captured = _drive_main_over_capture_dir(tmp_path, sidecar)
+
+    assert _find_splitter_cmd(captured) is None
+    assert "trace_input_capture_only" in json.loads(capsys.readouterr().out)["error"]
+
+
+def test_capture_classification_ignores_an_unrelated_ancestor_dir(tmp_path):
+    """An ancestor named ``capture_traces`` must not condemn a real trace.
+
+    Paths arrive absolute, so an unbounded component test would reject every
+    candidate whenever the session happened to live under a directory of that
+    name — pointing ``--trace-input`` inside a previous capture, say.
+    """
+    root = tmp_path / "capture_traces" / "torch_trace"
+    root.mkdir(parents=True)
+    real = _rank_trace(root / "rank_0.trace.json.gz", kernels=7)
+
+    assert not tla._is_capture_fragment(real, tla._capture_classification_root(root))
+    # A genuine sidecar below the root is still caught.
+    nested = _capture_sidecar(root / "capture_traces" / "bs_2_rank0.json.gz")
+    assert tla._is_capture_fragment(nested, tla._capture_classification_root(root))
+
+
+def test_bare_bs_prefix_is_not_enough_to_condemn_a_trace(tmp_path):
+    """``bs_`` without a batch number must not classify as a sidecar.
+
+    The classifier decides whether an input is rejected outright, not just how
+    it sorts, so matching three characters of a filename is too cheap a reason
+    to throw a real trace away. The sidecar shapes carry a batch number.
+    """
+    root = tmp_path / "torch_trace"
+    root.mkdir()
+    classify_root = tla._capture_classification_root(root)
+
+    assert tla._is_capture_fragment(root / "bs_2_rank0.json.gz", classify_root)
+    assert tla._is_capture_fragment(root / "bs_512.json.gz", classify_root)
+    assert tla._is_capture_fragment(root / "graph_capture_rank_0.pt.trace.json.gz", classify_root)
+    assert not tla._is_capture_fragment(root / "bs_baseline.trace.json.gz", classify_root)
+    assert not tla._is_capture_fragment(root / "rank_0.trace.json.gz", classify_root)
+
+
+def test_capture_sidecars_sort_behind_a_real_trace(tmp_path):
+    """Discovery ordering must keep sidecars behind the annotated trace.
+
+    The sort key and the preflight now share one classifier, so this pins the
+    ordering half: a sidecar that is *larger* than the real trace still sorts
+    behind it.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    real = _rank_trace(trace_dir / "rank_0.trace.json.gz", kernels=4)
+    big_sidecar = _capture_sidecar(trace_dir / "capture_traces" / "bs_2_rank0.json.gz", kernels=2)
+    assert big_sidecar.stat().st_size > real.stat().st_size
+
+    _kind, traces = tla.discover_trace_inputs(trace_dir)
+    assert traces[0] == real
+
+
 def test_skip_split_route_analyses_the_promoted_candidate(tmp_path):
     """The promotion must hold on the route xDiT actually takes.
 

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -1018,6 +1018,75 @@ _PHASE_FRAGMENT_RE = re.compile(
 )
 
 
+#: Directory both frameworks write CUDA-graph capture sidecars into.
+_CAPTURE_DIR_NAME = "capture_traces"
+
+#: Sidecar filename shapes: SGLang ``bs_<batch>[_rank<n>]``, vLLM
+#: ``graph_capture_*``. The batch number is required rather than a bare ``bs_``
+#: prefix because this classifier now *rejects* an input instead of only sorting
+#: it, and a real trace that merely starts with those three characters must not
+#: be thrown out. One definition, because both callers need the same answer:
+#: discovery demotes sidecars below a real capture, and the preflight refuses an
+#: input made of nothing else.
+_CAPTURE_FRAGMENT_RE = re.compile(r"^(?:bs_\d+|graph_capture)", re.IGNORECASE)
+
+
+def _is_capture_fragment(path: Path, root: Path | None = None) -> bool:
+    """Whether a trace path is a CUDA-graph capture sidecar.
+
+    Capture sidecars are recorded while the graph is being *built*, so the
+    launches in them go into the graph instead of onto the device. What lands is
+    a host-side Python call tree with a handful of stray kernels, one file per
+    (batch size, rank), each holding a single ``ProfilerStep``. There is no
+    iteration loop in one, which is what the steady-state splitter exists to cut
+    up.
+
+    Two signals, because either alone has a blind spot: the directory name
+    catches a sidecar whose filename nobody has seen before, and the filename
+    catches a flat layout that never made the directory.
+
+    ``root`` bounds the directory test to the input being analysed, the same way
+    :func:`_is_derived_trace` does it. Paths arrive absolute, so testing every
+    component would condemn every candidate whenever some ancestor happened to
+    be named ``capture_traces``. Callers pass the input directory, or a file's
+    parent so a single-file input is judged on its name alone.
+
+    Args:
+        path: The trace file path to classify.
+        root: Directory the classification is relative to, when known.
+
+    Returns:
+        True when ``path`` is a graph-capture sidecar rather than a workload
+        trace.
+    """
+    if _CAPTURE_FRAGMENT_RE.match(path.name) is not None:
+        return True
+    relative = path
+    if root is not None:
+        try:
+            relative = path.relative_to(root)
+        except ValueError:
+            relative = path
+    return any(part.lower() == _CAPTURE_DIR_NAME for part in relative.parts)
+
+
+def _capture_classification_root(trace_input: Path) -> Path:
+    """Root to classify candidates discovered from ``trace_input`` against.
+
+    A directory input is its own root, so a ``capture_traces/`` component below
+    it counts. A file input resolves to its parent, which leaves the filename as
+    the only component and keeps an unrelated ancestor directory out of the
+    decision.
+
+    Args:
+        trace_input: The ``--trace-input`` path.
+
+    Returns:
+        The directory candidate paths are made relative to.
+    """
+    return trace_input if trace_input.is_dir() else trace_input.parent
+
+
 def _is_derived_trace(path: Path, root: Path | None = None) -> bool:
     """Whether a trace path is splitter output rather than a raw capture.
 
@@ -1123,7 +1192,7 @@ def _trace_input_sort_key(path: Path, root: Path | None = None) -> tuple[int, in
         return (0, -size, name)
     if re.search(r"TP-\d+-DECODE\.trace\.json(?:\.gz)?$", name):
         return (2, -size, name)
-    if name.startswith("bs_") or name.startswith("graph_capture"):
+    if _is_capture_fragment(path, root):
         return (3, -size, name)
     return (1, -size, name)
 
@@ -7258,6 +7327,38 @@ def main() -> int:
         # push that None through every downstream call for a branch that cannot
         # be taken.
         analysis_trace_path = trace_files[0]
+
+        # Fail-fast when the input is nothing but CUDA-graph capture sidecars.
+        #
+        # Ahead of the kernel probe below because the two answer different
+        # questions and only this one is reliable here. A capture records the
+        # graph being built, so it carries a handful of stray kernels rather
+        # than none -- 2 out of 1.49M events on the run that prompted this --
+        # and a probe that asks "are there any kernels" therefore passes it and
+        # hands the splitter a file with no iteration loop in it. The splitter
+        # then fails with ``trace_split_no_steady_state``, which reads as "the
+        # window was too short" and sends the next person to lengthen a capture
+        # that was never a workload timeline to begin with.
+        #
+        # ``all`` rather than ``any``: a healthy profile writes the annotated
+        # trace *beside* its sidecars, and discovery already sorts those first.
+        # Only an input with nothing else in it is unanalysable.
+        if not args.dry_run and trace_files:
+            capture_root = _capture_classification_root(trace_input)
+            if all(_is_capture_fragment(p, capture_root) for p in trace_files):
+                raise RuntimeError(
+                    "trace_input_capture_only: "
+                    f"all {len(trace_files)} trace file(s) under {trace_input} "
+                    "are CUDA-graph capture sidecars. "
+                    "A capture records graph construction rather than "
+                    "execution, so it holds no per-iteration annotations for "
+                    "the steady-state splitter to cut on. "
+                    "The upstream profile produced no annotated workload trace: "
+                    "re-profile so the run writes one beside the sidecars. "
+                    "Sidecars are a supported auxiliary input -- pass them as "
+                    "--capture-folder alongside a real trace, never as "
+                    "--trace-input."
+                )
 
         # Fail-fast on CPU-only traces.
         #


### PR DESCRIPTION
## Problem

A CUDA-graph capture directory can reach TraceLens steady-state analysis and burn an entire KERNEL phase, and the error it eventually produces points at the wrong thing.

A capture is recorded while the graph is being *built*, so its launches go into the graph rather than onto the device. What lands on disk is a host-side Python call tree with a handful of stray kernels, one file per `(batch size, rank)`, each holding a single `ProfilerStep`. There is no iteration loop in it — which is exactly what the steady-state splitter exists to cut up.

The CPU-only preflight in `tracelens_analysis.py` is the check that should stop this, but it keys on `kernel_event_count == 0`:

```python
if kernel_event_count:      # 2 is truthy -> accepted, probing stops
    analysis_trace_path = candidate
    break
...
if kernel_event_count == 0: # 2 != 0 -> no raise
    raise RuntimeError(...)
```

Measured on a production capture: **2 GPU kernel events out of 1,489,559**. So the capture passes a check whose entire purpose is to reject traces with no GPU work, and the same truthiness test then *promotes* a `bs_2_rank1` fragment as the analysis input. The splitter then fails with `trace_split_no_steady_state`, which reads as "the profiled window was too short at this concurrency" and sends the next reader off to lengthen a capture that was never a workload timeline.

The cost is not theoretical. In one 720-minute session this happened twice (19:01 and 02:00), the retry used a byte-identical profile config so it was guaranteed to fail the same way, and the KERNEL phase closed with zero actions after 2h03m — `ceiling_available: false`, `kernel_roofline: {}`, `profile_report_paths: []`. The orchestration agent raised a high-severity alert with the wrong root cause and asked for a longer capture.

## Fix

Classify by **trace kind**, not by kernel count.

A density threshold on kernel events would be a guessed number that the next capture shape invalidates. What the profile actually writes is knowable: the `capture_traces/` directory and the two sidecar filename shapes (`bs_<batch>[_rank<n>]` for SGLang, `graph_capture_*` for vLLM). That is a fact about the producer, not a heuristic.

- New `_is_capture_fragment()` / `_capture_classification_root()` in `tracelens_analysis.py`. Two signals, because either alone has a blind spot: the directory name catches a sidecar whose filename nobody has seen before, the filename catches a flat layout that never made the directory. The directory test is bounded by a root the same way the existing `_is_derived_trace()` does it, so an unrelated ancestor named `capture_traces` cannot condemn every candidate.
- The preflight rejects the input when **every** discovered candidate is a sidecar, and it runs *ahead* of the kernel probe. The error carries a stable `trace_input_capture_only:` token and names the actual remedy (re-profile so an annotated trace is written) instead of implicating the splitter.
- `_trace_input_sort_key()` now shares that one classifier instead of keeping its own inline `startswith("bs_")` test, so the two cannot drift.

### Scope, deliberately narrow

- `all` rather than `any`: a healthy profile writes its annotated trace **beside** the sidecars, and discovery already sorts sidecars behind it. Only an input with nothing else in it is unanalysable. Getting this backwards would disable roofline for every well-formed profile, so there is a regression test pinning it.
- Capture sidecars stay a **supported auxiliary input**. `tracelens_skill_runner.discover_capture_folder()` passes them as `--capture-folder` next to a real trace, and that path is untouched. Only using them as the primary `--trace-input` is refused.
- The shared classifier requires a batch number (`bs_<digits>`) rather than a bare `bs_` prefix. The old inline test only decided sort order, where a false positive was cheap; this one decides rejection, where it is not.

No behaviour change for any input that was previously analysed successfully.

## Verification

Against the real 6.7 GB capture directory that triggered this:

```
files: 288 | all capture -> True
leading candidate: bs_2_rank1.json.gz
leading candidate kernel events: 2 | old check (== 0) would raise? False
```

Tests: `1895 passed, 29 skipped` in `src/hyperloom/agents/kernel/tests/`. Two failures in `test_n25_steady_state_mode.py` are pre-existing on `main` (a subprocess `PYTHONPATH` issue: `ModuleNotFoundError: No module named 'hyperloom'`) and were confirmed by re-running them on the base commit. `ruff check` clean; the added regions are `ruff format` clean.

## Test plan

- [x] Capture-only directory is rejected and the splitter is never invoked
- [x] A real trace beside capture sidecars still analyses (healthy layout unaffected)
- [x] `--trace-input` pointed straight at one sidecar is rejected by filename
- [x] An unrelated ancestor directory named `capture_traces` does not condemn a real trace
- [x] A sidecar *larger* than the real trace still sorts behind it
- [x] A bare `bs_` prefix without a batch number is not enough to reject a trace
- [x] Reproduced the classification on the original production capture directory

## Known gap, not addressed here

`profile.py` already sets `profile_trace_selection_reason = "capture_only_fallback"` for this layout and `roofline.py` already treats it as retryable, failing with an accurate `profile_capture_only` after 3 attempts. Both guards predate the session. I confirmed the classification helpers in `profile.py` return `capture_only = True` when run against the real directory, yet the session shows exactly **one** `benchmark_sglang_*` directory per roofline run (no retry) and a final `error_class` of `trace_analyze_failed`. So that upstream gate did not fire, and I could not explain it from static reading — the multi-node branch is excluded (`run_mode: local`, `nnodes=1`), and the profile sub-step is called in-process so the dict keys are not lost in transit. The most likely explanation is that an annotated trace existed at profile time and was removed by the S3 archive/clean step afterwards, which is not reproducible from the surviving artifacts.

That is worth its own investigation. It does not change this PR: the fix here is the last line of defence and the layer that owns the "is this trace analysable" question, and it holds regardless of what the upstream gate does.

Separately, `assets/configs/profile_sglang.yaml` still ships `--enable-profile-cuda-graph` alongside a steady-state `PROFILE_EXTRA_BODY` window (`start_step`/`num_steps`), which are two different intentions in one config. Reconciling that is a behaviour change to what gets profiled and belongs in its own PR.

Made with [Cursor](https://cursor.com)