### PR TITLE
fix(gemm): drop unreachable backend branch and misleading precision filter

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_sync_helpers_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_sync_helpers_coverage_unit.py
@@ -520,6 +520,49 @@ def test_gemm_tuning_required_before_kernel_opt(coord: Coordinator, monkeypatch)
     assert coord._gemm_tuning_required_before_kernel_opt() is False
 
 
+def test_only_forge_can_reach_the_gemm_gate(monkeypatch) -> None:
+    """The backend order decides the phase before the gate is consulted.
+
+    ``_on_enter_kernel`` hands the whole phase to GEAK and returns without
+    calling the gate whenever GEAK owns the order, so the gate is reachable
+    only under forge. A backend branch inside it was therefore dead, and its
+    comment ("legacy FP8 + SGLang only") read as a live precision filter --
+    which invites reading a skipped model as precision-filtered when GEMM
+    tuning was in fact never reached at all.
+    """
+    from hyperloom.orchestrator.kernel.request_handlers import (
+        _resolve_gemm_tuning_backend,
+        geak_selected,
+    )
+
+    for order, forge_owns in (("forge", True), ("geak", False), ("", False),
+                              ("forge,geak", False), ("FORGE", True)):
+        monkeypatch.setenv("KERNEL_OPT_BACKEND_ORDER", order)
+        # GEAK owning the phase and forge owning it are exact complements.
+        assert geak_selected() is not forge_owns, order
+        if forge_owns:
+            # ... and where the gate is reachable, the backend is always forge,
+            # so no branch on it can do anything.
+            assert _resolve_gemm_tuning_backend({}) == "forge", order
+
+
+def test_the_gemm_gate_does_not_filter_on_precision(coord: Coordinator, monkeypatch) -> None:
+    """Every precision forge supports must clear the gate.
+
+    Filtering here would silently drop a category that can optimize: real
+    end-to-end KEEPs span bf16/fp16/fp8/fp4/mxfp4, and bf16 dense alone was
+    worth +11.1%.
+    """
+    monkeypatch.delenv("INFERENCE_OPTIMIZER_SKIP_GEMM_TUNING", raising=False)
+    monkeypatch.setenv("KERNEL_OPT_BACKEND_ORDER", "forge")
+    ss = coord.shared_state
+    ss.last_gemm_tuning = {}
+    ss.framework = "sglang"
+    for precision in ("bf16", "fp16", "fp8", "fp4", "mxfp4", "", "int8"):
+        ss.precision = precision
+        assert coord._gemm_tuning_required_before_kernel_opt() is True, precision
+
+
 def test_should_continue_kernel_after_gemm(coord: Coordinator) -> None:
     coord.shared_state.continue_kernel_after_gemm = False
     assert coord._should_continue_kernel_after_gemm() is False

