### PR TITLE
chore: add mypy baseline config and advisory CI job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -138,3 +138,29 @@ jobs:
             hyperloom.agents.framework \
             hyperloom.agents.critic.runtime \
             hyperloom.agents.quantization
+
+  mypy:
+    name: mypy (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Install mypy and editable package
+        run: |
+          pip install --upgrade pip
+          pip install "mypy>=1.0"
+          pip install -e ".[test]"
+
+      - name: Mypy
+        id: mypy
+        continue-on-error: true
+        run: mypy src/hyperloom
+
+      - name: Advisory notice when Mypy failed
+        if: always() && steps.mypy.outcome == 'failure'
+        run: |
+          echo "::warning::Mypy reported type errors (advisory: step uses continue-on-error). Fix new errors in touched modules; flip to hard-fail after backlog shrinks."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,3 +52,14 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
+
+  # Enable once the mypy backlog is manageable (config in pyproject.toml):
+  # - repo: local
+  #   hooks:
+  #     - id: mypy
+  #       name: mypy (src/hyperloom)
+  #       entry: mypy src/hyperloom
+  #       language: system
+  #       types: [python]
+  #       pass_filenames: false
+  #       require_serial: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ This repository treats **documentation-only** pushes and pull requests the same 
 | **CodeQL** | [`.github/workflows/codeql.yml`](.github/workflows/codeql.yml) | Yes on **PR and push** when doc-only (`paths-ignore`); **no** — the **weekly schedule** on the default branch still runs a full analysis |
 | **Ruff** (lint + format check) | [`.github/workflows/lint.yml`](.github/workflows/lint.yml) (`ruff check` / `ruff format --check`; hard gate) | Yes (same `paths-ignore` as tests / CodeQL) |
 | **Pylint** (errors-only) | [`.github/workflows/lint.yml`](.github/workflows/lint.yml) (`pylint --errors-only` on `hyperloom.inference_optimizer`, `hyperloom.orchestrator`, `hyperloom.agents.robustness`, `hyperloom.agents.framework`, `hyperloom.agents.critic.runtime`, and `hyperloom.agents.quantization`; advisory `continue-on-error`) | Yes (same `paths-ignore`) |
-| **Mypy** | Local / optional tooling only here | N/A |
+| **Mypy** | [`.github/workflows/lint.yml`](.github/workflows/lint.yml) (advisory `continue-on-error`; config in `[tool.mypy]`) | Yes (same `paths-ignore`) |
 
 If you add standalone workflows for **pytest**, **ruff**, **pylint**, or similar, copy the **same** `paths-ignore` blocks as in `tests-coverage.yml` / `codeql.yml` so documentation-only PRs stay consistent and cheap.
 
@@ -70,8 +70,8 @@ Do not treat ad hoc local `pytest --cov=...` invocations or any other workflow a
 - Ruff:  
   `ruff check .`
 - Type checks (mypy):  
-  `mypy src/hyperloom`
-  - Adjust paths if you change package locations.
+  `mypy src/hyperloom`  
+  Configuration lives in `[tool.mypy]` in `pyproject.toml`. CI runs mypy as an **advisory** job until the type-check backlog is reduced.
 - CI runs **Pylint** with **`--errors-only`** (fatal/error severity only, not style) on several first-party packages from [`.github/workflows/lint.yml`](.github/workflows/lint.yml) (advisory `continue-on-error` today). Root **`[tool.pylint.main]`** in `pyproject.toml` holds minimal defaults (e.g. `jobs`); tighten or add message disables there as the backlog shrinks.
 
 ## Before opening a PR

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,12 @@ ast = [
 claude = [
     "claude-agent-sdk>=0.2.110",
 ]
+dev = [
+    "pre-commit>=4.0",
+    "ruff>=0.8,<1",
+    "mypy>=1.0",
+    "reuse>=5.0",
+]
 
 [project.scripts]
 inference_optimizer = "hyperloom.inference_optimizer.cli:main"
@@ -385,4 +391,23 @@ ignore = ["E501", "E741"]
 # scoped to Python so CI ``ruff format --check`` does not rewrite docs/skills.
 [tool.ruff.format]
 exclude = ["**/*.md", "**/*.rst"]
+
+[tool.mypy]
+python_version = "3.10"
+files = ["src/hyperloom"]
+exclude = [
+    ".*/tests/.*",
+    "build",
+    ".venv",
+    "_audit_artifacts",
+]
+ignore_missing_imports = true
+warn_return_any = true
+warn_unused_configs = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+no_implicit_optional = true
+check_untyped_defs = false
+disallow_untyped_defs = false
+show_error_codes = true
 


### PR DESCRIPTION
## Summary
- Add \[tool.mypy]\ to \pyproject.toml\ (Python 3.10, \src/hyperloom\, tests excluded, \ignore_missing_imports\ for gradual rollout).
- Add \dev\ optional dependency group (pre-commit, ruff, mypy, reuse).
- Add an **advisory** mypy job to \.github/workflows/lint.yml\ (\continue-on-error: true\).
- Document mypy in \CONTRIBUTING.md\; leave a commented pre-commit hook template for later.

## Test plan
- [x] \mypy src/hyperloom\ runs locally (expected: existing backlog reported, non-zero exit).
- [ ] Lint workflow mypy job completes and reports advisory warnings.
- [ ] New modules should add type hints per \[tool.mypy]\ defaults.

## Notes
~1650 existing mypy errors across the tree — this PR establishes config and CI visibility, not a hard gate. Flip \continue-on-error\ after incremental cleanup.

## Merge order
Stacked on #1256 → #1255 → merge to \main\ in sequence.


Made with [Cursor](https://cursor.com)