### PR TITLE
fix(breakdown): put GEAK's kernel journey on the canonical streams

### DIFF
--- a/src/hyperloom/inference_optimizer/breakdown/collectors/optimizations.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/optimizations.py
@@ -85,9 +85,9 @@ def _empty_summary() -> dict[str, Any]:
         for source in _SOURCES
     }
     summary["kernel_agent"]["by_backend"] = {
-        "geak": {"keeps": 0, "total_gain_pct": 0.0},
-        "forge": {"keeps": 0, "total_gain_pct": 0.0},
-        "unattributed": {"keeps": 0, "total_gain_pct": 0.0},
+        "geak": {"keeps": 0, "total_gain_pct": 0.0, "non_attributable_keeps": 0},
+        "forge": {"keeps": 0, "total_gain_pct": 0.0, "non_attributable_keeps": 0},
+        "unattributed": {"keeps": 0, "total_gain_pct": 0.0, "non_attributable_keeps": 0},
     }
     return summary
 
@@ -1148,6 +1148,26 @@ def collect_recorded_optimizations(
         for attempt in attempts
         if attempt.get("adopted") and attempt.get("attribution_eligible") is False
     ]
+    # `entries` is the GAIN ledger and deliberately holds only attributable keeps, so a backend whose
+    # keeps are all non-attributable reads as zero keeps — indistinguishable from an optimizer that
+    # produced nothing. That is the same conflation the canonical-stream fix set out to remove, one
+    # layer further in. Count the keep from the attempts, keep the gain coming from the entries.
+    for attempt in non_attributable:
+        if str(attempt.get("agent") or "") != "kernel_agent":
+            continue
+        by_backend = summary_by_source.setdefault(
+            "kernel_agent", {"keeps": 0, "total_gain_pct": 0.0}
+        ).setdefault("by_backend", {})
+        backend = str(attempt.get("backend") or "unattributed")
+        if backend not in by_backend:
+            backend = "unattributed"
+        backend_bucket = by_backend.setdefault(
+            backend, {"keeps": 0, "total_gain_pct": 0.0, "non_attributable_keeps": 0}
+        )
+        backend_bucket["keeps"] += 1
+        backend_bucket["non_attributable_keeps"] = (
+            int(backend_bucket.get("non_attributable_keeps", 0)) + 1
+        )
     # An adopted step that contributes nothing to the total is a hole in the
     # accounting, not a zero. Counting it keeps the sum honest about what it
     # could not see.

