### PR TITLE
feat(geak): keep the candidate's measurement basis past the rebench

### DIFF
--- a/src/hyperloom/inference_optimizer/breakdown/collectors/sessions.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/sessions.py
@@ -1293,6 +1293,13 @@ def collect_final(
         # main-flow rebench; surfaced as an audit-only note and EXCLUDED from the
         # headline gain. Empty on native/validated sessions.
         "geak_pending": (dict(state.get("geak_pending") or {}) if isinstance(state.get("geak_pending"), dict) else {}),
+        # The same candidate after the rebench settled it: GEAK's self-reported
+        # figures and measurement basis kept beside the measured outcome, which
+        # is what makes the two numbers reconcilable. Empty until a rebench
+        # resolves the candidate, and on sessions GEAK never engaged.
+        "geak_resolved": (
+            dict(state.get("geak_resolved") or {}) if isinstance(state.get("geak_resolved"), dict) else {}
+        ),
         "validated_at_stack_len": val_stack_len,
         "validated_ts": str(state.get("cumulative_gain_validated_ts") or ""),
         "stack_changed_after_validation": stack_len > val_stack_len > 0,

--- a/src/hyperloom/inference_optimizer/tests/test_geak_gain_alignment.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_gain_alignment.py
@@ -547,6 +547,145 @@ def test_promote_from_candidate_writes_measured_headline(tmp_path: Path) -> None
     assert not ss.geak_pending
 
 
+# ── the candidate's own numbers survive the pending record being cleared ─────
+
+
+def _aligned_result(*, final: float) -> dict:
+    """An ``_ok_result`` carrying the raw tok/s behind each speedup."""
+    result = _ok_result(final=final)
+    result["alignment_metrics"] = {
+        "final_basis": "cold",
+        "cold_geak_speedup": 1.1088,
+        "cold_speedup": 1.0903,
+        "hot_geak_speedup": 1.1499,
+        "hot_speedup": None,
+        "geak_cold_baseline_tok_s": 3081.699,
+        "geak_cold_final_tok_s": 3417.0,
+        "orchestrator_cold_baseline_tok_s": 3065.102,
+        "orchestrator_hot_baseline_tok_s": None,
+    }
+    result["accepted_heads"] = [{"short_name": "attn_stage1", "e2e_delta_pct": 14.04}]
+    return result
+
+
+def test_promote_keeps_both_sides_of_the_comparison(tmp_path: Path) -> None:
+    """A promote leaves the measured gain beside the self-reported one it beat.
+
+    The measured number alone cannot be reconciled against GEAK's claim, and
+    the claim lived only on ``geak_pending``, which the promote clears.
+    """
+    base, measured = 2844.209, 3270.0
+    coord = _coord(tmp_path, baseline=base, best_tput=3042.941)
+    result = _aligned_result(final=3236.489)
+    coord.shared_state.geak_result = result
+    coord._record_geak_candidate(result)
+    coord._promote_geak_from_candidate(result, measured_tput=measured)
+
+    resolved = coord.shared_state.geak_resolved
+    assert resolved["outcome"] == "promoted"
+    assert resolved["measured_tput"] == pytest.approx(measured)
+    assert resolved["measured_gain_pct"] == pytest.approx((measured - base) / base * 100.0)
+    assert resolved["self_reported_tput"] == pytest.approx(3236.489)
+    assert resolved["self_reported_gain_pct"] == pytest.approx((3236.489 - base) / base * 100.0)
+    # The baseline both gains divide by, so neither rests on its label alone.
+    assert resolved["baseline_tput"] == pytest.approx(base)
+    assert resolved["accepted_heads"][0]["e2e_delta_pct"] == pytest.approx(14.04)
+
+
+def test_alignment_snapshot_carries_the_baselines_behind_each_speedup(tmp_path: Path) -> None:
+    """The raw tok/s travel with the ratios.
+
+    A speedup on its own cannot say whether the two harnesses disagreed or the
+    kernel did: ``orchestrator_cold_baseline_tok_s`` beside
+    ``geak_cold_baseline_tok_s`` is what separates the two.
+    """
+    coord = _coord(tmp_path, baseline=2844.209, best_tput=3042.941)
+    result = _aligned_result(final=3236.489)
+    coord._record_geak_candidate(result)
+    coord._promote_geak_from_candidate(result, measured_tput=3270.0)
+
+    alignment = coord.shared_state.geak_resolved["alignment"]
+    assert alignment["final_basis"] == "cold"
+    assert alignment["cold_geak_speedup"] == pytest.approx(1.1088)
+    assert alignment["cold_speedup"] == pytest.approx(1.0903)
+    assert alignment["geak_cold_baseline_tok_s"] == pytest.approx(3081.699)
+    assert alignment["orchestrator_cold_baseline_tok_s"] == pytest.approx(3065.102)
+    # A regime GEAK could not compare across stays None rather than absent, so
+    # the reader can tell "not measured" from "not carried".
+    assert alignment["hot_speedup"] is None
+    assert "orchestrator_hot_baseline_tok_s" in alignment
+
+
+def test_resolution_prefers_the_candidate_time_alignment(tmp_path: Path) -> None:
+    """``geak_result`` is overwritten in place by whatever GEAK ran last.
+
+    A later failed run leaves an error stub with no ``alignment_metrics``, so
+    reading the basis from it at resolve time would lose the very numbers the
+    comparison needs. The pending record snapshotted them when the candidate
+    was accepted.
+    """
+    coord = _coord(tmp_path, baseline=2844.209, best_tput=3042.941)
+    coord._record_geak_candidate(_aligned_result(final=3236.489))
+    stub = {"status": "error", "error_class": "runner_timeout", "error": "timed out"}
+    coord.shared_state.geak_result = stub
+
+    coord._record_geak_resolution(
+        stub,
+        outcome="promoted",
+        measured_tput=3270.0,
+        provenance="geak_orch_harness_validated",
+    )
+
+    alignment = coord.shared_state.geak_resolved["alignment"]
+    assert alignment["cold_geak_speedup"] == pytest.approx(1.1088)
+    assert alignment["orchestrator_cold_baseline_tok_s"] == pytest.approx(3065.102)
+
+
+def test_rejected_rebench_records_what_was_dropped_and_why(tmp_path: Path) -> None:
+    """A measured rebench that loses to current_best still explains itself."""
+    base, current_best, measured = 7380.7, 10067.9, 9623.0
+    coord = _coord(tmp_path, baseline=base, best_tput=current_best)
+    result = _aligned_result(final=10500.0)
+    coord.shared_state.geak_result = result
+    coord._record_geak_candidate(result)
+    coord._promote_geak_from_candidate(result, measured_tput=measured)
+
+    resolved = coord.shared_state.geak_resolved
+    assert resolved["outcome"] == "rejected"
+    assert resolved["reason"] == "rebench_did_not_beat_current_best"
+    assert resolved["measured_tput"] == pytest.approx(measured)
+    assert resolved["self_reported_tput"] == pytest.approx(10500.0)
+    assert not coord.shared_state.geak_pending
+
+
+def test_final_section_carries_the_resolved_candidate(tmp_path: Path) -> None:
+    """The reconciliation reaches the breakdown, not just the state."""
+    from hyperloom.inference_optimizer.breakdown.collectors.sessions import collect_final
+
+    coord = _coord(tmp_path, baseline=2844.209, best_tput=3042.941)
+    result = _aligned_result(final=3236.489)
+    coord.shared_state.geak_result = result
+    coord._record_geak_candidate(result)
+    coord._promote_geak_from_candidate(result, measured_tput=3270.0)
+
+    state = {
+        "current_best": coord.shared_state.current_best,
+        "geak_pending": coord.shared_state.geak_pending,
+        "geak_resolved": coord.shared_state.geak_resolved,
+    }
+    final = collect_final(tmp_path, state, [])
+    assert final["geak_pending"] == {}
+    assert final["geak_resolved"]["outcome"] == "promoted"
+    assert final["geak_resolved"]["alignment"]["cold_speedup"] == pytest.approx(1.0903)
+
+
+def test_final_section_stays_empty_when_geak_never_ran(tmp_path: Path) -> None:
+    """Sessions GEAK never touched gain an empty key, not a half-filled one."""
+    from hyperloom.inference_optimizer.breakdown.collectors.sessions import collect_final
+
+    assert collect_final(tmp_path, {"current_best": {}}, [])["geak_resolved"] == {}
+
+
 def test_report_shows_pending_candidate_excluded_from_headline() -> None:
     """A pending GEAK candidate renders as an audit note + warning and is
     NOT presented as a validated headline gain."""

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -993,6 +993,7 @@ class Coordinator(metaclass=_CoordinatorMeta):
         "_geak_win_already_recorded": "phase_kernel",
         "_parse_geak_accepted_config": "phase_kernel",
         "_record_geak_candidate": "phase_kernel",
+        "_record_geak_resolution": "phase_kernel",
         "_promote_geak_from_candidate": "phase_kernel",
         "_record_geak_kernel_journey": "phase_kernel",
         "_ck_blockscale_switch_eligible": "phase_kernel",

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -894,6 +894,13 @@ class WritebackCollaborator:
                     result_payload.get("error") or result_payload.get("reason") or ""
                 )[:500]
                 self.shared_state.geak_result = geak_result
