### PR TITLE
fix(custom): restore operator bench scripts on --resume-from

### DIFF
--- a/src/hyperloom/inference_optimizer/cli/__init__.py
+++ b/src/hyperloom/inference_optimizer/cli/__init__.py
@@ -212,7 +212,9 @@ def _restore_operator_supplied_paths_from_state(args: Any, state: SharedState) -
     CLI flag is not written here: :func:`_apply_operator_supplied_paths`
     publishes it, and must see a vacant env for the flag to win. Archive is
     therefore applied only when neither the flag nor the env is set, matching
-    how ``--server-args`` / ``--extra-env`` resume.
+    how ``--server-args`` / ``--extra-env`` resume. ``benchmark_backend`` has
+    no CLI flag (env / install.sh only), so the env check alone is the full
+    precedence chain for that field.
 
     Args:
         args: Parsed CLI namespace (reads ``framework_path`` /
@@ -250,6 +252,10 @@ def _require_custom_entrypoint(framework: str, gpu_type: str | None = None) -> N
 
     No-op for shipped frameworks. Must run after GPU_TYPE is resolved: the
     runner suffix is part of the filename.
+
+    Side effect: publishes ``CUSTOM_REPO_PATH`` / ``CUSTOM_DIR`` into
+    ``os.environ`` via ``apply_scriptable_runtime_defaults``, which PolicyGate
+    needs anyway to allowlist the custom checkout.
 
     Args:
         framework: Resolved session framework.

--- a/src/hyperloom/inference_optimizer/cli/__init__.py
+++ b/src/hyperloom/inference_optimizer/cli/__init__.py
@@ -156,7 +156,9 @@ def _apply_operator_supplied_paths(args: Any, framework: str) -> None:
     benchmark, half an hour in. The benchmark backend is checked for the same
     reason: it defaults to Magpie, which cannot run an operator's script at all,
     and nothing downstream rejects the combination — the run would simply take
-    the wrong executor and fail somewhere less obvious.
+    the wrong executor and fail somewhere less obvious. Resume re-invokes this
+    after restoring archived paths so a re-passed ``--benchmark-scripts-dir``
+    is not silently dropped.
     """
     fatal: list[str] = []
     if framework == "custom":
@@ -201,6 +203,104 @@ def _apply_operator_supplied_paths(args: Any, framework: str) -> None:
         for line in fatal:
             print(f"ERROR: {line}", file=sys.stderr)
         sys.exit(2)
+
+
+def _restore_operator_supplied_paths_from_state(args: Any, state: SharedState) -> None:
+    """Fill custom-workload env from persisted state when this resume omitted it.
+
+    Priority is CLI flag > already-exported env > archived SharedState. The
+    CLI flag is not written here: :func:`_apply_operator_supplied_paths`
+    publishes it, and must see a vacant env for the flag to win. Archive is
+    therefore applied only when neither the flag nor the env is set, matching
+    how ``--server-args`` / ``--extra-env`` resume.
+
+    Args:
+        args: Parsed CLI namespace (reads ``framework_path`` /
+            ``benchmark_scripts_dir``).
+        state: Resumed session state.
+    """
+    from hyperloom.orchestrator.actions.executors.benchmark_backend import (
+        BENCHMARK_BACKEND_ENV,
+    )
+
+    cli_repo = str(getattr(args, "framework_path", None) or "").strip()
+    cli_scripts = str(getattr(args, "benchmark_scripts_dir", None) or "").strip()
+    if not cli_repo and not os.environ.get("FRAMEWORK_REPO_PATH", "").strip():
+        archived = str(getattr(state, "framework_repo_path", "") or "").strip()
+        if archived:
+            os.environ["FRAMEWORK_REPO_PATH"] = archived
+    if not cli_scripts and not os.environ.get("HYPERLOOM_BYPASS_SCRIPTS_DIR", "").strip():
+        archived = str(getattr(state, "bypass_scripts_dir", "") or "").strip()
+        if archived:
+            os.environ["HYPERLOOM_BYPASS_SCRIPTS_DIR"] = archived
+    if not os.environ.get(BENCHMARK_BACKEND_ENV, "").strip():
+        archived = str(getattr(state, "benchmark_backend", "") or "").strip()
+        if archived:
+            os.environ[BENCHMARK_BACKEND_ENV] = archived
+
+
+def _require_custom_entrypoint(framework: str, gpu_type: str | None = None) -> None:
+    """Fail at launch when ``--framework custom`` cannot resolve its script.
+
+    Walks the same chain the bypass runner uses (``apply_scriptable_runtime_defaults``
+    then :func:`resolve_scriptable_script`) so a missing ``custom_{runner}.sh``
+    (or lone operator script) exits in seconds with the candidate list, instead
+    of looping ``magpie_nonzero_invalid_measurement`` until robustness stops
+    the session.
+
+    No-op for shipped frameworks. Must run after GPU_TYPE is resolved: the
+    runner suffix is part of the filename.
+
+    Args:
+        framework: Resolved session framework.
+        gpu_type: Magpie runner GPU type (e.g. ``mi355x``).
+    """
+    if str(framework or "").strip().lower() != "custom":
+        return
+    from hyperloom.orchestrator.actions.executors._workload_envs import (
+        apply_scriptable_runtime_defaults,
+    )
+    from hyperloom.orchestrator.actions.executors.bypass_scriptable import (
+        resolve_scriptable_script,
+        scriptable_script_candidates,
+    )
+
+    bench: dict[str, Any] = {"framework": "custom"}
+    envs: dict[str, Any] = {}
+    apply_scriptable_runtime_defaults(
+        bench,
+        envs,
+        gpu_type=gpu_type,
+        explicit_benchmark_script=False,
+    )
+    runner_type = str(bench.get("runner_type") or "mi355x")
+    inferencex_root = (
+        os.environ.get("INFERENCEX_PATH", "").strip()
+        or os.environ.get("MAGPIE_INFERENCEX_PATH", "").strip()
+    )
+    script = resolve_scriptable_script("custom", runner_type, inferencex_root, bench)
+    if script is not None:
+        return
+    name = f"custom_{runner_type}.sh"
+    candidates = scriptable_script_candidates("custom", runner_type, inferencex_root, bench)
+    tried = "\n".join(f"  - {path}" for path in candidates) or "  (none)"
+    print(
+        f"ERROR: --framework custom could not resolve a benchmark entrypoint "
+        f"({name}). Tried:\n{tried}",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def _persist_operator_supplied_paths(state: SharedState) -> None:
+    """Mirror the live custom-workload env back onto ``state`` for the next resume."""
+    from hyperloom.orchestrator.actions.executors.benchmark_backend import (
+        BENCHMARK_BACKEND_ENV,
+    )
+
+    state.framework_repo_path = os.environ.get("FRAMEWORK_REPO_PATH", "").strip()
+    state.bypass_scripts_dir = os.environ.get("HYPERLOOM_BYPASS_SCRIPTS_DIR", "").strip()
+    state.benchmark_backend = os.environ.get(BENCHMARK_BACKEND_ENV, "").strip().lower()
 
 
 def _enforce_expected_framework(
@@ -1839,6 +1939,24 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             print(f"  re-exported server_args   : {_resume_server_args}")
         if _resume_extra_env:
             print(f"  re-exported extra_env     : {','.join(sorted(_resume_extra_env))}")
+        # Custom-workload paths: an explicit --framework-path /
+        # --benchmark-scripts-dir on this resume wins, else the persisted
+        # value. Without this, a fresh-shell resume leaves
+        # HYPERLOOM_BYPASS_SCRIPTS_DIR unset and every grid variant exits
+        # rc=2 before spawn (magpie_nonzero_invalid_measurement, blank error).
+        _restore_operator_supplied_paths_from_state(args, state)
+        _apply_operator_supplied_paths(args, state.framework or "sglang")
+        _require_custom_entrypoint(
+            state.framework,
+            gpu_type=os.environ.get("GPU_TYPE") or state.gpu_type,
+        )
+        _persist_operator_supplied_paths(state)
+        if state.framework_repo_path:
+            print(f"  re-exported FRAMEWORK_REPO_PATH: {state.framework_repo_path}")
+        if state.bypass_scripts_dir:
+            print(f"  re-exported HYPERLOOM_BYPASS_SCRIPTS_DIR: {state.bypass_scripts_dir}")
+        if state.benchmark_backend:
+            print(f"  re-exported HYPERLOOM_BENCHMARK_BACKEND: {state.benchmark_backend}")
         # Feeds the robustness defaults and the IR-8 check only. ``nodes_resolved``
         # was fixed from argv at the top of this function, so the cluster hand-off
         # is already settled and a multi-node resume must re-pass --nodes.
@@ -2055,6 +2173,7 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             os.environ.pop("GPU_TYPE", None)
             args.gpu_type = None
             print("GPU type        : <unset> (Magpie will auto-detect)")
+        _require_custom_entrypoint(framework, gpu_type=runner_gpu_type or gpu_type)
 
         # Runs here, not in _preflight, because the question it asks -- will
         # provenance be able to name the ISA? -- is unanswerable until

--- a/src/hyperloom/inference_optimizer/cli/bootstrap.py
+++ b/src/hyperloom/inference_optimizer/cli/bootstrap.py
@@ -352,6 +352,9 @@ def _seed_shared_state(
         # so a resume re-exports it from here rather than from argv.
         operator_server_args=str(getattr(args, "server_args", "") or "").strip(),
         operator_extra_env=parse_operator_extra_env(args),
+        bypass_scripts_dir=os.environ.get("HYPERLOOM_BYPASS_SCRIPTS_DIR", "").strip(),
+        framework_repo_path=os.environ.get("FRAMEWORK_REPO_PATH", "").strip(),
+        benchmark_backend=os.environ.get("HYPERLOOM_BENCHMARK_BACKEND", "").strip().lower(),
         nodes=max(1, int(getattr(args, "nodes", 1) or 1)),
         robustness_options=_build_robustness_options(args),
         warm_replay_enabled=not bool(getattr(args, "no_warm_replay", False)),

--- a/src/hyperloom/inference_optimizer/tests/test_bypass_backend.py
+++ b/src/hyperloom/inference_optimizer/tests/test_bypass_backend.py
@@ -1039,7 +1039,12 @@ def test_scriptable_run_missing_script_returns_config_error(tmp_path, monkeypatc
     )
 
     assert rc == 2
-    assert error == "scriptable benchmark script not found for xdit_mi300x.sh"
+    assert error is not None
+    assert "xdit_mi300x.sh" in error
+    log = (tmp_path / "ws" / "scriptable_stderr.log").read_text(encoding="utf-8")
+    assert "scriptable benchmark script not found" in log
+    assert "tried:" in log
+    assert "xdit_mi300x.sh" in log
 
 
 def test_scriptable_run_timeout_writes_stderr_log(tmp_path, monkeypatch):

--- a/src/hyperloom/inference_optimizer/tests/test_cli_bootstrap.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_bootstrap.py
@@ -142,6 +142,30 @@ def test_seed_shared_state_populates_geak_and_cli_overrides(
     assert json.loads((tmp_path / "state.json").read_text())["session_id"] == "session-1"
 
 
+def test_seed_shared_state_records_custom_workload_paths(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("FRAMEWORK", "custom")
+    monkeypatch.setenv("HYPERLOOM_BYPASS_SCRIPTS_DIR", "/scripts")
+    monkeypatch.setenv("FRAMEWORK_REPO_PATH", "/fw")
+    monkeypatch.setenv("HYPERLOOM_BENCHMARK_BACKEND", "bypass")
+    monkeypatch.setattr(cb, "_load_model_config_tags", lambda _p: {})
+    monkeypatch.setattr(cb, "_load_model_arch", lambda *_a, **_k: {})
+    monkeypatch.setattr(
+        cb, "_resolve_reference_recipe", lambda _args: ("", {}, "", "")
+    )
+    from hyperloom.orchestrator.policy import gate as policy
+
+    monkeypatch.setattr(policy, "detect_gpu_count", lambda: 1)
+    monkeypatch.setattr(policy, "research_lane_ceiling", lambda: 1)
+
+    state = cb._seed_shared_state(tmp_path, _args(framework="custom"), session_id="s-custom")
+    assert state.bypass_scripts_dir == "/scripts"
+    assert state.framework_repo_path == "/fw"
+    assert state.benchmark_backend == "bypass"
+
+
 def test_seed_shared_state_exact_forge_records_native_kernel_optimizer(
     tmp_path: Path,
     monkeypatch,

--- a/src/hyperloom/inference_optimizer/tests/test_cli_resume_launch_shape.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_resume_launch_shape.py
@@ -110,6 +110,9 @@ def test_launch_shape_survives_a_state_roundtrip():
         warm_replay_enabled=False,
         warm_replay_min_confidence=0.55,
         warm_replay_min_reproduce_pct=0.6,
+        bypass_scripts_dir="/scripts",
+        framework_repo_path="/fw",
+        benchmark_backend="bypass",
     )
 
     restored = SharedState.from_dict(state.to_dict())
@@ -121,6 +124,9 @@ def test_launch_shape_survives_a_state_roundtrip():
     assert restored.warm_replay_enabled is False
     assert restored.warm_replay_min_confidence == 0.55
     assert restored.warm_replay_min_reproduce_pct == 0.6
+    assert restored.bypass_scripts_dir == "/scripts"
+    assert restored.framework_repo_path == "/fw"
+    assert restored.benchmark_backend == "bypass"
 
 
 def test_pre_existing_state_without_the_fields_loads_defaults():
@@ -134,3 +140,45 @@ def test_pre_existing_state_without_the_fields_loads_defaults():
     assert restored.warm_replay_enabled is True
     assert restored.warm_replay_min_confidence == 0.7
     assert restored.warm_replay_min_reproduce_pct == 0.8
+    assert restored.bypass_scripts_dir == ""
+    assert restored.framework_repo_path == ""
+    assert restored.benchmark_backend == ""
+
+
+def test_restore_operator_paths_fills_env_from_state(monkeypatch):
+    from hyperloom.inference_optimizer.cli import _restore_operator_supplied_paths_from_state
+
+    monkeypatch.setenv("FRAMEWORK_REPO_PATH", "")
+    monkeypatch.setenv("HYPERLOOM_BYPASS_SCRIPTS_DIR", "")
+    monkeypatch.setenv("HYPERLOOM_BENCHMARK_BACKEND", "")
+    state = SharedState(
+        session_id="s",
+        framework_repo_path="/archived/fw",
+        bypass_scripts_dir="/archived/scripts",
+        benchmark_backend="bypass",
+    )
+    _restore_operator_supplied_paths_from_state(_ns(framework_path=None, benchmark_scripts_dir=None), state)
+    assert os.environ["FRAMEWORK_REPO_PATH"] == "/archived/fw"
+    assert os.environ["HYPERLOOM_BYPASS_SCRIPTS_DIR"] == "/archived/scripts"
+    assert os.environ["HYPERLOOM_BENCHMARK_BACKEND"] == "bypass"
+
+
+def test_restore_operator_paths_leaves_env_when_cli_repasses(monkeypatch):
+    from hyperloom.inference_optimizer.cli import _restore_operator_supplied_paths_from_state
+
+    monkeypatch.setenv("FRAMEWORK_REPO_PATH", "")
+    monkeypatch.setenv("HYPERLOOM_BYPASS_SCRIPTS_DIR", "")
+    monkeypatch.setenv("HYPERLOOM_BENCHMARK_BACKEND", "")
+    state = SharedState(
+        session_id="s",
+        framework_repo_path="/archived/fw",
+        bypass_scripts_dir="/archived/scripts",
+        benchmark_backend="bypass",
+    )
+    _restore_operator_supplied_paths_from_state(
+        _ns(framework_path="/cli/fw", benchmark_scripts_dir="/cli/scripts"),
+        state,
+    )
+    assert os.environ.get("FRAMEWORK_REPO_PATH", "") == ""
+    assert os.environ.get("HYPERLOOM_BYPASS_SCRIPTS_DIR", "") == ""
+    assert os.environ["HYPERLOOM_BENCHMARK_BACKEND"] == "bypass"

--- a/src/hyperloom/inference_optimizer/tests/test_custom_framework.py
+++ b/src/hyperloom/inference_optimizer/tests/test_custom_framework.py
@@ -12,7 +12,9 @@ blacklists the shipped frameworks rely on.
 
 from __future__ import annotations
 
+import json
 import os
+from pathlib import Path
 
 import pytest
 import yaml
@@ -431,3 +433,269 @@ class TestLaunchValidation:
 
         _apply_operator_supplied_paths(args, "custom")
         assert os.environ["FRAMEWORK_REPO_PATH"] == "/already/exported"
+
+
+class TestEntrypointFailFast:
+    def _args(self, **kw):
+        from argparse import Namespace
+
+        return Namespace(framework_path=None, benchmark_scripts_dir=None, **kw)
+
+    @pytest.fixture(autouse=True)
+    def _bypass_backend(self, monkeypatch):
+        monkeypatch.setenv("HYPERLOOM_BENCHMARK_BACKEND", "bypass")
+        monkeypatch.setenv("CUSTOM_REPO_PATH", "")
+        monkeypatch.setenv("CUSTOM_DIR", "")
+
+    def test_an_empty_scripts_dir_exits_listing_candidates(self, monkeypatch, tmp_path, capsys):
+        """Failing here beats looping magpie_nonzero_invalid_measurement for hours."""
+        from hyperloom.inference_optimizer.cli import _require_custom_entrypoint
+
+        repo, scripts = tmp_path / "fw", tmp_path / "sc"
+        repo.mkdir()
+        scripts.mkdir()
+        monkeypatch.setenv("FRAMEWORK_REPO_PATH", str(repo))
+        monkeypatch.setenv("HYPERLOOM_BYPASS_SCRIPTS_DIR", str(scripts))
+        monkeypatch.delenv("MAGPIE_PATH", raising=False)
+        monkeypatch.delenv("INFERENCEX_PATH", raising=False)
+
+        with pytest.raises(SystemExit) as exc:
+            _require_custom_entrypoint("custom", gpu_type="mi355x")
+        assert exc.value.code == 2
+        err = capsys.readouterr().err
+        assert "custom_mi355x.sh" in err
+        assert str(scripts / "custom_mi355x.sh") in err
+
+    def test_a_resolved_script_passes(self, monkeypatch, tmp_path):
+        from hyperloom.inference_optimizer.cli import _require_custom_entrypoint
+
+        repo, scripts = tmp_path / "fw", tmp_path / "sc"
+        repo.mkdir()
+        scripts.mkdir()
+        (scripts / "custom_mi355x.sh").write_text("#!/bin/sh\n")
+        monkeypatch.setenv("FRAMEWORK_REPO_PATH", str(repo))
+        monkeypatch.setenv("HYPERLOOM_BYPASS_SCRIPTS_DIR", str(scripts))
+
+        _require_custom_entrypoint("custom", gpu_type="mi355x")
+
+    def test_a_lone_operator_script_passes(self, monkeypatch, tmp_path):
+        from hyperloom.inference_optimizer.cli import _require_custom_entrypoint
+
+        repo, scripts = tmp_path / "fw", tmp_path / "sc"
+        repo.mkdir()
+        scripts.mkdir()
+        (scripts / "run_whatever.sh").write_text("#!/bin/sh\n")
+        monkeypatch.setenv("FRAMEWORK_REPO_PATH", str(repo))
+        monkeypatch.setenv("HYPERLOOM_BYPASS_SCRIPTS_DIR", str(scripts))
+
+        _require_custom_entrypoint("custom", gpu_type="mi355x")
+
+    def test_shipped_frameworks_are_not_gated(self):
+        from hyperloom.inference_optimizer.cli import _require_custom_entrypoint
+
+        _require_custom_entrypoint("sglang", gpu_type="mi300x")
+        _require_custom_entrypoint("xdit", gpu_type="mi300x")
+
+
+class TestResumeReappliesOperatorPaths:
+    def _args(self, **kw):
+        from argparse import Namespace
+
+        return Namespace(framework_path=None, benchmark_scripts_dir=None, **kw)
+
+    @pytest.fixture(autouse=True)
+    def _bypass_backend(self, monkeypatch):
+        monkeypatch.setenv("HYPERLOOM_BENCHMARK_BACKEND", "bypass")
+
+    def test_repassing_the_flags_publishes_them(self, monkeypatch, tmp_path):
+        from hyperloom.inference_optimizer.cli import _apply_operator_supplied_paths
+
+        repo, scripts = tmp_path / "fw", tmp_path / "sc"
+        repo.mkdir()
+        scripts.mkdir()
+        (scripts / "custom_mi355x.sh").write_text("#!/bin/sh\n")
+        monkeypatch.setenv("FRAMEWORK_REPO_PATH", "")
+        monkeypatch.setenv("HYPERLOOM_BYPASS_SCRIPTS_DIR", "")
+        args = self._args()
+        args.framework_path = str(repo)
+        args.benchmark_scripts_dir = str(scripts)
+
+        _apply_operator_supplied_paths(args, "custom")
+        assert os.environ["FRAMEWORK_REPO_PATH"] == str(repo.resolve())
+        assert os.environ["HYPERLOOM_BYPASS_SCRIPTS_DIR"] == str(scripts.resolve())
+
+    def test_archived_paths_fill_in_when_flags_are_omitted(self, monkeypatch, tmp_path):
+        from hyperloom.inference_optimizer.cli import (
+            _apply_operator_supplied_paths,
+            _restore_operator_supplied_paths_from_state,
+        )
+        from hyperloom.orchestrator.state.shared_state import SharedState
+
+        repo, scripts = tmp_path / "fw", tmp_path / "sc"
+        repo.mkdir()
+        scripts.mkdir()
+        (scripts / "custom_mi355x.sh").write_text("#!/bin/sh\n")
+        monkeypatch.setenv("FRAMEWORK_REPO_PATH", "")
+        monkeypatch.setenv("HYPERLOOM_BYPASS_SCRIPTS_DIR", "")
+        state = SharedState(
+            session_id="s",
+            framework="custom",
+            framework_repo_path=str(repo),
+            bypass_scripts_dir=str(scripts),
+            benchmark_backend="bypass",
+        )
+
+        _restore_operator_supplied_paths_from_state(self._args(), state)
+        _apply_operator_supplied_paths(self._args(), "custom")
+        assert os.environ["FRAMEWORK_REPO_PATH"] == str(repo)
+        assert os.environ["HYPERLOOM_BYPASS_SCRIPTS_DIR"] == str(scripts)
+
+    def test_a_repassed_flag_outranks_the_archive(self, monkeypatch, tmp_path):
+        from hyperloom.inference_optimizer.cli import (
+            _apply_operator_supplied_paths,
+            _restore_operator_supplied_paths_from_state,
+        )
+        from hyperloom.orchestrator.state.shared_state import SharedState
+
+        archived_scripts = tmp_path / "old"
+        archived_scripts.mkdir()
+        (archived_scripts / "custom_mi355x.sh").write_text("#!/bin/sh\n")
+        new_repo, new_scripts = tmp_path / "fw", tmp_path / "sc"
+        new_repo.mkdir()
+        new_scripts.mkdir()
+        (new_scripts / "custom_mi355x.sh").write_text("#!/bin/sh\n")
+        monkeypatch.setenv("FRAMEWORK_REPO_PATH", "")
+        monkeypatch.setenv("HYPERLOOM_BYPASS_SCRIPTS_DIR", "")
+        state = SharedState(
+            session_id="s",
+            framework="custom",
+            framework_repo_path=str(tmp_path / "old-fw"),
+            bypass_scripts_dir=str(archived_scripts),
+            benchmark_backend="bypass",
+        )
+        args = self._args()
+        args.framework_path = str(new_repo)
+        args.benchmark_scripts_dir = str(new_scripts)
+
+        _restore_operator_supplied_paths_from_state(args, state)
+        _apply_operator_supplied_paths(args, "custom")
+        assert os.environ["HYPERLOOM_BYPASS_SCRIPTS_DIR"] == str(new_scripts.resolve())
+        assert os.environ["FRAMEWORK_REPO_PATH"] == str(new_repo.resolve())
+
+
+class TestCustomAdapterMeasurement:
+    """Handoff probe: custom/native adapter emits nonzero throughput, no harness error."""
+
+    def test_custom_scriptable_run_emits_nonzero_throughput(self, tmp_path, monkeypatch):
+        import yaml
+        from hyperloom.orchestrator.actions.executors import bypass_runner
+
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        (scripts / "custom_mi355x.sh").write_text(
+            "#!/bin/bash\n"
+            'cat > "$RESULT_DIR/$RESULT_FILENAME.json" <<JSON\n'
+            '{"framework": "custom", "workload_kind": "scriptable", '
+            '"throughput_unit": "fps", "output_throughput": 1.29, '
+            '"quality_gate": {"passed": true}}\n'
+            "JSON\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HYPERLOOM_BYPASS_SCRIPTS_DIR", str(scripts))
+        monkeypatch.setenv("HYPERLOOM_BENCHMARK_BACKEND", "bypass")
+
+        cfg = {
+            "benchmark": {
+                "framework": "custom",
+                "model": "/models/custom",
+                "runner_type": "mi355x",
+                "run_mode": "local",
+                "timeout_seconds": 60,
+                "workload_kind": "scriptable",
+                "envs": {"TP": 8},
+            }
+        }
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+
+        rc = bypass_runner.run_benchmark(cfg_path, tmp_path / "out")
+        assert rc == 0
+        ws = sorted((tmp_path / "out").glob("benchmark_custom_*"))[-1]
+        rep = json.loads((ws / "benchmark_report.json").read_text(encoding="utf-8"))
+        assert rep["success"] is True
+        assert float(rep["throughput"]["output_throughput"]) == pytest.approx(1.29)
+
+    def test_an_inert_env_variant_measures_without_a_harness_error(
+        self, tmp_path, monkeypatch
+    ):
+        """A default-off extra_env must still produce a valid measurement (probe 3)."""
+        import asyncio
+        import subprocess
+        import sys
+        from unittest.mock import patch
+
+        from hyperloom.orchestrator.actions.executors._grid_runner import (
+            GridVariant,
+            run_grid,
+        )
+
+        base = tmp_path / "base.yaml"
+        base.write_text(
+            yaml.safe_dump(
+                {
+                    "benchmark": {
+                        "framework": "custom",
+                        "model": "/models/custom",
+                        "workload_kind": "scriptable",
+                        "run_mode": "local",
+                        "envs": {"TP": 8, "HYWORLD_HOIST": "0"},
+                        "timeout_seconds": 60,
+                    }
+                }
+            )
+        )
+
+        def _ok(cmd, *a, **k):
+            slot = Path(cmd[cmd.index("--output-dir") + 1])
+            ws = slot / "benchmark_custom_20260101_000000"
+            ws.mkdir(parents=True, exist_ok=True)
+            (ws / "benchmark_report.json").write_text(
+                json.dumps(
+                    {
+                        "success": True,
+                        "framework": "custom",
+                        "throughput": {
+                            "output_throughput": 1.29,
+                            "completed_requests": 1,
+                            "duration_seconds": 10.0,
+                        },
+                    }
+                )
+            )
+            return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+        monkeypatch.setenv("INFERENCE_OPTIMIZER_RUN_GRID_WARMUP", "0")
+        with patch(
+            "hyperloom.orchestrator.actions.executors._grid_runner.run_with_session_kill",
+            side_effect=_ok,
+        ):
+            results = asyncio.run(
+                run_grid(
+                    base_yaml_path=base,
+                    base_extra_args="",
+                    grid=[
+                        GridVariant(name="baseline"),
+                        GridVariant(
+                            name="inert-off",
+                            extra_envs={"HYWORLD_HOIST": "0"},
+                        ),
+                    ],
+                    output_root=tmp_path / "out",
+                    magpie_python=sys.executable,
+                    variant_timeout_sec=10,
+                    gpu_type="mi355x",
+                )
+            )
+        assert [r.status for r in results] == ["succeeded", "succeeded"]
+        assert all(not r.error_class for r in results)
+        assert not list((tmp_path / "out").glob("variant_*/abort_reason.json"))

--- a/src/hyperloom/inference_optimizer/tests/test_explore_executor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_explore_executor.py
@@ -2468,6 +2468,7 @@ def test_grid_variants_from_payload_carries_removal_controls():
 def test_on_disk_stderr_tail_reads_benchmark_stderr_log(tmp_path):
     from hyperloom.orchestrator.actions.executors._grid_runner import (
         _on_disk_stderr_tail,
+        _report_errors_summary,
     )
 
     (tmp_path / "benchmark_stderr.log").write_text(
@@ -2477,6 +2478,14 @@ def test_on_disk_stderr_tail_reads_benchmark_stderr_log(tmp_path):
     assert "unrecognized arguments" in tail
     # Empty dir → empty string (caller keeps its original blank error).
     assert _on_disk_stderr_tail(tmp_path / "nope") == ""
+    assert _report_errors_summary(None) == ""
+    assert _report_errors_summary({"errors": []}) == ""
+    assert (
+        _report_errors_summary(
+            {"errors": ["scriptable benchmark script not found for custom_mi355x.sh"]}
+        )
+        == "scriptable benchmark script not found for custom_mi355x.sh"
+    )
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner_behavior_lock.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner_behavior_lock.py
@@ -465,6 +465,38 @@ class TestKeepGoingAsymmetry:
         assert results[0].error_class == "magpie_nonzero_invalid_measurement"
         assert results[0].returncode == 1
 
+    def test_rc_nonzero_blank_pipe_uses_report_errors(self, tmp_path, monkeypatch):
+        """Pre-spawn miss: empty pipe + empty logs, diagnostic lives in report.errors."""
+        monkeypatch.setenv("INFERENCE_OPTIMIZER_RUN_GRID_WARMUP", "0")
+        base = tmp_path / "base.yaml"
+        _write_base_yaml(base)
+
+        def _blank_rc2(cmd, *a, **k):
+            out_idx = cmd.index("--output-dir")
+            slot = Path(cmd[out_idx + 1])
+            ws = slot / "benchmark_sglang_20260101_000000"
+            ws.mkdir(parents=True, exist_ok=True)
+            (ws / "benchmark_report.json").write_text(
+                json.dumps(
+                    {
+                        "success": False,
+                        "framework": "sglang",
+                        "errors": [
+                            "scriptable benchmark script not found for custom_mi355x.sh"
+                        ],
+                    }
+                )
+            )
+            return subprocess.CompletedProcess(cmd, 2, "", "")
+
+        results = self._run(_blank_rc2, base, tmp_path / "out")
+        assert len(results) == 1
+        assert results[0].error_class == "magpie_nonzero_invalid_measurement"
+        assert "custom_mi355x.sh" in (results[0].error or "")
+        marker_path = next((tmp_path / "out").glob("variant_*/abort_reason.json"))
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+        assert "custom_mi355x.sh" in marker["error"]
+
 
 # ---------------------------------------------------------------------------
 # auto-warmup teardown timing

--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner_behavior_lock.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner_behavior_lock.py
@@ -466,7 +466,13 @@ class TestKeepGoingAsymmetry:
         assert results[0].returncode == 1
 
     def test_rc_nonzero_blank_pipe_uses_report_errors(self, tmp_path, monkeypatch):
-        """Pre-spawn miss: empty pipe + empty logs, diagnostic lives in report.errors."""
+        """Last-resort: empty pipe and no log files, diagnostic only in report.errors.
+
+        The live scriptable miss writes ``scriptable_stderr.log`` (then aliased
+        to ``benchmark_stderr.log``), so the on-disk log fallback fires first.
+        This fixture is the remaining contract: abort_reason.json still gets
+        ``error`` when nothing on disk exists except the report.
+        """
         monkeypatch.setenv("INFERENCE_OPTIMIZER_RUN_GRID_WARMUP", "0")
         base = tmp_path / "base.yaml"
         _write_base_yaml(base)

--- a/src/hyperloom/inference_optimizer/tests/test_resume.py
+++ b/src/hyperloom/inference_optimizer/tests/test_resume.py
@@ -731,3 +731,25 @@ class TestTracelensRootEnvCorrection:
         good.mkdir()
         monkeypatch.setenv("TRACELENS_ROOT", str(good))
         cli_preflight._check_tracelens_root_exists()
+
+
+@pytest.mark.asyncio
+async def test_resume_preserves_custom_workload_paths(session_dir):
+    """Coordinator reload must not drop the paths a custom resume re-exports."""
+    SharedState(
+        session_id="custom-resume",
+        framework="custom",
+        bypass_scripts_dir="/opt/worldplay/scripts",
+        framework_repo_path="/opt/worldplay/src",
+        benchmark_backend="bypass",
+    ).save(session_dir)
+
+    coordinator = Coordinator(session_dir, backends=_backends_full())
+    try:
+        state = coordinator.shared_state
+        assert state.framework == "custom"
+        assert state.bypass_scripts_dir == "/opt/worldplay/scripts"
+        assert state.framework_repo_path == "/opt/worldplay/src"
+        assert state.benchmark_backend == "bypass"
+    finally:
+        await coordinator.stop()

--- a/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
@@ -2616,6 +2616,12 @@ async def run_grid(
                 # actual failure instead of a blank `error`.
                 if not error.strip():
                     error = redact_secret_values(_on_disk_stderr_tail(workspace, slot))
+                # Bypass writes the real diagnostic into benchmark_report.json
+                # ``errors`` on a pre-spawn miss (script not found) before any
+                # log file exists. Read it last so abort_reason.json is never
+                # blank when the report already named the failure.
+                if not error.strip():
+                    error = redact_secret_values(_report_errors_summary(report))
                 invalid_class = "magpie_nonzero_invalid_measurement"
             elif not report:
                 error = death_excerpt or "benchmark_report missing"
@@ -2789,6 +2795,30 @@ def _write_variant_abort_marker(
         error_summary=error_summary,
         extra_args=extra_args,
     )
+
+
+def _report_errors_summary(report: dict[str, Any] | None, limit: int = 2000) -> str:
+    """Join ``benchmark_report.json`` ``errors`` into a single diagnostic.
+
+    The bypass scriptable path records a pre-spawn miss (missing entrypoint)
+    here and nowhere else when the child logs were never opened. Empty or
+    non-list ``errors`` yield ``""`` so callers can chain this after the
+    on-disk log fallback.
+
+    Args:
+        report: Parsed ``benchmark_report.json`` mapping, or None.
+        limit: Max characters returned (tail).
+
+    Returns:
+        Joined error strings, or ``""``.
+    """
+    if not isinstance(report, dict):
+        return ""
+    errors = report.get("errors")
+    if not isinstance(errors, list):
+        return ""
+    text = "; ".join(str(item).strip() for item in errors if str(item).strip())
+    return text[-limit:] if text else ""
 
 
 def _on_disk_stderr_tail(*dirs: Path, limit: int = 2000) -> str:

--- a/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
@@ -2616,10 +2616,12 @@ async def run_grid(
                 # actual failure instead of a blank `error`.
                 if not error.strip():
                     error = redact_secret_values(_on_disk_stderr_tail(workspace, slot))
-                # Bypass writes the real diagnostic into benchmark_report.json
-                # ``errors`` on a pre-spawn miss (script not found) before any
-                # log file exists. Read it last so abort_reason.json is never
-                # blank when the report already named the failure.
+                # Last resort: report.errors when the pipe and on-disk logs are
+                # all empty. Scriptable pre-spawn miss normally hits the log
+                # fallback (run_scriptable writes scriptable_stderr.log, then
+                # write_log_aliases copies it to benchmark_stderr.log). This
+                # rung covers log-write OSError and other backends that named
+                # the failure only in the report.
                 if not error.strip():
                     error = redact_secret_values(_report_errors_summary(report))
                 invalid_class = "magpie_nonzero_invalid_measurement"
@@ -2800,10 +2802,10 @@ def _write_variant_abort_marker(
 def _report_errors_summary(report: dict[str, Any] | None, limit: int = 2000) -> str:
     """Join ``benchmark_report.json`` ``errors`` into a single diagnostic.
 
-    The bypass scriptable path records a pre-spawn miss (missing entrypoint)
-    here and nowhere else when the child logs were never opened. Empty or
-    non-list ``errors`` yield ``""`` so callers can chain this after the
-    on-disk log fallback.
+    Last-resort fallback after the parent pipe and on-disk logs: the report
+    may still name the failure when log writes were swallowed (``OSError``)
+    or another backend never opened a log. Empty or non-list ``errors``
+    yield ``""`` so callers can chain this after ``_on_disk_stderr_tail``.
 
     Args:
         report: Parsed ``benchmark_report.json`` mapping, or None.

--- a/src/hyperloom/orchestrator/actions/executors/bypass_scriptable.py
+++ b/src/hyperloom/orchestrator/actions/executors/bypass_scriptable.py
@@ -35,6 +35,56 @@ def _scriptable_script_name(framework: str, runner_type: str) -> str:
     return f"{framework}_{runner_type}.sh"
 
 
+def scriptable_script_candidates(
+    framework: str,
+    runner_type: str,
+    inferencex_root: str,
+    bench: dict[str, Any] | None = None,
+) -> list[Path]:
+    """Return the search list ``resolve_scriptable_script`` walks, in order.
+
+    The list is the forensic trail for a miss: launch-time fail-fast and the
+    pre-spawn rc=2 path both print it so the operator can see which drawers
+    were opened. Existence is not checked here.
+
+    Args:
+        framework: Scriptable framework name (e.g. xdit).
+        runner_type: GPU runner (e.g. mi300x).
+        inferencex_root: InferenceX checkout root (fallback location).
+        bench: Materialized benchmark section; absolute ``benchmark_script``
+            is listed first when present.
+
+    Returns:
+        Candidate paths in resolution order, duplicates dropped.
+    """
+    candidates: list[Path] = []
+    seen: set[str] = set()
+
+    def _add(path: Path) -> None:
+        key = str(path)
+        if key in seen:
+            return
+        seen.add(key)
+        candidates.append(path)
+
+    explicit = str((bench or {}).get("benchmark_script") or "").strip()
+    if explicit:
+        _add(Path(explicit))
+    name = _scriptable_script_name(framework, runner_type)
+    override = os.environ.get("HYPERLOOM_BYPASS_SCRIPTS_DIR", "").strip()
+    if override:
+        _add(Path(override) / name)
+    # Bundled entrypoints are version-matched to this checkout, so they must be
+    # reachable by name too: any rebuild path that re-pins the bare
+    # {framework}_{runner}.sh would otherwise resolve to nothing.
+    _add(asset_root() / "assets" / "benchmark_scripts" / name)
+    magpie_path = os.environ.get("MAGPIE_PATH", "").strip()
+    if magpie_path:
+        _add(Path(magpie_path, "Magpie", "scripts", "benchmark", name))
+    _add(Path(inferencex_root, "benchmarks", name))
+    return candidates
+
+
 def resolve_scriptable_script(
     framework: str,
     runner_type: str,
@@ -53,27 +103,11 @@ def resolve_scriptable_script(
     Returns:
         The resolved script path, or None when not found.
     """
-    explicit = str((bench or {}).get("benchmark_script") or "").strip()
-    if explicit:
-        explicit_path = Path(explicit)
-        if explicit_path.is_file():
-            return explicit_path
-    name = _scriptable_script_name(framework, runner_type)
-    candidates: list[Path] = []
-    override = os.environ.get("HYPERLOOM_BYPASS_SCRIPTS_DIR", "").strip()
-    if override:
-        candidates.append(Path(override) / name)
-    # Bundled entrypoints are version-matched to this checkout, so they must be
-    # reachable by name too: any rebuild path that re-pins the bare
-    # {framework}_{runner}.sh would otherwise resolve to nothing.
-    candidates.append(asset_root() / "assets" / "benchmark_scripts" / name)
-    magpie_path = os.environ.get("MAGPIE_PATH", "").strip()
-    if magpie_path:
-        candidates.append(Path(magpie_path, "Magpie", "scripts", "benchmark", name))
-    candidates.append(Path(inferencex_root, "benchmarks", name))
-    for c in candidates:
-        if c.is_file():
-            return c
+    for candidate in scriptable_script_candidates(
+        framework, runner_type, inferencex_root, bench
+    ):
+        if candidate.is_file():
+            return candidate
     return None
 
 
@@ -145,7 +179,18 @@ def run_scriptable(
     """
     script = resolve_scriptable_script(framework, runner_type, inferencex_root, bench)
     if script is None:
-        return 2, f"scriptable benchmark script not found for {framework}_{runner_type}.sh"
+        name = _scriptable_script_name(framework, runner_type)
+        candidates = scriptable_script_candidates(
+            framework, runner_type, inferencex_root, bench
+        )
+        tried = "\n".join(f"  - {path}" for path in candidates) or "  (none)"
+        error = f"scriptable benchmark script not found for {name}"
+        # Pre-spawn miss never opens Popen, so there is no child stderr. Write
+        # the search list onto the scriptable log so grid_runner's on-disk
+        # fallback (and the Magpie-compatible alias write_report builds) can
+        # carry the diagnostic instead of a blank abort_reason.json.
+        _write_logs(workspace, "", f"{error}\ntried:\n{tried}\n")
+        return 2, error
     env = build_scriptable_env(bench, runner_type, workspace, profile=profile, profile_dir=profile_dir)
     cmd = ["bash", str(script)]
     # Streamed straight to disk instead of captured in memory: a runner killed
@@ -195,6 +240,7 @@ def _write_logs(workspace: Path, stdout: str, stderr: str, *, append: bool = Fal
     """
     mode = "a" if append else "w"
     try:
+        workspace.mkdir(parents=True, exist_ok=True)
         if stdout:
             with (workspace / "scriptable_stdout.log").open(mode, encoding="utf-8") as fh:
                 fh.write(stdout)

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -657,6 +657,14 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
     operator_server_args: str = ""
     # ``--extra-env NAME=VALUE`` pins.
     operator_extra_env: dict[str, str] = field(default_factory=dict)
+    # Operator-supplied custom-workload paths. Fresh launch publishes them as
+    # env from ``--framework-path`` / ``--benchmark-scripts-dir``; a resume
+    # that does not re-pass those flags must re-export them from here or the
+    # scriptable runner cannot find the entrypoint (rc=2, no measurement).
+    bypass_scripts_dir: str = ""
+    framework_repo_path: str = ""
+    # ``HYPERLOOM_BENCHMARK_BACKEND`` at seed time (``bypass`` for custom).
+    benchmark_backend: str = ""
     # ``--nodes``, feeding the robustness defaults and the IR-8 check. NOT the
     # cluster hand-off, which is resolved from argv before this state loads.
     nodes: int = 1


### PR DESCRIPTION
## Description
`--resume-from` ignored `--benchmark-scripts-dir` / `--framework-path`. Those
flags are only published in the fresh-launch branch, and the paths were not
persisted in session state. After a preempted WorldPlay 24h run, every later
`sweep` / `integrate_patch` / parity variant exited in ~2s with
`magpie_nonzero_invalid_measurement (rc=2)` and a blank error, so Hyperloom
could not score candidates and reverted them.
The rc=2 came from `run_scriptable()` returning before spawn when
`resolve_scriptable_script()` missed every candidate (hard-coded "script not
found"). The diagnostic was written to `benchmark_report.json` `errors` but
grid_runner only looked at server.log, the parent pipe, and
`benchmark_stderr.log`.
This PR:
- Re-applies operator-supplied paths on resume (CLI flag > env > archived state)
- Persists `bypass_scripts_dir` / `framework_repo_path` / `benchmark_backend`
  on SharedState so a resume that omits the flags still works
- Fail-fast at launch when `--framework custom` cannot resolve its entrypoint,
  listing the paths that were tried
- Surfaces the report `errors` and writes the candidate list to
  `scriptable_stderr.log` so `abort_reason.json` is no longer blank
Not in this PR (separate follow-ups): GEAK `BENCH_CLIENT=inferencex` for custom
workloads; resume phase-budget reanchor; idempotent CLOSE.
## Linked issue(s)
No GitHub issue. Reported via the HY-WorldPlay 24h team handoff
(session `9b49404b…/20260816T181213Z`): after two preemptions, resume could not
verify further candidates. Validated stack was +332% (0.30 → 1.29 fps) and is
unaffected.
## Tests
Added/updated:
- `test_custom_framework.py` — resume re-pass vs archive restore; launch
  fail-fast with candidate list; custom adapter nonzero throughput; inert
  extra_env variant does not harness-fail
- `test_cli_resume_launch_shape.py` — SharedState round-trip + old-session defaults
- `test_resume.py` — Coordinator reload keeps the new fields
- `test_bypass_backend.py` — missing script writes `scriptable_stderr.log`
- `test_grid_runner_behavior_lock.py` — blank pipe uses report `errors` in
  `abort_reason.json`
- `test_cli_bootstrap.py` / `test_explore_executor.py` — seed + report-errors helper
Commands run:
pytest -q
src/hyperloom/inference_optimizer/tests/test_custom_framework.py
src/hyperloom/inference_optimizer/tests/test_cli_resume_launch_shape.py
src/hyperloom/inference_optimizer/tests/test_cli_bootstrap.py
src/hyperloom/inference_optimizer/tests/test_shared_state_persistence.py
src/hyperloom/inference_optimizer/tests/test_bypass_backend.py
src/hyperloom/inference_optimizer/tests/test_grid_runner_behavior_lock.py
src/hyperloom/inference_optimizer/tests/test_resume.py
188 passed.
## Breaking changes
No. Old `state.json` without the new fields loads as empty strings.
`--framework custom` now exits at launch if the entrypoint cannot be resolved
(previously it would start and fail every measurement). That is intentional.