### PR TITLE
chore: extend pre-commit hooks and dev tooling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig — https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.{md,rst}]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.sh]
+indent_style = space
+indent_size = 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,33 +1,51 @@
-# Pre-commit: single local front door for the CI static-analysis gates.
+# Pre-commit: local front door for static analysis and hygiene checks.
 #
-# Scope note: this wires the *check-only* hooks (no ``ruff-format``). The
-# repo-wide ``ruff format`` reflow (~170 files) is deferred to its own
-# mechanical PR; enable the ``ruff-format`` hook here once that lands so
-# formatting is enforced at authoring time.
+# Install:
+#   pip install pre-commit && pre-commit install
 #
-# Install locally with::
+# Run everything once:
+#   pre-commit run --all-files
 #
-#     pip install pre-commit && pre-commit install
+# Hooks run on staged/changed files by default. CI remains authoritative for
+# pytest, coverage, CodeQL, and full-tree Bandit on push.
 #
-# Run against everything once (baseline) with::
-#
-#     pre-commit run --all-files
-#
-# Hooks default to changed files only, so the existing lint backlog does not
-# block commits while it is drained; new/changed lines are gated immediately.
+# Rollout notes (see CONTRIBUTING.md and docs/contributing/style-guide.md):
+#   - ruff-format: enable after the mechanical format PR lands.
+#   - gitleaks: mirrors secret-scan.yml (Docker-backed hook).
+#   - Full pytest stays in CI only (tests-coverage.yml).
+
+default_language_version:
+  python: python3.11
+
 repos:
-  # Ruff: same rule set as ``[tool.ruff]`` / ``[tool.ruff.lint]`` and the
-  # ``lint.yml`` CI job (E/F/W). Check only -- formatting is deferred (see note).
+  # --- Universal hygiene (fast, low controversy) ---
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: ^docs/_build/
+      - id: end-of-file-fixer
+        exclude: ^docs/_build/
+      - id: check-merge-conflict
+      - id: check-yaml
+        exclude: ^docs/_build/
+      - id: check-toml
+      - id: check-added-large-files
+        args: ["--maxkb=512"]
+      - id: detect-private-key
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+
+  # --- Python: Ruff (same rules as pyproject.toml and lint.yml) ---
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.20
     hooks:
       - id: ruff
         args: ["--force-exclude"]
+      # Enable after the repo-wide ruff format PR merges:
+      # - id: ruff-format
 
-  # Bandit: reads ``[tool.bandit]`` (skips B101, excludes test trees). The
-  # ``bandit[toml]`` extra is required to parse the config from pyproject.
-  # ``exclude`` re-applies the test-tree filter here because pre-commit passes
-  # explicit filenames, which bypasses ``[tool.bandit].exclude_dirs``.
+  # --- Python: security (production paths; tests excluded) ---
   - repo: https://github.com/PyCQA/bandit
     rev: 1.9.4
     hooks:
@@ -36,25 +54,44 @@ repos:
         additional_dependencies: ["bandit[toml]"]
         exclude: "^.*/tests?/"
 
-  # ShellCheck: most hits are SC2086 (unquoted expansions) -- fast to fix.
-  # ``shellcheck-py`` ships a pip wheel (no Docker), unlike the koalaman
-  # docker-image hook, so it runs in any local/CI environment.
+  # --- Shell ---
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
 
-  # yamllint: ``relaxed`` preset + line-length disabled keeps the existing
-  # backlog from blocking commits while still flagging genuine YAML errors.
+  # --- YAML / GitHub Actions ---
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0
     hooks:
       - id: yamllint
         args: ["-d", "{extends: relaxed, rules: {line-length: disable}}"]
 
-  # actionlint: lints ``.github/workflows`` -- run locally so the workflow-lint
-  # error the audit hit (actionlint did not complete in CI) surfaces early.
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12
     hooks:
       - id: actionlint
+
+  # --- License compliance (mirrors reuse-lint.yml) ---
+  - repo: https://github.com/fsfe/reuse-tool
+    rev: v5.0.2
+    hooks:
+      - id: reuse
+        pass_filenames: false
+
+  # --- Secret scan (mirrors secret-scan.yml) ---
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.28.0
+    hooks:
+      - id: gitleaks
+
+  # --- Spelling (docs + comments) ---
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies: ["tomli"]
+        args:
+          - --ignore-words-list=rocm,hip,aiter,vllm,sglang,triton,jsonl,kwargs,nd,te,ser,crate,assertin
+          - --skip=*.json,*.jsonl,*.svg,*.lock,docs/_build,.venv,_audit_artifacts
+        exclude: ^(LICENSES/|docs/_build/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,33 @@ These GitHub jobs are optional from a default merge-policy perspective; skipping
 - To mirror the coverage CI job locally:  
   `pip install -e ".[test,ci]"` then run `pytest` with the same arguments as in the `[tool.hyperloom.tests_coverage]` table in `pyproject.toml` (see ``tests-coverage.yml`` for the exact list: marker filter + ``--cov`` flags).
 - If you plan to run lint/type checks, install tools:  
-  `pip install ruff mypy`
+  `pip install ruff mypy`  
+  Or install the bundled dev extra: `pip install -e ".[test,dev]"`
+
+## Pre-commit (recommended)
+
+Hyperloom ships a [`.pre-commit-config.yaml`](.pre-commit-config.yaml) that mirrors most static-analysis gates before code reaches CI.
+
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files   # optional baseline after clone
+```
+
+### Hooks
+
+| Hook | Purpose |
+|------|---------|
+| **pre-commit-hooks** | Trailing whitespace, EOF, merge conflicts, large files, private keys |
+| **ruff** | Python lint (`E`/`F`/`W`), same as `lint.yml` |
+| **bandit** | Security lint on production Python (tests excluded) |
+| **shellcheck** | Shell script analysis |
+| **yamllint** / **actionlint** | YAML and GitHub Actions workflow lint |
+| **reuse** | REUSE/SPDX compliance |
+| **gitleaks** | Secret scan (mirrors `secret-scan.yml`) |
+| **codespell** | Typos in docs and comments |
+
+**Intentionally not in pre-commit** (too slow or environment-specific): full **pytest**/coverage, **Pylint**, **CodeQL**, and E2E pytest markers.
 
 ## Testing
 - Run the full test suite from the repo root:  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,13 @@ ast = [
 claude = [
     "claude-agent-sdk>=0.2.110",
 ]
+# Local dev tooling: pre-commit hooks, formatters, type checker.
+dev = [
+    "pre-commit>=4.0",
+    "ruff>=0.8,<1",
+    "mypy>=1.0",
+    "reuse>=5.0",
+]
 
 [project.scripts]
 inference_optimizer = "hyperloom.inference_optimizer.cli:main"


### PR DESCRIPTION
## Summary
- Extend \.pre-commit-config.yaml\ with universal hygiene hooks, REUSE, Gitleaks, and codespell (alongside existing ruff/bandit/shellcheck/yamllint/actionlint).
- Add \.editorconfig\ for consistent indentation and line endings.
- Add \[project.optional-dependencies].dev\ for pre-commit, ruff, mypy, and reuse.
- Document pre-commit setup and hook inventory in \CONTRIBUTING.md\.

## Test plan
- [ ] \pip install pre-commit && pre-commit run --all-files\ on a clean clone.
- [ ] Verify Gitleaks hook runs (Docker required for the upstream hook).
- [ ] Merge after #1253 or rebase if \CONTRIBUTING.md\ conflicts.


Made with [Cursor](https://cursor.com)