+                self.phase_kernel._record_geak_resolution(
+                    geak_result,
+                    outcome="dropped",
+                    measured_tput=None,
+                    provenance="geak_rebench_failed",
+                    reason=str(geak_result.get("revalidation_error") or ""),
+                )
                 self.shared_state.geak_pending = {}
                 self.shared_state.resume_pending_revalidation = False
                 any_changed = True
@@ -3703,6 +3710,13 @@ class WritebackCollaborator:
                         )
                     except Exception:  # noqa: BLE001 - journey reject is best-effort
                         log.exception("geak no_material: journey rejection failed")
+                    self.phase_kernel._record_geak_resolution(
+                        ps_stamped,
+                        outcome="no_material",
+                        measured_tput=float(measured),
+                        provenance="geak_no_material",
+                        reason="geak_no_material_product",
+                    )
                     self.shared_state.geak_pending = {}
                     self.shared_state.resume_pending_revalidation = False
                 elif decision == "no_promote":
@@ -3731,6 +3745,13 @@ class WritebackCollaborator:
                         )
                     except Exception:  # noqa: BLE001 - observation is best-effort
                         log.exception("geak no_promote: observation emit failed")
+                    self.phase_kernel._record_geak_resolution(
+                        self.shared_state.geak_result,
+                        outcome="rejected",
+                        measured_tput=float(measured),
+                        provenance="geak_no_promote",
+                        reason="rebench_did_not_beat_current_best",
+                    )
                     self.shared_state.geak_pending = {}
                     self.shared_state.resume_pending_revalidation = False
                 else:
