### PR TITLE
ci: make Ruff lint and format hard gates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,10 +6,9 @@ name: Lint
 # Static analysis on push and pull_request for all branches. Skips when every
 # changed file matches paths-ignore (same list as ``tests-coverage.yml``).
 #
-# Ruff reads ``[tool.ruff]`` / ``[tool.ruff.lint]`` in ``pyproject.toml``. Step
-# ``continue-on-error: true`` keeps results advisory until the finding backlog
-# is cleared; then set those flags to ``false`` so merge gates can require a
-# green Lint job.
+# Ruff reads ``[tool.ruff]`` / ``[tool.ruff.lint]`` in ``pyproject.toml``. Ruff
+# check and format are hard gates. Bandit and Pylint remain advisory until their
+# backlogs are cleared.
 #
 # Pylint: ``--errors-only`` limits output to fatal/error-severity messages
 # (not convention or refactor hints). tree-reform.MD P2.5: critic-agent,
@@ -67,21 +66,11 @@ jobs:
 
       - name: Ruff check
         id: ruff_check
-        continue-on-error: true
         run: ruff check .
 
       - name: Ruff format (check only)
         id: ruff_format
-        continue-on-error: true
         run: ruff format --check .
-
-      - name: Advisory notice when Ruff failed
-        if: >-
-          always() &&
-          (steps.ruff_check.outcome == 'failure' ||
-           steps.ruff_format.outcome == 'failure')
-        run: |
-          echo "::warning::Ruff reported issues (advisory: step uses continue-on-error). Flip to hard-fail in this workflow after backlog is zero."
 
   bandit:
     name: bandit (medium+, production code)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ This repository treats **documentation-only** pushes and pull requests the same 
 |-----------------|------------------------|------------------------------|
 | **Pytest** (full suite with coverage reporting) | [`.github/workflows/tests-coverage.yml`](.github/workflows/tests-coverage.yml) (reads ``[tool.hyperloom.tests_coverage]`` / coverage config from ``pyproject.toml`` via inline Python) | Yes (`paths-ignore` on `push` / `pull_request` for all branches) |
 | **CodeQL** | [`.github/workflows/codeql.yml`](.github/workflows/codeql.yml) | Yes on **PR and push** when doc-only (`paths-ignore`); **no** — the **weekly schedule** on the default branch still runs a full analysis |
-| **Ruff** (lint + format check) | [`.github/workflows/lint.yml`](.github/workflows/lint.yml) (`ruff check` / `ruff format --check`; steps use `continue-on-error: true` until backlog is cleared) | Yes (same `paths-ignore` as tests / CodeQL) |
+| **Ruff** (lint + format check) | [`.github/workflows/lint.yml`](.github/workflows/lint.yml) (`ruff check` / `ruff format --check`; hard gate) | Yes (same `paths-ignore` as tests / CodeQL) |
 | **Pylint** (errors-only) | [`.github/workflows/lint.yml`](.github/workflows/lint.yml) (`pylint --errors-only` on `hyperloom.inference_optimizer`, `hyperloom.orchestrator`, `hyperloom.agents.robustness`, `hyperloom.agents.framework`, `hyperloom.agents.critic.runtime`, and `hyperloom.agents.quantization`; advisory `continue-on-error`) | Yes (same `paths-ignore`) |
 | **Mypy** | Local / optional tooling only here | N/A |
 


### PR DESCRIPTION
## Summary
- Remove \continue-on-error\ from the Ruff check and Ruff format steps in \.github/workflows/lint.yml\.
- Update \CONTRIBUTING.md\ to note Ruff is a hard gate.
- Bandit and Pylint remain advisory (\continue-on-error: true\) until their backlogs are cleared.

## Test plan
- [x] \uff check .\ and \uff format --check .\ pass on this branch.
- [ ] Lint workflow passes on this PR (stacked on #1255).

## Merge order
1. Merge #1255 (ruff format) into \main\.
2. Retarget this PR to \main\ (or merge as-is if GitHub allows stacked merge).


Made with [Cursor](https://cursor.com)