--- a/src/hyperloom/orchestrator/loop/dispatcher.py
+++ b/src/hyperloom/orchestrator/loop/dispatcher.py
@@ -1672,9 +1672,23 @@ class DispatcherCollaborator:
     def _gemm_tuning_required_before_kernel_opt(self) -> bool:
         """Decide whether GEMM tuning must run before kernel_opt.
 
-        When using the forge-gemm-tune backend: eligible on any supported
-        framework (sglang / vllm / vllm-aiter), with no precision or MoE
-        pre-filter. When using GEAK: only FP8 + SGLang (legacy behavior).
+        Only forge reaches here. ``_on_enter_kernel`` hands the whole phase to
+        GEAK and returns before calling this whenever GEAK owns the order, and
+        the order is ``["forge"]`` exactly when ``KERNEL_OPT_BACKEND_ORDER`` is
+        ``forge`` and ``["geak"]`` otherwise -- so the two are complements and
+        arriving here means forge.
+
+        This used to branch on the backend and apply a legacy FP8 + SGLang
+        filter for GEAK. That branch could not execute, and its comment read as
+        if a precision filter were live, which is misleading in the one
+        direction that matters: it invites the conclusion that a model was
+        skipped for its precision when in fact GEMM tuning was never reached.
+
+        Eligibility is therefore a supported framework and nothing else. No
+        precision or MoE pre-filter: real e2e KEEPs span bf16/fp16/fp8/fp4/mxfp4
+        and dense as well as MoE -- bf16 *dense* alone was worth +11.1% -- so
+        filtering here silently blocks a category that can optimize. forge
+        itself reports ``no_improvement`` when a shape cannot be beaten.
 
         Returns:
             bool: ``True`` when GEMM tuning should run before source-level
@@ -1683,26 +1697,9 @@ class DispatcherCollaborator:
         if self._skip_gemm_tuning():
             return False
         ss = self.shared_state
-        precision = str(getattr(ss, "precision", "") or "").strip().lower()
         framework = str(getattr(ss, "framework", "") or "").strip().lower()
 
-        from ..kernel.request_handlers import _resolve_gemm_tuning_backend
-
-        backend = _resolve_gemm_tuning_backend({})
-
-        if backend == "forge":
-            # forge-gemm-tune handles any precision (bf16/fp16/fp8/fp4/mxfp4),
-            # dense or MoE, on sglang/vllm. Real e2e KEEPs span all of these —
-            # including bf16 *dense* (+11.1%) — so we must NOT pre-filter on
-            # precision/MoE here, or a category that can optimize gets silently
-            # blocked. Gate only on a supported framework and let forge itself
-            # return no_improvement when a shape can't be beaten.
-            eligible = framework in ("sglang", "vllm", "vllm-aiter")
-        else:
-            # GEAK: legacy FP8 + SGLang only.
-            eligible = precision == "fp8" and framework == "sglang"
-
-        if not eligible:
+        if framework not in ("sglang", "vllm", "vllm-aiter"):
             return False
         last = getattr(ss, "last_gemm_tuning", {}) or {}
         status = str(last.get("status") or "").strip().lower()


### PR DESCRIPTION
## Summary

- Remove the backend branch in `_gemm_tuning_required_before_kernel_opt()` and the legacy FP8 + SGLang filter it applied. That branch cannot execute, so this is a **no-op for every configuration**.
- Eligibility is now a supported framework (`sglang` / `vllm` / `vllm-aiter`) and nothing else, with the reachability argument documented inline.
- Add two invariant tests: the backend order's two owners are exact complements (including `forge,geak`, which is not an exact match and so falls back to GEAK), and every precision forge supports clears the gate.

## Why the branch is unreachable

Backend selection is a **single switch** — `forge_explicitly_enabled()`, i.e. exactly `KERNEL_OPT_BACKEND_ORDER=forge` (case-insensitive). Both functions that matter here read that one switch and nothing else:

- `geak_selected()` → `_raw_kernel_backend_order()` returns `["forge"]` when it is true and `["geak"]` otherwise.
- `_resolve_gemm_tuning_backend()` returns `"forge"` when it is true and `"geak"` otherwise.

They are two views of the same switch, hence strict complements. `_on_enter_kernel()` hands the entire KERNEL_AGENT phase to the GEAK delegate and returns *before* this gate whenever GEAK owns the order. So arriving at the gate already implies forge, and re-resolving the backend inside it can only answer `forge` — no input could ever select the `else` branch.

## Why it was worth deleting anyway

Its comment read as a live precision filter ("legacy FP8 + SGLang only"), which points a reader at the wrong explanation in precisely the case they will investigate: a session where GEMM tuning produced nothing *looks* precision-filtered, when in truth the phase went to GEAK and tuning was never reached. That cost real time in a production investigation before the early return was spotted.

No precision / MoE pre-filter replaces it. Real end-to-end KEEPs span bf16/fp16/fp8/fp4/mxfp4, dense as well as MoE — bf16 *dense* alone was worth +11.1%. Filtering here would silently block a category that can optimize, and forge already reports `no_improvement` when a shape cannot be beaten.

## Note on an earlier RCA

A prior RCA attributed missing GEMM tuning to precision filtering at this gate. That was wrong on both counts: the filter never ran, and Forge does tune when a pipeline opts in (2026-08-09 forge batch: +24.51% GEMM gain in the session breakdown). The recent absence of forge batches is Conductor-side scheduling, not orchestrator gate logic.

For the same reason, a non-exact value such as `KERNEL_OPT_BACKEND_ORDER=perfskills` (used by one pipeline) falls back to GEAK like any other non-`forge` value. That is the documented contract, not a defect.

## Test plan

- [x] `pytest src/hyperloom/inference_optimizer/tests/test_coordinator_sync_helpers_coverage_unit.py -k gemm`
- [x] Unit / lint / CodeQL / docs / packaging CI green
- [ ] E2E smoke run (in progress)