@@ -3792,6 +3813,13 @@ class WritebackCollaborator:
                             or "GEAK harness fallback did not validate"
                         )[:500]
                         self.shared_state.geak_result = geak_result
+                        self.phase_kernel._record_geak_resolution(
+                            geak_result,
+                            outcome="dropped",
+                            measured_tput=None,
+                            provenance="geak_same_harness_geak",
+                            reason=str(geak_result.get("revalidation_error") or ""),
+                        )
                         self.shared_state.geak_pending = {}
                         self.shared_state.resume_pending_revalidation = False
                 changed = True

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -55,6 +55,25 @@ _CONTAINER_AITER_CONFIG_DIR = Path("/sgl-workspace/aiter/aiter/configs")
 # pending revalidation while the enqueue is in flight.
 _GEAK_REVALIDATE_IDEMPOTENCY_KEY = "geak-revalidate"
 
+# Keys copied verbatim out of GEAK's ``alignment_metrics``. The four speedups
+# are each a ratio against a baseline the reader cannot see, so the raw tok/s
+# travel with them: ``orchestrator_cold_baseline_tok_s`` is the same figure the
+# rebench measures against, which makes its distance from
+# ``geak_cold_baseline_tok_s`` the cross-harness term itself rather than an
+# inference about one.
+_GEAK_ALIGNMENT_KEYS: tuple[str, ...] = (
+    "hot_geak_speedup",
+    "cold_geak_speedup",
+    "hot_speedup",
+    "cold_speedup",
+    "geak_hot_baseline_tok_s",
+    "geak_hot_final_tok_s",
+    "geak_cold_baseline_tok_s",
+    "geak_cold_final_tok_s",
+    "orchestrator_hot_baseline_tok_s",
+    "orchestrator_cold_baseline_tok_s",
+)
+
 # Which table each aiter config env var is resolved under at serving time. Two
 # callers need it: the merge step, which has to find the runtime table to merge
 # our candidate into, and the apply check, which has to recognise our artifact
