### PR TITLE
fix(provenance,patcher): a declared framework venv wins over the orchestrator's interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,11 +99,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   of a shared install the run never served with when one happened to be present.
   `_resolve_framework_build` already walks the candidate interpreters and imports
   the framework to find the right one, but `_check_serving_framework` only
-  printed the winner; it is now published as `$HYPERLOOM_FRAMEWORK_PYTHON` and
-  the fingerprint reads its `site-packages`. The installer-written
-  `$VLLM_VENV_ROOT` is deliberately not consulted: it is only ever written, never
-  cleared, so it survives an isolated-to-shared move and would name an
-  environment the run no longer serves with.
+  printed the winner; it is now published as `$HYPERLOOM_RESOLVED_FRAMEWORK_PYTHON`
+  (paired with `$HYPERLOOM_RESOLVED_FRAMEWORK`, since the scan answers for one
+  framework and `sglang` is the default) and the fingerprint reads its
+  `site-packages`. The installer-written `$VLLM_VENV_ROOT` is no longer read by
+  the fingerprint directly: it is only ever written, never cleared, so on its own
+  it cannot say whether the tree it names still holds vLLM. It still leads
+  preflight's candidate list and is probed there, which is what the recorded
+  version now follows. A prefix that yields no `site-packages` — a system Python keeps its
+  packages in `dist-packages` — is treated as a failed derivation and falls back
+  to this process, not as an authoritative "not installed".<br/>
+  **Operator note**: the framework check returns before publishing when
+  `$HYPERLOOM_SKIP_FRAMEWORK_CHECK` is set, when `$BENCHMARK_BASE_URL` points at
+  a remote server, on external multi-node, and for scriptable frameworks (xDiT,
+  custom) that own their entrypoint — serving is not local on those paths, so
+  the fingerprint falls back to this process rather than reading a venv root
+  that describes some other host.
 
 - **Shell and loader hijack names are rejected from the `extra_envs` argument to
   `materialize_config_with_envs` before the config is persisted.** The predicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **The recorded framework version now comes from the interpreter preflight
+  resolved, not from whatever the orchestrator's own process happens to have.**
+  `--framework-env isolated` is the default for vLLM, whose ROCm wheel pins its
+  own torch, so the framework is installed where `importlib.metadata` in this
+  process cannot see it — and `detect_stack_fingerprint` probed this process
+  first, recording `unknown` on the default bare-metal vLLM path, or the version
+  of a shared install the run never served with when one happened to be present.
+  `_resolve_framework_build` already walks the candidate interpreters and imports
+  the framework to find the right one, but `_check_serving_framework` only
+  printed the winner; it is now published as `$HYPERLOOM_FRAMEWORK_PYTHON` and
+  the fingerprint reads its `site-packages`. The installer-written
+  `$VLLM_VENV_ROOT` is deliberately not consulted: it is only ever written, never
+  cleared, so it survives an isolated-to-shared move and would name an
+  environment the run no longer serves with.
+
 - **Shell and loader hijack names are rejected from the `extra_envs` argument to
   `materialize_config_with_envs` before the config is persisted.** The predicate
   was `valid_env_key`, a key-shape check that let `LD_PRELOAD`, `PYTHONPATH` and

--- a/src/hyperloom/common/provenance.py
+++ b/src/hyperloom/common/provenance.py
@@ -33,6 +33,7 @@ import hashlib
 import os
 import re
 import subprocess  # nosec B404 - best-effort, guarded provenance probes only.
+import sys
 from importlib import metadata as _im
 from pathlib import Path
 from typing import Any, Mapping
