### PR TITLE
fix(multi_node): cross-namespace rollback, kill exit code, and resume topology comparison

### DIFF
--- a/src/hyperloom/inference_optimizer/multi_node/cli.py
+++ b/src/hyperloom/inference_optimizer/multi_node/cli.py
@@ -1735,6 +1735,48 @@ def _resume_probe_timeout_s() -> int:
         return _DEFAULT_RESUME_PROBE_TIMEOUT_S
 
 
+def _rayjob_topology_fingerprint(args: argparse.Namespace, nnodes: int) -> dict[str, Any]:
+    """Every field that changes what the RayJob launcher spawns, as one record.
+
+    The resume fast path compares this record as a whole, so any field that
+    reaches the launcher belongs here: one left out lets a round that changed
+    it resume the previous launch and benchmark the previous topology under
+    this round's config.
+
+    Args:
+        args (argparse.Namespace): Parsed ``restart-server`` arguments.
+        nnodes (int): Node count this launch targets.
+
+    Returns:
+        dict[str, Any]: The comparable topology record.
+    """
+    pd_mode = (getattr(args, "pd_mode", "") or "aggregated").lower()
+    fingerprint: dict[str, Any] = {
+        "framework": str(args.framework),
+        "model": str(args.model),
+        "tp": int(args.tp),
+        "ep": int(getattr(args, "ep", 1) or 1),
+        "nnodes": int(nnodes),
+        "pd_mode": pd_mode,
+        "extra_args": _normalize_extra_args(getattr(args, "extra_args", "")),
+    }
+    if pd_mode == "disaggregated":
+        # Only meaningful under PD; leaving them out when aggregated keeps a
+        # stale value from an earlier PD run out of the comparison.
+        fingerprint.update(
+            {
+                "pd_prefill_nodes": int(getattr(args, "pd_prefill_nodes", 0) or 0),
+                "pd_decode_nodes": int(getattr(args, "pd_decode_nodes", 0) or 0),
+                "pd_prefill_tp": int(getattr(args, "pd_prefill_tp", 0) or 0),
+                "pd_decode_tp": int(getattr(args, "pd_decode_tp", 0) or 0),
+                "pd_transfer_backend": (getattr(args, "pd_transfer_backend", "") or "").strip(),
+                "pd_ib_device": (getattr(args, "pd_ib_device", "") or "").strip(),
+                "pd_bootstrap_port": int(getattr(args, "pd_bootstrap_port", 0) or 0),
+            }
+        )
+    return fingerprint
+
+
 def cmd_restart_server(args: argparse.Namespace) -> int:
     """Kill any prior vllm/sglang server and launch a new one.
 
@@ -1800,20 +1842,12 @@ def cmd_restart_server(args: argparse.Namespace) -> int:
             "off",
         )
         prev_sub = str(state.get("last_restart_submission_id") or "").strip()
-        # Normalize live args to match the stored (normalized) extra_args so
-        # whitespace differences don't miss the resume fast path. extra_args must
-        # be compared: it carries every variant flag, and ignoring it would
-        # resume sglang with the previous variant's args.
-        prev_match = bool(prev_sub) and (
-            str(state.get("last_restart_framework") or "") == str(args.framework)
-            and str(state.get("last_restart_model") or "") == str(args.model)
-            and int(state.get("last_restart_tp") or 0) == int(args.tp)
-            and int(state.get("last_restart_ep") or 1) == int(getattr(args, "ep", 1) or 1)
-            and str(state.get("last_restart_pd_mode") or "aggregated")
-            == (getattr(args, "pd_mode", "") or "aggregated").lower()
-            and _normalize_extra_args(state.get("last_restart_extra_args"))
-            == _normalize_extra_args(getattr(args, "extra_args", ""))
-        )
+        # The whole topology record must match. extra_args is normalized on both
+        # sides so whitespace alone does not miss the fast path, and it is part
+        # of the record because it carries every variant flag. A state file
+        # holding no record does not match and takes the full KILL+LAUNCH.
+        topology = _rayjob_topology_fingerprint(args, nnodes)
+        prev_match = bool(prev_sub) and state.get("last_restart_topology") == topology
         if resume_enabled and prev_match:
             _prev_status = ""
             try:
@@ -1884,6 +1918,10 @@ def cmd_restart_server(args: argparse.Namespace) -> int:
             state["last_restart_ep"] = int(getattr(args, "ep", 1) or 1)
             state["last_restart_pd_mode"] = (getattr(args, "pd_mode", "") or "aggregated").lower()
             state["last_restart_extra_args"] = _normalize_extra_args(getattr(args, "extra_args", ""))
+            # A poll-timeout retry resumes from this checkpoint, so it carries
+            # the topology record as well; the per-field pd_* keys below are
+            # written only once the poll returns.
+            state["last_restart_topology"] = topology
             _save_state(state)
 
             def _fetch_launch():
@@ -1991,7 +2029,11 @@ def cmd_restart_server(args: argparse.Namespace) -> int:
         state["last_restart_model"] = args.model
         state["last_restart_tp"] = args.tp
         state["last_restart_ep"] = int(getattr(args, "ep", 1) or 1)
-        # Persist PD state so later invocations can fall back when a flag is omitted.
+        state["last_restart_topology"] = topology
+        # Persist PD state so later invocations can fall back when a flag is
+        # omitted. The orchestrator's PD arg resolution
+        # (_multi_node_server_lifecycle) reads these per-field keys, so they are
+        # kept alongside the topology record rather than folded into it.
         pd_mode_persist = (getattr(args, "pd_mode", "") or "aggregated").lower()
         state["last_restart_pd_mode"] = pd_mode_persist
         if pd_mode_persist == "disaggregated":

--- a/src/hyperloom/inference_optimizer/multi_node/cli.py
+++ b/src/hyperloom/inference_optimizer/multi_node/cli.py
@@ -1743,6 +1743,14 @@ def _rayjob_topology_fingerprint(args: argparse.Namespace, nnodes: int) -> dict[
     it resume the previous launch and benchmark the previous topology under
     this round's config.
 
+    ``--pd-prefill-ep`` / ``--pd-decode-ep`` and the per-role extra-args are
+    deliberately absent: ``_build_multinode_launch_entrypoint`` does not
+    forward them, so on this backend they change nothing that gets spawned.
+    Infera compares them (``_infera_restart_config_matches``) because its
+    launch path does serve them. Forwarding any of them here means adding it
+    to this record in the same change, or a round that changed only that flag
+    resumes the previous launch again.
+
     Args:
         args (argparse.Namespace): Parsed ``restart-server`` arguments.
         nnodes (int): Node count this launch targets.

--- a/src/hyperloom/inference_optimizer/multi_node/commands/infera.py
+++ b/src/hyperloom/inference_optimizer/multi_node/commands/infera.py
@@ -320,14 +320,16 @@ def _infera_restart_config_matches(
     args: argparse.Namespace,
     framework: str,
     pd_mode: str,
+    kv_transfer_backend: str = "",
 ) -> bool:
     """Whether the requested restart matches the last successful Infera launch.
 