@@ -1285,7 +1304,6 @@ class KernelPhase(PhaseHandler):
         accepted_flags, parsed_envs = self._parse_geak_accepted_config(result)
         base = float(self.shared_state.baseline_tput or 0.0)
         self_gain = ((new_tput - base) / base * 100.0) if base > 0 else None
-        am = result.get("alignment_metrics") or {}
         self.shared_state.geak_pending = {
             "status": "awaiting_rebench",
             # Audit-only self-reported numbers (not the headline until rebench).
@@ -1300,6 +1318,7 @@ class KernelPhase(PhaseHandler):
             # pending record, so a later promotion can name what it adopted
             # without re-reading result.json.
             "accepted_kernels": result.get("accepted_kernels") or [],
+            "accepted_heads": result.get("accepted_heads") or [],
             "geak_status": str(result.get("status") or ""),
             "baseline_alignment_status": str((result.get("baseline_alignment") or {}).get("status") or ""),
             "final_overlay": result.get("final_overlay") or "",
@@ -1307,14 +1326,7 @@ class KernelPhase(PhaseHandler):
             "bench_script": result.get("bench_script"),
             "eval_dir": result.get("eval_dir"),
             # GEAK's own within-harness speedups, for the report's audit cross-check.
-            "alignment": {
-                "hot_geak_speedup": am.get("hot_geak_speedup"),
-                "cold_geak_speedup": am.get("cold_geak_speedup"),
-                "hot_speedup": am.get("hot_speedup"),
-                "cold_speedup": am.get("cold_speedup"),
-                "final_basis": am.get("final_basis") or result.get("final_throughput_basis"),
-                "geak_throughput_speedup": result.get("throughput_speedup"),
-            },
+            "alignment": self._geak_alignment_snapshot(result),
             "ts": datetime.now(timezone.utc).isoformat(),
         }
         # Surface a large cross-harness measurement divergence as a warning only.
@@ -1332,6 +1344,108 @@ class KernelPhase(PhaseHandler):
                 float(mdiv),
                 _GEAK_MEASUREMENT_DIVERGENCE_WARN_PCT,
             )
