### PR TITLE
fix(kernel-agent): stop the KERNEL phase acting on unusable profile traces

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
@@ -297,6 +297,23 @@ def test_bs_named_fragment_without_subdir_is_deprioritized(tmp_path):
     assert resolved is not None and resolved.name == main.name
 
 
+def test_unpatched_sglang_capture_dir_is_deprioritized(tmp_path):
+    # Both routes now share one classifier, so the bypass reader also knows the
+    # SGLang-without-profiler-patch layout: a ``graph_capture_profile/`` holding
+    # ``cuda_graph_capture-*``. The reader's own copy of the rule only knew
+    # ``bs_<n>_rank<n>`` / ``capture_traces/`` and took the sidecar as a trace.
+    d = tmp_path / "torch_trace"
+    main = _write_main_tp_trace(d)
+    cap_dir = d / "graph_capture_profile"
+    cap_dir.mkdir(parents=True, exist_ok=True)
+    _write_capture_fragment(cap_dir, 512)
+    (cap_dir / "cuda_graph_capture-DecodeCudaGraphRunner-TP-3.json.gz").write_bytes(
+        (cap_dir / "bs_512_rank0.json.gz").read_bytes()
+    )
+    resolved = reader.resolve_trace_file(d)
+    assert resolved is not None and resolved.name == main.name
+
+
 def test_capture_traces_detection_is_relative_to_trace_root(tmp_path):
     # An unrelated ancestor dir named ``capture_traces`` above the trace root must
     # not flag the main trace; only a genuine subdir within the root marks shards.

--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -816,6 +816,38 @@ def test_discover_capture_shards_dedups_tp_ranks(tmp_path):
     assert len(shards) == 2
 
 
+def test_discover_capture_shards_dedups_a_runner_prefixed_batch(tmp_path):
+    # An SGLang without the profiler patch prefixes the runner name:
+    # DecodeCudaGraphRunner_bs_104_rank0. The batch token is still what
+    # identifies the variant, so the ranks must collapse the same way — an
+    # anchored read finds nothing here and falls back to the per-rank stem,
+    # which silently turns one variant into one-per-rank.
+    d = tmp_path / "graph_capture_profile"
+    d.mkdir()
+    for f in (
+        "DecodeCudaGraphRunner_bs_104_rank0.json",
+        "DecodeCudaGraphRunner_bs_104_rank1.json",
+        "DecodeCudaGraphRunner_bs_8_rank0.json",
+    ):
+        (d / f).write_text("{}", encoding="utf-8")
+    shards = bta._discover_capture_shards(str(d), str(d))
+    assert sorted(lbl for _p, lbl, _m in shards) == ["bs_104", "bs_8"]
+
+
+def test_discover_capture_shards_skips_a_whole_capture_per_rank_file(tmp_path):
+    # ``cuda_graph_capture-<runner>-TP-<n>`` is one file per rank holding every
+    # batch size at once, so it carries no variant identity. Indexing it mints a
+    # bogus variant per rank (TP=8 -> eight shape-identical entries) because the
+    # label falls back to the stem, which differs per rank. It is a capture
+    # sidecar — the shared classifier is right to demote it from analysis — but
+    # that is a wider question than "does this shard name a variant".
+    d = tmp_path / "graph_capture_profile"
+    d.mkdir()
+    for rank in range(3):
+        (d / f"cuda_graph_capture-DecodeCudaGraphRunner-TP-{rank}.json").write_text("{}", encoding="utf-8")
+    assert bta._discover_capture_shards(str(d), str(d)) == []
+
+
 # ── CUDA/HIP graph-mode under-recording ──────────────────────────────────────
 
 

--- a/src/hyperloom/agents/kernel/tests/test_idle_gate.py
+++ b/src/hyperloom/agents/kernel/tests/test_idle_gate.py
@@ -5,10 +5,10 @@
 # See LICENSE for license information.
 ###############################################################################
 
-"""Unit tests for the shared idle-gate helpers (_idle_gate).
+"""Unit tests for the shared trace-health gate helpers (_idle_gate).
 
 Locks threshold resolution (default + env override + bad-value fallback) and
-the high-idle warning shape.
+the warning shapes for both the high-idle and low-compute gates.
 """
 
 from __future__ import annotations
@@ -54,3 +54,58 @@ def test_high_idle_warning_shape():
     assert w["source"] == "/tmp/analysis.md"
     assert "GPU was idle 91.23%" in w["message"]
     assert "parameter optimization" in w["message"]
+
+
+# ---------------------------------------------------------------------------
+# Low-compute gate
+# ---------------------------------------------------------------------------
+
+
+def test_min_compute_threshold_default(monkeypatch):
+    monkeypatch.delenv(ig.LOW_COMPUTE_PCT_THRESHOLD_ENV, raising=False)
+    assert ig.resolve_min_compute_pct_threshold() == ig.LOW_COMPUTE_PCT_THRESHOLD_DEFAULT == 10.0
+
+
+def test_min_compute_threshold_env_override(monkeypatch):
+    monkeypatch.setenv(ig.LOW_COMPUTE_PCT_THRESHOLD_ENV, "20")
+    assert ig.resolve_min_compute_pct_threshold() == 20.0
+
+
+def test_min_compute_threshold_bad_value_falls_back(monkeypatch):
+    monkeypatch.setenv(ig.LOW_COMPUTE_PCT_THRESHOLD_ENV, "nope")
+    assert ig.resolve_min_compute_pct_threshold() == 10.0
+
+
+def test_min_compute_threshold_negative_falls_back(monkeypatch):
+    monkeypatch.setenv(ig.LOW_COMPUTE_PCT_THRESHOLD_ENV, "-1")
+    assert ig.resolve_min_compute_pct_threshold() == 10.0
+
+
+def test_low_compute_warning_shape():
+    w = ig.build_low_compute_warning(
+        compute_pct=3.994,
+        threshold_pct=10.0,
+        report_path=Path("/tmp/analysis.md"),
+        exposed_comm_pct=95.991,
+    )
+    assert w["code"] == "low_gpu_compute_pct"
+    assert w["severity"] == "warning"
+    assert w["compute_pct"] == 3.99  # rounded to 2 dp
+    assert w["threshold_pct"] == 10.0
+    assert w["exposed_comm_pct"] == 95.99
+    assert w["source"] == "/tmp/analysis.md"
+    assert "Only 3.99% of trace wall time is compute" in w["message"]
+    assert "95.99%" in w["message"]
+    # The warning must name the spin-wait failure mode, since a near-zero idle
+    # share is exactly what lets this trace slip past the idle gate.
+    assert "spin-waiting collective" in w["message"]
+
+
+def test_low_compute_warning_omits_comm_when_unknown():
+    w = ig.build_low_compute_warning(
+        compute_pct=5.0,
+        threshold_pct=10.0,
+        report_path=Path("/tmp/analysis.md"),
+    )
+    assert "exposed_comm_pct" not in w
+    assert "Exposed communication accounts for" not in w["message"]

--- a/src/hyperloom/agents/kernel/tests/test_other_bucket_candidate_fallback.py
+++ b/src/hyperloom/agents/kernel/tests/test_other_bucket_candidate_fallback.py
@@ -453,30 +453,105 @@ def test_recover_normalizes_gpu_pct_against_trace_window(tmp_path):
     assert recovered[0]["gpu_pct_basis"] == tla.GPU_PCT_BASIS_E2E
 
 
-def test_recover_drops_op_that_only_looks_hot_against_compute(tmp_path):
-    """GLM-5.2 regression: 16.8% of compute is 0.67% of the window — not a candidate.
+def test_admission_is_unchanged_by_the_reporting_basis(tmp_path):
+    """GLM-5.2: 16.8% of compute is 0.67% of the window — recovered, but labelled.
 
-    Under the old share-of-listed-ops basis this op cleared the 10% floor and
-    was dispatched to kernel-opt; against the trace window it is noise.
+    ``min_gpu_pct`` keeps its original meaning (a large slice of the GPU work we
+    know about), so switching the *published* number to an e2e share must not
+    quietly raise the admission bar; the same op is recovered with or without a
+    window total, and only ``gpu_pct`` / ``gpu_pct_basis`` differ. Suppressing a
+    window like this one is the low-compute gate's job, not this path's.
     """
     _write(
         tmp_path / "ops_summary.csv",
         _ops_summary_csv("moe_flydsl_stage1,MoE_unfused,121.821899\n"),
     )