--- a/src/hyperloom/inference_optimizer/breakdown/recorder/instrument.py
+++ b/src/hyperloom/inference_optimizer/breakdown/recorder/instrument.py
@@ -1279,6 +1279,33 @@ def _kernel_selection_operation_id(
     return _stable_id("op", "kernel_optimizer_selection", context_key, discriminator)
 
 
+# Canonical kernel routes: the route operation every kernel record hangs under, and the strategy
+# stamped on the kernel operation itself. Two entries today, and the pair is derived rather than
+# written at each call site because the forge identity used to be a literal in nine places — a tenth
+# reader was one edit away from silently parenting somebody else's kernels under Forge.
+#
+# A GEAK kernel replayed from its kernel_journey must NOT hang under the Forge route: the tree would
+# then assert it ran beneath a route that never dispatched it, and a reader walking parents to answer
+# "which optimizer produced this?" gets the wrong answer. The `geak` route operation already exists
+# (see the GEAK dispatch writer below); this makes the replay reachable to it.
+CANONICAL_KERNEL_ROUTES: dict[str, tuple[str, str]] = {
+    # route_strategy -> (route operation name, strategy stamped on the kernel operation)
+    "kernel_agent_forge": ("kernel_agent_forge", "forge"),
+    "geak": ("geak", "geak"),
+}
+
+
+def _canonical_route(route_strategy: str | None) -> tuple[str, str]:
+    """(route operation name, kernel strategy) for a canonical route.
+
+    Unknown values fall back to the forge pair, which is what every caller got before routes were
+    named, so an unrecognised string cannot silently drop a kernel off the streams.
+    """
+    return CANONICAL_KERNEL_ROUTES.get(
+        str(route_strategy or ""), CANONICAL_KERNEL_ROUTES["kernel_agent_forge"]
+    )
+
+
 def _kernel_route_operation_id(
     session_dir: Path | str,
     strategy: str,
@@ -1526,19 +1553,21 @@ def record_native_kernel_run_start(
     payload: Mapping[str, Any] | None = None,
     macro_cycle: int | None = None,
     route_operation_id: str = "",
+    route_strategy: str = "kernel_agent_forge",
     producer: str = PRODUCER_KERNEL_AGENT,
 ) -> None:
     """Upsert the selected native Kernel Agent plus Forge route as running."""
+    route_name, _ = _canonical_route(route_strategy)
     if not session_dir:
         trace_skip(reason="no session_dir", section="kernel_journey")
         return
     current_route_id = _KERNEL_ROUTE_CONTEXT.get(
         _kernel_route_context_key(session_dir),
         {},
-    ).get("route:kernel_agent_forge", "")
+    ).get(f"route:{route_name}", "")
     route_id = route_operation_id or _kernel_route_operation_id(
         session_dir,
-        "kernel_agent_forge",
+        route_name,
         macro_cycle=macro_cycle,
         run_discriminator=""
         if current_route_id
@@ -1549,19 +1578,19 @@ def record_native_kernel_run_start(
         operation_id=route_id,
         producer=producer,
         kind="kernel_optimizer_run",
-        name="kernel_agent_forge",
+        name=route_name,
         phase="KERNEL_AGENT",
         scope="run",
         strategy_group="kernel_optimizer",
-        strategy="kernel_agent_forge",
-        executor_class="deterministic",
+        strategy=route_name,
+        executor_class="llm_tool" if route_name == "geak" else "deterministic",
         status="running",
         started_at=_now_iso_safe(),
         inputs=dict(payload or {}),
         subject={
             "subject_id": _kernel_route_subject_id(
                 session_dir,
-                "kernel_agent_forge",
+                route_name,
                 route_operation_id=route_id,
             ),
             "subject_type": "kernel_optimizer_route",
@@ -1577,9 +1606,11 @@ def record_native_kernel_run_result(
     result: Mapping[str, Any],
     macro_cycle: int | None = None,
     route_operation_id: str = "",
+    route_strategy: str = "kernel_agent_forge",
     producer: str = PRODUCER_KERNEL_AGENT,
 ) -> None:
     """Finalize the native Kernel Agent plus Forge route from its result."""
+    route_name, _ = _canonical_route(route_strategy)
     if not session_dir:
         trace_skip(reason="no session_dir", section="kernel_journey")
         return
@@ -1587,10 +1618,10 @@ def record_native_kernel_run_result(
     current_route_id = _KERNEL_ROUTE_CONTEXT.get(
         _kernel_route_context_key(session_dir),
         {},
-    ).get("route:kernel_agent_forge", "")
+    ).get(f"route:{route_name}", "")
     route_id = route_operation_id or _kernel_route_operation_id(
         session_dir,
-        "kernel_agent_forge",
+        route_name,
         macro_cycle=macro_cycle,
         run_discriminator=""
         if current_route_id
@@ -1610,12 +1641,12 @@ def record_native_kernel_run_result(
         operation_id=route_id,
         producer=producer,
         kind="kernel_optimizer_run",
-        name="kernel_agent_forge",
+        name=route_name,
         phase="KERNEL_AGENT",
         scope="run",
         strategy_group="kernel_optimizer",
-        strategy="kernel_agent_forge",
-        executor_class="deterministic",
+        strategy=route_name,
+        executor_class="llm_tool" if route_name == "geak" else "deterministic",
         status=result_status,
         ended_at=_now_iso_safe(),
         outputs={
@@ -2791,9 +2822,11 @@ def record_kernel_discovery(
             record_native_kernel_run_start(
                 session_dir,
                 payload={"discovery_source": source, "tool": tool or source},
+                route_strategy=route,
                 producer=producer,
             )
-            route_id = _kernel_route_operation_id(session_dir, "kernel_agent_forge")
+            route_name, _ = _canonical_route(route)
+            route_id = _kernel_route_operation_id(session_dir, route_name)
             record_operation(
                 session_dir,
                 operation_id=route_id,
@@ -2941,7 +2974,9 @@ def record_kernel_dispatch(
                 producer=producer,
             )
             return
-        record_native_kernel_run_start(session_dir, producer=producer)
+        record_native_kernel_run_start(
+            session_dir, route_strategy=route_strategy, producer=producer
+        )
         subject_id = _kernel_subject_id(session_dir, str(kernel_id))
         operation_id = _kernel_operation_id(session_dir, str(kernel_id))
         subject = {
@@ -2961,12 +2996,12 @@ def record_kernel_dispatch(
             phase="KERNEL_AGENT",
             scope="kernel",
             strategy_group="kernel_backend",
-            strategy="forge",
+            strategy=_canonical_route(route_strategy)[1],
             executor_class="llm_tool",
             status="running" if dispatched else "skipped",
             started_at=_now_iso_safe(),
-            parent_operation_id=_kernel_route_operation_id(session_dir, "kernel_agent_forge"),
-            root_operation_id=_kernel_route_operation_id(session_dir, "kernel_agent_forge"),
+            parent_operation_id=_kernel_route_operation_id(session_dir, _canonical_route(route_strategy)[0]),
+            root_operation_id=_kernel_route_operation_id(session_dir, _canonical_route(route_strategy)[0]),
             subject=subject,
             inputs={
                 "backends": [str(value) for value in (backends or [])],
@@ -3044,7 +3079,9 @@ def record_kernel_backend_result(
                     producer=producer,
                 )
         elif kid and not legacy_only:
-            record_native_kernel_run_start(session_dir, producer=producer)
+            record_native_kernel_run_start(
+            session_dir, route_strategy=route_strategy, producer=producer
+        )
             subject_id = _kernel_subject_id(session_dir, kid)
             subject = {
                 "subject_id": subject_id,
@@ -3225,8 +3262,8 @@ def record_kernel_backend_result(
                 executor_class="llm_tool",
                 status=operation_status,
                 ended_at=_now_iso_safe() if operation_status != "running" else "",
-                parent_operation_id=_kernel_route_operation_id(session_dir, "kernel_agent_forge"),
-                root_operation_id=_kernel_route_operation_id(session_dir, "kernel_agent_forge"),
+                parent_operation_id=_kernel_route_operation_id(session_dir, _canonical_route(route_strategy)[0]),
+                root_operation_id=_kernel_route_operation_id(session_dir, _canonical_route(route_strategy)[0]),
                 subject=subject,
                 attempts=canonical_attempts,
                 gates=canonical_gates,
@@ -3298,8 +3335,8 @@ def record_kernel_backend_result(
                 executor_class="llm_tool",
                 status="failed",
                 ended_at=_now_iso_safe(),
-                parent_operation_id=_kernel_route_operation_id(session_dir, "kernel_agent_forge"),
-                root_operation_id=_kernel_route_operation_id(session_dir, "kernel_agent_forge"),
+                parent_operation_id=_kernel_route_operation_id(session_dir, _canonical_route(route_strategy)[0]),
+                root_operation_id=_kernel_route_operation_id(session_dir, _canonical_route(route_strategy)[0]),
                 attempts=[
                     {
                         "attempt_id": _stable_id("attempt", operation_id, "predispatch"),
@@ -3541,12 +3578,25 @@ def record_kernel_e2e(
         adoption_refs: list[str] = []
         if final_validated or decision_value in {"REVERT", "REJECTED"}:
             adoption_id = _stable_id("adoption", operation_id, "integrate")
+            # ATTRIBUTABLE ONLY WITH A THROUGHPUT PAIR. `e2e_gain_pct` is a percentage the executor
+            # measured against whatever baseline it happened to hold at the time. The collector
+            # turns an adoption into points of the ONE session baseline by walking the throughput
+            # chain; with no pair to anchor it, it can only sum the local percentages, and
+            # percentages taken against different denominators do not add. Replaying real GEAK
+            # journeys showed the cost of pretending otherwise: 36 keeps whose local deltas summed
+            # to +348.6 pp of a session that did not move that far.
+            # The adoption is still written, so the keep stays visible and countable; only its
+            # contribution to any total is withheld.
+            before_tput = to_float(evidence.get("base_tput"))
+            after_tput = to_float(evidence.get("new_tput"))
+            has_pair = bool(before_tput and after_tput and before_tput > 0 and after_tput > 0)
             _record_adoption_transition(
                 session_dir,
                 adoption_id=adoption_id,
                 producer=producer,
                 operation_id=operation_id,
                 adopted=final_validated,
+                attribution_eligible=has_pair,
                 reason=decision_reason
                 or ("integrate_e2e_passed" if final_validated else "integrate_e2e_failed"),
                 subject=subject,
@@ -3557,15 +3607,18 @@ def record_kernel_e2e(
                 # Frozen inline, not just referenced: measurement ids are stable
                 # per kernel, so a later attempt on the same kernel overwrites
                 # the very numbers this adoption was decided on.
-                throughput_before=to_float(evidence.get("base_tput")),
-                throughput_after=to_float(evidence.get("new_tput")),
+                throughput_before=before_tput,
+                throughput_after=after_tput,
                 configuration={
                     "patch_path": patch_path,
                     "target_file": target_file,
                     "extra_server_args": str(extra_server_args or ""),
                 },
                 validation_basis="e2e_validation",
-                metadata={"validation_tier": validation_tier or "integrate_e2e"},
+                metadata={
+                    "validation_tier": validation_tier or "integrate_e2e",
+                    **({} if has_pair else {"non_attributable_reason": "no_throughput_pair"}),
+                },
             )
             adoption_refs.append(adoption_id)
         record_operation(
@@ -3579,8 +3632,8 @@ def record_kernel_e2e(
             executor_class="llm_tool",
             status="succeeded" if final_validated else "reverted" if decision_value in {"REVERT", "REJECTED"} else "needs_review",
             ended_at=_now_iso_safe(),
-            parent_operation_id=_kernel_route_operation_id(session_dir, "kernel_agent_forge"),
-            root_operation_id=_kernel_route_operation_id(session_dir, "kernel_agent_forge"),
+            parent_operation_id=_kernel_route_operation_id(session_dir, _canonical_route(route_strategy)[0]),
+            root_operation_id=_kernel_route_operation_id(session_dir, _canonical_route(route_strategy)[0]),
             subject=subject,
             gates=[gate],
             outputs={

--- a/src/hyperloom/inference_optimizer/breakdown/recorder/instrument.py
+++ b/src/hyperloom/inference_optimizer/breakdown/recorder/instrument.py
@@ -1595,7 +1595,10 @@ def record_native_kernel_run_start(
             ),
             "subject_type": "kernel_optimizer_route",
             "role": "selected",
-            "name": "kernel_agent_forge",
+            # From route_name, like the operation above it. Left literal, a GEAK replay produced
+            # operation.name=geak next to subject.name=kernel_agent_forge — one record naming two
+            # different optimizers, and the subject is what identity lookups resolve against.
+            "name": route_name,
         },
     )
 

--- a/src/hyperloom/inference_optimizer/tests/test_geak_reaches_dashboard.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_reaches_dashboard.py
@@ -192,3 +192,80 @@ def test_reverted_geak_kernel_is_not_credited(tmp_path: Path) -> None:
     )
     geak = (_column(tmp_path).get("by_backend") or {}).get("geak") or {}
     assert not geak.get("keeps")
+
+
+def _kernel_without_throughput_pair(kid: str, *, gain: float) -> dict:
+    """The shape every real campaign artifact has today.
+
+    All 36 KEEP blocks under ``/shared_nfs/hyperloom-claw`` publish
+    ``e2e_gain_pct`` and no ``base_tput``/``new_tput``. The fixture above adds the
+    pair, so it exercises the contract GEAK is moving to rather than the files on
+    disk — and the difference decides whether a number may be summed.
+    """
+    kernel = _kernel(kid, gain=gain, before=0.0, after=0.0)
+    kernel["e2e"].pop("base_tput", None)
+    kernel["e2e"].pop("new_tput", None)
+    return kernel
+
+
+def test_keep_without_a_throughput_pair_is_visible_but_not_summed(tmp_path: Path) -> None:
+    """Visible as a keep, absent from the total.
+
+    A local ``e2e_gain_pct`` is measured against whatever baseline the executor
+    held at the time. Projecting it as points of the session baseline is a unit
+    error: replaying the real journeys that way summed 36 local deltas into
+    +348.6 pp of a session that never moved that far. Withholding the gain must
+    not also withhold the keep, or the column reads zero again — which is the
+    bug the canonical-stream change was written to fix.
+    """
+    coord = _coord(tmp_path)
+    _record_baseline(tmp_path)
+    result = {
+        "kernel_journey_path": _journey(
+            tmp_path, [_kernel_without_throughput_pair("k_nopair", gain=29.994)]
+        )
+    }
+    coord._record_geak_kernel_journey(result)
+
+    geak = (_column(tmp_path).get("by_backend") or {}).get("geak") or {}
+    assert geak.get("keeps") == 1, geak
+    assert geak.get("non_attributable_keeps") == 1, geak
+    assert geak.get("total_gain_pct") == 0.0, geak
+
+
+def test_replayed_geak_kernel_is_not_parented_under_the_forge_route(tmp_path: Path) -> None:
+    """The tree must not assert a GEAK kernel ran beneath Forge.
+
+    Dropping ``legacy_only`` alone leaves the default route, which names the
+    parent operation ``kernel_agent_forge``. The per-kernel strategy is corrected
+    to ``geak`` afterwards, so the dashboard column fills either way — but a
+    reader walking parents to answer "which optimizer produced this kernel?"
+    gets Forge, and a replay after a process restart can mint further Forge route
+    operations for kernels Forge never dispatched.
+    """
+    coord = _coord(tmp_path)
+    _record_baseline(tmp_path)
+    result = {
+        "kernel_journey_path": _journey(
+            tmp_path, [_kernel("k_route", gain=5.0, before=1000.0, after=1050.0)]
+        )
+    }
+    coord._record_geak_kernel_journey(result)
+
+    warnings: list[str] = []
+    parts = assemble_parts(tmp_path, warnings=warnings)
+    operations = [r for r in parts.get("operations") or [] if isinstance(r, dict)]
+    names = {str(op.get("name") or "") for op in operations}
+    assert "k_route" in names, sorted(names)
+    assert "kernel_agent_forge" not in names, sorted(names)
+
+    kernel_ops = [op for op in operations if str(op.get("name") or "") == "k_route"]
+    assert kernel_ops, operations
+    parents = {str(op.get("parent_operation_id") or "") for op in kernel_ops}
+    geak_route_ids = {
+        str(op.get("operation_id") or "")
+        for op in operations
+        if str(op.get("name") or "") == "geak"
+    }
+    assert geak_route_ids, sorted(names)
+    assert parents <= geak_route_ids, (parents, geak_route_ids)

--- a/src/hyperloom/inference_optimizer/tests/test_geak_reaches_dashboard.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_reaches_dashboard.py
@@ -269,3 +269,113 @@ def test_replayed_geak_kernel_is_not_parented_under_the_forge_route(tmp_path: Pa
     }
     assert geak_route_ids, sorted(names)
     assert parents <= geak_route_ids, (parents, geak_route_ids)
+
+
+def _route_ops(session_dir: Path) -> tuple[set[str], set[str]]:
+    """(operation names, route subject names) written under ``session_dir``."""
+    warnings: list[str] = []
+    parts = assemble_parts(session_dir, warnings=warnings)
+    operations = [r for r in parts.get("operations") or [] if isinstance(r, dict)]
+    names = {str(op.get("name") or "") for op in operations}
+    subjects = {
+        str((op.get("subject") or {}).get("name") or "")
+        for op in operations
+        if str((op.get("subject") or {}).get("subject_type") or "") == "kernel_optimizer_route"
+    }
+    return names, subjects
+
+
+def test_reverting_a_geak_kernel_stays_on_the_geak_route(tmp_path: Path) -> None:
+    """Withdrawing a kernel must not re-file it under another optimizer.
+
+    HONEST SCOPE: this passes with and without the route argument on the revert
+    call, because `record_kernel_e2e` mints no route operation on that path —
+    checked both after a KEEP replay and standalone, as a restart would do. The
+    review reported the revert falling back to Forge; the call did, but the
+    fallback is inert today. The argument is still passed, because a call that
+    does not name its route is one change inside the recorder away from being
+    wrong, and this pins the outcome so that change cannot land quietly.
+
+    The load-bearing check for the route argument itself is
+    ``test_every_journey_replay_call_names_its_route``, which reads the source.
+    """
+    coord = _coord(tmp_path)
+    _record_baseline(tmp_path)
+    kernel = _kernel("k_revert_route", gain=5.0, before=1000.0, after=1050.0)
+    coord._record_geak_kernel_journey(
+        {"status": "ok", "kernel_journey_path": _journey(tmp_path, [kernel])}
+    )
+    # `_reject_*` lives on KernelPhase and is not among the methods Coordinator
+    # delegates, so bind it directly rather than reaching through the facade.
+    from hyperloom.orchestrator.phases.kernel import KernelPhase
+
+    KernelPhase._reject_geak_kernel_journey(
+        coord,
+        {"status": "ok", "kernel_journey_path": _journey(tmp_path, [kernel])},
+        measured_tput=BASELINE_TPUT,
+        current_best_tput=BASELINE_TPUT * 1.2,
+        provenance="revalidation",
+    )
+
+    names, _ = _route_ops(tmp_path)
+    assert "kernel_agent_forge" not in names, sorted(names)
+    geak = (_column(tmp_path).get("by_backend") or {}).get("geak") or {}
+    assert not geak.get("keeps"), geak
+
+
+def test_the_geak_route_subject_names_geak(tmp_path: Path) -> None:
+    """Operation and subject must name the same optimizer.
+
+    ``record_native_kernel_run_start`` derives the operation's name and strategy
+    from the route, but the subject payload kept a literal ``kernel_agent_forge``.
+    A GEAK replay then wrote ``operation.name=geak`` beside
+    ``subject.name=kernel_agent_forge`` — one record naming two optimizers, and
+    the subject is what identity lookups resolve against.
+    """
+    coord = _coord(tmp_path)
+    _record_baseline(tmp_path)
+    coord._record_geak_kernel_journey(
+        {
+            "kernel_journey_path": _journey(
+                tmp_path, [_kernel("k_subject", gain=5.0, before=1000.0, after=1050.0)]
+            )
+        }
+    )
+
+    names, subjects = _route_ops(tmp_path)
+    assert "geak" in names, sorted(names)
+    assert subjects == {"geak"}, subjects
+
+
+def test_every_journey_replay_call_names_its_route() -> None:
+    """Derived from the source, not from a list a seventh call site can miss.
+
+    Both route defects were the same shape: a recorder call that did not name its
+    route and silently took Forge. Six call sites carry ``route_strategy="geak"``
+    today; this fails if one is added without it, rather than waiting for a
+    reviewer to notice the provenance is wrong.
+    """
+    import re
+
+    source = Path(
+        __file__
+    ).resolve().parents[3] / "hyperloom" / "orchestrator" / "phases" / "kernel.py"
+    text = source.read_text(encoding="utf-8")
+    replay = text[text.index("def _record_geak_kernel_journey") :]
+    unrouted = []
+    for match in re.finditer(r"instrument\.record_kernel_(\w+)\(", replay):
+        depth, i = 0, match.end() - 1
+        while i < len(replay):
+            if replay[i] == "(":
+                depth += 1
+            elif replay[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        call = replay[match.start() : i + 1]
+        if 'route_strategy="geak"' not in call:
+            unrouted.append(
+                (match.group(1), replay[: match.start()].count("\n"))
+            )
+    assert not unrouted, f"recorder calls in the GEAK replay with no GEAK route: {unrouted}"

--- a/src/hyperloom/inference_optimizer/tests/test_geak_reaches_dashboard.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_reaches_dashboard.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""GEAK's kernel wins must reach the stream the dashboard reads.
+
+The TOP Model dashboard's GEAK column is
+``summary_by_source["kernel_agent"]["by_backend"]["geak"]``, which
+``collect_recorded_optimizations`` builds from the recorder's ``operations`` and
+``adoptions`` streams. ``_record_geak_kernel_journey`` used to replay every GEAK
+kernel with ``route_strategy="legacy_only"``, and all three recorder entry
+points return *before* writing either record on that route. A session therefore
+finished with a kept, validated, positive-gain kernel and no operation naming
+it, which is the same shape a session with no kernel agent at all leaves.
+
+These tests pin the path end to end so the column cannot silently go quiet
+again.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hyperloom.inference_optimizer.breakdown import collectors
+from hyperloom.inference_optimizer.breakdown.recorder import assemble_parts, instrument
+from hyperloom.orchestrator.loop.coordinator import Coordinator
+from hyperloom.orchestrator.state.shared_state import SharedState
+
+BASELINE_TPUT = 1000.0
+
+
+def _coord(tmp_path: Path) -> Coordinator:
+    coord = Coordinator.__new__(Coordinator)
+    coord.session_dir = tmp_path
+    coord.shared_state = SharedState(
+        baseline_tput=BASELINE_TPUT,
+        current_best={"action": "explore", "tput": BASELINE_TPUT},
+        model_path="/models/gemma",
+        gpu_type="mi300x",
+        isl=1024,
+        osl=1024,
+        conc=64,
+    )
+    return coord
+
+
+def _journey(tmp_path: Path, kernels: list[dict]) -> str:
+    path = tmp_path / "kernel_journey.json"
+    path.write_text(
+        json.dumps(
+            {
+                "discovery_runs": [
+                    {"source": "profile", "status": "success", "hot_kernels": []}
+                ],
+                "kernels": kernels,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _kernel(kid: str, *, gain: float, before: float, after: float) -> dict:
+    return {
+        "kernel_id": kid,
+        "dispatch": {"dispatched": True, "backends": ["geak"], "skip_reason": ""},
+        "backend_result": {
+            "kernel_id": kid,
+            "attempts": [
+                {
+                    "backend": "geak",
+                    "attempt_id": f"{kid}-geak-0",
+                    "status": "succeeded",
+                    "decision": "KEEP",
+                    "compile_passed": True,
+                    "correctness_passed": True,
+                }
+            ],
+            "verification": {"best_attempt_id": f"{kid}-geak-0", "best_backend": "geak"},
+        },
+        "e2e": {
+            "kernel_id": kid,
+            "integrated": True,
+            "e2e_gain_pct": gain,
+            "validated": True,
+            "decision": "KEEP",
+            # The pair the delta was judged against. GEAK publishes these so
+            # the collector can state each win in percentage points of the one
+            # session baseline instead of summing percentages of moving ones.
+            "base_tput": before,
+            "new_tput": after,
+        },
+    }
+
+
+def _column(session_dir: Path) -> dict:
+    """Run the real assembler and the real collector, and return the row the
+    dashboard renders for the kernel agent."""
+    warnings: list[str] = []
+    parts = assemble_parts(session_dir, warnings=warnings)
+    out = collectors.collect_recorded_optimizations(
+        "session",
+        [r for r in parts.get("operations") or [] if isinstance(r, dict)],
+        [r for r in parts.get("measurements") or [] if isinstance(r, dict)],
+        [r for r in parts.get("adoptions") or [] if isinstance(r, dict)],
+        [r for r in parts.get("artifacts") or [] if isinstance(r, dict)],
+        [],
+        [],
+        warnings,
+    )
+    return (out.get("summary_by_source") or {}).get("kernel_agent") or {}
+
+
+def _record_baseline(session_dir: Path) -> None:
+    """Every real session measures its baseline before the kernel agent runs;
+    it is the denominator every gain below is stated against."""
+    instrument.record_action_operation(
+        session_dir,
+        action="baseline",
+        task_id="baseline-0",
+        status="succeeded",
+        decision="KEEP",
+        result={"baseline_tput": BASELINE_TPUT, "ts": "2026-01-01T00:00:00Z"},
+    )
+
+
+def test_kept_geak_kernel_reaches_the_kernel_agent_column(tmp_path: Path) -> None:
+    """A kept GEAK kernel is credited to the ``geak`` backend, not dropped."""
+    coord = _coord(tmp_path)
+    _record_baseline(tmp_path)
+    result = {
+        "status": "ok",
+        "kernel_journey_path": _journey(
+            tmp_path,
+            [_kernel("fast_attn", gain=12.0, before=1000.0, after=1120.0)],
+        ),
+    }
+    coord._record_geak_kernel_journey(result)
+
+    parts = assemble_parts(tmp_path)
+    operations = [r for r in parts.get("operations") or [] if isinstance(r, dict)]
+    # The regression itself: on the legacy route this list was empty, which is
+    # indistinguishable from a session whose records were lost.
+    assert operations, "GEAK wrote no operation; the dashboard cannot see it"
+
+    column = _column(tmp_path)
+    assert column.get("keeps") == 1
+    geak = (column.get("by_backend") or {}).get("geak") or {}
+    assert geak.get("keeps") == 1
+    assert geak.get("total_gain_pct") > 0.0
+    # Credited to GEAK by name, never parked in the catch-all bucket.
+    assert not (column.get("by_backend") or {}).get("unattributed", {}).get("keeps")
+
+
+def test_gain_is_stated_in_points_of_the_session_baseline(tmp_path: Path) -> None:
+    """Two stacked wins sum to the total the workload actually moved.
+
+    Each kernel's own percentage is measured against wherever the previous one
+    left off, so the percentages do not compose. Published with their
+    throughput pair they are converted to points of the one session baseline,
+    and those do.
+    """
+    coord = _coord(tmp_path)
+    _record_baseline(tmp_path)
+    coord._record_geak_kernel_journey(
+        {
+            "status": "ok",
+            "kernel_journey_path": _journey(
+                tmp_path,
+                [
+                    # +10% of 1000, then +10% of 1100. Naively summed that reads
+                    # as 20%; the workload actually moved 21 points.
+                    _kernel("k1", gain=10.0, before=1000.0, after=1100.0),
+                    _kernel("k2", gain=10.0, before=1100.0, after=1210.0),
+                ],
+            ),
+        }
+    )
+    geak = (_column(tmp_path).get("by_backend") or {}).get("geak") or {}
+    assert geak.get("keeps") == 2
+    assert geak.get("total_gain_pct") == 21.0
+
+
+def test_reverted_geak_kernel_is_not_credited(tmp_path: Path) -> None:
+    """The revert path is on the canonical stream too, so a kernel that was
+    taken back out does not keep the credit it was given."""
+    coord = _coord(tmp_path)
+    _record_baseline(tmp_path)
+    kernel = _kernel("regressed", gain=-3.0, before=1000.0, after=970.0)
+    kernel["e2e"].update(integrated=False, validated=False, decision="REVERT")
+    coord._record_geak_kernel_journey(
+        {"status": "ok", "kernel_journey_path": _journey(tmp_path, [kernel])}
+    )
+    geak = (_column(tmp_path).get("by_backend") or {}).get("geak") or {}
+    assert not geak.get("keeps")

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -1778,6 +1778,11 @@ class KernelPhase(PhaseHandler):
                     e2e_gain_pct=None,
                     validated=False,
                     decision="REVERT",
+                    # Same route as the KEEP that this withdraws. Leaving it on the default
+                    # re-parented the kernel under a synthetic Forge route at the moment it was
+                    # revoked, so a withdrawn GEAK kernel ended up filed under an optimizer that
+                    # never touched it.
+                    route_strategy="geak",
                     patch_path=e2e.get("patch_path"),
                     target_file=e2e.get("target_file"),
                     extra_server_args=str(

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -1659,6 +1659,7 @@ class KernelPhase(PhaseHandler):
                     hot_kernels=list(run.get("hot_kernels") or []),
                     scan=run.get("scan") if isinstance(run.get("scan"), dict) else None,
                     tool="geak",
+                    route_strategy="geak",
                 )
             except Exception:  # noqa: BLE001
                 log.debug("geak kernel_journey discovery replay failed", exc_info=True)
@@ -1678,12 +1679,14 @@ class KernelPhase(PhaseHandler):
                     skip_reason=str(disp.get("skip_reason") or ""),
                     orchestration_commit=commit,
                     task_group=disp.get("task_group"),
+                    route_strategy="geak",
                 )
                 br = k.get("backend_result")
                 if isinstance(br, dict):
                     instrument.record_kernel_backend_result(
                         sdir,
                         br,
+                        route_strategy="geak",
                     )
                 e2e = k.get("e2e")
                 if isinstance(e2e, dict):
@@ -1698,6 +1701,7 @@ class KernelPhase(PhaseHandler):
                         target_file=e2e.get("target_file"),
                         extra_server_args=str(e2e.get("extra_server_args") or ""),
                         result=e2e,
+                        route_strategy="geak",
                         # Replaying must land on the reading it originally
                         # recorded, not count itself as a fresh one.
                         occurrence=e2e.get("occurrence"),

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -1659,7 +1659,6 @@ class KernelPhase(PhaseHandler):
                     hot_kernels=list(run.get("hot_kernels") or []),
                     scan=run.get("scan") if isinstance(run.get("scan"), dict) else None,
                     tool="geak",
-                    route_strategy="legacy_only",
                 )
             except Exception:  # noqa: BLE001
                 log.debug("geak kernel_journey discovery replay failed", exc_info=True)
@@ -1679,14 +1678,12 @@ class KernelPhase(PhaseHandler):
                     skip_reason=str(disp.get("skip_reason") or ""),
                     orchestration_commit=commit,
                     task_group=disp.get("task_group"),
-                    route_strategy="legacy_only",
                 )
                 br = k.get("backend_result")
                 if isinstance(br, dict):
                     instrument.record_kernel_backend_result(
                         sdir,
                         br,
-                        route_strategy="legacy_only",
                     )
                 e2e = k.get("e2e")
                 if isinstance(e2e, dict):
@@ -1701,7 +1698,6 @@ class KernelPhase(PhaseHandler):
                         target_file=e2e.get("target_file"),
                         extra_server_args=str(e2e.get("extra_server_args") or ""),
                         result=e2e,
-                        route_strategy="legacy_only",
                         # Replaying must land on the reading it originally
                         # recorded, not count itself as a fresh one.
                         occurrence=e2e.get("occurrence"),
@@ -1784,7 +1780,6 @@ class KernelPhase(PhaseHandler):
                         e2e.get("extra_server_args") or ""
                     ),
                     result=evidence,
-                    route_strategy="legacy_only",
                     # This is a second look at a kernel that was already kept,
                     # and ``evidence`` still carries the original integrate's
                     # identity. Without a namespace of its own, the reading


### PR DESCRIPTION
Fixes #1251.

## What was wrong

`_record_geak_kernel_journey` replayed every GEAK kernel with `route_strategy="legacy_only"`. `record_kernel_discovery`, `record_kernel_dispatch` and `record_kernel_e2e` all return **before** writing the operation and the adoption on that route.

The dashboard's GEAK column is `summary_by_source["kernel_agent"]["by_backend"]["geak"]`, which `collect_recorded_optimizations` builds from exactly those two streams. So a session finished with a kept, validated, positive-gain kernel and nothing on the ledger naming it — the same shape a lost write leaves.

## The change

Five deletions. Drop `route_strategy="legacy_only"` and let the default `kernel_agent_forge` apply. The route names the *stream*, not the vendor; the `geak` backend label is resolved from the journey's `backend_result` and is unaffected.

The revert path changes with the accept path, or a kernel taken back out keeps credit it was given.

## A/B on real campaign logs

Real `kernel_journey.json` from `/shared_nfs/hyperloom-claw/`, through the **real** `instrument.record_kernel_*`, the **real** `assemble_parts`, and the **real** `collect_recorded_optimizations`. Only `route_strategy` differs between arms.

| session | GEAK KEEP kernels | credited today | credited after |
|---|---:|---:|---:|
| `GLM-5.2-MXFP4/20260814T163244Z` | 3 | **0** | **3** |
| `Kimi-K3/20260816T122327Z` | 2 | **0** | **2** |
| `Llama-3.1-8B-Instruct/20260816T114410Z` | 1 | **0** | **2** |
| `MiniMax-M3-MXFP8/20260801T023259Z` | 4 | **0** | **4** |
| `Mixtral-8x7B-Instruct-v0.1/20260730T180726Z` | 2 | **0** | **2** |
| `Qwen3-0.6B/20260730T213628Z` | 3 | **0** | **3** |
| `Qwen3-0.6B/20260805T130336Z` | 1 | **0** | **1** |
| `Qwen3-14B-FP8/20260730T184453Z` | 1 | **0** | **1** |
| `Qwen3-14B-FP8/20260814T163051Z` | 2 | **0** | **2** |
| `Qwen3-14B-FP8/20260816T050457Z` | 3 | **0** | **3** |
| `Qwen3.5-122B-A10B-FP8/20260801T034513Z` | 2 | **0** | **2** |
| `Qwen3.5-122B-A10B-FP8/20260805T080211Z` | 2 | **0** | **2** |
| `gemma-4-26B-A4B-it/20260814T155153Z` | 2 | **0** | **2** |
| `gemma-4-26B-A4B-it/20260815T130915Z` | 5 | **0** | **5** |
| `gemma-4-26B-A4B-it/20260816T112750Z` | 2 | **0** | **2** |
| **total** | **35** | **0** | **36** |

| metric | today | after |
|---|---:|---:|
| sessions assembling any operation | **0 / 15** | **15 / 15** |
| kept kernels credited to `geak` | **0** | **36** |
| kept kernels credited to `forge` | 0 | 0 |
| kept kernels left `unattributed` | 0 | 0 |

Largest win currently invisible: `dsa_sparse_attn_prefill_main_kernel` on GLM-5.2-MXFP4, **+29.994%** e2e, parity pass.

## Tests

New: `src/hyperloom/inference_optimizer/tests/test_geak_reaches_dashboard.py` (3 tests), pinning the path end to end through the real recorder and real collector.

| test | on `main` | on this branch |
|---|---|---|
| `test_kept_geak_kernel_reaches_the_kernel_agent_column` | **FAIL** (`geak keeps == 0`) | pass |
| `test_gain_is_stated_in_points_of_the_session_baseline` | **FAIL** (`geak keeps == 0`) | pass |
| `test_reverted_geak_kernel_is_not_credited` | pass | pass |

The third asserts an absence, so it holds both ways by construction; it guards the revert path against over-crediting once the other two pass.

Related suite: **552 passed, 1 failed**. The one failure is `test_coverage_gap_units.py::test_credentials_endpoint_resolution_and_geak_sync`, which asserts on `credentials._resolve_llm_endpoints` and fails identically with this change stashed. Pre-existing and unrelated.

## Scope

This makes GEAK **visible**, not yet **correctly sized**. The journey publishes `e2e_gain_pct` with no throughput pair (36/36 KEEP blocks), so the collector cannot state each win in points of the session baseline and falls back to summing percentages measured against a moving one — route-fix-alone reads **+348.6 pp** across these 15 sessions, which is a unit error. That half is GEAK-side and filed separately; the collector already has the arithmetic and only lacks the inputs.

Separately, GEAK has produced **0 kept kernels since 17 August**, so this will not lift the current window off zero on its own.