+
+    @staticmethod
+    def _geak_alignment_snapshot(result: dict[str, Any]) -> dict[str, Any]:
+        """Copy GEAK's measurement basis out of ``result.json``.
+
+        Args:
+            result: GEAK's ``result.json`` payload.
+
+        Returns:
+            dict[str, Any]: The keys in :data:`_GEAK_ALIGNMENT_KEYS` plus the
+            basis GEAK promoted on and its own headline speedup. A value is
+            ``None`` where GEAK did not measure that regime, which is itself
+            the answer to why a cross-harness ratio is missing.
+        """
+        am = result.get("alignment_metrics")
+        if not isinstance(am, Mapping):
+            am = {}
+        snapshot: dict[str, Any] = {key: am.get(key) for key in _GEAK_ALIGNMENT_KEYS}
+        snapshot["final_basis"] = am.get("final_basis") or result.get("final_throughput_basis")
+        snapshot["geak_throughput_speedup"] = result.get("throughput_speedup")
+        return snapshot
+
+    def _record_geak_resolution(
+        self,
+        result: dict[str, Any],
+        *,
+        outcome: str,
+        measured_tput: float | None,
+        provenance: str,
+        reason: str = "",
+    ) -> None:
+        """Keep the candidate's own numbers past the point ``geak_pending`` is dropped.
+
+        ``geak_pending`` is the only place GEAK's self-reported figures and the
+        basis it measured them on survive, and every resolution path empties
+        it. What reached the breakdown afterwards was a measured gain beside a
+        self-reported one with nothing to account for the distance between
+        them. Writing both sides plus the basis here — at the same point the
+        pending record is cleared — is what makes that distance attributable
+        rather than merely visible.
+
+        The pending record is preferred over ``result`` for every figure it
+        holds. ``geak_result`` is overwritten in place by whatever GEAK ran
+        last, so by the time a rebench settles it can be an error stub with no
+        ``alignment_metrics`` left, while the pending record still carries the
+        snapshot taken when the candidate was accepted.
+
+        Args:
+            result: GEAK's ``result.json`` payload, used where the pending
+                record is missing or was never written.
+            outcome: ``promoted`` when the rebench wrote the headline,
+                otherwise why the candidate was let go.
+            measured_tput: The rebench measurement, when one was taken.
+            provenance: Which validation path produced the outcome.
+            reason: Free-text detail behind a non-promoted outcome.
+        """
+        pending = self.shared_state.geak_pending
+        pending = dict(pending) if isinstance(pending, Mapping) else {}
+        if not isinstance(result, Mapping):
+            result = {}
+        baseline = float(self.shared_state.baseline_tput or 0.0)
+        try:
+            self_tput = float(
+                pending.get("self_reported_tput") or result.get("final_throughput_tok_s") or 0.0
+            )
+        except (TypeError, ValueError):
+            self_tput = 0.0
+        self_gain = pending.get("self_reported_gain_pct")
+        if self_gain is None and baseline > 0 and self_tput > 0:
+            self_gain = (self_tput - baseline) / baseline * 100.0
+        measured_gain = None
+        if measured_tput and baseline > 0:
+            measured_gain = (measured_tput - baseline) / baseline * 100.0
+        alignment = pending.get("alignment")
+        if not isinstance(alignment, Mapping) or not alignment:
+            alignment = self._geak_alignment_snapshot(result)
+        self.shared_state.geak_resolved = {
+            "outcome": outcome,
+            "reason": reason,
+            "provenance": provenance,
+            # The denominator both gains are taken against, so neither has to
+            # be trusted on its label alone.
+            "baseline_tput": baseline or None,
+            "measured_tput": measured_tput,
+            "measured_gain_pct": measured_gain,
+            "self_reported_tput": self_tput or None,
+            "self_reported_gain_pct": self_gain,
+            "self_reported_speedup": (
+                pending.get("self_reported_speedup") or result.get("throughput_speedup")
+            ),
+            "self_reported_basis": (
+                pending.get("self_reported_basis") or result.get("final_throughput_basis")
+            ),
+            # GEAK's self-report, unconditionally: the stack entry carries these
+            # only when the overlay was proven loaded, which is the right bar
+            # for crediting a kernel but the wrong one for showing what GEAK
+            # claimed.
+            "accepted_heads": (pending.get("accepted_heads") or result.get("accepted_heads") or []),
+            "alignment": dict(alignment),
+            "eval_dir": pending.get("eval_dir") or result.get("eval_dir"),
+            "ts": datetime.now(timezone.utc).isoformat(),
+        }
 
     @staticmethod
     def _geak_stack_entry_extra(
@@ -1447,6 +1561,13 @@ class KernelPhase(PhaseHandler):
                     "geak v4 final validation rejection recording failed",
                     exc_info=True,
                 )
+            self._record_geak_resolution(
+                result,
+                outcome="rejected",
+                measured_tput=measured,
+                provenance="geak_promote_rejected",
+                reason="rebench_did_not_beat_current_best",
+            )
             self.shared_state.geak_pending = {}
             self.shared_state.resume_pending_revalidation = False
             return