-    assert (
-        tla.recover_other_bucket_candidates(
-            tmp_path,
-            [],
-            top_k=10,
-            total_window_us=18186603.0,
-        )
-        == []
+    with_window = tla.recover_other_bucket_candidates(
+        tmp_path,
+        [],
+        top_k=10,
+        total_window_us=18186603.0,
     )
-    # Same input, no window total: the legacy share-of-listed-ops basis still
-    # applies so behaviour is unchanged where we cannot do better.
-    legacy = tla.recover_other_bucket_candidates(tmp_path, [], top_k=10)
-    assert [c["name"] for c in legacy] == ["moe_flydsl_stage1"]
-    assert legacy[0]["gpu_pct_basis"] == tla.GPU_PCT_BASIS_LISTED_OPS
+    assert [c["name"] for c in with_window] == ["moe_flydsl_stage1"]
+    assert with_window[0]["gpu_pct"] == pytest.approx(0.67, abs=1e-2)
+    assert with_window[0]["gpu_pct_basis"] == tla.GPU_PCT_BASIS_E2E
+
+    without_window = tla.recover_other_bucket_candidates(tmp_path, [], top_k=10)
+    assert [c["name"] for c in without_window] == ["moe_flydsl_stage1"]
+    assert without_window[0]["gpu_pct_basis"] == tla.GPU_PCT_BASIS_LISTED_OPS
+
+
+def test_window_basis_does_not_starve_a_healthy_compute_bound_trace(tmp_path):
+    """A 60%-compute trace with work spread over eight kernels keeps its candidates.
+
+    Comparing the 10% floor against an e2e share instead of an op share raises
+    the bar by the reciprocal of the compute share; on this shape that is 12.5%
+    op time vs 7.5% e2e, and every candidate would silently disappear.
+    """
+    rows = "".join(f"k{i},other,75.0\n" for i in range(8))
+    _write(tmp_path / "ops_summary.csv", _ops_summary_csv(rows))
+    recovered = tla.recover_other_bucket_candidates(
+        tmp_path,
+        [],
+        top_k=10,
+        total_window_us=1_000_000.0,  # 1000 ms wall, 600 ms of kernel
+    )
+    assert len(recovered) == 8
+    assert recovered[0]["gpu_pct"] == pytest.approx(7.5, abs=1e-6)
+    assert recovered[0]["gpu_pct_basis"] == tla.GPU_PCT_BASIS_E2E
+
+
+def test_recover_flags_a_batch_that_mixes_gpu_pct_bases(tmp_path):
+    """Two bases in one batch is the unrankable state the label exists to catch.
+
+    Reachable within a single sidecar when only some rows carry an absolute GPU
+    time: those are normalized against the e2e window, while a row that reports
+    only a percentage keeps whatever denominator the sidecar used.
+    """
+    _write(
+        tmp_path / "priority_data.json",
+        json.dumps(
+            {
+                "findings": [
+                    {"name": "has_time", "category": "other", "gpu_time_ms": 900.0},
+                    {"name": "pct_only", "category": "other", "gpu_pct": 40.0},
+                ]
+            }
+        ),
+    )
+    logged: list[str] = []
+    recovered = tla.recover_other_bucket_candidates(
+        tmp_path,
+        [],
+        top_k=10,
+        total_window_us=1_000_000.0,
+        log=logged.append,
+    )
+    by_name = {c["name"]: c["gpu_pct_basis"] for c in recovered}
+    assert by_name == {
+        "has_time": tla.GPU_PCT_BASIS_E2E,  # 900 ms of a 1 s window -> 90%
+        "pct_only": tla.GPU_PCT_BASIS_SIDECAR,  # no absolute time to rescale
+    }
+    assert [m for m in logged if "not mutually comparable" in m]
+
+
+def test_recover_stays_quiet_on_a_single_basis_batch(tmp_path):
+    """The mixed-basis note must not fire on the ordinary all-e2e batch."""
+    _write(
+        tmp_path / "ops_summary.csv",
+        _ops_summary_csv("a,other,900.0\nb,other,300.0\n"),
+    )
+    logged: list[str] = []
+    recovered = tla.recover_other_bucket_candidates(
+        tmp_path,
+        [],
+        top_k=10,
+        total_window_us=1_000_000.0,
+        log=logged.append,
+    )
+    # ops_summary.csv wins discovery, so this batch is single-basis and quiet.
+    assert {c["gpu_pct_basis"] for c in recovered} == {tla.GPU_PCT_BASIS_E2E}
+    assert not [m for m in logged if "not mutually comparable" in m]
 
 
 def test_recover_falls_back_to_sidecar_pct_without_window(tmp_path):

--- a/src/hyperloom/agents/kernel/tests/test_other_bucket_candidate_fallback.py
+++ b/src/hyperloom/agents/kernel/tests/test_other_bucket_candidate_fallback.py
@@ -421,3 +421,71 @@ def test_recovered_moe_fused_real_schema_routes_to_geak(tmp_path, monkeypatch):
     # Triton .py under a reusable root -> routable to GEAK.
     assert item["source_type"] == "triton"
     assert item["reusable_native_kernel"] is True, item.get("skip_reason")
+
+
+# ---------------------------------------------------------------------------
+# gpu_pct basis — the denominator must match what parse_analysis_md reports
+# ---------------------------------------------------------------------------
+
+
+def test_recover_normalizes_gpu_pct_against_trace_window(tmp_path):
+    """With the trace wall span known, gpu_pct is an end-to-end share.
+
+    ``ops_summary.csv`` percentages are a share of total *op* time, which
+    excludes collectives. On a comm-dominated trace that inflates them by an
+    order of magnitude relative to the analysis.md candidates they get ranked
+    against, so the window total wins when it is available.
+    """
+    _write(
+        tmp_path / "ops_summary.csv",
+        _ops_summary_csv("fused_moe_kernel,other,121.821899\naten::mm,GEMM,48.708459\n"),
+    )
+    recovered = tla.recover_other_bucket_candidates(
+        tmp_path,
+        [{"name": "aten::mm"}],
+        top_k=10,
+        # 18186.60 ms window against 121.82 ms of kernel -> 0.67% e2e.
+        total_window_us=18186603.0,
+        min_gpu_pct=0.5,
+    )
+    assert [c["name"] for c in recovered] == ["fused_moe_kernel"]
+    assert recovered[0]["gpu_pct"] == pytest.approx(0.67, abs=1e-2)
+    assert recovered[0]["gpu_pct_basis"] == tla.GPU_PCT_BASIS_E2E
+
+
+def test_recover_drops_op_that_only_looks_hot_against_compute(tmp_path):
+    """GLM-5.2 regression: 16.8% of compute is 0.67% of the window — not a candidate.
+
+    Under the old share-of-listed-ops basis this op cleared the 10% floor and
+    was dispatched to kernel-opt; against the trace window it is noise.
+    """
+    _write(
+        tmp_path / "ops_summary.csv",
+        _ops_summary_csv("moe_flydsl_stage1,MoE_unfused,121.821899\n"),
+    )
+    assert (
+        tla.recover_other_bucket_candidates(
+            tmp_path,
+            [],
+            top_k=10,
+            total_window_us=18186603.0,
+        )
+        == []
+    )
+    # Same input, no window total: the legacy share-of-listed-ops basis still
+    # applies so behaviour is unchanged where we cannot do better.
+    legacy = tla.recover_other_bucket_candidates(tmp_path, [], top_k=10)
+    assert [c["name"] for c in legacy] == ["moe_flydsl_stage1"]
+    assert legacy[0]["gpu_pct_basis"] == tla.GPU_PCT_BASIS_LISTED_OPS
+
+
+def test_recover_falls_back_to_sidecar_pct_without_window(tmp_path):
+    """A JSON sidecar carrying only a percentage keeps working, but is labelled."""
+    _write(
+        tmp_path / "priority_data.json",
+        json.dumps({"findings": [{"name": "fused_moe_kernel", "category": "other", "gpu_pct": 67.0}]}),
+    )
+    recovered = tla.recover_other_bucket_candidates(tmp_path, [], top_k=10)
+    assert [c["name"] for c in recovered] == ["fused_moe_kernel"]
+    assert recovered[0]["gpu_pct"] == 67.0
+    assert recovered[0]["gpu_pct_basis"] == tla.GPU_PCT_BASIS_SIDECAR

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -2468,6 +2468,55 @@ def test_capture_sidecars_sort_behind_a_real_trace(tmp_path):
     assert traces[0] == real
 
 
+@pytest.mark.parametrize(
+    "relpath, expected",
+    [
+        # Hyperloom-patched SGLang.
+        ("capture_traces/bs_2_rank0.json.gz", True),
+        ("capture_traces/bs_64_rank7.json.gz", True),
+        # Unpatched SGLang: neither the directory nor the filename matches the
+        # patched shape, and the ``cuda_`` prefix defeats a start-anchored test.
+        ("graph_capture_profile/cuda_graph_capture-DecodeCudaGraphRunner-TP-3.json.gz", True),
+        # vLLM.
+        ("graph_capture_rank0.json.gz", True),
+        # Workload traces must survive all of the above.
+        ("1786734684.9990146-TP-0.trace.json.gz", False),
+        ("rank_0.trace.json.gz", False),
+        ("merged-annotated.trace.json.gz", False),
+    ],
+)
+def test_capture_classifier_covers_every_observed_profile_layout(tmp_path, relpath, expected):
+    """The classifier keys on shape, so a new layout does not slip through.
+
+    Each entry is a layout a production profile actually wrote. An exact-name
+    whitelist passed the first two and missed the SGLang-without-patch one.
+    """
+    path = tmp_path / relpath
+    assert tla._is_capture_fragment(path, tmp_path) is expected
+
+
+def test_unpatched_sglang_capture_sorts_behind_the_workload_trace(tmp_path):
+    """GLM-5.2 regression: a 103 MB capture must not outrank a 20 MB trace.
+
+    ``graph_capture_profile/`` matched no known capture shape, so its files
+    shared the default bucket with the workload traces, where the tie-break is
+    descending size. The capture is the larger file, so it led discovery, the
+    probe stopped on it, and the splitter cut a bs=1/conc=1 graph-capture window
+    that carried zero GPU events. The whole kernel phase was lost to it.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    real = _rank_trace(trace_dir / "1786734684.9990146-TP-0.trace.json.gz", kernels=8)
+    big_capture = _capture_sidecar(
+        trace_dir / "graph_capture_profile" / "cuda_graph_capture-DecodeCudaGraphRunner-TP-3.json.gz",
+        kernels=2,
+    )
+    assert big_capture.stat().st_size > real.stat().st_size
+
+    _kind, traces = tla.discover_trace_inputs(trace_dir)
+    assert traces[0] == real
+
+
 def test_skip_split_route_analyses_the_promoted_candidate(tmp_path):
     """The promotion must hold on the route xDiT actually takes.
 

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -2495,6 +2495,40 @@ def test_capture_classifier_covers_every_observed_profile_layout(tmp_path, relpa
     assert tla._is_capture_fragment(path, tmp_path) is expected
 
 
+def test_capture_dir_match_is_anchored_so_a_descriptive_name_is_safe(tmp_path):
+    """``graph_capture`` anchors in a directory name, unlike in a filename.
+
+    A directory is named for what it holds, so an unanchored token would also
+    condemn ``torch_profiler_with_graph_capture/`` -- and the capture-only
+    preflight is an ``all(...)``, so one false positive rejects the whole input.
+    """
+    safe = tmp_path / "torch_profiler_with_graph_capture" / "rank_0.trace.json.gz"
+    assert tla._is_capture_fragment(safe, tmp_path) is False
+    for capture_dir in ("graph_capture", "graph_capture_profile", "capture_traces"):
+        assert tla._is_capture_fragment(tmp_path / capture_dir / "rank_0.trace.json.gz", tmp_path) is True
+
+
+def test_discover_capture_folder_finds_the_unpatched_sglang_layout(tmp_path):
+    """The capture folder must be locatable, not merely demoted during ranking.
+
+    Ranking keeps the sidecars out of the analysis input; discovery is what
+    hands them to TraceLens as ``--capture_folder``. Two hard-coded names meant
+    a run could pick the right workload trace and still lose its graph-capture
+    input.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    (trace_dir / "graph_capture_profile").mkdir(parents=True)
+    real = _rank_trace(trace_dir / "1786735404.4274018-TP-0.trace.json.gz", kernels=4)
+    assert tlr.discover_capture_folder(trace_dir, [real]) == trace_dir / "graph_capture_profile"
+
+
+def test_discover_capture_folder_ignores_a_descriptive_sibling(tmp_path):
+    trace_dir = tmp_path / "torch_trace"
+    (trace_dir / "torch_profiler_with_graph_capture").mkdir(parents=True)
+    real = _rank_trace(trace_dir / "rank_0.trace.json.gz", kernels=4)
+    assert tlr.discover_capture_folder(trace_dir, [real]) is None
+
+
 def test_unpatched_sglang_capture_sorts_behind_the_workload_trace(tmp_path):
     """GLM-5.2 regression: a 103 MB capture must not outrank a 20 MB trace.
 
@@ -5110,6 +5144,53 @@ def test_extract_compute_pct_returns_none_when_absent(tmp_path):
     _write_gpu_timeline(tmp_path, "type,time ms,percent\ntotal_time,1000.0,100.0\n")
     assert tla._extract_compute_pct_from_gpu_timeline(tmp_path) is None
     assert tla._extract_exposed_comm_pct_from_gpu_timeline(tmp_path) is None
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        # Share column renamed beyond the known aliases: the row is found, the
+        # number is not. Column drift is not hypothetical -- the row *labels*
+        # already needed multi-spelling tolerance.
+        "type,time ms,share_of_total\ncomputation_time,725.85,3.99\n",
+        # Row truncated: DictReader yields None for the missing cell, and
+        # float(None) raises TypeError rather than ValueError.
+        "type,time ms,percent\ncomputation_time,725.85\n",
+        # Present but blank.
+        "type,time ms,percent\ncomputation_time,725.85,\n",
+        # Present but not a number.
+        "type,time ms,percent\ncomputation_time,725.85,n/a\n",
+    ],
+)
+def test_unreadable_compute_cell_is_none_not_zero(tmp_path, body):
+    """An unreadable share must fail open, never read as ``0%``.
+
+    The low-compute gate fires *below* its threshold, so defaulting a missing
+    or unparseable cell to 0 would suppress the hot-kernel list on every trace,
+    silently, with ``status`` still ``ok`` -- the exact opposite of the idle
+    gate, where a 0 default is harmless.
+    """
+    _write_gpu_timeline(tmp_path, body)
+    assert tla._extract_compute_pct_from_gpu_timeline(tmp_path) is None
+    _, warning = tla._evaluate_low_compute_gate(
+        tla._extract_compute_pct_from_gpu_timeline(tmp_path),
+        None,
+        tmp_path / "analysis.md",
+    )
+    assert warning is None, "an unknown compute share must not suppress candidates"
+
+
+@pytest.mark.parametrize("column", ["percent", "percentage", "Percentage (%)", "pct"])
+def test_known_percent_column_spellings_are_read(tmp_path, column):
+    """Known alias spellings are read rather than discarded as unknown."""
+    _write_gpu_timeline(tmp_path, f"type,time ms,{column}\ncomputation_time,725.85,3.99\n")
+    assert tla._extract_compute_pct_from_gpu_timeline(tmp_path) == 3.99
+
+
+def test_total_time_is_none_when_its_cell_is_unreadable(tmp_path):
+    """Same fail-open contract for the window total the gpu_pct basis needs."""
+    _write_gpu_timeline(tmp_path, "type,time ms,percent\ntotal_time,,100.0\n")
+    assert tla._extract_total_time_us_from_gpu_timeline(tmp_path) is None
 
 
 def test_low_compute_gate_fires_on_spin_wait_window(monkeypatch, tmp_path):

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -4905,6 +4905,94 @@ def test_extract_total_time_us_returns_none_when_missing(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Low-compute gate: gpu_timeline readers + gate evaluation
+# ---------------------------------------------------------------------------
+
+
+def _write_gpu_timeline(tmp_path, body: str):
+    csv_dir = tmp_path / "perf_report_csvs"
+    csv_dir.mkdir(exist_ok=True)
+    (csv_dir / "gpu_timeline.csv").write_text(body, encoding="utf-8")
+
+
+def test_extract_compute_pct_accepts_schema_spellings(tmp_path):
+    for label in ("computation_time", "compute_time", "computation", "compute"):
+        _write_gpu_timeline(
+            tmp_path,
+            f"type,time ms,percent\n{label},725.85,3.99\ntotal_time,18186.6,100.0\n",
+        )
+        assert tla._extract_compute_pct_from_gpu_timeline(tmp_path) == 3.99
+
+
+def test_extract_exposed_comm_pct_accepts_schema_spellings(tmp_path):
+    for label in ("exposed_comm_time", "exposed_communication_time", "exposed_communication"):
+        _write_gpu_timeline(
+            tmp_path,
+            f"type,time ms,percent\n{label},17456.98,95.99\ntotal_time,18186.6,100.0\n",
+        )
+        assert tla._extract_exposed_comm_pct_from_gpu_timeline(tmp_path) == 95.99
+
+
+def test_extract_compute_pct_returns_none_when_absent(tmp_path):
+    _write_gpu_timeline(tmp_path, "type,time ms,percent\ntotal_time,1000.0,100.0\n")
+    assert tla._extract_compute_pct_from_gpu_timeline(tmp_path) is None
+    assert tla._extract_exposed_comm_pct_from_gpu_timeline(tmp_path) is None
+
+
+def test_low_compute_gate_fires_on_spin_wait_window(monkeypatch, tmp_path):
+    """GLM-5.2 regression: 3.99% compute / 0.02% idle must not pass as healthy.
+
+    A collective that spin-waits on peer ranks is charged as GPU-busy, so the
+    idle gate sees 0.02% and lets the window through. The compute share is what
+    exposes it.
+    """
+    monkeypatch.delenv(idle_gate.LOW_COMPUTE_PCT_THRESHOLD_ENV, raising=False)
+    threshold, warning = tla._evaluate_low_compute_gate(3.99, 95.99, tmp_path / "analysis.md")
+    assert threshold == 10.0
+    assert warning is not None
+    assert warning["code"] == "low_gpu_compute_pct"
+    assert warning["compute_pct"] == 3.99
+    assert warning["exposed_comm_pct"] == 95.99
+
+
+def test_low_compute_gate_passes_healthy_window(monkeypatch, tmp_path):
+    monkeypatch.delenv(idle_gate.LOW_COMPUTE_PCT_THRESHOLD_ENV, raising=False)
+    _, warning = tla._evaluate_low_compute_gate(99.3, 0.42, tmp_path / "analysis.md")
+    assert warning is None
+
+
+def test_low_compute_gate_skipped_when_pct_unknown(monkeypatch, tmp_path):
+    """No compute row in the report: fail open rather than suppress candidates."""
+    monkeypatch.delenv(idle_gate.LOW_COMPUTE_PCT_THRESHOLD_ENV, raising=False)
+    _, warning = tla._evaluate_low_compute_gate(None, None, tmp_path / "analysis.md")
+    assert warning is None
+
+
+def test_extract_compute_and_comm_pct_from_analysis_md(tmp_path):
+    md = tmp_path / "analysis.md"
+    md.write_text(
+        "# Analysis\n\n"
+        "| Metric | Value |\n"
+        "|--------|-------|\n"
+        "| Total Time | 18186.60 ms |\n"
+        "| Compute % | 3.99% |\n"
+        "| Idle % | 0.02% |\n"
+        "| Exposed Communication % | 95.99% |\n",
+        encoding="utf-8",
+    )
+    assert tlr.extract_compute_pct_from_analysis_md(md) == 3.99
+    assert tlr.extract_exposed_comm_pct_from_analysis_md(md) == 95.99
+    assert tlr.extract_idle_pct_from_analysis_md(md) == 0.02
+
+
+def test_extract_compute_pct_from_analysis_md_missing_row(tmp_path):
+    md = tmp_path / "analysis.md"
+    md.write_text("# Analysis\n\n| Idle % | 1.0% |\n", encoding="utf-8")
+    assert tlr.extract_compute_pct_from_analysis_md(md) is None
+    assert tlr.extract_exposed_comm_pct_from_analysis_md(md) is None
+
+
+# ---------------------------------------------------------------------------
 # _normalize_profiler_op_name / graph-captured keyword recovery
 # ---------------------------------------------------------------------------
 

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -2344,6 +2344,130 @@ def test_analysis_input_is_left_alone_when_the_first_candidate_has_kernels(tmp_p
     assert str(first) in [str(p) for p in splitter]
 
 
+def _capture_sidecar(path: Path, kernels: int = 2) -> Path:
+    """Write a CUDA-graph capture sidecar in its production shape.
+
+    ``kernels`` defaults to 2 on purpose. A capture records the graph being
+    built, so a couple of launches still reach the device while the rest of the
+    file is host-side call tree — the run this guards against had 2 kernels in
+    1.49M events. A sidecar with *zero* kernels would already be stopped by the
+    CPU-only preflight; two is the count that gets through it.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return _rank_trace(path, kernels=kernels, cpu_events=200)
+
+
+def test_capture_only_input_is_rejected_before_the_splitter(tmp_path, capsys):
+    """A directory holding nothing but graph-capture sidecars must not analyse.
+
+    The sidecars carry kernels, so the CPU-only preflight passes them and the
+    splitter is handed a file with no iteration loop in it. It then reports
+    ``trace_split_no_steady_state``, which reads as "the profiled window was too
+    short" and sends the next person to lengthen a capture that was never a
+    workload timeline. The rejection has to name the real cause instead.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    capture = trace_dir / "capture_traces"
+    for bs in (2, 4, 8):
+        for rank in (0, 1):
+            _capture_sidecar(capture / f"bs_{bs}_rank{rank}.json.gz")
+
+    # Precondition: this is exactly the shape the old check waved through.
+    _kind, traces = tla.discover_trace_inputs(trace_dir)
+    assert len(traces) == 6
+    assert tla._count_kernels_if_readable(traces[0])[1] > 0
+
+    captured = _drive_main_over_capture_dir(tmp_path, trace_dir)
+
+    assert _find_splitter_cmd(captured) is None, "the splitter must never be invoked"
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "failed"
+    assert "trace_input_capture_only" in result["error"]
+    # The message has to point at the profile, not at the splitter or the window.
+    assert "re-profile" in result["error"]
+
+
+def test_capture_sidecars_beside_a_real_trace_still_analyse(tmp_path):
+    """The healthy layout must be unaffected.
+
+    A normal profile writes its annotated trace *beside* the capture sidecars,
+    which is why the rejection tests ``all`` and not ``any``. Getting this
+    backwards would disable roofline for every well-formed profile.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    real = _rank_trace(trace_dir / "rank_0.trace.json.gz", kernels=12)
+    _capture_sidecar(trace_dir / "capture_traces" / "bs_2_rank0.json.gz")
+
+    captured = _drive_main_over_capture_dir(tmp_path, trace_dir)
+
+    splitter = _find_splitter_cmd(captured)
+    assert splitter is not None, "a real trace beside sidecars must still analyse"
+    assert str(real) in [str(p) for p in splitter]
+
+
+def test_lone_capture_sidecar_file_is_rejected_by_name(tmp_path, capsys):
+    """``--trace-input`` pointed straight at one sidecar is the same mistake."""
+    sidecar = _capture_sidecar(tmp_path / "torch_trace" / "bs_16_rank3.json.gz")
+
+    captured = _drive_main_over_capture_dir(tmp_path, sidecar)
+
+    assert _find_splitter_cmd(captured) is None
+    assert "trace_input_capture_only" in json.loads(capsys.readouterr().out)["error"]
+
+
+def test_capture_classification_ignores_an_unrelated_ancestor_dir(tmp_path):
+    """An ancestor named ``capture_traces`` must not condemn a real trace.
+
+    Paths arrive absolute, so an unbounded component test would reject every
+    candidate whenever the session happened to live under a directory of that
+    name — pointing ``--trace-input`` inside a previous capture, say.
+    """
+    root = tmp_path / "capture_traces" / "torch_trace"
+    root.mkdir(parents=True)
+    real = _rank_trace(root / "rank_0.trace.json.gz", kernels=7)
+
+    assert not tla._is_capture_fragment(real, tla._capture_classification_root(root))
+    # A genuine sidecar below the root is still caught.
+    nested = _capture_sidecar(root / "capture_traces" / "bs_2_rank0.json.gz")
+    assert tla._is_capture_fragment(nested, tla._capture_classification_root(root))
+
+
+def test_bare_bs_prefix_is_not_enough_to_condemn_a_trace(tmp_path):
+    """``bs_`` without a batch number must not classify as a sidecar.
+
+    The classifier decides whether an input is rejected outright, not just how
+    it sorts, so matching three characters of a filename is too cheap a reason
+    to throw a real trace away. The sidecar shapes carry a batch number.
+    """
+    root = tmp_path / "torch_trace"
+    root.mkdir()
+    classify_root = tla._capture_classification_root(root)
+
+    assert tla._is_capture_fragment(root / "bs_2_rank0.json.gz", classify_root)
+    assert tla._is_capture_fragment(root / "bs_512.json.gz", classify_root)
+    assert tla._is_capture_fragment(root / "graph_capture_rank_0.pt.trace.json.gz", classify_root)
+    assert not tla._is_capture_fragment(root / "bs_baseline.trace.json.gz", classify_root)
+    assert not tla._is_capture_fragment(root / "rank_0.trace.json.gz", classify_root)
+
+
+def test_capture_sidecars_sort_behind_a_real_trace(tmp_path):
+    """Discovery ordering must keep sidecars behind the annotated trace.
+
+    The sort key and the preflight now share one classifier, so this pins the
+    ordering half: a sidecar that is *larger* than the real trace still sorts
+    behind it.
+    """
+    trace_dir = tmp_path / "torch_trace"
+    trace_dir.mkdir()
+    real = _rank_trace(trace_dir / "rank_0.trace.json.gz", kernels=4)
+    big_sidecar = _capture_sidecar(trace_dir / "capture_traces" / "bs_2_rank0.json.gz", kernels=2)
+    assert big_sidecar.stat().st_size > real.stat().st_size
+
+    _kind, traces = tla.discover_trace_inputs(trace_dir)
+    assert traces[0] == real
+
+
 def test_skip_split_route_analyses_the_promoted_candidate(tmp_path):
     """The promotion must hold on the route xDiT actually takes.
 

--- a/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
+++ b/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
@@ -34,6 +34,10 @@ import re
 from pathlib import Path
 from typing import Any, Iterator
 
+# Stdlib-only sibling; keeps this reader independent of TraceLens while sharing
+# one capture-vs-workload rule with the TraceLens route.
+from _capture_shapes import is_capture_fragment as _shared_is_capture_fragment
+
 # GPU device-side event categories (Kineto ``cat`` values).
 _GPU_KERNEL_CAT = "kernel"
 _GPU_MEMCPY_CATS = ("gpu_memcpy", "gpu_memset")
@@ -131,32 +135,17 @@ def _trace_candidates(root: Path) -> list[Path]:
     return out
 
 
-# sglang CUDA-graph capture shards (``bs_<batch>_rank<n>.json.gz`` under
-# ``capture_traces/``) are rank-tagged but device-kernel sparse and must not be
-# mistaken for the content-rich main profiler trace.
-_CAPTURE_DIR_NAME = "capture_traces"
-_CAPTURE_FRAGMENT_RE = re.compile(r"^bs_\d+_rank\d+", re.IGNORECASE)
-
-
 def _is_capture_fragment(path: str | Path, root: str | Path | None = None) -> bool:
-    """True if ``path`` is a sglang CUDA-graph capture shard, not a main trace.
+    """True if ``path`` is a CUDA-graph capture shard, not a main trace.
 
-    Detected by either the ``bs_<batch>_rank<n>`` capture filename or a
-    ``capture_traces/`` directory *within the trace tree*. The directory check
-    is made relative to ``root`` when given, so an unrelated ancestor named
-    ``capture_traces`` above the search root never trips it, and it is
-    case-insensitive to match the filename regex.
+    Capture shards are device-kernel sparse and must not be mistaken for the
+    content-rich main profiler trace. Delegates to
+    :func:`_capture_shapes.is_capture_fragment` so this route and the TraceLens
+    route classify identically; the local copy this replaced only knew the
+    ``bs_<batch>_rank<n>`` / ``capture_traces/`` shapes and silently accepted a
+    ``graph_capture_profile/cuda_graph_capture-*`` sidecar as a workload trace.
     """
-    p = Path(path)
-    if _CAPTURE_FRAGMENT_RE.match(p.name) is not None:
-        return True
-    parts: tuple[str, ...] = p.parts
-    if root is not None:
-        try:
-            parts = p.relative_to(root).parts
-        except ValueError:
-            parts = p.parts
-    return any(part.lower() == _CAPTURE_DIR_NAME for part in parts)
+    return _shared_is_capture_fragment(path, root)
 
 
 def _main_trace_candidates(candidates: list[Path], root: str | Path | None = None) -> list[Path]:

--- a/src/hyperloom/agents/kernel/tools/_capture_shapes.py
+++ b/src/hyperloom/agents/kernel/tools/_capture_shapes.py
@@ -39,9 +39,14 @@ import re
 from pathlib import Path
 
 #: Directory shapes a profile writes capture sidecars into, matched per path
-#: component: ``capture_traces`` exactly, plus any component carrying
-#: ``graph_capture`` (e.g. ``graph_capture_profile``).
-CAPTURE_DIR_RE = re.compile(r"\Acapture_traces\Z|graph_capture", re.IGNORECASE)
+#: component: ``capture_traces`` exactly, or a name *starting* with
+#: ``graph_capture`` (``graph_capture``, ``graph_capture_profile``), which
+#: covers every layout observed. Anchored, unlike the filename rule below: a
+#: directory is named for what it holds, so an unanchored token would also
+#: condemn e.g. ``torch_profiler_with_graph_capture/`` -- and because the
+#: capture-only preflight is an ``all(...)``, one such false positive rejects
+#: the entire input.
+CAPTURE_DIR_RE = re.compile(r"\Acapture_traces\Z|\Agraph_capture", re.IGNORECASE)
 
 #: Sidecar filename shapes: ``bs_<batch>[_rank<n>]`` anchored to the start, and
 #: ``graph_capture`` anywhere in the name (an unpatched SGLang prefixes it with
@@ -51,6 +56,24 @@ CAPTURE_DIR_RE = re.compile(r"\Acapture_traces\Z|graph_capture", re.IGNORECASE)
 #: out. ``graph_capture`` needs no such guard: a workload trace is not named
 #: after graph capture.
 CAPTURE_FRAGMENT_RE = re.compile(r"\Abs_\d+|graph_capture", re.IGNORECASE)
+
+
+def is_capture_dir_name(name: str) -> bool:
+    """Whether one path component names a graph-capture output directory.
+
+    Exposed separately from :func:`is_capture_fragment` because discovery has to
+    *find* the capture folder to hand it to TraceLens as ``--capture_folder``,
+    not merely recognise files already under it. Both answers come from one
+    pattern so a layout that is demoted during ranking is also the layout that
+    gets located here.
+
+    Args:
+        name: A single path component.
+
+    Returns:
+        True when the component names a capture directory.
+    """
+    return CAPTURE_DIR_RE.search(name) is not None
 
 
 def is_capture_fragment(path: str | Path, root: str | Path | None = None) -> bool:
@@ -83,4 +106,4 @@ def is_capture_fragment(path: str | Path, root: str | Path | None = None) -> boo
             parts = resolved.relative_to(root).parts
         except ValueError:
             parts = resolved.parts
-    return any(CAPTURE_DIR_RE.search(part) is not None for part in parts)
+    return any(is_capture_dir_name(part) for part in parts)

--- a/src/hyperloom/agents/kernel/tools/_capture_shapes.py
+++ b/src/hyperloom/agents/kernel/tools/_capture_shapes.py
@@ -1,0 +1,86 @@
+###############################################################################
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Shared classifier for CUDA-graph capture sidecars vs workload traces.
+
+Single source of truth for BOTH trace-analysis routes (the TraceLens pipeline
+and the standalone bypass reader), so a capture sidecar is recognised
+identically no matter which backend reads the profile. The two routes used to
+carry their own copy of this rule and the copies drifted -- the bypass one never
+learned about ``graph_capture`` names at all -- which is the drift this module
+exists to prevent.
+
+A capture sidecar is recorded while the CUDA/HIP graph is being *built*, so its
+launches go into the graph instead of onto the device. What lands is a host-side
+call tree with a handful of stray kernels and no iteration loop, which is
+useless to a steady-state splitter and must never be mistaken for the workload
+trace beside it.
+
+Matching is by *shape*, not by an exact name, because the profile's layout
+varies with framework and patch level: an SGLang carrying Hyperloom's profiler
+patch writes ``capture_traces/bs_<batch>_rank<n>``, an unpatched one writes
+``graph_capture_profile/cuda_graph_capture-<runner>-TP-<n>``, and vLLM writes
+``graph_capture_*``. An exact-name whitelist silently misses the shapes it has
+not been taught, and a missed sidecar is not merely ranked late: it shares the
+default discovery bucket with the workload trace, where the tie-break is
+descending file size, and a capture is the larger file.
+
+Kept dependency-free (stdlib only) so the bypass reader can consume it without
+importing or shelling out to TraceLens.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+#: Directory shapes a profile writes capture sidecars into, matched per path
+#: component: ``capture_traces`` exactly, plus any component carrying
+#: ``graph_capture`` (e.g. ``graph_capture_profile``).
+CAPTURE_DIR_RE = re.compile(r"\Acapture_traces\Z|graph_capture", re.IGNORECASE)
+
+#: Sidecar filename shapes: ``bs_<batch>[_rank<n>]`` anchored to the start, and
+#: ``graph_capture`` anywhere in the name (an unpatched SGLang prefixes it with
+#: ``cuda_``). The batch number is required rather than a bare ``bs_`` prefix
+#: because this classifier can *reject* an input rather than only sort it, and a
+#: real trace that merely starts with those three characters must not be thrown
+#: out. ``graph_capture`` needs no such guard: a workload trace is not named
+#: after graph capture.
+CAPTURE_FRAGMENT_RE = re.compile(r"\Abs_\d+|graph_capture", re.IGNORECASE)
+
+
+def is_capture_fragment(path: str | Path, root: str | Path | None = None) -> bool:
+    """Whether a trace path is a CUDA-graph capture sidecar.
+
+    Two signals, because either alone has a blind spot: the directory name
+    catches a sidecar whose filename nobody has seen before, and the filename
+    catches a flat layout that never made the directory.
+
+    ``root`` bounds the directory test to the input being analysed. Paths arrive
+    absolute, so testing every component would condemn every candidate whenever
+    some ancestor happened to be named after graph capture. Callers pass the
+    input directory, or a file's parent so a single-file input is judged on its
+    name alone.
+
+    Args:
+        path: The trace file path to classify.
+        root: Directory the classification is relative to, when known.
+
+    Returns:
+        True when ``path`` is a graph-capture sidecar rather than a workload
+        trace.
+    """
+    resolved = Path(path)
+    if CAPTURE_FRAGMENT_RE.search(resolved.name) is not None:
+        return True
+    parts: tuple[str, ...] = resolved.parts
+    if root is not None:
+        try:
+            parts = resolved.relative_to(root).parts
+        except ValueError:
+            parts = resolved.parts
+    return any(CAPTURE_DIR_RE.search(part) is not None for part in parts)

--- a/src/hyperloom/agents/kernel/tools/_idle_gate.py
+++ b/src/hyperloom/agents/kernel/tools/_idle_gate.py
@@ -1,15 +1,31 @@
-"""Shared GPU-idle gate: threshold resolution + high-idle trace-health warning.
+"""Shared GPU work-share gates: threshold resolution + trace-health warnings.
 
-Single source of truth for the idle-percent gate applied by BOTH trace-analysis
+Single source of truth for the trace-health gates applied by BOTH trace-analysis
 routes (the TraceLens agent/deterministic pipeline and the standalone bypass
-reader), so the threshold, gate semantics, and warning shape stay identical
+reader), so the thresholds, gate semantics, and warning shapes stay identical
 regardless of which backend produced the trace analysis.
 
-Idle metric convention (unified across routes): ``idle_pct`` is the GPU idle
-fraction of the analyzed trace's wall span -- ``idle_time / total_time * 100``.
-TraceLens reads it from ``gpu_timeline.csv`` (or the Executive Summary); bypass
-computes ``idle_ms / total_ms * 100`` from the profiler timeline. Both express
-the same quantity, so the same threshold gates them consistently.
+Two complementary gates live here, both answering "can rewriting a kernel move
+end-to-end latency on this trace?":
+
+* **High idle** -- ``idle_pct`` is the GPU idle fraction of the analyzed trace's
+  wall span (``idle_time / total_time * 100``). TraceLens reads it from
+  ``gpu_timeline.csv`` (or the Executive Summary); bypass computes
+  ``idle_ms / total_ms * 100`` from the profiler timeline.
+* **Low compute** -- ``compute_pct`` is the fraction of that same span spent in
+  compute kernels. Idle alone cannot catch a window dominated by *exposed
+  communication*, because a spin-waiting collective (e.g. a custom all-reduce
+  that polls peer-rank signals from inside the kernel) is charged as GPU-busy
+  time. Such a window reports a near-zero idle share while carrying almost no
+  usable work, so it slips through the idle gate. Gating on the compute share
+  restores the original intent for both regimes.
+
+The high-idle gate runs on both routes. The low-compute gate currently runs on
+the TraceLens route only, because the bypass reader does not model exposed
+communication (``_bypass_report`` reports ``exposed_comm_pct: None``) and so
+cannot separate compute from collective time. Wiring bypass in requires teaching
+it to classify collectives first; until then it keeps the idle gate alone rather
+than gating on a compute share it cannot measure.
 
 Kept dependency-free (stdlib only) so the bypass reader can consume it without
 importing or shelling out to TraceLens.
@@ -24,6 +40,31 @@ from typing import Any
 HIGH_IDLE_PCT_THRESHOLD_DEFAULT = 80.0
 HIGH_IDLE_PCT_THRESHOLD_ENV = "HYPERLOOM_TRACELENS_IDLE_PCT_THRESHOLD"
 
+LOW_COMPUTE_PCT_THRESHOLD_DEFAULT = 10.0
+LOW_COMPUTE_PCT_THRESHOLD_ENV = "HYPERLOOM_TRACELENS_MIN_COMPUTE_PCT_THRESHOLD"
+
+
+def _resolve_pct_threshold(env_name: str, default: float) -> float:
+    """Return a percentage threshold from ``env_name``, falling back to ``default``.
+
+    Args:
+        env_name: Environment variable holding the override.
+        default: Value used when the override is unset, unparseable, or negative.
+
+    Returns:
+        The resolved percentage threshold.
+    """
+    raw = os.environ.get(env_name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    if value < 0.0:
+        return default
+    return value
+
 
 def resolve_idle_pct_threshold() -> float:
     """Return the idle-percent gate threshold (default 80.0%).
@@ -33,16 +74,27 @@ def resolve_idle_pct_threshold() -> float:
     Returns:
         The idle-percent gate threshold.
     """
-    raw = os.environ.get(HIGH_IDLE_PCT_THRESHOLD_ENV, "").strip()
-    if not raw:
-        return HIGH_IDLE_PCT_THRESHOLD_DEFAULT
-    try:
-        value = float(raw)
-    except (TypeError, ValueError):
-        return HIGH_IDLE_PCT_THRESHOLD_DEFAULT
-    if value < 0.0:
-        return HIGH_IDLE_PCT_THRESHOLD_DEFAULT
-    return value
+    return _resolve_pct_threshold(
+        HIGH_IDLE_PCT_THRESHOLD_ENV,
+        HIGH_IDLE_PCT_THRESHOLD_DEFAULT,
+    )
+
+
+def resolve_min_compute_pct_threshold() -> float:
+    """Return the minimum-compute-percent gate threshold (default 10.0%).
+
+    Deliberately well below the ``100 - HIGH_IDLE_PCT_THRESHOLD_DEFAULT`` (20%)
+    that would make this gate the exact mirror of the idle gate, so it only
+    fires on unambiguously degenerate windows. Pin via
+    ``HYPERLOOM_TRACELENS_MIN_COMPUTE_PCT_THRESHOLD``.
+
+    Returns:
+        The minimum-compute-percent gate threshold.
+    """
+    return _resolve_pct_threshold(
+        LOW_COMPUTE_PCT_THRESHOLD_ENV,
+        LOW_COMPUTE_PCT_THRESHOLD_DEFAULT,
+    )
 
 
 def build_high_idle_warning(
@@ -82,6 +134,55 @@ def build_high_idle_warning(
             "can route to params/backends."
         ),
     }
+
+
+def build_low_compute_warning(
+    *,
+    compute_pct: float,
+    threshold_pct: float,
+    report_path: Path,
+    exposed_comm_pct: float | None = None,
+) -> dict[str, Any]:
+    """Build the ``trace_health_warnings[]`` entry for a low-compute-share trace.
+
+    Consumed by the Coordinator the same way ``high_gpu_idle_pct`` is: the
+    hot-kernel list is suppressed and the session is routed to comm/parameter
+    optimization instead of per-kernel rewriting.
+
+    Args:
+        compute_pct: The measured compute share of trace wall time.
+        threshold_pct: The minimum-compute threshold that was not met.
+        report_path: Path to the source report, recorded in the entry.
+        exposed_comm_pct: Exposed-communication share, when known, so the
+            Coordinator can tell a comm-bound window from a host-bound one.
+
+    Returns:
+        The structured ``low_gpu_compute_pct`` warning entry.
+    """
+    entry: dict[str, Any] = {
+        "code": "low_gpu_compute_pct",
+        "severity": "warning",
+        "compute_pct": round(compute_pct, 2),
+        "threshold_pct": round(threshold_pct, 2),
+        "source": str(report_path),
+    }
+    comm_note = ""
+    if isinstance(exposed_comm_pct, (int, float)) and not isinstance(exposed_comm_pct, bool):
+        entry["exposed_comm_pct"] = round(float(exposed_comm_pct), 2)
+        comm_note = f" Exposed communication accounts for {float(exposed_comm_pct):.2f}% of the window."
+    entry["message"] = (
+        f"Only {compute_pct:.2f}% of trace wall time is compute (threshold "
+        f"{threshold_pct:.2f}%).{comm_note} A kernel rewrite is bounded by the "
+        "compute share, so it cannot move end-to-end latency in this regime "
+        "even at infinite speedup. Note that a spin-waiting collective is "
+        "charged as GPU-busy time, so this window can report near-zero idle "
+        "while carrying almost no usable work — check for cross-rank arrival "
+        "skew (one collective invocation absorbing the window) before reading "
+        "it as a genuine communication bottleneck. Hyperloom is suppressing "
+        "the hot-kernel candidate list and surfacing this warning so the "
+        "Coordinator can route to comm/params instead."
+    )
+    return entry
 
 
 def build_graph_under_recorded_warning(

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -49,6 +49,7 @@ try:
     from hyperloom.common.provenance import build_provenance as _shared_build_provenance
 except Exception:  # noqa: BLE001 — standalone invocation without the package installed.
     _shared_build_provenance = None
+from _capture_shapes import CAPTURE_FRAGMENT_RE as _shared_capture_fragment_re  # noqa: E402
 from _idle_gate import (  # noqa: E402
     build_graph_under_recorded_warning,
     build_high_idle_warning,
@@ -203,8 +204,15 @@ _SHAPE_MANIFEST_ENV = "HYPERLOOM_TRACE_SHAPE_MANIFEST"
 _GFX_ENV = "HYPERLOOM_GFX_ARCH"
 #: sglang capture shard filename -> ``bs_<batch>`` variant. vLLM instead emits
 #: ``graph_capture_rank_*`` files whose batch/mode live in execution_details.json.
-_VARIANT_RE = re.compile(r"^(bs_\d+)", re.IGNORECASE)
-_CAPTURE_FILE_RE = re.compile(r"^(bs_\d+_rank\d+|graph_capture)", re.IGNORECASE)
+#: Unanchored because an unpatched SGLang prefixes the runner name, as in
+#: ``DecodeCudaGraphRunner_bs_104_rank0``; an anchored match fell through to the
+#: bare stem and lost the batch identity the manifest dedups on.
+_VARIANT_RE = re.compile(r"(bs_\d+)", re.IGNORECASE)
+#: Which files count as capture shards worth indexing. Shared with the ranking
+#: and preflight classifiers rather than re-spelled here: the local copy this
+#: replaced was start-anchored, so an unpatched SGLang's
+#: ``cuda_graph_capture-*`` shard was skipped and its shapes never indexed.
+_CAPTURE_FILE_RE = _shared_capture_fragment_re
 #: Optional cap on how many capture files to index (0 = all). Logged when hit.
 _MAX_CAPTURES_ENV = "HYPERLOOM_TRACE_SHAPE_MANIFEST_MAX_CAPTURES"
 
@@ -263,7 +271,9 @@ def _discover_capture_shards(trace_input: str, capture_folder: str) -> list[tupl
             continue
         for cand in _reader._trace_candidates(root):
             name = cand.name
-            if not _CAPTURE_FILE_RE.match(name):
+            # ``search``: the shared pattern anchors only its ``bs_<digits>``
+            # alternative, so ``graph_capture`` still matches mid-name.
+            if not _CAPTURE_FILE_RE.search(name):
                 continue
             key = str(cand.resolve())
             if key in seen:
@@ -272,7 +282,7 @@ def _discover_capture_shards(trace_input: str, capture_folder: str) -> list[tupl
             pdir = cand.parent
             if pdir not in exec_cache:
                 exec_cache[pdir] = _load_execution_details(pdir)
-            if name.lower().startswith("graph_capture"):
+            if "graph_capture" in name.lower():
                 meta = exec_cache[pdir].get(name, {})
                 bs = meta.get("batch_size")
                 mode = meta.get("mode")

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -49,7 +49,6 @@ try:
     from hyperloom.common.provenance import build_provenance as _shared_build_provenance
 except Exception:  # noqa: BLE001 — standalone invocation without the package installed.
     _shared_build_provenance = None
-from _capture_shapes import CAPTURE_FRAGMENT_RE as _shared_capture_fragment_re  # noqa: E402
 from _idle_gate import (  # noqa: E402
     build_graph_under_recorded_warning,
     build_high_idle_warning,
@@ -204,15 +203,22 @@ _SHAPE_MANIFEST_ENV = "HYPERLOOM_TRACE_SHAPE_MANIFEST"
 _GFX_ENV = "HYPERLOOM_GFX_ARCH"
 #: sglang capture shard filename -> ``bs_<batch>`` variant. vLLM instead emits
 #: ``graph_capture_rank_*`` files whose batch/mode live in execution_details.json.
-#: Unanchored because an unpatched SGLang prefixes the runner name, as in
-#: ``DecodeCudaGraphRunner_bs_104_rank0``; an anchored match fell through to the
-#: bare stem and lost the batch identity the manifest dedups on.
+#: Searched rather than matched from the start: an SGLang without the profiler
+#: patch prefixes the runner name, as in ``DecodeCudaGraphRunner_bs_104_rank0``,
+#: and an anchored read falls through to the bare stem -- which differs per rank,
+#: so the label dedup below stops collapsing the ranks of one batch.
 _VARIANT_RE = re.compile(r"(bs_\d+)", re.IGNORECASE)
-#: Which files count as capture shards worth indexing. Shared with the ranking
-#: and preflight classifiers rather than re-spelled here: the local copy this
-#: replaced was start-anchored, so an unpatched SGLang's
-#: ``cuda_graph_capture-*`` shard was skipped and its shapes never indexed.
-_CAPTURE_FILE_RE = _shared_capture_fragment_re
+#: Which files carry an indexable per-variant shape. Deliberately NOT the shared
+#: ``_capture_shapes`` classifier: that one answers "is this a sidecar rather
+#: than a workload trace", which is a wider question than this one. A
+#: whole-capture-per-rank file such as an unpatched SGLang's
+#: ``cuda_graph_capture-<runner>-TP-<n>`` is certainly a sidecar, but it holds
+#: every batch size at once and carries no variant identity, so admitting it
+#: mints one bogus variant per rank -- TP=8 would inflate ``variant_count`` by
+#: eight shape-identical entries and defeat the dedup a few lines down. Admit a
+#: ``bs_<batch>`` token anywhere (both SGLang layouts) or the vLLM prefix whose
+#: batch/mode arrive via execution_details.json.
+_CAPTURE_FILE_RE = re.compile(r"bs_\d+|\Agraph_capture", re.IGNORECASE)
 #: Optional cap on how many capture files to index (0 = all). Logged when hit.
 _MAX_CAPTURES_ENV = "HYPERLOOM_TRACE_SHAPE_MANIFEST_MAX_CAPTURES"
 
@@ -271,8 +277,6 @@ def _discover_capture_shards(trace_input: str, capture_folder: str) -> list[tupl
             continue
         for cand in _reader._trace_candidates(root):
             name = cand.name
-            # ``search``: the shared pattern anchors only its ``bs_<digits>``
-            # alternative, so ``graph_capture`` still matches mid-name.
             if not _CAPTURE_FILE_RE.search(name):
                 continue
             key = str(cand.resolve())
@@ -282,7 +286,11 @@ def _discover_capture_shards(trace_input: str, capture_folder: str) -> list[tupl
             pdir = cand.parent
             if pdir not in exec_cache:
                 exec_cache[pdir] = _load_execution_details(pdir)
-            if "graph_capture" in name.lower():
+            # vLLM only: its shards are named ``graph_capture_*`` and keep
+            # batch/mode in execution_details.json. An SGLang name that merely
+            # *contains* the token writes no such file, so routing it here would
+            # yield bs=None and fall back to the per-rank stem.
+            if name.lower().startswith("graph_capture"):
                 meta = exec_cache[pdir].get(name, {})
                 bs = meta.get("batch_size")
                 mode = meta.get("mode")
@@ -292,8 +300,8 @@ def _discover_capture_shards(trace_input: str, capture_folder: str) -> list[tupl
                     label = f"bs_{bs}_{str(mode).lower()}" if mode else f"bs_{bs}"
                 else:
                     label = cand.stem
-            else:  # sglang bs_<batch>_rank<n>
-                m = _VARIANT_RE.match(name)
+            else:  # sglang bs_<batch>_rank<n>, with or without a runner prefix
+                m = _VARIANT_RE.search(name)
                 label = m.group(1).lower() if m else cand.stem
                 mode = None
             # TP>1 emits one capture shard per rank with the SAME variant label

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -60,6 +60,8 @@ from tracelens_skill_runner import (
     _resolve_launcher_to_abs_source,
     aggregate_by_source_function,
     discover_capture_folder,
+    extract_compute_pct_from_analysis_md,
+    extract_exposed_comm_pct_from_analysis_md,
     extract_idle_pct_from_analysis_md,
     normalize_upstream_category,
     parse_analysis_md,
@@ -77,7 +79,9 @@ from _paths import workspace_root
 from _idle_gate import (
     build_graph_under_recorded_warning as _build_graph_under_recorded_warning,
     build_high_idle_warning as _build_high_idle_warning,
+    build_low_compute_warning as _build_low_compute_warning,
     resolve_idle_pct_threshold,
+    resolve_min_compute_pct_threshold,
 )
 
 # Canonical roofline_source provenance enum, shared with the bypass route so both
@@ -488,6 +492,42 @@ def _evaluate_idle_gate_with_graph_guard(
         )
     _, high_idle_warning = _evaluate_high_idle_gate(idle_pct, report_path)
     return threshold, high_idle_warning, None
+
+
+def _evaluate_low_compute_gate(
+    compute_pct: float | None,
+    exposed_comm_pct: float | None,
+    report_path: Path,
+) -> tuple[float, dict[str, Any] | None]:
+    """Return the compute threshold plus a warning when the compute share is too low.
+
+    Complements :func:`_evaluate_idle_gate_with_graph_guard`. The idle gate
+    cannot see a window whose wall time is consumed by a spin-waiting
+    collective, because that wait is charged as GPU-busy time -- such a trace
+    reports ~0% idle alongside a single-digit compute share. Since a kernel
+    rewrite is bounded by the compute share, both regimes warrant the same
+    response: suppress the hot-kernel list and let the Coordinator route
+    elsewhere.
+
+    Args:
+        compute_pct: Compute share of trace wall time, or ``None`` when the
+            source report did not expose it (gate is skipped).
+        exposed_comm_pct: Exposed-communication share, for warning context.
+        report_path: Path to the source report, recorded in the warning.
+
+    Returns:
+        The resolved threshold and the ``low_gpu_compute_pct`` warning, or
+        ``None`` when the gate does not fire.
+    """
+    threshold = resolve_min_compute_pct_threshold()
+    if compute_pct is None or compute_pct >= threshold:
+        return threshold, None
+    return threshold, _build_low_compute_warning(
+        compute_pct=compute_pct,
+        threshold_pct=threshold,
+        report_path=report_path,
+        exposed_comm_pct=exposed_comm_pct,
+    )
 
 
 def _build_trace_split_warning(
@@ -3899,12 +3939,22 @@ def _resolve_other_bucket_min_gpu_pct() -> float:
     return _DEFAULT_OTHER_BUCKET_MIN_GPU_PCT
 
 
+# Provenance for a candidate's ``gpu_pct``. Only ``e2e_window`` is comparable
+# with the percentages ``parse_analysis_md`` lifts out of analysis.md; the other
+# two are best-effort and are recorded so a consumer can tell them apart instead
+# of silently ranking incomparable numbers against each other.
+GPU_PCT_BASIS_E2E = "e2e_window"
+GPU_PCT_BASIS_SIDECAR = "sidecar_reported"
+GPU_PCT_BASIS_LISTED_OPS = "listed_ops_sum"
+
+
 def recover_other_bucket_candidates(
     skill_output_dir: Path | str | None,
     existing_candidates: list[dict[str, Any]],
     *,
     top_k: int = 10,
     min_gpu_pct: float | None = None,
+    total_window_us: float | None = None,
     log: Callable[[str], None] | None = None,
 ) -> list[dict[str, Any]]:
     """Recover HIGH-GPU-time ops missing from analysis.md (any category).
@@ -3922,12 +3972,30 @@ def recover_other_bucket_candidates(
     Fires for ops that are (a) absent from ``existing_candidates`` by name and
     (b) at or above ``min_gpu_pct`` of total GPU time.
 
+    Whenever ``total_window_us`` is known, ``gpu_pct`` is normalized against it
+    -- the same denominator ``parse_analysis_md`` uses -- so both candidate
+    sources stay comparable inside one ranked ``hot_kernels[]``. The sidecar's
+    own percentage column is preferred only as a fallback, because its
+    denominator is not the trace wall span: ``ops_summary.csv`` normalizes
+    against total *op* time, which excludes collectives, so on a comm-dominated
+    trace its percentages run an order of magnitude above the end-to-end share.
+    Mixing the two bases in one field silently produced unrankable candidate
+    lists (a fallback op at "23.5% GPU" outranking an analysis.md op at "4.7%
+    GPU" when the true e2e shares were 0.5% and 4.7%). The basis actually used
+    is recorded on each candidate as ``gpu_pct_basis``.
+
     Args:
         skill_output_dir: The TraceLens skill output directory to scan.
         existing_candidates: Candidates already extracted from analysis.md.
         top_k: Maximum number of recovered candidates to return.
         min_gpu_pct: Minimum GPU-time percentage to qualify; defaults to the
-            ``HYPERLOOM_OTHER_BUCKET_MIN_GPU_PCT`` env value (10%).
+            ``HYPERLOOM_OTHER_BUCKET_MIN_GPU_PCT`` env value (10%). Compared
+            against whichever basis was used, so it is a materially higher bar
+            under ``e2e_window`` than under the pre-existing bases.
+        total_window_us: Wall span of the analyzed trace, in microseconds. When
+            omitted or non-positive the function falls back to the sidecar's
+            reported percentage, then to a share of the listed ops, and marks
+            the candidates accordingly.
         log: Optional logging callable for diagnostics.
 
     Returns:
@@ -3941,41 +4009,48 @@ def recover_other_bucket_candidates(
         min_gpu_pct = _resolve_other_bucket_min_gpu_pct()
 
     have = {str(c.get("name") or "").strip().lower() for c in existing_candidates if isinstance(c, dict)}
-    total_us = sum(r["gpu_us"] for r in ranking if r.get("gpu_us") is not None) or 0.0
+    listed_ops_us = sum(r["gpu_us"] for r in ranking if r.get("gpu_us") is not None) or 0.0
+    window_us = float(total_window_us) if total_window_us is not None and total_window_us > 0 else 0.0
 
-    def _pct(rec: dict[str, Any]) -> float | None:
-        """Return a record's GPU-time percentage.
+    def _pct(rec: dict[str, Any]) -> tuple[float, str] | None:
+        """Return a record's GPU-time percentage and the basis it was computed on.
 
         Args:
             rec: A ranking record.
 
         Returns:
-            The explicit ``gpu_pct`` when present, else the share of
-            ``total_us`` derived from ``gpu_us``, else ``None``.
+            A ``(percentage, basis)`` pair, or ``None`` when the record carries
+            neither a usable GPU time nor a reported percentage.
         """
+        gpu_us = rec.get("gpu_us")
+        if window_us > 0 and gpu_us is not None:
+            return gpu_us / window_us * 100.0, GPU_PCT_BASIS_E2E
+        # No trace wall span available (e.g. a JSON sidecar with no
+        # gpu_timeline.csv beside it): fall back to whatever the sidecar
+        # reported, then to a share of the rows we can see.
         if rec.get("gpu_pct") is not None:
-            return float(rec["gpu_pct"])
-        if total_us > 0 and rec.get("gpu_us") is not None:
-            return rec["gpu_us"] / total_us * 100.0
+            return float(rec["gpu_pct"]), GPU_PCT_BASIS_SIDECAR
+        if listed_ops_us > 0 and gpu_us is not None:
+            return gpu_us / listed_ops_us * 100.0, GPU_PCT_BASIS_LISTED_OPS
         return None
 
-    qualifying: list[tuple[float, dict[str, Any]]] = []
+    qualifying: list[tuple[float, str, dict[str, Any]]] = []
     for rec in ranking:
         name_l = str(rec.get("name") or "").strip().lower()
         if not name_l or name_l in have:
             continue
         # Gate on any high-GPU-time op missing from existing candidates.
-        pct = _pct(rec)
-        if pct is None or pct < min_gpu_pct:
+        scored = _pct(rec)
+        if scored is None or scored[0] < min_gpu_pct:
             continue
-        qualifying.append((pct, rec))
+        qualifying.append((scored[0], scored[1], rec))
 
     if not qualifying:
         return []
     qualifying.sort(key=lambda t: t[0], reverse=True)
 
     out: list[dict[str, Any]] = []
-    for pct, rec in qualifying[: max(1, top_k)]:
+    for pct, pct_basis, rec in qualifying[: max(1, top_k)]:
         gpu_us = rec.get("gpu_us")
         out.append(
             {
@@ -3987,6 +4062,7 @@ def recover_other_bucket_candidates(
                 "shapes": [],
                 "tracelens_category": rec.get("category") or "other",
                 "gpu_pct": round(pct, 3),
+                "gpu_pct_basis": pct_basis,
                 "candidate_source": "other_bucket_fallback",
             }
         )
@@ -3994,6 +4070,7 @@ def recover_other_bucket_candidates(
             log(
                 f"candidate recovery fallback (#514/#515): recovered "
                 f"high-GPU-time op {rec['name']!r} (~{pct:.1f}% GPU time, "
+                f"basis={pct_basis}, "
                 f"category={rec.get('category') or 'other'!r}) that has no "
                 f"analysis.md reasoning-candidate block; routing through "
                 f"classify_patchability so a reusable native kernel still "
@@ -5378,6 +5455,64 @@ def _extract_idle_pct_from_gpu_timeline(output_dir: Path) -> float | None:
         # malformed CSV numeric field; treat as absent
         return None
     return None
+
+
+# TraceLens has spelled the compute / exposed-communication timeline rows
+# several ways across versions; accept every spelling seen in the wild rather
+# than silently reporting "no compute row" (which would disable the gate).
+_COMPUTE_TIMELINE_TYPES = ("computation_time", "compute_time", "computation", "compute")
+_EXPOSED_COMM_TIMELINE_TYPES = ("exposed_comm_time", "exposed_communication_time", "exposed_communication")
+
+
+def _extract_pct_from_gpu_timeline(output_dir: Path, row_types: tuple[str, ...]) -> float | None:
+    """Read a percentage from the first matching gpu_timeline.csv row type.
+
+    Args:
+        output_dir: The analysis output directory holding
+            ``perf_report_csvs/gpu_timeline.csv``.
+        row_types: Accepted ``type`` spellings, in priority order.
+
+    Returns:
+        The percentage, or ``None`` when the CSV is absent or carries none of
+        the accepted row types.
+    """
+    try:
+        rows = _load_gpu_timeline_rows(output_dir)
+        by_type = {(row.get("type") or "").strip().lower(): row for row in rows}
+        for row_type in row_types:
+            row = by_type.get(row_type)
+            if row is not None:
+                return float(row.get("percent", 0))
+    except ValueError:
+        # malformed CSV numeric field; treat as absent
+        return None
+    return None
+
+
+def _extract_compute_pct_from_gpu_timeline(output_dir: Path) -> float | None:
+    """Read the GPU compute percentage from gpu_timeline.csv.
+
+    Args:
+        output_dir: The analysis output directory holding
+            ``perf_report_csvs/gpu_timeline.csv``.
+
+    Returns:
+        The compute percentage, or ``None`` when unavailable.
+    """
+    return _extract_pct_from_gpu_timeline(output_dir, _COMPUTE_TIMELINE_TYPES)
+
+
+def _extract_exposed_comm_pct_from_gpu_timeline(output_dir: Path) -> float | None:
+    """Read the exposed-communication percentage from gpu_timeline.csv.
+
+    Args:
+        output_dir: The analysis output directory holding
+            ``perf_report_csvs/gpu_timeline.csv``.
+
+    Returns:
+        The exposed-communication percentage, or ``None`` when unavailable.
+    """
+    return _extract_pct_from_gpu_timeline(output_dir, _EXPOSED_COMM_TIMELINE_TYPES)
 
 
 def _extract_total_time_us_from_gpu_timeline(output_dir: Path) -> float | None:
@@ -7717,25 +7852,50 @@ def main() -> int:
                         raw_trace_path,
                     )
                 )
+                compute_pct_value = _extract_compute_pct_from_gpu_timeline(tracelens_dir)
+                exposed_comm_pct_value = _extract_exposed_comm_pct_from_gpu_timeline(
+                    tracelens_dir,
+                )
+                compute_pct_threshold, low_compute_warning = _evaluate_low_compute_gate(
+                    compute_pct_value,
+                    exposed_comm_pct_value,
+                    tracelens_dir / "analysis.md",
+                )
                 if graph_under_recorded_warning is not None:
+                    # Under-recording deflates every recorded share alike, so the
+                    # compute share is as unreliable as idle% here.
+                    low_compute_warning = None
                     trace_health_warnings.append(graph_under_recorded_warning)
                     append_log(
                         log_path,
                         "deterministic: high idle% is a graph under-recording "
                         "artifact (profiler captured ~1 of N graph replays); "
-                        "skipping the idle gate and keeping hot_kernels[].",
+                        "skipping the idle/compute gates and keeping hot_kernels[].",
                     )
-                if high_idle_warning is not None:
-                    assert idle_pct_value is not None
+                if high_idle_warning is not None or low_compute_warning is not None:
                     agent_candidates = []
                     allow_empty_candidates = True
-                    trace_health_warnings.append(high_idle_warning)
-                    append_log(
-                        log_path,
-                        f"deterministic: GPU Idle % = {idle_pct_value:.2f}% "
-                        f"(threshold {idle_pct_threshold:.2f}%); "
-                        "suppressing hot_kernels[]",
-                    )
+                    if high_idle_warning is not None:
+                        assert idle_pct_value is not None
+                        trace_health_warnings.append(high_idle_warning)
+                        append_log(
+                            log_path,
+                            f"deterministic: GPU Idle % = {idle_pct_value:.2f}% "
+                            f"(threshold {idle_pct_threshold:.2f}%); "
+                            "suppressing hot_kernels[]",
+                        )
+                    if low_compute_warning is not None:
+                        assert compute_pct_value is not None
+                        trace_health_warnings.append(low_compute_warning)
+                        append_log(
+                            log_path,
+                            f"deterministic: GPU Compute % = "
+                            f"{compute_pct_value:.2f}% (threshold "
+                            f"{compute_pct_threshold:.2f}%); suppressing "
+                            "hot_kernels[] — a kernel rewrite is bounded by "
+                            "the compute share and cannot move end-to-end "
+                            "latency here",
+                        )
                 else:
                     if idle_pct_value is not None and graph_under_recorded_warning is None:
                         append_log(
@@ -7838,31 +7998,61 @@ def main() -> int:
                             raw_trace_path,
                         )
                     )
+                    compute_pct_value = extract_compute_pct_from_analysis_md(
+                        skill_result.report_path,
+                    )
+                    exposed_comm_pct_value = extract_exposed_comm_pct_from_analysis_md(
+                        skill_result.report_path,
+                    )
+                    compute_pct_threshold, low_compute_warning = _evaluate_low_compute_gate(
+                        compute_pct_value,
+                        exposed_comm_pct_value,
+                        skill_result.report_path,
+                    )
                     if graph_under_recorded_warning is not None:
+                        # Under-recording deflates every recorded share alike, so
+                        # the compute share is as unreliable as idle% here.
+                        low_compute_warning = None
                         trace_health_warnings.append(graph_under_recorded_warning)
                         append_log(
                             log_path,
                             "TraceLens high idle% is a graph under-recording "
                             "artifact (profiler captured ~1 of N graph replays); "
-                            "skipping the idle gate and keeping hot_kernels[].",
+                            "skipping the idle/compute gates and keeping hot_kernels[].",
                         )
-                    if high_idle_warning is not None:
-                        assert idle_pct_value is not None
+                    if high_idle_warning is not None or low_compute_warning is not None:
                         agent_candidates = []
                         allow_empty_candidates = True
-                        trace_health_warnings.append(high_idle_warning)
-                        report_source = "skipped:high_gpu_idle_pct"
-                        append_log(
-                            log_path,
-                            f"TraceLens Executive Summary reports "
-                            f"Idle % = {idle_pct_value:.2f}% (threshold "
-                            f"{idle_pct_threshold:.2f}%); suppressing "
-                            "hot_kernels[] — kernel rewriting cannot move "
-                            "end-to-end latency in the high-idle regime. "
-                            "Coordinator will see this in "
-                            "trace_health_warnings[] and route to "
-                            "parameter optimization.",
-                        )
+                        if high_idle_warning is not None:
+                            assert idle_pct_value is not None
+                            trace_health_warnings.append(high_idle_warning)
+                            report_source = "skipped:high_gpu_idle_pct"
+                            append_log(
+                                log_path,
+                                f"TraceLens Executive Summary reports "
+                                f"Idle % = {idle_pct_value:.2f}% (threshold "
+                                f"{idle_pct_threshold:.2f}%); suppressing "
+                                "hot_kernels[] — kernel rewriting cannot move "
+                                "end-to-end latency in the high-idle regime. "
+                                "Coordinator will see this in "
+                                "trace_health_warnings[] and route to "
+                                "parameter optimization.",
+                            )
+                        if low_compute_warning is not None:
+                            assert compute_pct_value is not None
+                            trace_health_warnings.append(low_compute_warning)
+                            report_source = "skipped:low_gpu_compute_pct"
+                            append_log(
+                                log_path,
+                                f"TraceLens Executive Summary reports "
+                                f"Compute % = {compute_pct_value:.2f}% "
+                                f"(threshold {compute_pct_threshold:.2f}%); "
+                                "suppressing hot_kernels[] — a kernel rewrite "
+                                "is bounded by the compute share and cannot "
+                                "move end-to-end latency here. Coordinator "
+                                "will see this in trace_health_warnings[] and "
+                                "route to comm/parameter optimization.",
+                            )
                     else:
                         if idle_pct_value is not None and graph_under_recorded_warning is None:
                             append_log(
@@ -7884,6 +8074,9 @@ def main() -> int:
                             skill_result.output_dir,
                             report_cands,
                             top_k=args.top_k,
+                            total_window_us=_extract_total_time_us_from_gpu_timeline(
+                                skill_result.output_dir,
+                            ),
                             log=lambda msg: append_log(log_path, msg),
                         )
                         if fallback_cands:

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -1058,6 +1058,75 @@ _PHASE_FRAGMENT_RE = re.compile(
 )
 
 
+#: Directory both frameworks write CUDA-graph capture sidecars into.
+_CAPTURE_DIR_NAME = "capture_traces"
+
+#: Sidecar filename shapes: SGLang ``bs_<batch>[_rank<n>]``, vLLM
+#: ``graph_capture_*``. The batch number is required rather than a bare ``bs_``
+#: prefix because this classifier now *rejects* an input instead of only sorting
+#: it, and a real trace that merely starts with those three characters must not
+#: be thrown out. One definition, because both callers need the same answer:
+#: discovery demotes sidecars below a real capture, and the preflight refuses an
+#: input made of nothing else.
+_CAPTURE_FRAGMENT_RE = re.compile(r"^(?:bs_\d+|graph_capture)", re.IGNORECASE)
+
+
+def _is_capture_fragment(path: Path, root: Path | None = None) -> bool:
+    """Whether a trace path is a CUDA-graph capture sidecar.
+
+    Capture sidecars are recorded while the graph is being *built*, so the
+    launches in them go into the graph instead of onto the device. What lands is
+    a host-side Python call tree with a handful of stray kernels, one file per
+    (batch size, rank), each holding a single ``ProfilerStep``. There is no
+    iteration loop in one, which is what the steady-state splitter exists to cut
+    up.
+
+    Two signals, because either alone has a blind spot: the directory name
+    catches a sidecar whose filename nobody has seen before, and the filename
+    catches a flat layout that never made the directory.
+
+    ``root`` bounds the directory test to the input being analysed, the same way
+    :func:`_is_derived_trace` does it. Paths arrive absolute, so testing every
+    component would condemn every candidate whenever some ancestor happened to
+    be named ``capture_traces``. Callers pass the input directory, or a file's
+    parent so a single-file input is judged on its name alone.
+
+    Args:
+        path: The trace file path to classify.
+        root: Directory the classification is relative to, when known.
+
+    Returns:
+        True when ``path`` is a graph-capture sidecar rather than a workload
+        trace.
+    """
+    if _CAPTURE_FRAGMENT_RE.match(path.name) is not None:
+        return True
+    relative = path
+    if root is not None:
+        try:
+            relative = path.relative_to(root)
+        except ValueError:
+            relative = path
+    return any(part.lower() == _CAPTURE_DIR_NAME for part in relative.parts)
+
+
+def _capture_classification_root(trace_input: Path) -> Path:
+    """Root to classify candidates discovered from ``trace_input`` against.
+
+    A directory input is its own root, so a ``capture_traces/`` component below
+    it counts. A file input resolves to its parent, which leaves the filename as
+    the only component and keeps an unrelated ancestor directory out of the
+    decision.
+
+    Args:
+        trace_input: The ``--trace-input`` path.
+
+    Returns:
+        The directory candidate paths are made relative to.
+    """
+    return trace_input if trace_input.is_dir() else trace_input.parent
+
+
 def _is_derived_trace(path: Path, root: Path | None = None) -> bool:
     """Whether a trace path is splitter output rather than a raw capture.
 
@@ -1163,7 +1232,7 @@ def _trace_input_sort_key(path: Path, root: Path | None = None) -> tuple[int, in
         return (0, -size, name)
     if re.search(r"TP-\d+-DECODE\.trace\.json(?:\.gz)?$", name):
         return (2, -size, name)
-    if name.startswith("bs_") or name.startswith("graph_capture"):
+    if _is_capture_fragment(path, root):
         return (3, -size, name)
     return (1, -size, name)
 
@@ -7393,6 +7462,38 @@ def main() -> int:
         # push that None through every downstream call for a branch that cannot
         # be taken.
         analysis_trace_path = trace_files[0]
+
+        # Fail-fast when the input is nothing but CUDA-graph capture sidecars.
+        #
+        # Ahead of the kernel probe below because the two answer different
+        # questions and only this one is reliable here. A capture records the
+        # graph being built, so it carries a handful of stray kernels rather
+        # than none -- 2 out of 1.49M events on the run that prompted this --
+        # and a probe that asks "are there any kernels" therefore passes it and
+        # hands the splitter a file with no iteration loop in it. The splitter
+        # then fails with ``trace_split_no_steady_state``, which reads as "the
+        # window was too short" and sends the next person to lengthen a capture
+        # that was never a workload timeline to begin with.
+        #
+        # ``all`` rather than ``any``: a healthy profile writes the annotated
+        # trace *beside* its sidecars, and discovery already sorts those first.
+        # Only an input with nothing else in it is unanalysable.
+        if not args.dry_run and trace_files:
+            capture_root = _capture_classification_root(trace_input)
+            if all(_is_capture_fragment(p, capture_root) for p in trace_files):
+                raise RuntimeError(
+                    "trace_input_capture_only: "
+                    f"all {len(trace_files)} trace file(s) under {trace_input} "
+                    "are CUDA-graph capture sidecars. "
+                    "A capture records graph construction rather than "
+                    "execution, so it holds no per-iteration annotations for "
+                    "the steady-state splitter to cut on. "
+                    "The upstream profile produced no annotated workload trace: "
+                    "re-profile so the run writes one beside the sidecars. "
+                    "Sidecars are a supported auxiliary input -- pass them as "
+                    "--capture-folder alongside a real trace, never as "
+                    "--trace-input."
+                )
 
         # Fail-fast on CPU-only traces.
         #

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -74,12 +74,12 @@ from _nccl_summary_candidates import extract_collective_candidates
 # Standalone-tool workspace-root resolver (cannot import hyperloom.inference_optimizer.session.paths; see _paths.py).
 from _paths import workspace_root
 
-# Idle-gate threshold + high-idle warning: shared single source of truth so the
-# TraceLens and bypass routes gate on identical semantics.
-# Capture-vs-workload trace classification, shared with the bypass route so a
-# sidecar is recognised identically whichever backend reads the profile.
+# Capture-vs-workload trace classification, shared across routes so a sidecar is
+# recognised identically whichever backend reads the profile.
 from _capture_shapes import is_capture_fragment as _shared_is_capture_fragment
 
+# Trace-health gate thresholds + warnings (high idle, low compute): shared single
+# source of truth so the TraceLens and bypass routes gate on identical semantics.
 from _idle_gate import (
     build_graph_under_recorded_warning as _build_graph_under_recorded_warning,
     build_high_idle_warning as _build_high_idle_warning,
@@ -4024,14 +4024,22 @@ def recover_other_bucket_candidates(
     GPU" when the true e2e shares were 0.5% and 4.7%). The basis actually used
     is recorded on each candidate as ``gpu_pct_basis``.
 
+    Note this bypasses rather than repairs the ambiguity: ``_RANK_PCT_KEYS``
+    still maps both ``% of compute time`` and ``%e2e`` onto one ``gpu_pct``, so
+    a run with no ``gpu_timeline.csv`` to supply ``total_window_us`` falls back
+    to whatever the sidecar reported and carries the original mixed-basis
+    hazard -- now labelled ``sidecar_reported`` rather than silent. Splitting
+    those aliases into separate fields is the real repair and is not done here.
+
     Args:
         skill_output_dir: The TraceLens skill output directory to scan.
         existing_candidates: Candidates already extracted from analysis.md.
         top_k: Maximum number of recovered candidates to return.
         min_gpu_pct: Minimum GPU-time percentage to qualify; defaults to the
             ``HYPERLOOM_OTHER_BUCKET_MIN_GPU_PCT`` env value (10%). Compared
-            against whichever basis was used, so it is a materially higher bar
-            under ``e2e_window`` than under the pre-existing bases.
+            against the sidecar's own share, not against ``gpu_pct``, so
+            admission is unchanged by the reporting basis (see
+            ``_admission_pct``).
         total_window_us: Wall span of the analyzed trace, in microseconds. When
             omitted or non-positive the function falls back to the sidecar's
             reported percentage, then to a share of the listed ops, and marks
@@ -4052,8 +4060,35 @@ def recover_other_bucket_candidates(
     listed_ops_us = sum(r["gpu_us"] for r in ranking if r.get("gpu_us") is not None) or 0.0
     window_us = float(total_window_us) if total_window_us is not None and total_window_us > 0 else 0.0
 
-    def _pct(rec: dict[str, Any]) -> tuple[float, str] | None:
-        """Return a record's GPU-time percentage and the basis it was computed on.
+    def _admission_pct(rec: dict[str, Any]) -> float | None:
+        """Return the share ``min_gpu_pct`` has always been compared against.
+
+        Deliberately the pre-existing quantity -- the sidecar's own percentage,
+        else the record's share of the rows we can see -- and NOT the e2e share
+        below. ``min_gpu_pct`` is a tuned constant (10%) whose meaning is "a
+        large slice of the GPU work we know about"; re-pointing it at the wall
+        span would silently raise the bar by the reciprocal of the compute
+        share, and on an ordinary compute-bound trace (60% compute, work spread
+        over eight kernels) that takes this whole recovery path from eight
+        candidates to zero. Admission stays on the old basis; only the number we
+        publish moves.
+
+        Args:
+            rec: A ranking record.
+
+        Returns:
+            The admission share, or ``None`` when the record carries neither a
+            reported percentage nor a usable GPU time.
+        """
+        if rec.get("gpu_pct") is not None:
+            return float(rec["gpu_pct"])
+        gpu_us = rec.get("gpu_us")
+        if listed_ops_us > 0 and gpu_us is not None:
+            return gpu_us / listed_ops_us * 100.0
+        return None
+
+    def _reported_pct(rec: dict[str, Any]) -> tuple[float, str] | None:
+        """Return the percentage to publish and the basis it was computed on.
 
         Args:
             rec: A ranking record.
@@ -4080,8 +4115,11 @@ def recover_other_bucket_candidates(
         if not name_l or name_l in have:
             continue
         # Gate on any high-GPU-time op missing from existing candidates.
-        scored = _pct(rec)
-        if scored is None or scored[0] < min_gpu_pct:
+        admission = _admission_pct(rec)
+        if admission is None or admission < min_gpu_pct:
+            continue
+        scored = _reported_pct(rec)
+        if scored is None:
             continue
         qualifying.append((scored[0], scored[1], rec))
 
@@ -4116,6 +4154,18 @@ def recover_other_bucket_candidates(
                 f"classify_patchability so a reusable native kernel still "
                 f"reaches GEAK"
             )
+    # One batch on two bases is the state this labelling exists to prevent: the
+    # percentages are then not comparable with each other, let alone with the
+    # analysis.md candidates they get ranked against. It is reachable when only
+    # some ranking rows carry an absolute GPU time, so say so rather than leave
+    # the evidence buried in a field nothing reads yet.
+    bases = {c["gpu_pct_basis"] for c in out}
+    if len(bases) > 1 and log is not None:
+        log(
+            f"candidate recovery fallback: gpu_pct spans {sorted(bases)} in one "
+            f"batch, so the recovered candidates are not mutually comparable; "
+            f"rank them on gpu_pct_basis-matched subsets only"
+        )
     return out
 
 
@@ -5476,6 +5526,53 @@ def _load_gpu_timeline_rows(output_dir: Path) -> list[dict[str, str]]:
         return []
 
 
+# TraceLens has spelled the compute / exposed-communication timeline rows
+# several ways across versions; accept every spelling seen in the wild rather
+# than silently reporting "no compute row" (which would disable the gate).
+_COMPUTE_TIMELINE_TYPES = ("computation_time", "compute_time", "computation", "compute")
+_EXPOSED_COMM_TIMELINE_TYPES = ("exposed_comm_time", "exposed_communication_time", "exposed_communication")
+
+#: Column spellings for the share and duration cells of a gpu_timeline row. The
+#: row *labels* were already matched by shape; the columns holding the numbers
+#: need the same tolerance, or a renamed header reads as "value 0" instead of
+#: "value unknown".
+_GPU_TIMELINE_PCT_COLUMNS = ("percent", "percentage", "percentage (%)", "pct", "%")
+_GPU_TIMELINE_MS_COLUMNS = ("time ms", "time (ms)", "time_ms", "ms")
+
+
+def _gpu_timeline_cell(row: dict[str, str], columns: tuple[str, ...]) -> float | None:
+    """Read one numeric cell from a gpu_timeline row, or ``None`` if unusable.
+
+    Absent, blank and unparseable all collapse to ``None`` rather than to a
+    number. A defaulted ``0`` is not a neutral answer here: the low-compute gate
+    fires *below* its threshold, so a renamed or truncated column would read as
+    "0% compute" and suppress the hot-kernel list on every trace, silently and
+    with ``status`` still ``ok``. Every caller must be able to distinguish "the
+    profile says zero" from "this file did not tell us".
+
+    Args:
+        row: A parsed ``gpu_timeline.csv`` row.
+        columns: Accepted column spellings, in priority order.
+
+    Returns:
+        The cell value, or ``None`` when no accepted column carries a number.
+    """
+    lowered = {str(k).strip().lower(): v for k, v in row.items() if k}
+    for column in columns:
+        if column not in lowered:
+            continue
+        raw = lowered[column]
+        if raw is None or str(raw).strip() == "":
+            continue
+        try:
+            # csv.DictReader hands back None for a short row, and float(None)
+            # raises TypeError rather than ValueError.
+            return float(str(raw).strip().rstrip("%"))
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
 def _extract_idle_pct_from_gpu_timeline(output_dir: Path) -> float | None:
     """Read GPU idle percentage directly from gpu_timeline.csv.
 
@@ -5485,23 +5582,12 @@ def _extract_idle_pct_from_gpu_timeline(output_dir: Path) -> float | None:
 
     Returns:
         The GPU idle percentage, or ``None`` when the CSV is absent or has no
-        idle-time row.
+        usable idle-time row.
     """
-    try:
-        for row in _load_gpu_timeline_rows(output_dir):
-            if (row.get("type") or "").strip().lower() == "idle_time":
-                return float(row.get("percent", 0))
-    except ValueError:
-        # malformed CSV numeric field; treat as absent
-        return None
+    for row in _load_gpu_timeline_rows(output_dir):
+        if (row.get("type") or "").strip().lower() == "idle_time":
+            return _gpu_timeline_cell(row, _GPU_TIMELINE_PCT_COLUMNS)
     return None
-
-
-# TraceLens has spelled the compute / exposed-communication timeline rows
-# several ways across versions; accept every spelling seen in the wild rather
-# than silently reporting "no compute row" (which would disable the gate).
-_COMPUTE_TIMELINE_TYPES = ("computation_time", "compute_time", "computation", "compute")
-_EXPOSED_COMM_TIMELINE_TYPES = ("exposed_comm_time", "exposed_communication_time", "exposed_communication")
 
 
 def _extract_pct_from_gpu_timeline(output_dir: Path, row_types: tuple[str, ...]) -> float | None:
@@ -5513,19 +5599,15 @@ def _extract_pct_from_gpu_timeline(output_dir: Path, row_types: tuple[str, ...])
         row_types: Accepted ``type`` spellings, in priority order.
 
     Returns:
-        The percentage, or ``None`` when the CSV is absent or carries none of
-        the accepted row types.
+        The percentage, or ``None`` when the CSV is absent, carries none of the
+        accepted row types, or holds no readable share column.
     """
-    try:
-        rows = _load_gpu_timeline_rows(output_dir)
-        by_type = {(row.get("type") or "").strip().lower(): row for row in rows}
-        for row_type in row_types:
-            row = by_type.get(row_type)
-            if row is not None:
-                return float(row.get("percent", 0))
-    except ValueError:
-        # malformed CSV numeric field; treat as absent
-        return None
+    rows = _load_gpu_timeline_rows(output_dir)
+    by_type = {(row.get("type") or "").strip().lower(): row for row in rows}
+    for row_type in row_types:
+        row = by_type.get(row_type)
+        if row is not None:
+            return _gpu_timeline_cell(row, _GPU_TIMELINE_PCT_COLUMNS)
     return None
 
 
@@ -5564,15 +5646,12 @@ def _extract_total_time_us_from_gpu_timeline(output_dir: Path) -> float | None:
 
     Returns:
         The trace total time in microseconds, or ``None`` when the CSV is
-        absent or has no total-time row.
+        absent or has no usable total-time row.
     """
-    try:
-        for row in _load_gpu_timeline_rows(output_dir):
-            if (row.get("type") or "").strip().lower() == "total_time":
-                return float(row.get("time ms", 0)) * 1000.0
-    except ValueError:
-        # malformed CSV numeric field; treat as absent
-        return None
+    for row in _load_gpu_timeline_rows(output_dir):
+        if (row.get("type") or "").strip().lower() == "total_time":
+            ms = _gpu_timeline_cell(row, _GPU_TIMELINE_MS_COLUMNS)
+            return None if ms is None else ms * 1000.0
     return None
 
 
@@ -8095,10 +8174,15 @@ def main() -> int:
                     if high_idle_warning is not None or low_compute_warning is not None:
                         agent_candidates = []
                         allow_empty_candidates = True
+                        # Both gates can fire on one window (95% idle AND 3%
+                        # compute is a real shape), so accumulate rather than
+                        # let the second suppression erase the first, matching
+                        # the "+".join the non-suppressed path already uses.
+                        skipped_sources: list[str] = []
                         if high_idle_warning is not None:
                             assert idle_pct_value is not None
                             trace_health_warnings.append(high_idle_warning)
-                            report_source = "skipped:high_gpu_idle_pct"
+                            skipped_sources.append("skipped:high_gpu_idle_pct")
                             append_log(
                                 log_path,
                                 f"TraceLens Executive Summary reports "
@@ -8113,7 +8197,7 @@ def main() -> int:
                         if low_compute_warning is not None:
                             assert compute_pct_value is not None
                             trace_health_warnings.append(low_compute_warning)
-                            report_source = "skipped:low_gpu_compute_pct"
+                            skipped_sources.append("skipped:low_gpu_compute_pct")
                             append_log(
                                 log_path,
                                 f"TraceLens Executive Summary reports "
@@ -8125,6 +8209,7 @@ def main() -> int:
                                 "will see this in trace_health_warnings[] and "
                                 "route to comm/parameter optimization.",
                             )
+                        report_source = "+".join(skipped_sources)
                     else:
                         if idle_pct_value is not None and graph_under_recorded_warning is None:
                             append_log(

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -76,6 +76,10 @@ from _paths import workspace_root
 
 # Idle-gate threshold + high-idle warning: shared single source of truth so the
 # TraceLens and bypass routes gate on identical semantics.
+# Capture-vs-workload trace classification, shared with the bypass route so a
+# sidecar is recognised identically whichever backend reads the profile.
+from _capture_shapes import is_capture_fragment as _shared_is_capture_fragment
+
 from _idle_gate import (
     build_graph_under_recorded_warning as _build_graph_under_recorded_warning,
     build_high_idle_warning as _build_high_idle_warning,
@@ -1058,38 +1062,13 @@ _PHASE_FRAGMENT_RE = re.compile(
 )
 
 
-#: Directory both frameworks write CUDA-graph capture sidecars into.
-_CAPTURE_DIR_NAME = "capture_traces"
-
-#: Sidecar filename shapes: SGLang ``bs_<batch>[_rank<n>]``, vLLM
-#: ``graph_capture_*``. The batch number is required rather than a bare ``bs_``
-#: prefix because this classifier now *rejects* an input instead of only sorting
-#: it, and a real trace that merely starts with those three characters must not
-#: be thrown out. One definition, because both callers need the same answer:
-#: discovery demotes sidecars below a real capture, and the preflight refuses an
-#: input made of nothing else.
-_CAPTURE_FRAGMENT_RE = re.compile(r"^(?:bs_\d+|graph_capture)", re.IGNORECASE)
-
-
 def _is_capture_fragment(path: Path, root: Path | None = None) -> bool:
     """Whether a trace path is a CUDA-graph capture sidecar.
 
-    Capture sidecars are recorded while the graph is being *built*, so the
-    launches in them go into the graph instead of onto the device. What lands is
-    a host-side Python call tree with a handful of stray kernels, one file per
-    (batch size, rank), each holding a single ``ProfilerStep``. There is no
-    iteration loop in one, which is what the steady-state splitter exists to cut
-    up.
-
-    Two signals, because either alone has a blind spot: the directory name
-    catches a sidecar whose filename nobody has seen before, and the filename
-    catches a flat layout that never made the directory.
-
-    ``root`` bounds the directory test to the input being analysed, the same way
-    :func:`_is_derived_trace` does it. Paths arrive absolute, so testing every
-    component would condemn every candidate whenever some ancestor happened to
-    be named ``capture_traces``. Callers pass the input directory, or a file's
-    parent so a single-file input is judged on its name alone.
+    Thin alias over :func:`_capture_shapes.is_capture_fragment`, which both
+    trace-analysis routes share so the answer cannot drift between them. Both
+    callers here need that same answer: discovery demotes sidecars below a real
+    capture, and the preflight refuses an input made of nothing else.
 
     Args:
         path: The trace file path to classify.
@@ -1099,15 +1078,7 @@ def _is_capture_fragment(path: Path, root: Path | None = None) -> bool:
         True when ``path`` is a graph-capture sidecar rather than a workload
         trace.
     """
-    if _CAPTURE_FRAGMENT_RE.match(path.name) is not None:
-        return True
-    relative = path
-    if root is not None:
-        try:
-            relative = path.relative_to(root)
-        except ValueError:
-            relative = path
-    return any(part.lower() == _CAPTURE_DIR_NAME for part in relative.parts)
+    return _shared_is_capture_fragment(path, root)
 
 
 def _capture_classification_root(trace_input: Path) -> Path:

--- a/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
@@ -1080,6 +1080,40 @@ _IDLE_PCT_TABLE_RE = re.compile(
     r"^\|\s*Idle\s*%\s*\|\s*([0-9]+(?:\.[0-9]+)?)\s*%\s*\|",
     re.IGNORECASE | re.MULTILINE,
 )
+_COMPUTE_PCT_TABLE_RE = re.compile(
+    r"^\|\s*Compute\s*%\s*\|\s*([0-9]+(?:\.[0-9]+)?)\s*%\s*\|",
+    re.IGNORECASE | re.MULTILINE,
+)
+_EXPOSED_COMM_PCT_TABLE_RE = re.compile(
+    r"^\|\s*Exposed\s+Communication\s*%\s*\|\s*([0-9]+(?:\.[0-9]+)?)\s*%\s*\|",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _extract_exec_summary_pct(md_path: Path, pattern: re.Pattern[str]) -> float | None:
+    """Extract one percentage row from an ``analysis.md`` Executive Summary table.
+
+    Args:
+        md_path: Path to the ``analysis.md`` report.
+        pattern: Row regex whose first group is the numeric percentage.
+
+    Returns:
+        The percentage, or ``None`` when the file or row is missing or
+        unparseable, so callers skip their gate gracefully.
+    """
+    try:
+        text = md_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    match = pattern.search(text)
+    if not match:
+        return None
+
+    try:
+        return float(match.group(1))
+    except (TypeError, ValueError):
+        return None
 
 
 def extract_idle_pct_from_analysis_md(md_path: Path) -> float | None:
@@ -1094,20 +1128,38 @@ def extract_idle_pct_from_analysis_md(md_path: Path) -> float | None:
         The idle percentage, or ``None`` when missing/unparseable so callers
         skip the gate gracefully.
     """
-    try:
-        text = md_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return None
+    return _extract_exec_summary_pct(md_path, _IDLE_PCT_TABLE_RE)
 
-    match = _IDLE_PCT_TABLE_RE.search(text)
-    if not match:
-        return None
 
-    raw = match.group(1)
-    try:
-        return float(raw)
-    except (TypeError, ValueError):
-        return None
+def extract_compute_pct_from_analysis_md(md_path: Path) -> float | None:
+    """Extract ``Compute %`` from an ``analysis.md`` Executive Summary table.
+
+    Used by the low-compute gate.
+
+    Args:
+        md_path: Path to the ``analysis.md`` report.
+
+    Returns:
+        The compute percentage, or ``None`` when missing/unparseable so callers
+        skip the gate gracefully.
+    """
+    return _extract_exec_summary_pct(md_path, _COMPUTE_PCT_TABLE_RE)
+
+
+def extract_exposed_comm_pct_from_analysis_md(md_path: Path) -> float | None:
+    """Extract ``Exposed Communication %`` from an ``analysis.md`` summary table.
+
+    Context for the low-compute gate: it distinguishes a comm-dominated window
+    from a host-bound one.
+
+    Args:
+        md_path: Path to the ``analysis.md`` report.
+
+    Returns:
+        The exposed-communication percentage, or ``None`` when
+        missing/unparseable.
+    """
+    return _extract_exec_summary_pct(md_path, _EXPOSED_COMM_PCT_TABLE_RE)
 
 
 def _efficiency_sort_key(candidate: dict[str, Any]) -> float:
@@ -1735,6 +1787,8 @@ __all__ = [
     "aggregate_by_source_function",
     "build_orchestrator_prompt",
     "discover_capture_folder",
+    "extract_compute_pct_from_analysis_md",
+    "extract_exposed_comm_pct_from_analysis_md",
     "extract_idle_pct_from_analysis_md",
     "infer_analysis_mode",
     "normalize_upstream_category",

--- a/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
@@ -34,6 +34,7 @@ from hyperloom.orchestrator.roles.agent_role import DEFAULT_CODEX_MODEL
 
 # Sibling import works whether run as a script or loaded via importlib.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _capture_shapes import is_capture_dir_name  # noqa: E402
 from _io_utils import safe_float  # noqa: E402
 from _task_group_contract import (  # noqa: E402
     build_operator_identity,
@@ -282,9 +283,13 @@ def infer_analysis_mode(framework: str, requested: str) -> str:
 def discover_capture_folder(trace_input: Path, trace_files: list[Path]) -> Path | None:
     """Find a graph-capture folder near a Magpie torch_trace input.
 
-    Checks the conventional ``capture_traces`` / ``graph_capture`` siblings of
-    the trace input directory and of the first trace file, returning the first
-    one that exists.
+    Scans the trace input directory and the first trace file's neighbourhood for
+    a subdirectory whose name matches the shared capture-directory shape, so a
+    layout that ranking already demotes is also a layout discovery can find.
+    Matching by shape rather than by two hard-coded names is what lets an
+    unpatched SGLang's ``graph_capture_profile/`` through: it was previously
+    missed here, so the capture folder went unpassed even on runs that had
+    correctly picked the workload trace.
 
     Args:
         trace_input (Path): The trace input path (file or directory).
@@ -294,24 +299,23 @@ def discover_capture_folder(trace_input: Path, trace_files: list[Path]) -> Path 
         Path | None: The capture folder if one exists nearby, else ``None``.
     """
 
-    candidates: list[Path] = []
+    search_roots: list[Path] = []
     if trace_input.is_dir():
-        candidates.extend(
-            [
-                trace_input / "capture_traces",
-                trace_input / "graph_capture",
-            ]
-        )
+        search_roots.append(trace_input)
     for trace_file in trace_files[:1]:
-        candidates.extend(
-            [
-                trace_file.parent / "capture_traces",
-                trace_file.parent.parent / "capture_traces",
-            ]
-        )
-    for candidate in candidates:
-        if candidate.is_dir():
-            return candidate
+        search_roots.extend([trace_file.parent, trace_file.parent.parent])
+    seen: set[Path] = set()
+    for root in search_roots:
+        if root in seen or not root.is_dir():
+            continue
+        seen.add(root)
+        try:
+            children = sorted(root.iterdir())
+        except OSError:
+            continue
+        for child in children:
+            if child.is_dir() and is_capture_dir_name(child.name):
+                return child
     return None
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -3253,6 +3253,63 @@ def test_format_last_trace_analyze_renders_idle_warning_inline(session_dir):
     assert "warnings=[" in rendered
 
 
+def test_format_last_trace_analyze_renders_low_compute_warning_numbers(session_dir):
+    """The compact line must carry the numbers the Coordinator routes on.
+
+    ``low_gpu_compute_pct`` exists to send a run to comm/params instead of
+    kernel rewriting, and telling a comm-bound window from a host-bound one
+    needs ``exposed_comm_pct``. A per-field ``if`` chain that only knew
+    ``idle_pct`` rendered this warning as a bare code with every number gone.
+    """
+    from hyperloom.orchestrator.state.shared_state import SharedState
+
+    state = SharedState.load_or_init(session_dir)
+    state.record_trace_analyze(
+        {"trace_input": "/tmp/trace.json.gz"},
+        {
+            "status": "ok",
+            "hot_kernels": [],
+            "trace_health_warnings": [
+                {
+                    "code": "low_gpu_compute_pct",
+                    "severity": "warning",
+                    "compute_pct": 3.99,
+                    "threshold_pct": 10.0,
+                    "exposed_comm_pct": 95.99,
+                    "source": "/tmp/x/analysis.md",
+                    "message": "low compute",
+                }
+            ],
+        },
+    )
+    rendered = state._format_trace_analyze_blob(state.last_trace_analyze)
+    assert "low_gpu_compute_pct(" in rendered
+    assert "compute=3.99%" in rendered
+    assert "exposed_comm=95.99%" in rendered
+    assert "threshold=10.0%" in rendered
+
+
+def test_format_last_trace_analyze_renders_both_gate_warnings(session_dir):
+    """Both gates can fire on one window; neither may erase the other's numbers."""
+    from hyperloom.orchestrator.state.shared_state import SharedState
+
+    state = SharedState.load_or_init(session_dir)
+    state.record_trace_analyze(
+        {"trace_input": "/tmp/trace.json.gz"},
+        {
+            "status": "ok",
+            "hot_kernels": [],
+            "trace_health_warnings": [
+                {"code": "high_gpu_idle_pct", "severity": "warning", "idle_pct": 95.0, "threshold_pct": 80.0},
+                {"code": "low_gpu_compute_pct", "severity": "warning", "compute_pct": 3.0, "threshold_pct": 10.0},
+            ],
+        },
+    )
+    rendered = state._format_trace_analyze_blob(state.last_trace_analyze)
+    assert "high_gpu_idle_pct(idle=95.0%,threshold=80.0%)" in rendered
+    assert "low_gpu_compute_pct(compute=3.0%,threshold=10.0%)" in rendered
+
+
 def test_format_last_trace_analyze_renders_failure_warning_with_rc(session_dir):
     """Tool-failure warning carries ``returncode``; the prompt must surface ``rc=N`` to distinguish a crash from a benign skip."""
     from hyperloom.orchestrator.state.shared_state import SharedState

--- a/src/hyperloom/orchestrator/actions/executors/profile.py
+++ b/src/hyperloom/orchestrator/actions/executors/profile.py
@@ -452,10 +452,12 @@ def _is_split_chunk(path: Path, root: Path) -> bool:
 def _trace_files_for_dir(trace_dir: Path) -> list[Path]:
     """Return annotated ``*.trace.json.gz`` files under ``trace_dir``.
 
-    Excludes capture sidecars under ``capture_traces/`` (see
-    :func:`_is_capture_trace`) so a vLLM ``graph_capture_*.pt.trace.json.gz`` is
-    never promoted as the primary annotated trace, and steady-state chunks under
-    ``trace_split/`` for the same reason.
+    Excludes CUDA-graph capture sidecars (see :func:`_is_capture_trace`, which
+    matches them by shape rather than by one directory name) so a vLLM
+    ``graph_capture_*.pt.trace.json.gz`` or an unpatched SGLang's
+    ``graph_capture_profile/cuda_graph_capture-*`` is never promoted as the
+    primary annotated trace, and steady-state chunks under ``trace_split/`` for
+    the same reason.
 
     Ordered largest first. Consumers fall back to ``trace_files[0]`` when
     ``main_trace_path`` is absent, and at that point a 938-byte chunk and a
@@ -479,14 +481,15 @@ def _trace_files_for_dir(trace_dir: Path) -> list[Path]:
 def _capture_sidecar_traces_for_dir(trace_dir: Path) -> list[Path]:
     """Return CUDA-graph capture sidecars under ``trace_dir`` (fallback only).
 
-    Anything under a ``capture_traces/`` directory, regardless of name — both
-    SGLang ``bs_*`` and vLLM ``graph_capture_*`` sidecars.
+    Whatever :func:`_is_capture_trace` classifies as a sidecar: SGLang ``bs_*``
+    under ``capture_traces/``, vLLM ``graph_capture_*``, and an unpatched
+    SGLang's ``graph_capture_profile/cuda_graph_capture-*``.
 
     Args:
         trace_dir: The directory to scan recursively.
 
     Returns:
-        Sorted capture sidecar paths found under ``capture_traces/``.
+        Sorted capture sidecar paths found under ``trace_dir``.
     """
     return sorted(p for p in trace_dir.rglob("*.json.gz") if _is_capture_trace(p, trace_dir))
 

--- a/src/hyperloom/orchestrator/actions/executors/profile.py
+++ b/src/hyperloom/orchestrator/actions/executors/profile.py
@@ -38,6 +38,9 @@ from typing import Any
 
 import yaml
 
+from hyperloom.agents.kernel.tools._capture_shapes import (
+    is_capture_fragment as _shared_is_capture_fragment,
+)
 from hyperloom.common.io import safe_mtime
 from hyperloom.common.profile_args import sanitize_profile_server_args as _sanitize_profile_server_args
 from hyperloom.inference_optimizer.session.paths import asset_root, mn_profile_trace_root
@@ -397,17 +400,24 @@ PROFILE_DEFAULT_CONFIG = asset_root() / "assets" / "configs" / "profile_sglang.y
 PROFILE_DEFAULT_TIMEOUT_SEC = 14400  # 4 h wall cap
 
 
-def _is_capture_trace(path: Path) -> bool:
-    """True when ``path`` lives under a ``capture_traces`` directory.
+def _is_capture_trace(path: Path, root: Path | None = None) -> bool:
+    """True when ``path`` is a CUDA-graph capture sidecar rather than a trace.
 
-    CUDA-graph capture sidecars are written under ``capture_traces/`` by both
-    frameworks: SGLang as ``bs_*_rank*.json.gz`` and vLLM as
-    ``graph_capture_*.pt.trace.json.gz`` (which also ends in ``.trace.json.gz``
-    and would otherwise be mistaken for a real annotated trace). They carry no
-    per-iteration annotations, so the steady-state splitter cannot use them; the
-    parent directory is the only framework-agnostic discriminator.
+    Capture sidecars carry no per-iteration annotations, so the steady-state
+    splitter cannot use them, yet a vLLM ``graph_capture_*.pt.trace.json.gz``
+    also ends in ``.trace.json.gz`` and would otherwise be promoted as the
+    primary annotated trace.
+
+    Delegates to the shared classifier so this executor recognises the same
+    layouts the kernel-agent routes do. The exact-``capture_traces`` test this
+    replaced missed an unpatched SGLang's ``graph_capture_profile/``.
+
+    Args:
+        path: The candidate path.
+        root: Directory to judge the path relative to, so an unrelated ancestor
+            named after graph capture does not condemn everything beneath it.
     """
-    return any(part == "capture_traces" for part in path.parts)
+    return _shared_is_capture_fragment(path, root)
 
 
 def _trace_size_bytes(path: Path) -> int:
@@ -461,7 +471,7 @@ def _trace_files_for_dir(trace_dir: Path) -> list[Path]:
     """
     candidates = [
         p for p in trace_dir.rglob("*.trace.json.gz")
-        if not _is_capture_trace(p) and not _is_split_chunk(p, trace_dir)
+        if not _is_capture_trace(p, trace_dir) and not _is_split_chunk(p, trace_dir)
     ]
     return sorted(candidates, key=lambda p: (-_trace_size_bytes(p), str(p)))
 
@@ -478,7 +488,7 @@ def _capture_sidecar_traces_for_dir(trace_dir: Path) -> list[Path]:
     Returns:
         Sorted capture sidecar paths found under ``capture_traces/``.
     """
-    return sorted(p for p in trace_dir.rglob("*.json.gz") if _is_capture_trace(p))
+    return sorted(p for p in trace_dir.rglob("*.json.gz") if _is_capture_trace(p, trace_dir))
 
 
 def _preferred_main_trace_path(trace_dir: Path, trace_files: list[Path]) -> Path:

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -30,6 +30,9 @@ import time
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Mapping
 
+from hyperloom.agents.kernel.tools._capture_shapes import (
+    is_capture_fragment as _shared_is_capture_fragment,
+)
 from hyperloom.common import codex_session, llm_config
 from hyperloom.common.env import env_bool, forge_explicitly_enabled, is_truthy
 from hyperloom.common.git_safety import safe_directory_args
@@ -3028,7 +3031,10 @@ def _extract_vllm_block_fp8_profile_shapes(
     import gzip
 
     def _is_capture_sidecar(path: Path) -> bool:
-        return "capture_traces" in path.parts
+        # Shared classifier, so a layout the kernel-agent routes demote is also
+        # kept out of the shape harvest here; the exact-``capture_traces`` test
+        # this replaced missed ``graph_capture_profile/``.
+        return _shared_is_capture_fragment(path, trace_input if trace_input.is_dir() else trace_input.parent)
 
     shapes: set[tuple[int, int, int]] = set()
     # ``Path("")`` normalizes to ``Path(".")``, which would otherwise walk the

--- a/src/hyperloom/orchestrator/state/_shared_state/render.py
+++ b/src/hyperloom/orchestrator/state/_shared_state/render.py
@@ -29,6 +29,21 @@ _FAILURE_EXCERPT_CHARS = 600
 # Width budget for artifact anchors; sized so a full uuid4 fid still fits ws=.
 _VARIANT_ANCHOR_MAX_CHARS = 100
 
+# Numeric fields a ``trace_health_warnings[]`` entry may carry, as
+# ``(key, label, suffix)`` in render order. The compact warning line is the part
+# of the blob an LLM reads first, so a gate's numbers have to reach it: a router
+# tells a comm-bound window from a host-bound one by comparing these, not by the
+# code alone. Table-driven because the previous per-field ``if`` chain silently
+# dropped every number a newly added gate carried -- a gate now registers its
+# field here rather than growing another branch.
+_WARNING_EXTRA_FIELDS: tuple[tuple[str, str, str], ...] = (
+    ("idle_pct", "idle", "%"),
+    ("compute_pct", "compute", "%"),
+    ("exposed_comm_pct", "exposed_comm", "%"),
+    ("threshold_pct", "threshold", "%"),
+    ("returncode", "rc", ""),
+)
+
 
 class _RenderMixin:
     def to_policy_denial_summary(self, *, top_k: int = 6) -> str:
@@ -1118,12 +1133,9 @@ class _RenderMixin:
             if not isinstance(w, dict):
                 continue
             code = str(w.get("code") or "unknown")
-            extras: list[str] = []
-            if "idle_pct" in w and "threshold_pct" in w:
-                extras.append(f"idle={w['idle_pct']}%")
-                extras.append(f"threshold={w['threshold_pct']}%")
-            if "returncode" in w:
-                extras.append(f"rc={w['returncode']}")
+            extras: list[str] = [
+                f"{label}={w[key]}{suffix}" for key, label, suffix in _WARNING_EXTRA_FIELDS if key in w
+            ]
             if extras:
                 rendered.append(f"{code}({','.join(extras)})")
             else:


### PR DESCRIPTION
## Why

Four GLM-5.2 / Qwen3.8 sessions on MI355X/SGLang lost their whole KERNEL phase, each to a different defect, and in two of them nothing in the pipeline noticed. One burned 4.6 h — 40% of the session — analysing a trace that was never a workload timeline.

**Supersedes #1248**: its commit is in this branch's history unchanged, then extended. #1248 is closed so one PR carries the whole incident.

## Fix 1 — gate on the GPU compute share

Session `20260818T062821Z` profiled an 18186.60 ms window holding **725.85 ms of compute (3.99%)**, 0.02% idle, 95.99% exposed communication. One `aiter::cross_device_reduce_2stage` invocation ran **17456.08 ms** — 99.99% of all collective time — while the other 63 invocations of the same kernel had a median of **14.3 µs**.

That event is cross-rank arrival skew at the profiler-start boundary. Across the eight per-rank traces every rank exits that collective within 1 µs of the others while entry timestamps span **17.46 s**, and each rank's background-thread spans show the profiler windows ending together but starting 17.46 s apart. Steady state has no skew: after it retires, 726.7 ms of decode runs with ~2.4 ms of collectives total.

A custom all-reduce polls peer signals from inside the kernel, so the wait is charged as GPU-**busy**. Every existing gate defends only against "GPU too idle", so the window passed all three as maximally healthy:

| Gate | Judgement | Measured | Verdict |
|---|---|---|---|
| N25 `steady_state_chunk_empty` | `num_gpu_events > 0 and gpu_busy_duration > 0` | 73056 / 18183589 µs | pass |
| N36 `steady_state_chunk_low_quality` | `busy_ratio >= 0.05` | **0.99994** | pass |
| idle gate | `idle_pct <= 80.0` | **0.02%** | pass |

`trace_health_warnings` came back empty. `busy_ratio` is inverted in this regime: the worse the skew, the healthier the chunk looks.

Added a low-compute gate beside the idle gate — both answer the same question (can a kernel rewrite move end-to-end latency here) and a rewrite is bounded by the compute share. It reuses the proven idle-gate response rather than inventing a mechanism: suppress `hot_kernels[]`, emit `low_gpu_compute_pct`, let the Coordinator route to comm/params.

- Default 10%, via `HYPERLOOM_TRACELENS_MIN_COMPUTE_PCT_THRESHOLD`, deliberately below the 20% that would exactly mirror the idle gate.
- **Fails open.** Skipped under graph under-recording, and skipped when the share is unknown. Reading the number distinguishes absent / blank / unparseable from a real zero, because this gate fires *below* its threshold: a defaulted `0` would suppress the hot-kernel list on every trace, silently, with `status` still `ok`. Share-column spellings get the same tolerance the row labels already needed, and `float(None)` on a short row raises `TypeError`, which the inherited `except ValueError` did not catch.
- Wired into the deterministic route (`gpu_timeline.csv`) and the agent route (`analysis.md`).
- Numeric fields of *every* trace-health warning now render from one table, so the compact prompt line carries `compute=` / `exposed_comm=` instead of a bare code. Telling a comm-bound window from a host-bound one is exactly what the Coordinator uses those two for.

## Fix 2 — publish `gpu_pct` on one basis, and say which

`ops_summary.csv` normalizes against total *op* time (collectives excluded) while `parse_analysis_md` reports an end-to-end share — and both wrote `gpu_pct`. In round 1 of the same session that put `hipLaunchKernel` at "23.495%" (compute basis) above `main_kernel` at "4.681%" (e2e basis) in one ranked list; the true e2e shares were 0.54% and 4.68%, so the ranking was inverted.

`gpu_pct` is now normalized against the trace wall span when `gpu_timeline.csv` supplies it, and every candidate carries `gpu_pct_basis` (`e2e_window` / `sidecar_reported` / `listed_ops_sum`). A batch that ends up spanning two bases — reachable when only some ranking rows carry an absolute GPU time — is called out in the log, since that is the unrankable state the label exists to catch.

Two honest limits:

- **Admission is deliberately *not* moved onto the new basis.** `min_gpu_pct` (10%) is a tuned constant meaning "a large slice of the GPU work we know about"; re-pointing it at the wall span raises the bar by the reciprocal of the compute share, and on an ordinary 60%-compute trace with work spread over eight kernels that takes this recovery path from eight candidates to zero. The floor stays on the share it was tuned against; only the published number moves. Consequence: on `20260818T062821Z` the four fallback candidates are still *recovered*, now reported at their true 0.67 / 0.54 / 0.45 / 0.40% — that session ends up with an empty `hot_kernels[]` because of Fix 1, not because of Fix 2.
- **This bypasses rather than repairs the alias collision.** `_RANK_PCT_KEYS` still maps both `% of compute time` and `%e2e` onto one field, so a run with no `gpu_timeline.csv` falls back to the sidecar's number and carries the original mixed-basis hazard — now labelled `sidecar_reported` rather than silent. Splitting those aliases into separate fields is the real repair and is not done here.

## Fix 3 — classify capture sidecars by shape

Session `20260814T163244Z` had a **healthy** serving trace: 20096 reduce invocations per rank, max 0.05 ms, median 12–13 µs, no skew. It still lost its kernel phase, because Hyperloom analysed the wrong file.

Discovery ranks candidates into buckets and breaks ties by **descending size**. An SGLang without the profiler patch writes `graph_capture_profile/cuda_graph_capture-<runner>-TP-<n>`, matching neither the `capture_traces/` directory name nor a start-anchored filename test — the `cuda_` prefix defeats the anchor. The sidecars landed in the **default bucket alongside the workload traces**, and at 103.87 MB vs 20.03 MB the capture won the tie:

```
trace_input_type=capture_dir
trace_files=16
trace_gpu_kernel_events=186795 (probed=cuda_graph_capture-DecodeCudaGraphRunner-TP-3.json.gz=186795)
```

The probe stops on the first candidate with kernels, so it never reached the serving trace. The splitter cut a bs=1/conc=1 window with zero GPU events and N25 correctly refused — but the kernel track (`kernel_opt_attempts`, `last_gemm_tuning`, `last_fusion` all empty) was already lost.

The size tie-break exists precisely as a name-independent safety net; its docstring says *"ordering by descending size puts the right file first even for a fragment shape nobody has seen yet."* Here the unrecognised file is the larger one, so the safety net selected the wrong trace.

Matching is now by shape: `graph_capture` anywhere in a filename, `capture_traces` exactly or a name starting with `graph_capture` for a directory, keeping #1248's anchored `bs_<digits>` guard.

| Layout | before | after |
|---|---|---|
| `capture_traces/bs_64_rank7.json.gz` | detected | detected |
| `graph_capture_rank0.json.gz` (vLLM) | detected | detected |
| `graph_capture_profile/cuda_graph_capture-*` | **missed** | detected |
| `graph_capture_profile/DecodeCudaGraphRunner_bs_104_rank0.json.gz` | **missed** | detected (directory rule) |
| `<ts>-TP-0.trace.json.gz`, `rank_0.trace.json.gz`, `merged-*` | kept | kept |
| `torch_profiler_with_graph_capture/rank_0.trace.json.gz` | kept | kept (directory rule is anchored) |

The directory half is anchored while the filename half is not: a filename carries the `cuda_` prefix, but a directory is named for what it holds, and an unanchored token there would condemn a descriptive sibling — which the capture-only preflight's `all(...)` turns into a rejection of the whole input.

`discover_capture_folder` matches by the same shape, so `graph_capture_profile/` is *located* rather than merely demoted. Without that a run could pick the right workload trace and still lose `--capture_folder`.

## Fix 4 — reject a capture-only trace input (from #1248)

A directory holding nothing but capture sidecars is refused before analysis, instead of producing an empty chunk and a `trace_split_no_steady_state` that reads as "the window was too short" and sends the next reader to lengthen a capture that was never a workload timeline.

## Refactor — one capture rule, four call sites

Each trace-analysis path carried its own copy and the copies **had already drifted**: the bypass reader never learned `graph_capture` names at all, and `bypass_trace_analysis` was start-anchored so a `cuda_graph_capture-*` shard was skipped and its shapes never indexed. The rule now lives in `_capture_shapes` (stdlib-only, so the bypass reader stays independent of TraceLens, mirroring `_idle_gate`) and is used by `tracelens_analysis`, `_bypass_trace_reader`, `bypass_trace_analysis`, `tracelens_skill_runner`, `profile.py` and `request_handlers`.

## Blast radius

- `ta_result.status` stays `ok` with empty `hot_kernels` — identical in shape to what the idle gate has always produced, so no new retry path is reachable. `cuda_graph_attribution_degraded` is guarded on `per_kernel_attribution_degraded` (not merely `not hot`) and the multi-node compute-bound re-profile on `_trace_is_high_idle`, so neither misfires.
- Widening the capture classifier only ever *demotes* a candidate, and the capture-only preflight uses `all(...)`, so a mixed directory is never rejected.
- `_VARIANT_RE` in `bypass_trace_analysis` is unanchored too, so `DecodeCudaGraphRunner_bs_104_rank0` now yields the `bs_104` variant label instead of falling through to the bare stem.
- Low-compute gate is TraceLens-route only: `_bypass_report` reports `exposed_comm_pct: None`, so the bypass reader cannot measure a compute share and keeps the idle gate alone. Documented in the `_idle_gate` docstring.

## What this does *not* fix

- Two Qwen3.8 sessions (`20260814T175123Z`, `20260817T220229Z`) stay broken. Their root cause is **graph under-recording**: the profiler captured GPU activity for **1 of 128** graph replays (`graph_launches_with_kernels: 1`, GPU-side `step[DECODE]` annotation 1/128, 3,604 kernel events against ~293,000 on a comparable healthy trace). Hyperloom's own detector identifies this correctly and `cuda_graph_attribution_degraded` already carries the right remedy (`--enforce-eager`), but N25 raises first and `roofline.py` returns early on `status != "ok"`, so neither warning is ever emitted. Wiring that up is the obvious next PR.
- sglang's `/start_profile` has no cross-rank barrier before the first forward (Fix 1's upstream trigger). A barrier alone is not sufficient — it must be host-side and placed after the expensive profiler preparation, or the wait just moves into another spin-waiting kernel.
- Hyperloom's heaviest profiler options inflate per-rank start cost and therefore the skew.
- The Coordinator reads only compute-category reasoning-candidate blocks, so TraceLens's system-tier P-item — which diagnosed this arrival skew correctly and recommended trimming the window — is never consumed.

## Test plan

Whole suite, branch vs `origin/main`, same environment. `PYTHONPATH=$PWD/src` so subprocess-spawning tests can import the package (it is not pip-installed here); without it 9 further tests fail on both sides for that reason alone.

```
branch:  6 failed, 13318 passed, 32 skipped, 15 subtests passed in 878.48s
```

The 6 failures reproduce identically on `origin/main` (verified in a clean worktree at `2f681a05d`: `6 failed, 54 passed`), all in isolated-venv version detection this PR does not touch:

- `test_common_provenance.py::test_a_framework_in_its_own_venv_is_still_versioned`
- `test_common_provenance.py::test_a_venv_root_that_is_not_there_is_not_a_failure`
- `test_manifest_unit.py::test_manifest_versions_a_framework_installed_in_its_own_venv`
- `test_server_patcher_vllm_isolated_venv.py` (3 tests)

**No test regressions.** Coverage added by this PR:

- Fix 1: threshold resolution (default / env / bad / negative); warning shape with and without comm context; `gpu_timeline.csv` readers across every row-label and column spelling; gate fires on the real numbers (3.99% / 95.99%), passes a healthy window (99.3%), skipped when unknown; `analysis.md` extractors
- Fix 1 fail-open regression: unknown column, truncated row, blank cell and non-numeric cell each yield `None` and leave candidates untouched
- Fix 2: e2e normalization when the window total is passed; admission unchanged with and without it; a healthy 60%-compute / eight-kernel trace keeps all eight candidates; sidecar-only and listed-ops fallbacks labelled; mixed-basis batch logged
- Fix 3: classifier parametrized over every observed layout including the two workload shapes and the descriptive-sibling directory it must not touch; discovery regression pinning the 103 MB capture behind the 20 MB trace; `discover_capture_folder` finds `graph_capture_profile/` and ignores the descriptive sibling; bypass-route equivalent
- Renderer: `low_gpu_compute_pct` reaches the prompt with its numbers; both gates render side by side
- `ruff check` clean on every touched file

Known gap: **`main()` wiring for Fix 1 is untested.** Both route branches and the `graph_under_recorded` suppression sit inside `main()` and need a testability refactor first; Fix 3 has `_drive_main_over_capture_dir`, Fix 1 has no equivalent. The gate logic, both extractors and the fail-open contract are covered directly.