-    Mirrors the RayJob resume fast-path config check: same framework / model /
-    tp / ep / pd_mode / normalized extra-args (plus per-role PD knobs when
-    disaggregated). A mismatch means the round changed a served flag, so the
-    server MUST be relaunched (never resumed) or the benchmark would measure
-    stale config.
+    Covers the same ground as the RayJob resume fast path, which compares one
+    topology record rather than these fields one by one: framework / model /
+    tp / ep / pd_mode / normalized extra-args, plus the per-role PD knobs and
+    the KV transfer backend when disaggregated. A mismatch means the round
+    changed a served flag, so the server MUST be relaunched (never resumed) or
+    the benchmark would measure stale config.
 
     Args:
         state (dict[str, Any]): The infera multi-node state (carries
@@ -335,6 +337,10 @@ def _infera_restart_config_matches(
         args (argparse.Namespace): Parsed ``restart-server`` arguments.
         framework (str): Resolved framework for this restart.
         pd_mode (str): Resolved PD mode (``"aggregated"`` / ``"disaggregated"``).
+        kv_transfer_backend (str): Resolved PD KV-transfer backend for this
+            restart. It reaches the pods as
+            ``--disaggregation-transfer-backend``, so it is a served flag and
+            must block a resume when it changes.
 
     Returns:
         bool: True only when every served-config field matches the last launch.
@@ -363,6 +369,7 @@ def _infera_restart_config_matches(
     return (
         args_pn == state_pn
         and args_dn == state_dn
+        and (state.get("last_restart_pd_transfer_backend") or "").strip() == (kv_transfer_backend or "").strip()
         and int(state.get("last_restart_pd_prefill_tp") or 0) == int(getattr(args, "pd_prefill_tp", 0) or 0)
         and int(state.get("last_restart_pd_decode_tp") or 0) == int(getattr(args, "pd_decode_tp", 0) or 0)
         and int(state.get("last_restart_pd_prefill_ep") or 0) == int(getattr(args, "pd_prefill_ep", 0) or 0)
@@ -481,7 +488,7 @@ def _infera_restart_server(args: argparse.Namespace) -> int:
         "no",
         "off",
     )
-    if resume_enabled and _infera_restart_config_matches(state, args, framework, pd_mode):
+    if resume_enabled and _infera_restart_config_matches(state, args, framework, pd_mode, kv):
         probe_timeout = min(30, max(10, int(poll_timeout)))
         if _infera_servers_alive(state, _infera_all_gpu_targets(state), timeout=probe_timeout):
             info(
@@ -619,6 +626,9 @@ def _infera_restart_server(args: argparse.Namespace) -> int:
         state["last_restart_pd_decode_nodes"] = pd_decode_nodes
         state["last_restart_pd_prefill_tp"] = int(getattr(args, "pd_prefill_tp", 0) or 0)
         state["last_restart_pd_decode_tp"] = int(getattr(args, "pd_decode_tp", 0) or 0)
+        # The orchestrator's PD arg resolution reads this key as its fallback
+        # tier between an explicit argument and $PD_TRANSFER_BACKEND.
+        state["last_restart_pd_transfer_backend"] = kv
         state["last_restart_pd_prefill_ep"] = int(getattr(args, "pd_prefill_ep", 0) or 0)
         state["last_restart_pd_decode_ep"] = int(getattr(args, "pd_decode_ep", 0) or 0)
         state["last_restart_pd_prefill_extra_args"] = getattr(args, "pd_prefill_extra_args", "") or ""

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/kill_multinode.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/kill_multinode.py
@@ -543,8 +543,9 @@ def main() -> int:
     as JSON to stdout.
 
     Returns:
-        int: Process exit code; ``0`` on success even when some nodes had
-        nothing to kill.
+        int: ``0`` when every node finished its kill cleanly (having nothing to
+        kill counts as clean); ``1`` when any node errored, left a signalled pid
+        alive, or left a rendezvous/serving port bound.
     """
     p = argparse.ArgumentParser(
         prog="kill_multinode.py",
@@ -633,6 +634,20 @@ def main() -> int:
 
     sys.stdout.write(json.dumps(out, indent=2) + "\n")
     sys.stdout.flush()
+
+    # The caller sequences LAUNCH directly after this, so an incomplete kill has
+    # to be reported as a failure: a surviving pid or a bound rendezvous/serving
+    # port leaves the next rank 0 racing a dying server for the TCPStore / :8888.
+    #
+    # gpu_busy is advisory only. Its fallback reclaim wait is a coarse per-card
+    # threshold that an unrelated co-tenant's VRAM can trip, and _wait_gpu_free
+    # is time-boxed so it cannot stall teardown.
+    blocking = ("error", "still_alive", "ports_busy")
+    bad = {node: {k: summary[k] for k in blocking if summary.get(k)} for node, summary in out.items()}
+    bad = {node: reasons for node, reasons in bad.items() if reasons}
+    if bad:
+        _log(f"FAILED kill incomplete on {len(bad)} node(s): {json.dumps(bad, sort_keys=True)}")
+        return 1
     _log("done")
     return 0
 

--- a/src/hyperloom/inference_optimizer/multi_node/scripts/launch_multinode.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/launch_multinode.py
@@ -634,6 +634,37 @@ def _spawn_remote(
     return _detach_framework_launch(cmd, log_file, pid_file, sub_env, node_rank)
 
 
+# Budget for one node-pinned rollback kill (SIGTERM + report; no death-wait).
+_ROLLBACK_TIMEOUT_SEC = 30
+
+
+def _rollback_remote(pid: int) -> str:
+    """SIGTERM a spawned rank's process group, ON the node that owns the PID.
+
+    Must run as a NodeAffinity-pinned actor on that rank's own node: the PID is
+    resolvable only in the namespace that produced it.
+
+    Args:
+        pid: The PID reported by that node's spawn actor.
+
+    Returns:
+        str: A short human-readable outcome for the driver's log.
+    """
+    import os as _os
+    import signal as _signal
+
+    if pid <= 0:
+        return f"skipped: sentinel pid={pid}"
+    try:
+        _os.killpg(_os.getpgid(pid), _signal.SIGTERM)
+    except ProcessLookupError:
+        return f"no-op: pid={pid} already gone"
+    except PermissionError:
+        # Not ours to signal -- report rather than pretend it was cleaned up.
+        return f"DENIED: pid={pid} not signallable by this uid"
+    return f"SIGTERM sent to pgid of pid={pid}"
+
+
 def _rank0_pid_from_log(pid_dir: str) -> int | None:
     """Read rank 0 PID from ``{pid_dir}/rank_0.pid`` (best-effort).
 
@@ -1065,8 +1096,11 @@ def main() -> int:
 
     # Spawn one actor per rank (num_gpus=0; the framework reserves GPUs itself).
     SpawnActor = ray.remote(num_cpus=1, num_gpus=0)(_spawn_remote)
-    pids: dict[str, int] = {}  # pid_file_name -> real PID
-    refs: list[tuple[str, Any]] = []  # noqa: F821  Any imported below
+    # tag -> (node_id, real PID). A PID is only meaningful in the namespace that
+    # produced it, and this driver shares one only with rank 0 (_pick_head_first),
+    # so every PID travels with the node that owns it.
+    pids: dict[str, tuple[str, int]] = {}
+    refs: list[tuple[str, str, Any]] = []  # (tag, node_id, actor_ref)
 
     if pd_mode == "disaggregated":
         # Group A: prefill — nodes[0:pn], TP=ptp; rank-0 binds the prefill port.
@@ -1100,7 +1134,7 @@ def main() -> int:
                 pd_kv_parallel_size=2,
                 pid_file_name=f"prefill_{grp_rank}.pid",
             )
-            refs.append((f"prefill_{grp_rank}", actor_ref))
+            refs.append((f"prefill_{grp_rank}", node["NodeID"], actor_ref))
 
         # Group B: decode — nodes[pn:pn+dn]; dist-init port = prefill + 1.
         decode_head_ip = nodes[pn].get("NodeManagerAddress", head_ip)
@@ -1133,7 +1167,7 @@ def main() -> int:
                 pd_kv_parallel_size=2,
                 pid_file_name=f"decode_{grp_rank}.pid",
             )
-            refs.append((f"decode_{grp_rank}", actor_ref))
+            refs.append((f"decode_{grp_rank}", node["NodeID"], actor_ref))
     else:
         # Aggregated: single server group spans all nodes.
         for rank, node in enumerate(nodes):
@@ -1156,27 +1190,50 @@ def main() -> int:
                 torch_profiler_dir=args.torch_profiler_dir,
                 ep=int(args.ep or 1),
             )
-            refs.append((f"rank_{rank}", actor_ref))
+            refs.append((f"rank_{rank}", node["NodeID"], actor_ref))
 
-    for tag, ref in refs:
+    RollbackActor = ray.remote(num_cpus=0, num_gpus=0)(_rollback_remote)
+    for tag, node_id, ref in refs:
         try:
             pid = ray.get(ref, timeout=120)
-            pids[tag] = pid
+            pids[tag] = (node_id, pid)
             _log(f"{tag}: spawned pid={pid}")
         except Exception as exc:  # noqa: BLE001
             _log(f"{tag}: spawn FAILED: {type(exc).__name__}: {exc}")
             # Roll back already-spawned ranks so no half-started servers leak.
-            for tag2, p2 in pids.items():
-                _log(f"rolling back {tag2} pid={p2}")
+            # Each kill is dispatched to the node that owns the PID; PIDs are
+            # namespace-local and are never signalled from here. A pid <= 0 is
+            # the vLLM worker sentinel and names no process -- os.getpgid(0)
+            # would resolve to this driver's own process group.
+            for tag2, (node_id2, p2) in pids.items():
+                if p2 <= 0:
+                    _log(f"rolling back {tag2}: sentinel pid={p2} (no process); skipped")
+                    continue
                 try:
-                    os.killpg(os.getpgid(p2), 15)
-                except (ProcessLookupError, PermissionError):
-                    pass
+                    outcome = ray.get(
+                        RollbackActor.options(
+                            scheduling_strategy=NodeAffinitySchedulingStrategy(
+                                node_id=node_id2,
+                                soft=False,
+                            ),
+                        ).remote(p2),
+                        timeout=_ROLLBACK_TIMEOUT_SEC,
+                    )
+                    _log(f"rolling back {tag2} pid={p2} on node={node_id2[:16]}...: {outcome}")
+                except Exception as rb_exc:  # noqa: BLE001
+                    # An unreachable rank keeps its GPUs until the platform
+                    # reclaims the cluster, so it is reported rather than dropped.
+                    _log(
+                        f"WARN rollback of {tag2} pid={p2} on node={node_id2[:16]}... "
+                        f"FAILED: {type(rb_exc).__name__}: {rb_exc}; that rank may "
+                        f"still hold GPU memory"
+                    )
             return 1
 
     # Health-tail probe targets the leader: rank_0 (aggregated) / prefill_0 (PD).
     leader_tag = "rank_0" if pd_mode == "aggregated" else "prefill_0"
-    _log_rank0_post_spawn(Path(args.log_dir), pids.get(leader_tag))
+    _leader_entry = pids.get(leader_tag)
+    _log_rank0_post_spawn(Path(args.log_dir), _leader_entry[1] if _leader_entry else None)
 
     summary: dict[str, Any] = {
         "framework": args.framework,
@@ -1186,7 +1243,7 @@ def main() -> int:
         "nnodes": args.nnodes,
         "head_ip": head_ip,
         "dist_init_port": args.dist_init_port,
-        "ranks": [{"tag": r, "pid": pids[r]} for r in sorted(pids)],
+        "ranks": [{"tag": r, "node_id": pids[r][0], "pid": pids[r][1]} for r in sorted(pids)],
         "pid_dir": args.pid_dir,
         "log_dir": args.log_dir,
         "inference_port": _INFERENCE_PORT,

--- a/src/hyperloom/inference_optimizer/tests/test_external_multi_node.py
+++ b/src/hyperloom/inference_optimizer/tests/test_external_multi_node.py
@@ -633,6 +633,62 @@ def test_launch_entrypoint_quotes_state_derived_paths(monkeypatch: pytest.Monkey
     assert "--log-dir '/tmp/my logs'" in entrypoint
 
 
+_PD_FINGERPRINT_ARGS = {
+    "framework": "sglang",
+    "model": "/models/test",
+    "tp": 8,
+    "ep": 1,
+    "pd_mode": "disaggregated",
+    "extra_args": "",
+    "pd_prefill_nodes": 1,
+    "pd_decode_nodes": 1,
+    "pd_prefill_tp": 8,
+    "pd_decode_tp": 8,
+    "pd_transfer_backend": "mooncake",
+    "pd_ib_device": "mlx5_0",
+    "pd_bootstrap_port": 8998,
+}
+
+
+@pytest.mark.parametrize(
+    ("field", "changed"),
+    [
+        ("pd_prefill_nodes", 3),
+        ("pd_decode_nodes", 3),
+        ("pd_prefill_tp", 4),
+        ("pd_decode_tp", 4),
+        ("pd_transfer_backend", "nixl"),
+        ("pd_ib_device", "mlx5_1"),
+        ("pd_bootstrap_port", 9999),
+    ],
+)
+def test_a_changed_pd_flag_the_launcher_serves_blocks_a_resume(field: str, changed: object) -> None:
+    """Every PD flag the launch entrypoint forwards must keep a resume from matching.
+
+    The fast path compares this record as a whole, so a forwarded flag left
+    out of it lets a round that changed the topology reuse the previous launch
+    and benchmark the previous topology under this round's config -- a plausible
+    number rather than a visible failure. This is the list that says which
+    changes are allowed to resume, so widening it is a behaviour change and
+    should break here first.
+    """
+    from hyperloom.inference_optimizer.multi_node import cli as mncli
+
+    reference = mncli._rayjob_topology_fingerprint(argparse.Namespace(**_PD_FINGERPRINT_ARGS), 2)
+    changed_args = argparse.Namespace(**{**_PD_FINGERPRINT_ARGS, field: changed})
+
+    assert mncli._rayjob_topology_fingerprint(changed_args, 2) != reference
+
+
+def test_a_changed_node_count_blocks_a_resume() -> None:
+    """--nnodes reaches the launcher as well, and no per-field check ever compared it."""
+    from hyperloom.inference_optimizer.multi_node import cli as mncli
+
+    args = argparse.Namespace(**_PD_FINGERPRINT_ARGS)
+
+    assert mncli._rayjob_topology_fingerprint(args, 2) != mncli._rayjob_topology_fingerprint(args, 4)
+
+
 _AGGREGATED_STATE = {"service_url": "http://frontend:8000"}
 _PD_STATE = {
     "service_url": "http://frontend:8000",

--- a/src/hyperloom/inference_optimizer/tests/test_external_multi_node.py
+++ b/src/hyperloom/inference_optimizer/tests/test_external_multi_node.py
@@ -906,6 +906,20 @@ def test_resume_needs_a_cluster_that_still_serves(
         last_restart_ep=1,
         last_restart_pd_mode="aggregated",
         last_restart_extra_args="",
+        # The resume fast path matches on the whole topology record, so seeding
+        # the per-field keys alone is not a prior launch it will recognise.
+        # Spelled out rather than built from the helper: changing what the
+        # fingerprint covers changes which restarts may resume, and that should
+        # break this test rather than silently follow it.
+        last_restart_topology={
+            "framework": "sglang",
+            "model": "/models/test",
+            "tp": 8,
+            "ep": 1,
+            "nnodes": 2,
+            "pd_mode": "aggregated",
+            "extra_args": "",
+        },
     )
 
     submitted: list[str] = []


### PR DESCRIPTION
Three defects in the multi-node control plane, from a review of the `multi_node/` package. Each was traced end to end before changing anything; several other items from the same review were checked and deliberately left alone (below).

Single-node paths are out of scope and untouched.

## What changed

### `launch_multinode.py` — roll back on the node that owns the PID

The launch driver runs inside the Ray head pod and shares a PID namespace only with rank 0, but the spawn-failure rollback signalled every rank's PID locally. For each remote rank `os.getpgid()` raised `ProcessLookupError`, which the handler swallowed, so the stated purpose — *"so no half-started servers leak"* — never held for any rank but rank 0. Those servers kept running and kept their GPUs.

Sentinel PID `0`, written for vLLM worker ranks, was worse where reachable (vllm with ≥3 aggregated nodes, or PD with `prefill ≥ 2`): `os.getpgid(0)` resolves to the **caller's** process group, so the first rollback step SIGTERMed the driver itself and nothing was rolled back at all. Verified empirically:

```
>>> os.getpgid(0) == os.getpgrp()
True
```

Each rank's node id now travels with its PID, the kill is dispatched through a NodeAffinity-pinned actor, `pid <= 0` is skipped, and a rank that cannot be reached is logged rather than swallowed.

### `kill_multinode.py` — return non-zero when the kill did not finish

`still_alive` / `ports_busy` / `error` were collected into the JSON summary and then discarded: `main()` returned `0` unconditionally and no caller read the JSON. The caller sequences LAUNCH straight after, so a half-finished kill surfaced later as `port_base not available` or `TCPStore shut down too early` rather than as a kill failure.

Restarts that used to limp past an incomplete kill now fail and take the orchestrator's reclaim-and-retry — the same thing `launch_infera_node._kill_prior` already does when a prior server will not die.

`gpu_busy` stays advisory: its fallback wait is a coarse per-card threshold an unrelated co-tenant can trip, and it is already time-boxed. The port probe *is* safe to gate on — it binds without `SO_REUSEADDR`, so a released listen socket reports free immediately and there are no TIME_WAIT false positives.

### `restart-server` — compare the whole topology before resuming

The RayJob resume fast path compared `framework/model/tp/ep/pd_mode/extra_args` while persisting six more fields it never read back, so a round changing only the PD node split, per-role TP, transfer backend or IB device matched the previous launch and resumed it — and the benchmark then measured the previous topology under this round's config.

Replaced with a single topology record compared as a whole, written at the early checkpoint too since that is the one a poll-timeout retry reads. The per-field keys stay: the orchestrator reads them as PD argument fallbacks.

**This is latent rather than live on the orchestrated path** — PD topology there is resolved from state and env by `_resolve_pd_args` and does not vary per round. It is reachable through `restart-server`'s own flags, which the skill documents as a supported way to drive a cluster.

On infera the same comparator ignored the KV transfer backend, which reaches the pods as `--disaggregation-transfer-backend`, and never persisted it — leaving that tier of the orchestrator's three-tier fallback dead on this backend.

## Reviewed and deliberately not changed

- **Exit-code 1/2 inconsistency.** The sole programmatic caller (`_multi_node_server_lifecycle._restart_and_wait`) checks only `rc != 0` and bounds retries at exactly one, so nothing loops on a config error. Reporting terminal failures as `2` would instead make the agent path abandon a cluster on a transient dashboard blip.
- **`launch_infera_node`'s cmdline reaper scope.** Each infera pod has its own PID namespace and the engine port is hardcoded, so two engines cannot share a namespace and the reaper only ever sees its own pod's.
- **`known_hosts` refresh on host-key mismatch.** Pod re-provisioning with IP reuse is a plausible legitimate source of a changed key; ruling that out needs platform knowledge this change does not have.
- **Quoting the SSH interpreter.** The sandbox already holds the pod SSH key and `ssh_run_script` ships arbitrary script bodies to pods, so `$HYPERLOOM_MN_POD_PYTHON` grants no capability an attacker would not already have. Constraining it to a validated absolute path would be real hardening; shell-quoting alone only looks like one.

## Known gaps left open

Feature gaps rather than defects, not addressed here:

- RayJob drops `--pd-prefill-ep` / `--pd-decode-ep` / per-role extra-args (infera implements them).
- infera never reads `--pd-ib-device` at all (RayJob forwards it).

## Testing

`342 passed` across the multi-node, infera launcher, SSH client and grid-runner suites, rebased onto current `main`.

Five failures in `test_common_utils` / `test_coverage_gap_units` (claude config, credentials, LLM audit) are pre-existing — reproduced on a clean tree with these changes stashed.