@@ -58,15 +59,29 @@ _STACK_FINGERPRINT_ENVS: dict[str, tuple[str, ...]] = {
 # ``importlib.metadata`` here cannot see it, and the version silently degraded to
 # "unknown" on the default bare-metal vLLM path.
 #
-# Preflight already walks the candidate interpreters and imports the framework to
-# find this one, so it describes the runtime this session resolved. The installer's
-# ``$VLLM_VENV_ROOT`` is deliberately not consulted: it is host state that is only
-# ever written, never cleared, so it survives an isolated -> shared move and would
-# name an environment the run no longer serves with.
-_FRAMEWORK_PYTHON_ENV: str = "HYPERLOOM_FRAMEWORK_PYTHON"
+# Preflight already walks the candidate interpreters and locates the framework
+# under one of them, so it describes the runtime this session resolved. The
+# installer's ``$VLLM_VENV_ROOT`` is no longer read here directly: it is host
+# state that is only ever written, never cleared, so on its own it cannot say
+# whether the tree it names still holds the framework. It stays in play through
+# preflight, which leads with it and probes it -- and that is the right answer
+# either way, because ``_derive_runtime_paths`` also puts that root at the head
+# of ``PATH`` and vLLM starts as a bare ``vllm serve``, so a root that still
+# holds a working vLLM *is* what serves. A root that no longer does fails the
+# probe and the scan moves on, where reading it directly would have recorded a
+# version from an environment the run never touched.
+#
+# Distinct from ``HYPERLOOM_FRAMEWORK_PYTHON``, the per-attempt YAML key a
+# framework-agent attempt uses to force its own launch interpreter: that one is
+# a per-benchmark override, this one is the session-wide resolution.
+#: Published by preflight; read here. Public so the two stay in one place.
+RESOLVED_FRAMEWORK_PYTHON_ENV: str = "HYPERLOOM_RESOLVED_FRAMEWORK_PYTHON"
 
-# Components served by that interpreter. Others live in this process.
-_FRAMEWORK_COMPONENTS: frozenset[str] = frozenset({"vllm", "sglang"})
+#: The framework that interpreter was resolved for. The scan answers for one
+#: framework only, so the pair has to travel together: an SGLang session
+#: publishes an interpreter that knows nothing about vLLM, and reading it as the
+#: vLLM answer reports "unknown" for a vLLM this process can see.
+RESOLVED_FRAMEWORK_ENV: str = "HYPERLOOM_RESOLVED_FRAMEWORK"
 
 #: Runtime-arch overrides only. ``PYTORCH_ROCM_ARCH`` is deliberately absent:
 #: it names the archs a wheel is *compiled* for, not the installed device, and
@@ -206,25 +221,49 @@ def detect_stack_fingerprint(env: Mapping[str, str], *, probe: bool = True) -> d
 def _framework_site_packages(env: Mapping[str, str], component: str) -> list[str] | None:
     """``site-packages`` dirs of the interpreter preflight resolved, if any.
 
-    ``None`` when this component is not served by a resolved interpreter, or
-    when preflight published none -- both are the shared-environment case that
-    the running interpreter already answers.
+    ``None`` means "no answer from a separate interpreter" and lets the caller
+    fall back to this process. That covers four cases: nothing was published,
+    the interpreter was resolved for a different framework, it *is* this
+    process, or its prefix is not a venv layout so the derivation below cannot
+    be trusted.
 
-    A resolved interpreter that has no importable tree yields an empty list.
-    That is distinct from ``None``: the interpreter was chosen for this run, so
-    the version has to come from it or not at all.
+    A non-empty list is authoritative: the prefix really is venv-shaped, so an
+    absent distribution there means the served environment lacks it, and
+    answering from this process would report a version the run never served
+    with. The caller must not fall back on that.
+
+    The path is used literally. ``resolve()`` would follow ``bin/python`` down
+    its symlink chain to the base interpreter (``/usr/bin/python3.12``), whose
+    ``parent.parent`` is ``/usr`` -- and a system prefix keeps its packages in
+    ``dist-packages``, so every lookup would degrade to "unknown" including the
+    shared case this process answers on its own. ``sys.executable`` inside a
+    venv is likewise the unresolved venv path.
     """
-    if component not in _FRAMEWORK_COMPONENTS:
+    resolved_for = _env_first(env, RESOLVED_FRAMEWORK_ENV)
+    if not resolved_for or resolved_for.strip().lower() != component:
         return None
-    python_exe = _env_first(env, _FRAMEWORK_PYTHON_ENV)
-    if not python_exe:
+    python_exe = _env_first(env, RESOLVED_FRAMEWORK_PYTHON_ENV)
+    if not python_exe or python_exe == sys.executable:
+        # This process already answers for its own interpreter, without a
+        # derivation that only holds for venv-shaped prefixes.
         return None
-    # ``<venv>/bin/python`` -> ``<venv>/lib/python*/site-packages``.
-    venv_root = Path(python_exe).resolve().parent.parent
+    # ``<venv>/bin/python`` -> ``<venv>/lib/python*/site-packages``. Only a venv
+    # keeps packages there; a system prefix uses ``dist-packages`` and a bare
+    # ``python3`` would glob the working directory, so both are refused rather
+    # than silently yielding an empty authoritative answer.
+    exe_path = Path(python_exe)
+    if not exe_path.is_absolute():
+        return None
+    venv_root = exe_path.parent.parent
     try:
-        return [str(p) for p in sorted(venv_root.glob("lib/python*/site-packages"))]
+        hits = [str(p) for p in sorted(venv_root.glob("lib/python*/site-packages"))]
     except OSError:
-        return []
+        return None
+    # No match means the prefix is not venv-shaped (a system prefix keeps its
+    # packages in ``dist-packages``), so the derivation failed and this process
+    # is the better answer. Only a real hit is authoritative -- then an absent
+    # distribution genuinely means the served environment lacks it.
+    return hits or None
 
 
 def _probe_pkg_version(component: str, venv_path: list[str] | None = None) -> str:
@@ -388,6 +427,8 @@ def build_provenance(
 __all__ = [
     "PROVENANCE_VERSION",
     "PROVENANCE_SOURCE",
+    "RESOLVED_FRAMEWORK_ENV",
+    "RESOLVED_FRAMEWORK_PYTHON_ENV",
     "build_provenance",
     "server_args_hash",
     "detect_gfx_arch",

--- a/src/hyperloom/common/provenance.py
+++ b/src/hyperloom/common/provenance.py
@@ -52,15 +52,21 @@ _STACK_FINGERPRINT_ENVS: dict[str, tuple[str, ...]] = {
     "vllm": ("VLLM_VERSION",),
 }
 
-# Where a component lives when it was installed into a venv of its own instead
-# of the interpreter running this code. ``--framework-env isolated`` is the
-# default for vLLM, whose ROCm wheel pins its own torch and so must not share
-# the orchestrator's environment -- which also means ``importlib.metadata``
-# here cannot see it, and the version silently degraded to "unknown" on the
-# default bare-metal vLLM path. Setup records the root it installed into.
-_STACK_VENV_ROOT_ENVS: dict[str, tuple[str, ...]] = {
-    "vllm": ("VLLM_VENV_ROOT",),
-}
+# The interpreter preflight resolved for the serving framework. ``--framework-env
+# isolated`` is the default for vLLM, whose ROCm wheel pins its own torch and so
+# must not share the orchestrator's environment -- which also means
+# ``importlib.metadata`` here cannot see it, and the version silently degraded to
+# "unknown" on the default bare-metal vLLM path.
+#
+# Preflight already walks the candidate interpreters and imports the framework to
+# find this one, so it describes the runtime this session resolved. The installer's
+# ``$VLLM_VENV_ROOT`` is deliberately not consulted: it is host state that is only
+# ever written, never cleared, so it survives an isolated -> shared move and would
+# name an environment the run no longer serves with.
+_FRAMEWORK_PYTHON_ENV: str = "HYPERLOOM_FRAMEWORK_PYTHON"
+
+# Components served by that interpreter. Others live in this process.
+_FRAMEWORK_COMPONENTS: frozenset[str] = frozenset({"vllm", "sglang"})
 
 #: Runtime-arch overrides only. ``PYTORCH_ROCM_ARCH`` is deliberately absent:
 #: it names the archs a wheel is *compiled* for, not the installed device, and
@@ -192,23 +198,31 @@ def detect_stack_fingerprint(env: Mapping[str, str], *, probe: bool = True) -> d
                     val = v
                     break
         if not val and probe:
-            val = _probe_pkg_version(component, _venv_site_packages(env, component))
+            val = _probe_pkg_version(component, _framework_site_packages(env, component))
         out[component] = val or "unknown"
     return out
 
 
-def _venv_site_packages(env: Mapping[str, str], component: str) -> list[str]:
-    """``site-packages`` dirs of the venv a component was installed into.
+def _framework_site_packages(env: Mapping[str, str], component: str) -> list[str] | None:
+    """``site-packages`` dirs of the interpreter preflight resolved, if any.
 
-    Empty when the component has no isolated-venv convention or the run did not
-    use one, which is the shared-environment case the interpreter already
-    covers.
+    ``None`` when this component is not served by a resolved interpreter, or
+    when preflight published none -- both are the shared-environment case that
+    the running interpreter already answers.
+
+    A resolved interpreter that has no importable tree yields an empty list.
+    That is distinct from ``None``: the interpreter was chosen for this run, so
+    the version has to come from it or not at all.
     """
-    root = _env_first(env, *_STACK_VENV_ROOT_ENVS.get(component, ()))
-    if not root:
-        return []
+    if component not in _FRAMEWORK_COMPONENTS:
+        return None
+    python_exe = _env_first(env, _FRAMEWORK_PYTHON_ENV)
+    if not python_exe:
+        return None
+    # ``<venv>/bin/python`` -> ``<venv>/lib/python*/site-packages``.
+    venv_root = Path(python_exe).resolve().parent.parent
     try:
-        return [str(p) for p in sorted(Path(root).glob("lib/python*/site-packages"))]
+        return [str(p) for p in sorted(venv_root.glob("lib/python*/site-packages"))]
     except OSError:
         return []
 
@@ -222,28 +236,29 @@ def _probe_pkg_version(component: str, venv_path: list[str] | None = None) -> st
     runs on the session-manifest build path. Env vars (e.g. ``VLLM_VERSION``,
     ``AITER_COMMIT``) still take priority in ``detect_stack_fingerprint``.
 
-    Falls back to ``venv_path`` when the running interpreter has no such
-    distribution: an isolated framework venv is invisible to this process
-    otherwise, and reporting a framework the run actually served with as
-    "unknown" is worse than the extra directory scan.
+    ``venv_path`` (not ``None``) means preflight resolved a separate interpreter
+    for this framework, and it is authoritative: the framework serving the run
+    lives there, not in this process. Any same-named distribution installed here
+    belongs to a different environment, so answering from it would report a
+    version the run never served with -- worse than "unknown", because it looks
+    right. This process is consulted only when no interpreter was resolved.
     """
     dist = {"sglang": "sglang", "vllm": "vllm", "aiter": "aiter"}.get(component)
     if not dist:
         return ""
+    if venv_path is not None:
+        try:
+            for found in _im.distributions(path=list(venv_path)):
+                name = (found.metadata["Name"] or "").strip().lower().replace("_", "-")
+                if name == dist:
+                    return (found.version or "").strip()
+        except Exception:  # noqa: BLE001 — an unreadable venv is not a failure.
+            return ""
+        return ""
     try:
         return (_im.version(dist) or "").strip()
     except Exception:  # noqa: BLE001 — a missing package is normal.
-        pass
-    if not venv_path:
         return ""
-    try:
-        for found in _im.distributions(path=list(venv_path)):
-            name = (found.metadata["Name"] or "").strip().lower().replace("_", "-")
-            if name == dist:
-                return (found.version or "").strip()
-    except Exception:  # noqa: BLE001 — an unreadable venv is not a failure.
-        return ""
-    return ""
 
 
 def detect_code_revision(env: Mapping[str, str], *, probe: bool = True) -> str:

--- a/src/hyperloom/inference_optimizer/cli/preflight.py
+++ b/src/hyperloom/inference_optimizer/cli/preflight.py
@@ -34,7 +34,11 @@ from hyperloom.common.llm_config import (
 )
 from hyperloom.common.gpu_identity import AMD_GPU_DISPATCH_IDENTITIES
 from hyperloom.common.platform_probe import probe_cpu_platform
-from hyperloom.common.provenance import detect_gfx_arch
+from hyperloom.common.provenance import (
+    RESOLVED_FRAMEWORK_ENV,
+    RESOLVED_FRAMEWORK_PYTHON_ENV,
+    detect_gfx_arch,
+)
 
 from .credentials import (
     _is_stale_proxy_url,
@@ -951,13 +955,26 @@ def _check_serving_framework(args, benchmark_python: str) -> None:
 
     interpreters = _framework_probe_interpreters(framework, benchmark_python)
     found, probe = _resolve_framework_build(framework, interpreters)
-    # Publish the interpreter this scan resolved to. It is the only value that
-    # was proven to import the framework here, so consumers that would otherwise
-    # re-derive it from installer-written host state (``$VLLM_VENV_ROOT``, which
-    # survives an isolated -> shared move) can read the resolved answer instead.
-    # A refuted build is not published: it is provably the wrong one.
+    # Publish the interpreter this scan resolved to, so consumers that would
+    # otherwise re-derive it from installer-written host state read the probed
+    # answer instead. ``$VLLM_VENV_ROOT`` leads the candidate list above, but
+    # only this scan establishes whether the tree it names still holds the
+    # framework -- the variable itself is never cleared.
+    #
+    # The framework goes with it: this scan answers for one framework only, and
+    # ``sglang`` is the default, so an unlabelled interpreter would be read as
+    # the vLLM answer on every SGLang session and report "unknown" for a vLLM
+    # this process can see.
+    #
+    # Only a refuted build is withheld -- it is provably the wrong one. A
+    # ROCm-probe timeout is not: ``_resolve_framework_build`` has already
+    # located the distribution under the candidate (``_framework_importable``
+    # answers with ``find_spec``) before probing the build at all, and the check
+    # below keeps serving with it after a warning. Reading a version wants the
+    # ``dist-info`` metadata, which does not require the package to import.
     if found and probe.verdict is not False:
-        os.environ["HYPERLOOM_FRAMEWORK_PYTHON"] = found
+        os.environ[RESOLVED_FRAMEWORK_PYTHON_ENV] = found
+        os.environ[RESOLVED_FRAMEWORK_ENV] = framework
     evidence = _rocm_evidence(framework)
     if found and probe.verdict is True:
         print(f"Preflight: {framework} importable ({found}); {evidence} confirms a ROCm build")

--- a/src/hyperloom/inference_optimizer/cli/preflight.py
+++ b/src/hyperloom/inference_optimizer/cli/preflight.py
@@ -951,6 +951,13 @@ def _check_serving_framework(args, benchmark_python: str) -> None:
 
     interpreters = _framework_probe_interpreters(framework, benchmark_python)
     found, probe = _resolve_framework_build(framework, interpreters)
+    # Publish the interpreter this scan resolved to. It is the only value that
+    # was proven to import the framework here, so consumers that would otherwise
+    # re-derive it from installer-written host state (``$VLLM_VENV_ROOT``, which
+    # survives an isolated -> shared move) can read the resolved answer instead.
+    # A refuted build is not published: it is provably the wrong one.
+    if found and probe.verdict is not False:
+        os.environ["HYPERLOOM_FRAMEWORK_PYTHON"] = found
     evidence = _rocm_evidence(framework)
     if found and probe.verdict is True:
         print(f"Preflight: {framework} importable ({found}); {evidence} confirms a ROCm build")

--- a/src/hyperloom/inference_optimizer/tests/test_common_provenance.py
+++ b/src/hyperloom/inference_optimizer/tests/test_common_provenance.py
@@ -294,38 +294,55 @@ def test_code_revision_falls_back_when_git_absent(monkeypatch):
 # --- isolated framework venv ------------------------------------------------
 
 
-def _installed(venv_root, name: str, version: str):
-    """A distribution installed under ``venv_root`` and nowhere this process looks."""
+def _installed(venv_root, name: str, version: str) -> str:
+    """A distribution installed under ``venv_root`` and nowhere this process looks.
+
+    Returns the interpreter path preflight would publish for that venv.
+    """
     site = venv_root / "lib" / "python3.12" / "site-packages"
     info = site / f"{name}-{version}.dist-info"
     info.mkdir(parents=True)
     (info / "METADATA").write_text(f"Metadata-Version: 2.4\nName: {name}\nVersion: {version}\n")
-    return venv_root
+    return str(venv_root / "bin" / "python")
 
 
 def test_a_framework_in_its_own_venv_is_still_versioned(tmp_path):
     """``--framework-env isolated`` is the default for vLLM, whose ROCm wheel
     pins its own torch. The orchestrator's interpreter cannot see that venv, so
-    without following ``VLLM_VENV_ROOT`` every bare-metal vLLM report recorded
-    the framework it actually served with as "unknown"."""
-    root = _installed(tmp_path / "vllm-venv", "vllm", "0.27.1+rocm723")
-    fp = _prov.detect_stack_fingerprint({"VLLM_VENV_ROOT": str(root)}, probe=True)
+    without following the interpreter preflight resolved, every bare-metal vLLM
+    report recorded the framework it actually served with as "unknown"."""
+    python_exe = _installed(tmp_path / "vllm-venv", "vllm", "0.27.1+rocm723")
+    fp = _prov.detect_stack_fingerprint({"HYPERLOOM_FRAMEWORK_PYTHON": python_exe}, probe=True)
     assert fp["vllm"] == "0.27.1+rocm723"
 
 
-def test_an_operator_pin_still_wins_over_the_venv(tmp_path):
-    root = _installed(tmp_path / "vllm-venv", "vllm", "0.27.1+rocm723")
-    fp = _prov.detect_stack_fingerprint({"VLLM_VENV_ROOT": str(root), "VLLM_VERSION": "0.28.0-rc1"}, probe=True)
+def test_an_operator_pin_still_wins_over_the_resolved_interpreter(tmp_path):
+    python_exe = _installed(tmp_path / "vllm-venv", "vllm", "0.27.1+rocm723")
+    fp = _prov.detect_stack_fingerprint(
+        {"HYPERLOOM_FRAMEWORK_PYTHON": python_exe, "VLLM_VERSION": "0.28.0-rc1"}, probe=True
+    )
     assert fp["vllm"] == "0.28.0-rc1"
 
 
-def test_a_venv_root_that_is_not_there_is_not_a_failure(tmp_path):
-    fp = _prov.detect_stack_fingerprint({"VLLM_VENV_ROOT": str(tmp_path / "gone")}, probe=True)
+def test_a_resolved_interpreter_with_no_tree_is_not_a_failure(tmp_path):
+    fp = _prov.detect_stack_fingerprint(
+        {"HYPERLOOM_FRAMEWORK_PYTHON": str(tmp_path / "gone" / "bin" / "python")}, probe=True
+    )
     assert fp["vllm"] == "unknown"
+
+
+def test_an_installer_venv_root_is_not_consulted(tmp_path):
+    """``$VLLM_VENV_ROOT`` is host state the installer only ever writes; it
+    survives an isolated -> shared move and would name an environment the run no
+    longer serves with. Only the resolved interpreter is authoritative."""
+    root = tmp_path / "stale-venv"
+    _installed(root, "vllm", "0.27.1+rocm723")
+    fp = _prov.detect_stack_fingerprint({"VLLM_VENV_ROOT": str(root)}, probe=True)
+    assert fp["vllm"] != "0.27.1+rocm723"
 
 
 def test_the_venv_is_not_scanned_under_probe_false(tmp_path):
     """probe=False is the hermetic contract: env only, no filesystem."""
-    root = _installed(tmp_path / "vllm-venv", "vllm", "0.27.1+rocm723")
-    fp = _prov.detect_stack_fingerprint({"VLLM_VENV_ROOT": str(root)}, probe=False)
+    python_exe = _installed(tmp_path / "vllm-venv", "vllm", "0.27.1+rocm723")
+    fp = _prov.detect_stack_fingerprint({"HYPERLOOM_FRAMEWORK_PYTHON": python_exe}, probe=False)
     assert fp["vllm"] == "unknown"

--- a/src/hyperloom/inference_optimizer/tests/test_common_provenance.py
+++ b/src/hyperloom/inference_optimizer/tests/test_common_provenance.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 
 from hyperloom.common.provenance import (
     PROVENANCE_SOURCE,
@@ -297,13 +298,23 @@ def test_code_revision_falls_back_when_git_absent(monkeypatch):
 def _installed(venv_root, name: str, version: str) -> str:
     """A distribution installed under ``venv_root`` and nowhere this process looks.
 
+    Builds the ``bin/python -> python3.12 -> <base>`` symlink chain a real venv
+    has, so a lookup that resolves the interpreter path lands on the base
+    prefix (``/usr``) instead of the venv and finds no ``site-packages``. A
+    fixture of plain non-existent paths cannot catch that: ``Path.resolve()``
+    does not follow symlinks that are not there.
+
     Returns the interpreter path preflight would publish for that venv.
     """
     site = venv_root / "lib" / "python3.12" / "site-packages"
     info = site / f"{name}-{version}.dist-info"
     info.mkdir(parents=True)
     (info / "METADATA").write_text(f"Metadata-Version: 2.4\nName: {name}\nVersion: {version}\n")
-    return str(venv_root / "bin" / "python")
+    bin_dir = venv_root / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    (bin_dir / "python3.12").symlink_to(sys.executable)
+    (bin_dir / "python").symlink_to("python3.12")
+    return str(bin_dir / "python")
 
 
 def test_a_framework_in_its_own_venv_is_still_versioned(tmp_path):
@@ -312,30 +323,73 @@ def test_a_framework_in_its_own_venv_is_still_versioned(tmp_path):
     without following the interpreter preflight resolved, every bare-metal vLLM
     report recorded the framework it actually served with as "unknown"."""
     python_exe = _installed(tmp_path / "vllm-venv", "vllm", "0.27.1+rocm723")
-    fp = _prov.detect_stack_fingerprint({"HYPERLOOM_FRAMEWORK_PYTHON": python_exe}, probe=True)
+    fp = _prov.detect_stack_fingerprint(
+        {"HYPERLOOM_RESOLVED_FRAMEWORK": "vllm", "HYPERLOOM_RESOLVED_FRAMEWORK_PYTHON": python_exe}, probe=True
+    )
     assert fp["vllm"] == "0.27.1+rocm723"
 
 
 def test_an_operator_pin_still_wins_over_the_resolved_interpreter(tmp_path):
     python_exe = _installed(tmp_path / "vllm-venv", "vllm", "0.27.1+rocm723")
     fp = _prov.detect_stack_fingerprint(
-        {"HYPERLOOM_FRAMEWORK_PYTHON": python_exe, "VLLM_VERSION": "0.28.0-rc1"}, probe=True
+        {
+            "HYPERLOOM_RESOLVED_FRAMEWORK": "vllm",
+            "HYPERLOOM_RESOLVED_FRAMEWORK_PYTHON": python_exe,
+            "VLLM_VERSION": "0.28.0-rc1",
+        },
+        probe=True,
     )
     assert fp["vllm"] == "0.28.0-rc1"
 
 
-def test_a_resolved_interpreter_with_no_tree_is_not_a_failure(tmp_path):
+def test_an_interpreter_whose_prefix_yields_nothing_falls_back(tmp_path):
+    """No ``site-packages`` under the prefix means the derivation failed.
+
+    A system prefix keeps packages in ``dist-packages`` and a vanished venv has
+    no tree at all; treating either as an authoritative empty answer would
+    report "unknown" for a framework this process can see. Only a prefix that
+    really yields ``site-packages`` speaks for the run.
+    """
     fp = _prov.detect_stack_fingerprint(
-        {"HYPERLOOM_FRAMEWORK_PYTHON": str(tmp_path / "gone" / "bin" / "python")}, probe=True
+        {
+            "HYPERLOOM_RESOLVED_FRAMEWORK": "vllm",
+            "HYPERLOOM_RESOLVED_FRAMEWORK_PYTHON": str(tmp_path / "gone" / "bin" / "python"),
+        },
+        probe=True,
+    )
+    assert fp["vllm"] == _prov.detect_stack_fingerprint({}, probe=True)["vllm"]
+
+
+def test_a_real_venv_without_the_distribution_is_authoritative(tmp_path):
+    """A resolved venv that genuinely lacks the package must not be papered over.
+
+    This process may well have its own copy, but the run is not served by it.
+    """
+    venv_root = tmp_path / "vllm-venv"
+    (venv_root / "lib" / "python3.12" / "site-packages").mkdir(parents=True)
+    bin_dir = venv_root / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "python").symlink_to(sys.executable)
+
+    fp = _prov.detect_stack_fingerprint(
+        {
+            "HYPERLOOM_RESOLVED_FRAMEWORK": "vllm",
+            "HYPERLOOM_RESOLVED_FRAMEWORK_PYTHON": str(bin_dir / "python"),
+        },
+        probe=True,
     )
     assert fp["vllm"] == "unknown"
 
 
 def test_an_installer_venv_root_is_not_consulted(tmp_path):
-    """``$VLLM_VENV_ROOT`` is host state the installer only ever writes; it
-    survives an isolated -> shared move and would name an environment the run no
-    longer serves with. Only the resolved interpreter is authoritative."""
-    root = tmp_path / "stale-venv"
+    """Provenance records a resolution, it does not perform one.
+
+    ``$VLLM_VENV_ROOT`` is host state the installer only ever writes, so on its
+    own it cannot say whether that tree still holds vLLM. Preflight leads its
+    candidate list with it and probes it; only that outcome is published here.
+    Reading the raw variable would be a second, weaker discovery path.
+    """
+    root = tmp_path / "installer-venv"
     _installed(root, "vllm", "0.27.1+rocm723")
     fp = _prov.detect_stack_fingerprint({"VLLM_VENV_ROOT": str(root)}, probe=True)
     assert fp["vllm"] != "0.27.1+rocm723"
@@ -344,5 +398,7 @@ def test_an_installer_venv_root_is_not_consulted(tmp_path):
 def test_the_venv_is_not_scanned_under_probe_false(tmp_path):
     """probe=False is the hermetic contract: env only, no filesystem."""
     python_exe = _installed(tmp_path / "vllm-venv", "vllm", "0.27.1+rocm723")
-    fp = _prov.detect_stack_fingerprint({"HYPERLOOM_FRAMEWORK_PYTHON": python_exe}, probe=False)
+    fp = _prov.detect_stack_fingerprint(
+        {"HYPERLOOM_RESOLVED_FRAMEWORK": "vllm", "HYPERLOOM_RESOLVED_FRAMEWORK_PYTHON": python_exe}, probe=False
+    )
     assert fp["vllm"] == "unknown"

--- a/src/hyperloom/inference_optimizer/tests/test_manifest_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_manifest_unit.py
@@ -312,7 +312,8 @@ def test_manifest_versions_a_framework_installed_in_its_own_venv(monkeypatch, tm
     info.mkdir(parents=True)
     (info / "METADATA").write_text("Metadata-Version: 2.4\nName: vllm\nVersion: 0.27.1+rocm723\n", encoding="utf-8")
     monkeypatch.delenv("VLLM_VERSION", raising=False)
-    monkeypatch.setenv("HYPERLOOM_FRAMEWORK_PYTHON", str(venv_root / "bin" / "python"))
+    monkeypatch.setenv("HYPERLOOM_RESOLVED_FRAMEWORK", "vllm")
+    monkeypatch.setenv("HYPERLOOM_RESOLVED_FRAMEWORK_PYTHON", str(venv_root / "bin" / "python"))
     m = mf.build_manifest(Path("/tmp/sd"))
     assert m["stack_fingerprint"]["vllm"] == "0.27.1+rocm723"
 

--- a/src/hyperloom/inference_optimizer/tests/test_manifest_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_manifest_unit.py
@@ -312,7 +312,7 @@ def test_manifest_versions_a_framework_installed_in_its_own_venv(monkeypatch, tm
     info.mkdir(parents=True)
     (info / "METADATA").write_text("Metadata-Version: 2.4\nName: vllm\nVersion: 0.27.1+rocm723\n", encoding="utf-8")
     monkeypatch.delenv("VLLM_VERSION", raising=False)
-    monkeypatch.setenv("VLLM_VENV_ROOT", str(venv_root))
+    monkeypatch.setenv("HYPERLOOM_FRAMEWORK_PYTHON", str(venv_root / "bin" / "python"))
     m = mf.build_manifest(Path("/tmp/sd"))
     assert m["stack_fingerprint"]["vllm"] == "0.27.1+rocm723"
 

--- a/src/hyperloom/inference_optimizer/tests/test_preflight_serving_framework.py
+++ b/src/hyperloom/inference_optimizer/tests/test_preflight_serving_framework.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -14,6 +15,10 @@ import sys
 import pytest
 
 from hyperloom.common import provenance
+from hyperloom.common.provenance import (
+    RESOLVED_FRAMEWORK_ENV,
+    RESOLVED_FRAMEWORK_PYTHON_ENV,
+)
 from hyperloom.inference_optimizer.cli import preflight
 
 _SKIP_ENV = "HYPERLOOM_SKIP_FRAMEWORK_CHECK"
@@ -31,8 +36,18 @@ def _clear_env(monkeypatch):
         "INFERENCE_OPTIMIZER_NODES",
         "KUBERNETES_SERVICE_HOST",
         "HYPERLOOM_IMAGE",
+        # The check publishes these; without the reset they leak into every
+        # later test in the session and into provenance lookups.
+        RESOLVED_FRAMEWORK_PYTHON_ENV,
+        RESOLVED_FRAMEWORK_ENV,
     ):
         monkeypatch.delenv(key, raising=False)
+    yield
+    # ``delenv`` records no undo for a key that was absent, and the check writes
+    # these through ``os.environ`` rather than the fixture, so monkeypatch never
+    # sees them. Without this they outlive the file.
+    for key in (RESOLVED_FRAMEWORK_PYTHON_ENV, RESOLVED_FRAMEWORK_ENV):
+        os.environ.pop(key, None)
 
 
 def _args(framework: str | None = None) -> argparse.Namespace:
@@ -709,3 +724,113 @@ def test_the_remedy_matches_the_documented_setup_invocation(framework):
     assert documented, f"no documented setup line for {framework}"
 
     assert preflight._setup_install_command(framework) in documented
+
+
+# --- the resolved-interpreter publish contract -----------------------------
+
+
+def test_a_resolved_interpreter_is_published_with_its_framework(monkeypatch):
+    """provenance reads the pair; an unlabelled interpreter is unusable.
+
+    The scan answers for one framework, and ``sglang`` is the default, so the
+    name has to travel with the path or a vLLM lookup would read an SGLang
+    interpreter as its own answer.
+    """
+    _probe_result(monkeypatch, importable=True)
+
+    preflight._check_serving_framework(_args("vllm"), "/usr/bin/python3")
+
+    assert os.environ[RESOLVED_FRAMEWORK_PYTHON_ENV] == "/usr/bin/python3"
+    assert os.environ[RESOLVED_FRAMEWORK_ENV] == "vllm"
+
+
+def test_a_refuted_build_is_not_published(monkeypatch):
+    """A candidate proven to be the wrong build must not become the answer.
+
+    The check exits on a refuted build; the point here is that nothing was
+    published on the way out.
+    """
+    _probe_result(monkeypatch, importable=True, rocm=False)
+    monkeypatch.setattr(preflight, "_in_container", lambda: False)
+
+    with pytest.raises(SystemExit):
+        preflight._check_serving_framework(_args("vllm"), "/usr/bin/python3")
+
+    assert RESOLVED_FRAMEWORK_PYTHON_ENV not in os.environ
+    assert RESOLVED_FRAMEWORK_ENV not in os.environ
+
+
+def test_a_rocm_probe_timeout_still_publishes(monkeypatch):
+    """The timeout is in the ROCm verdict, not in importability.
+
+    ``_resolve_framework_build`` proves the candidate importable before probing
+    the build at all, and the check keeps serving with it after a warning.
+    Withholding it here would send provenance back to this process and record
+    the orchestrator's own version for a run served by the isolated venv.
+    """
+    calls: list[list[str]] = []
+
+    class _Proc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(preflight.subprocess, "run", lambda cmd, *a, **k: (calls.append(list(cmd)), _Proc())[1])
+    monkeypatch.setattr(
+        preflight,
+        "_probe_rocm_build",
+        lambda _fw, _py: preflight._Probe(None, timed_out=True),
+    )
+
+    preflight._check_serving_framework(_args("vllm"), "/usr/bin/python3")
+
+    assert os.environ.get(RESOLVED_FRAMEWORK_PYTHON_ENV) == "/usr/bin/python3"
+    assert os.environ.get(RESOLVED_FRAMEWORK_ENV) == "vllm"
+
+
+@pytest.mark.parametrize(
+    "setup",
+    [
+        pytest.param(lambda mp: mp.setenv(_SKIP_ENV, "1"), id="skip_env"),
+        pytest.param(lambda mp: mp.setenv("BENCHMARK_BASE_URL", "http://serving-host:8888"), id="remote_url"),
+        pytest.param(
+            lambda mp: (
+                mp.setenv("HYPERLOOM_MN_EXT_SERVICE_URL", "http://claw-rayjob:8000"),
+                mp.setenv("INFERENCE_OPTIMIZER_NODES", "2"),
+            ),
+            id="external_multi_node",
+        ),
+    ],
+)
+def test_an_exempt_path_publishes_nothing(monkeypatch, setup):
+    """Serving is not local on these paths, so there is no resolution to publish."""
+    setup(monkeypatch)
+    _refuse_probe(monkeypatch)
+
+    preflight._check_serving_framework(_args("vllm"), "/usr/bin/python3")
+
+    assert RESOLVED_FRAMEWORK_PYTHON_ENV not in os.environ
+    assert RESOLVED_FRAMEWORK_ENV not in os.environ
+
+
+def test_a_non_venv_interpreter_does_not_force_unknown(monkeypatch, tmp_path):
+    """A system prefix keeps packages in ``dist-packages``, not ``site-packages``.
+
+    Deriving ``<prefix>/lib/python*/site-packages`` finds nothing there, and
+    treating that as an authoritative empty answer would record "unknown" for a
+    framework this process can see -- the failure mode this whole path exists to
+    remove. Bare-metal Debian/Ubuntu without a venv is a supported layout.
+
+    The prefix is built here rather than probing the host's own ``/usr``: RHEL
+    and several ROCm images do keep ``lib/python*/site-packages`` under it, so
+    asserting against the real one would pass or fail by runner.
+    """
+    (tmp_path / "lib" / "python3.12" / "dist-packages").mkdir(parents=True)
+    (tmp_path / "bin").mkdir()
+    interpreter = tmp_path / "bin" / "python3"
+    interpreter.touch()
+
+    _probe_result(monkeypatch, importable=True)
+    preflight._check_serving_framework(_args("vllm"), str(interpreter))
+
+    assert provenance._framework_site_packages(os.environ, "vllm") is None


### PR DESCRIPTION


## Problem

`--framework-env isolated` is the default for vLLM, so `$VLLM_VENV_ROOT` names the vLLM a run actually serves with. But two places consulted the orchestrator's own interpreter first and only fell back to that venv when the lookup failed:

```python
# provenance.py — version recorded in the session manifest
try:
    return (_im.version(dist) or "").strip()   # this interpreter
except Exception:
    pass
if not venv_path:
    return ""
...                                            # venv, only as a fallback

# _server_patcher.py — which vLLM gets the TraceLens patch
try:
    import vllm                                # this interpreter
    ...
except Exception as e:   # any import failure → isolated-venv fallback
    probed = _probe_isolated_vllm()
```

On any host where vLLM is also installed alongside the orchestrator, that fallback is dead code — the interpreter always answers first. Consequences:

- the session manifest records the version of an environment the run never used
- the TraceLens patch is applied to that same wrong tree, so the served vLLM stays unpatched (no profiler annotations) while an unrelated install is modified

The version case is worse than the `vllm unknown` it replaced: `unknown` is honest, a wrong version looks right.

`provenance.py` also could not express "a venv was declared but is unusable" — `_venv_site_packages()` returned `[]` both when no venv was declared and when one was declared but empty, so the caller had no way to tell them apart.

## Fix

Both sites now branch on what the run **declared**, not on what happens to be importable:

```python
# provenance.py
if venv_path is not None:        # a venv was declared -> authoritative
    ...scan it; not found is ""  # never falls back to the interpreter
try:                             # no venv declared -> shared environment
    return (_im.version(dist) or "").strip()
except Exception:
    return ""

# _server_patcher.py
if os.environ.get("VLLM_VENV_ROOT", "").strip():
    probed = _probe_isolated_vllm()
    if probed is None:
        return None              # skip the patch rather than patch another env
    ...
else:
    import vllm                  # shared environment
```

`_venv_site_packages()` returns `None` (no venv declared) instead of `[]`, so `[]` now unambiguously means "declared but holds nothing" — and the `venv_path is not None` test keeps that case out of the interpreter branch.

A declared-but-unusable venv reports `unknown` / skips the patch. For the patcher that is deliberate: patching the wrong tree is worse than not patching, since the served vLLM stays unpatched either way and the wrong one gets modified.

## Verification

**Behaviour matrix.** Both functions, all four combinations, before vs after:

`detect_stack_fingerprint()["vllm"]`

| vLLM in interpreter | venv declared | before | after |
|---|---|---|---|
| no | no | `unknown` | `unknown` |
| no | yes | `9.9.9` | `9.9.9` |
| yes | no | `0.24.0+rocm723` | `0.24.0+rocm723` |
| yes | yes | `0.24.0+rocm723` | **`9.9.9`** |

`_discover_vllm_install()`

| vLLM in interpreter | venv declared | before | after |
|---|---|---|---|
| no | no | `None` | `None` |
| no | yes | venv `0.21.0` | venv `0.21.0` |
| yes | no | system `/opt/venv` | system `/opt/venv` |
| yes | yes | **system `/opt/venv`** | **venv `0.21.0`** |

Six of eight cells are unchanged. The two that move are exactly the defect. The first two rows of each table are the CI environment (no vLLM installed), so CI behaviour is identical.

**Tests.** Six existing tests that fail on any host with vLLM installed now pass:

```
test_common_provenance.py::test_a_framework_in_its_own_venv_is_still_versioned
test_common_provenance.py::test_a_venv_root_that_is_not_there_is_not_a_failure
test_manifest_unit.py::test_manifest_versions_a_framework_installed_in_its_own_venv
test_server_patcher_vllm_isolated_venv.py::test_isolated_venv_discovers_plan
test_server_patcher_vllm_isolated_venv.py::test_isolated_venv_missing_returns_none
test_server_patcher_vllm_isolated_venv.py::test_isolated_venv_no_profiler_sentinel_returns_none
```

They pass on CI today only because the runner has no vLLM; on a bare-metal Hyperloom host — the environment this code targets — they fail.

**Full suite.** `3 failed, 14758 passed` — down from `9 failed` on `main`. The remaining three are pre-existing robustness heartbeat failures (`assert 2 == 1`), unrelated to this change and equally present on a clean `main`.

`ruff check` passes. `ruff format` and `mypy` each report findings that are already present on `main` for these files, so they are left alone.

## One existing test was modified

`test_isolated_venv_missing_returns_none` gained `monkeypatch.setitem(sys.modules, "vllm", None)`.

Without `$VLLM_VENV_ROOT` the run is in the shared-environment case, where patching the interpreter's vLLM is the *correct* answer — so asserting `None` there only holds on a machine with no vLLM installed. The added line makes the test state the case it actually means (no venv declared **and** nothing importable here), which is what the assertion was always about, and makes it independent of the host.