@@ -1481,6 +1602,12 @@ class KernelPhase(PhaseHandler):
                 measured,
                 source="geak_e2e_promote",
             )
+        self._record_geak_resolution(
+            result,
+            outcome="promoted",
+            measured_tput=measured,
+            provenance=provenance,
+        )
         self.shared_state.resume_pending_revalidation = False
         self.shared_state.geak_pending = {}
         try:

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -689,6 +689,12 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
     # main-flow rebench; kept OUT of current_best / optimization_stack / the
     # headline gain until validated. Cleared once promoted from a measured rebench.
     geak_pending: dict[str, Any] = field(default_factory=dict)
+    # What ``geak_pending`` held once the rebench settled it, plus the measured
+    # outcome. Every resolution path clears the pending record, so without this
+    # the self-reported figures and the basis they were taken on are gone by
+    # the time anything reads the session, leaving the gap between GEAK's claim
+    # and the measurement unexplainable.
+    geak_resolved: dict[str, Any] = field(default_factory=dict)
     # Tput watermark for gain-driven roofline refresh; Coordinator re-enqueues at a compound 10% step.
     last_roofline_tput: float = 0.0
     stop_reason: str = ""


### PR DESCRIPTION
## Why

A GEAK session ends with two numbers that disagree: the delta GEAK reports per accepted head, and the gain the orchestrator measures when it re-benches the whole accepted config. Today the breakdown carries both and nothing else, so the gap is visible but not attributable.

The data that explains it already exists. GEAK records an `alignment_metrics` block holding its own speedup over its own baseline *and* the same optimized throughput scored against the orchestrator's baseline. Hyperloom copies it into `state.geak_pending` — and then every path that settles the candidate clears that record to `{}`.

Checked against production: **0 of 160** GEAK-active breakdowns retain the alignment after a rebench settles, and the three sessions that actually have a measured gain are exactly the three that lost it.

## What changed

`final.geak_resolved` is written at the same point `geak_pending` is dropped, carrying GEAK's self-reported figures, the accepted heads, the measured outcome, and the alignment.

Two details that matter:

- **The raw tok/s travel with the speedups.** A ratio alone cannot say whether the two harnesses disagreed or the kernel did. `orchestrator_cold_baseline_tok_s` is the same figure the rebench divides by — verified equal to the entry's `throughput_before` to full precision on session 100123 — so its distance from `geak_cold_baseline_tok_s` *is* the cross-harness term.
- **The pending record wins over `geak_result`.** `geak_result` is overwritten in place by whatever GEAK ran last; on session 101687 it is an error stub by the time the rebench settles, while the pending record still holds the snapshot from when the candidate was accepted.

All six clearing sites are covered: promote, promote-rejected, `no_material`, `no_promote`, `fallback_failed`, and rebench task failure. The paths that leave `geak_pending` populated with a status (`rebench_unavailable`, `rebench_cancelled`) are untouched, since those already keep the record.

## What it buys

Reconstructed for session 101687, the −4.56 pp gap decomposes fully:

| Stage | Gain | Step |
|---|---|---|
| Sum of per-head reports | +14.04 pp | |
| GEAK's whole-config result (cold) | +10.88 pp | −3.16 |
| Scored against the session baseline | +9.03 pp | −1.85 |
| Re-bench measurement | +9.48 pp | +0.45 |

The Pulse side that renders this is a separate PR.

## Test plan

- [x] 6 new tests in `test_geak_gain_alignment.py`: promote keeps both sides, the snapshot carries the baselines, resolution prefers the candidate-time alignment over an overwritten `geak_result`, a rejected rebench records why, and the collector emits the field (and leaves it empty when GEAK never ran)
- [x] `test_geak_gain_alignment.py` — 46 passed
- [x] Full `inference_optimizer` suite — 11293 passed, 9 failed; the 9 are `critic_agent` / `external_multi_node` / `robustness_agent_e2e` and fail identically on unmodified `main`
- [x] `ruff check` clean on all touched files

Made with [Cursor](https://cursor.com)