### PR TITLE
Tighten PolicyGate freeform wave validation and ProposalScorer contract (P2-36, P2-37)

### DIFF
--- a/src/hyperloom/common/jsonio.py
+++ b/src/hyperloom/common/jsonio.py
@@ -201,6 +201,57 @@ def extract_first_json_with_key(
     return found
 
 
+def extract_last_json_with_key(
+    text: str,
+    required_key: str | None = None,
+) -> dict[str, Any] | None:
+    """Return the last JSON object in *text* (by start offset) that qualifies.
+
+    Scans fenced blocks and every bare ``{`` opener in document order so a
+    trailing fenced envelope wins over an earlier bare draft, and objects
+    whose first field is not *required_key* (e.g. ``{"meta": ..., "scores": ...}``)
+    still qualify when the key is present.
+
+    Args:
+        text: Raw model reply that may contain fenced or bare JSON objects.
+        required_key: Top-level key the returned dict must contain. When
+            ``None``, any parsed JSON object qualifies.
+
+    Returns:
+        The last qualifying dict by start offset, or ``None`` when none parses.
+    """
+    if not text:
+        return None
+
+    def _qualifies(data: Any) -> bool:
+        return isinstance(data, dict) and (required_key is None or required_key in data)
+
+    candidates: list[tuple[int, dict[str, Any]]] = []
+    for m in _FENCED_JSON_RE.finditer(text):
+        try:
+            data = json.loads(m.group(1))
+        except json.JSONDecodeError:
+            continue
+        if _qualifies(data):
+            candidates.append((m.start(), data))
+    for i, ch in enumerate(text):
+        if ch != "{":
+            continue
+        candidate = text[i:]
+        for end in range(len(candidate), 0, -1):
+            try:
+                data = json.loads(candidate[:end])
+            except json.JSONDecodeError:
+                continue
+            if _qualifies(data):
+                candidates.append((i, data))
+            break
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: item[0])
+    return candidates[-1][1]
+
+
 def iter_sse_objects(raw: str) -> Iterator[Any]:
     """Yield JSON objects decoded from an MCP HTTP response body.
 
@@ -250,6 +301,7 @@ def iter_sse_objects(raw: str) -> Iterator[Any]:
 __all__ = [
     "coerce_dict",
     "extract_first_json_with_key",
+    "extract_last_json_with_key",
     "iter_sse_objects",
     "read_json",
     "read_jsonl",

--- a/src/hyperloom/inference_optimizer/tests/test_common_jsonio.py
+++ b/src/hyperloom/inference_optimizer/tests/test_common_jsonio.py
@@ -8,7 +8,7 @@ import re
 
 import pytest
 
-from hyperloom.common.jsonio import coerce_dict, extract_first_json_with_key, read_json, read_jsonl
+from hyperloom.common.jsonio import coerce_dict, extract_first_json_with_key, extract_last_json_with_key, read_json, read_jsonl
 
 _BARE = re.compile(r"(\{.*\})", re.DOTALL)
 
@@ -160,3 +160,18 @@ class TestExtractFirstJson:
         text = 'bare {"k": 1} no fence'
         # bare_re None -> only fenced blocks considered
         assert extract_first_json_with_key(text, "k") is None
+
+
+class TestExtractLastJson:
+    def test_meta_prefix_scores(self):
+        text = '{"meta": "draft", "scores": {"proposal_0": {"score": 9, "reason": "ok"}}}'
+        out = extract_last_json_with_key(text, "scores")
+        assert out["scores"]["proposal_0"]["score"] == 9
+
+    def test_bare_then_fenced_prefers_later_offset(self):
+        text = (
+            '{"scores": {"proposal_0": {"score": 1, "reason": "old"}}} '
+            '```json\n{"meta": "final", "scores": {"proposal_0": {"score": 8, "reason": "new"}}}\n```'
+        )
+        out = extract_last_json_with_key(text, "scores")
+        assert out["scores"]["proposal_0"]["score"] == 8

--- a/src/hyperloom/inference_optimizer/tests/test_common_jsonio.py
+++ b/src/hyperloom/inference_optimizer/tests/test_common_jsonio.py
@@ -8,7 +8,13 @@ import re
 
 import pytest
 
-from hyperloom.common.jsonio import coerce_dict, extract_first_json_with_key, extract_last_json_with_key, read_json, read_jsonl
+from hyperloom.common.jsonio import (
+    coerce_dict,
+    extract_first_json_with_key,
+    extract_last_json_with_key,
+    read_json,
+    read_jsonl,
+)
 
 _BARE = re.compile(r"(\{.*\})", re.DOTALL)
 

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_async_batch2_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_async_batch2_unit.py
@@ -1727,7 +1727,10 @@ async def test_fan_out_wave_dispatches_valid_task(coord: Coordinator, monkeypatc
         seen.append(dict(intent.payload.get("params") or {}))
 
     monkeypatch.setattr(coord, "_handle_delegate", _fake_delegate)
-    intent = Intent(type=IntentType.DELEGATE, payload={"idempotency_key": "wave"})
+    intent = Intent(
+        type=IntentType.DELEGATE,
+        payload={"idempotency_key": "wave", "action_name": "specialist"},
+    )
     await coord._fan_out_specialist_wave(
         "orchestration",
         intent,

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_async_methods_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_async_methods_coverage_unit.py
@@ -1084,21 +1084,24 @@ async def test_auto_retry_caps_attempts(coord: Coordinator, monkeypatch) -> None
     assert await coord._maybe_auto_retry_specialist(task, res) is False
 
 
-# -- _fan_out_specialist_wave (skip path) ----------------------------------
+# -- _fan_out_specialist_wave (invalid entries) ---------------------------
 @pytest.mark.asyncio
-async def test_fan_out_wave_skips_invalid_entries(coord: Coordinator, monkeypatch) -> None:
+async def test_fan_out_wave_rejects_invalid_entries(coord: Coordinator, monkeypatch) -> None:
     called = []
     monkeypatch.setattr(
         coord,
         "_handle_delegate",
         lambda *a, **k: called.append(a),
     )
-    intent = Intent(type=IntentType.DELEGATE, payload={"idempotency_key": "w"})
-    await coord._fan_out_specialist_wave(
-        "orchestration",
-        intent,
-        {"tasks": ["not-a-dict", {}, {"task_description": "   "}]},
-    )
+    intent = Intent(type=IntentType.DELEGATE, payload={"idempotency_key": "w", "action_name": "specialist"})
+    from hyperloom.orchestrator.policy.gate import PolicyDenied
+
+    with pytest.raises(PolicyDenied):
+        await coord._fan_out_specialist_wave(
+            "orchestration",
+            intent,
+            {"tasks": ["not-a-dict", {}, {"task_description": "   "}]},
+        )
     assert called == []
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_per_domain_prompts.py
+++ b/src/hyperloom/inference_optimizer/tests/test_per_domain_prompts.py
@@ -691,22 +691,24 @@ def test_R2_max_turns_zero_allowed_unbounded(gate):
     )
 
 
-def test_R2_max_turns_negative_allowed(gate):
-    """A negative max_turns is self-limiting (empty turn range), so it is not denied."""
-    gate.validate_intent(
-        "orchestration",
-        Intent(
-            type=IntentType.DELEGATE,
-            payload={
-                "action_name": "specialist",
-                "params": {
-                    "domain": "serving_specialist",
-                    "gap_canonical_id": "gap.x",
-                    "max_turns": -1,
+def test_R2_max_turns_negative_denied(gate):
+    with pytest.raises(PolicyDenied) as exc:
+        gate.validate_intent(
+            "orchestration",
+            Intent(
+                type=IntentType.DELEGATE,
+                payload={
+                    "action_name": "specialist",
+                    "params": {
+                        "domain": "serving_specialist",
+                        "gap_canonical_id": "gap.x",
+                        "max_turns": -1,
+                    },
                 },
-            },
-        ),
-    )
+            ),
+        )
+    assert exc.value.rule == "specialist_dispatch_source"
+    assert "max_turns" in str(exc.value)
 
 
 # research_lane lane registration.

--- a/src/hyperloom/inference_optimizer/tests/test_proposal_scorer.py
+++ b/src/hyperloom/inference_optimizer/tests/test_proposal_scorer.py
@@ -19,6 +19,7 @@ from hyperloom.orchestrator.scoring.proposal_scorer import (
     DEFAULT_SCORER_MODELS,
     ProposalScorer,
     _extract_scores_json,
+    _prepare_scoring_proposals,
 )
 from hyperloom.orchestrator.policy.gate import SPECIALIST_FROM_AGENT_PREFIX
 from hyperloom.inference_optimizer.session.session_paths import (
@@ -130,7 +131,7 @@ _PROPOSALS = [
 
 
 def _scores_json(*pairs: tuple[str, float, str]) -> str:
-    body = ", ".join(f'"{name}": {{"score": {score}, "reason": "{reason}"}}' for name, score, reason in pairs)
+    body = ", ".join(f'"{stable_id}": {{"score": {score}, "reason": "{reason}"}}' for stable_id, score, reason in pairs)
     return f'```json\n{{"scores": {{{body}}}}}\n```'
 
 
@@ -139,12 +140,12 @@ def _scores_json(*pairs: tuple[str, float, str]) -> str:
 async def test_score_two_models_happy_path():
     behaviour = {
         "claude-opus-4-7": _scores_json(
-            ("cuda_graph_bs_512", 8.0, "strong fit"),
-            ("disable_radix", 4.0, "marginal"),
+            ("proposal_0", 8.0, "strong fit"),
+            ("proposal_1", 4.0, "marginal"),
         ),
         "gpt-5.4": _scores_json(
-            ("cuda_graph_bs_512", 6.5, "plausible"),
-            ("disable_radix", 5.0, "ok"),
+            ("proposal_0", 6.5, "plausible"),
+            ("proposal_1", 5.0, "ok"),
         ),
     }
     scorer = _make_scorer(behaviour)
@@ -171,7 +172,7 @@ async def test_scoring_call_writes_full_conversation_trace(tmp_path: Path):
     session_dir.mkdir()
     client = _FakeClient(
         {
-            "claude-opus-4-7": _scores_json(("cuda_graph_bs_512", 8.0, "fit")),
+            "claude-opus-4-7": _scores_json(("proposal_0", 8.0, "fit")),
         }
     )
     scorer = ProposalScorer(
@@ -189,7 +190,7 @@ async def test_scoring_call_writes_full_conversation_trace(tmp_path: Path):
     assert row["model"] == "claude-opus-4-7"
     assert row["task_id"] == "spec-7"
     assert "cuda_graph_bs_512" in row["prompt"]
-    assert "cuda_graph_bs_512" in row["response"]
+    assert "proposal_0" in row["response"]
 
     token_rows = _read_jsonl(llm_calls_path(session_dir))
     scorer_rows = [r for r in token_rows if r["component"] == "proposal_scorer"]
@@ -244,14 +245,14 @@ async def test_failed_scoring_call_writes_an_error_row(tmp_path: Path):
 @pytest.mark.asyncio
 async def test_scoring_without_session_dir_writes_no_trace(tmp_path: Path):
     """The default (tests / no full-trace) path writes no conversation file."""
-    scorer = _make_scorer({"m1": _scores_json(("cuda_graph_bs_512", 7.0, "x"))})
+    scorer = _make_scorer({"m1": _scores_json(("proposal_0", 7.0, "x"))})
     await scorer.score(gap=_GAP, proposals=_PROPOSALS)
     assert scorer.session_dir is None
 
 
 @pytest.mark.asyncio
 async def test_group_prompt_contains_all_proposals_and_gap():
-    behaviour = {"m1": _scores_json(("cuda_graph_bs_512", 7.0, "x"))}
+    behaviour = {"m1": _scores_json(("proposal_0", 7.0, "x"))}
     scorer = _make_scorer(behaviour)
     await scorer.score(gap=_GAP, proposals=_PROPOSALS)
     client = scorer._client
@@ -265,7 +266,7 @@ async def test_group_prompt_contains_all_proposals_and_gap():
 @pytest.mark.asyncio
 async def test_per_model_degrade_one_raises_other_survives():
     behaviour = {
-        "good": _scores_json(("cuda_graph_bs_512", 9.0, "great")),
+        "good": _scores_json(("proposal_0", 9.0, "great")),
         "bad": RuntimeError("gateway 404 unknown model"),
     }
     scorer = _make_scorer(behaviour)
@@ -289,8 +290,8 @@ async def test_unparseable_reply_recorded_as_error():
 async def test_scores_clamped_and_unknown_names_dropped():
     behaviour = {
         "m1": _scores_json(
-            ("cuda_graph_bs_512", 99.0, "over"),  # clamp to 10
-            ("disable_radix", -3.0, "under"),  # clamp to 0
+            ("proposal_0", 99.0, "over"),  # clamp to 10
+            ("proposal_1", -3.0, "under"),  # clamp to 0
             ("ghost_variant", 5.0, "not in set"),  # dropped
         ),
     }
@@ -312,11 +313,13 @@ async def test_empty_proposals_returns_empty_envelope():
 
 
 def test_extract_scores_json_bare_and_fenced():
-    fenced = _scores_json(("a", 1.0, "x"))
-    assert _extract_scores_json(fenced)["scores"]["a"]["score"] == 1.0
-    bare = '{"scores": {"a": {"score": 2, "reason": "y"}}}'
-    assert _extract_scores_json(bare)["scores"]["a"]["score"] == 2
+    fenced = _scores_json(("proposal_0", 1.0, "x"))
+    assert _extract_scores_json(fenced)["scores"]["proposal_0"]["score"] == 1.0
+    bare = '{"scores": {"proposal_0": {"score": 2, "reason": "y"}}}'
+    assert _extract_scores_json(bare)["scores"]["proposal_0"]["score"] == 2
     assert _extract_scores_json("no json here") is None
+    meta = '```json\n{"meta": "draft", "scores": {"proposal_0": {"score": 9, "reason": "final"}}}\n```'
+    assert _extract_scores_json(meta)["scores"]["proposal_0"]["score"] == 9
 
 
 def test_default_models_constant():
@@ -387,7 +390,7 @@ def _done():
 async def test_coordinator_attaches_ensemble_scores(tmp_path):
     scorer = _make_scorer(
         {
-            "claude-opus-4-7": _scores_json(("cuda_graph_bs_512", 8.0, "fit")),
+            "claude-opus-4-7": _scores_json(("proposal_0", 8.0, "fit")),
         }
     )
     c = _coord(tmp_path, scorer)
@@ -433,7 +436,7 @@ async def test_coordinator_scorer_exception_still_records(tmp_path):
 
 @pytest.mark.asyncio
 async def test_coordinator_empty_proposals_not_scored(tmp_path):
-    scorer = _make_scorer({"m1": _scores_json(("x", 1.0, "y"))})
+    scorer = _make_scorer({"m1": _scores_json(("proposal_0", 1.0, "y"))})
     c = _coord(tmp_path, scorer)
     payload = _done()
     payload["proposal_set"] = []
@@ -563,7 +566,7 @@ def test_render_rater_labels_stable_across_rounds():
 async def test_resume_idempotent_on_round_id(tmp_path):
     scorer = _make_scorer(
         {
-            "m1": _scores_json(("cuda_graph_bs_512", 8.0, "fit")),
+            "m1": _scores_json(("proposal_0", 8.0, "fit")),
         }
     )
     c = _coord(tmp_path, scorer)
@@ -639,9 +642,10 @@ def _scripted_scorer(chunks: list[Any], *, stall: bool = False, call_timeout_s: 
 
 @pytest.mark.asyncio
 async def test_stream_flag_is_passed():
-    chunks = [_content_chunk(_scores_json(("p", 5, "ok"))), _usage_chunk(_FakeUsage(10, 20))]
+    chunks = [_content_chunk(_scores_json(("proposal_0", 5, "ok"))), _usage_chunk(_FakeUsage(10, 20))]
     scorer, client = _scripted_scorer(chunks)
-    await scorer._score_one_model("m", "prompt", ["p"])
+    entries = _prepare_scoring_proposals([{"name": "p"}])
+    await scorer._score_one_model("m", "prompt", entries)
     call = client.chat.completions.calls[0]
     assert call["stream"] is True
     assert call["stream_options"] == {"include_usage": True}
@@ -650,7 +654,7 @@ async def test_stream_flag_is_passed():
 @pytest.mark.asyncio
 async def test_multiple_content_chunks_are_accumulated():
     # Split a valid scores JSON across content deltas.
-    body = _scores_json(("p", 7, "good"))
+    body = _scores_json(("proposal_0", 7, "good"))
     third = len(body) // 3
     chunks = [
         _content_chunk(body[:third]),
@@ -659,7 +663,8 @@ async def test_multiple_content_chunks_are_accumulated():
         _usage_chunk(_FakeUsage(11, 22)),
     ]
     scorer, _ = _scripted_scorer(chunks)
-    out = await scorer._score_one_model("m", "prompt", ["p"])
+    entries = _prepare_scoring_proposals([{"name": "p"}])
+    out = await scorer._score_one_model("m", "prompt", entries)
     assert out["p"]["score"] == 7.0
 
 
@@ -668,14 +673,16 @@ async def test_stalled_stream_body_times_out():
     # Stream stalls after one chunk: the deadline must cover the consumption loop.
     chunks = [_content_chunk('{"scores": {')]
     scorer, _ = _scripted_scorer(chunks, stall=True, call_timeout_s=0.05)
+    entries = _prepare_scoring_proposals([{"name": "p"}])
     with pytest.raises(RuntimeError, match="timed out"):
-        await scorer._score_one_model("m", "prompt", ["p"])
+        await scorer._score_one_model("m", "prompt", entries)
 
 
 @pytest.mark.asyncio
 async def test_missing_usage_chunk_degrades_cleanly():
     # No usage-bearing chunk: scoring still succeeds.
-    chunks = [_content_chunk(_scores_json(("p", 4, "fine")))]
+    chunks = [_content_chunk(_scores_json(("proposal_0", 4, "fine")))]
     scorer, _ = _scripted_scorer(chunks)
-    out = await scorer._score_one_model("m", "prompt", ["p"])
+    entries = _prepare_scoring_proposals([{"name": "p"}])
+    out = await scorer._score_one_model("m", "prompt", entries)
     assert out["p"]["score"] == 4.0

--- a/src/hyperloom/inference_optimizer/tests/test_proposal_scorer_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_proposal_scorer_coverage_unit.py
@@ -13,10 +13,12 @@ import pytest
 from hyperloom.orchestrator.scoring import proposal_scorer as proposal_scorer_module
 from hyperloom.orchestrator.scoring.proposal_scorer import (
     ProposalScorer,
+    _ScoringProposal,
     _clip,
     _coerce_score,
     _extract_scores_json,
     _normalise_model_scores,
+    _prepare_scoring_proposals,
 )
 
 
@@ -27,9 +29,18 @@ def test_extract_scores_json_empty():
 
 def test_extract_scores_json_bare_with_trailing():
     # bare object with trailing prose -> shrink loop trims to valid JSON.
-    text = 'here are scores {"scores": {"a": {"score": 1, "reason": "x"}}} thanks'
+    text = 'here are scores {"scores": {"proposal_0": {"score": 1, "reason": "x"}}} thanks'
     out = _extract_scores_json(text)
-    assert out["scores"]["a"]["score"] == 1
+    assert out["scores"]["proposal_0"]["score"] == 1
+
+
+def test_extract_scores_json_prefers_last_envelope():
+    text = (
+        'draft {"scores": {"proposal_0": {"score": 1, "reason": "old"}}} '
+        'final {"scores": {"proposal_0": {"score": 8, "reason": "new"}}}'
+    )
+    out = _extract_scores_json(text)
+    assert out["scores"]["proposal_0"]["score"] == 8
 
 
 def test_extract_scores_json_wrong_shape():
@@ -41,6 +52,8 @@ def test_extract_scores_json_wrong_shape():
 def test_coerce_score_edges():
     assert _coerce_score("nan") is None
     assert _coerce_score("bad") is None
+    assert _coerce_score(True) is None
+    assert _coerce_score(False) is None
     assert _coerce_score(99) == 10.0
     assert _coerce_score(-5) == 0.0
 
@@ -52,21 +65,35 @@ def test_clip_truncates():
 
 # ---- _normalise_model_scores ----
 def test_normalise_scores_not_dict():
-    assert _normalise_model_scores({"scores": "x"}, proposal_names=["a"]) == {}
+    assert _normalise_model_scores({"scores": "x"}, scoring_entries=[]) == {}
 
 
 def test_normalise_drops_unknown_and_bad_score():
+    entries = [
+        _ScoringProposal(stable_id="proposal_0", display_name="a", proposal={"name": "a"}),
+        _ScoringProposal(stable_id="proposal_1", display_name="b", proposal={"name": "b"}),
+    ]
     parsed = {
         "scores": {
-            "a": {"score": 5, "reason": "ok"},
-            "ghost": {"score": 3},  # unknown name -> dropped
-            "b": {"score": "x"},  # bad score -> dropped
+            "proposal_0": {"score": 5, "reason": "ok"},
+            "ghost": {"score": 3},
+            "proposal_1": {"score": "x"},
         }
     }
-    out = _normalise_model_scores(parsed, proposal_names=["a", "b"])
+    out = _normalise_model_scores(parsed, scoring_entries=entries)
     assert "a" in out
     assert "ghost" not in out
     assert "b" not in out
+
+
+def test_prepare_scoring_proposals_rejects_duplicate_names():
+    with pytest.raises(ValueError, match="duplicate proposal name"):
+        _prepare_scoring_proposals(
+            [
+                {"name": "same"},
+                {"name": "same"},
+            ]
+        )
 
 
 # ---- _ensure_client ----
@@ -211,7 +238,7 @@ async def test_score_caps_proposals():
 @pytest.mark.asyncio
 async def test_score_streams_with_usage_and_keeps_the_token_cap():
     """The shared streaming helper adds stream + include_usage; the 4096 cap survives."""
-    client = _FakeClient({"m": '{"scores": {"p": {"score": 5, "reason": "ok"}}}'})
+    client = _FakeClient({"m": '{"scores": {"proposal_0": {"score": 5, "reason": "ok"}}}'})
     scorer = ProposalScorer(models=("m",), client_factory=lambda: client)
     out = await scorer.score(gap={"domain": "d"}, proposals=[{"name": "p"}])
     assert out["models"]["m"]["p"]["score"] == 5.0
@@ -241,16 +268,35 @@ async def test_score_no_usable_scores():
 
 
 @pytest.mark.asyncio
+async def test_score_duplicate_names_recorded_as_input_error():
+    client = _FakeClient({"m": '{"scores": {}}'})
+    scorer = ProposalScorer(models=("m",), client_factory=lambda: client)
+    out = await scorer.score(
+        gap={"domain": "d"},
+        proposals=[{"name": "dup"}, {"name": "dup"}],
+    )
+    assert out["models"] == {}
+    assert "duplicate proposal name" in out["errors"]["input"]
+
+
+@pytest.mark.asyncio
+async def test_score_duplicate_model_slugs_rejected_at_construction():
+    with pytest.raises(ValueError, match="duplicate scorer model slug"):
+        ProposalScorer(models=("m", "m"), client_factory=lambda: object())
+
+
+@pytest.mark.asyncio
 async def test_build_prompt_includes_evidence():
     client = _FakeClient({"m": '{"scores": {}}'})
     scorer = ProposalScorer(models=("m",), client_factory=lambda: client)
     gap = {"domain": "d", "gap_evidence": {"e": 1}, "gap_symptom": "s"}
-    prompt = scorer._build_prompt(
-        gap=gap,
-        proposals=[
+    entries = _prepare_scoring_proposals(
+        [
             {"name": "p", "extra_args": "--x", "extra_envs": {"E": "1"}, "reason": "r", "kb_evidence": ["k"]},
-        ],
+        ]
     )
+    prompt = scorer._build_prompt(gap=gap, scoring_entries=entries)
     assert "evidence:" in prompt
     assert "extra_envs:" in prompt
     assert "kb_evidence:" in prompt
+    assert "id: proposal_0" in prompt

--- a/src/hyperloom/inference_optimizer/tests/test_proposal_scorer_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_proposal_scorer_coverage_unit.py
@@ -70,8 +70,18 @@ def test_normalise_scores_not_dict():
 
 def test_normalise_drops_unknown_and_bad_score():
     entries = [
-        _ScoringProposal(stable_id="proposal_0", display_name="a", proposal={"name": "a"}),
-        _ScoringProposal(stable_id="proposal_1", display_name="b", proposal={"name": "b"}),
+        _ScoringProposal(
+            stable_id="proposal_0",
+            output_name="a",
+            label_name="a",
+            proposal={"name": "a"},
+        ),
+        _ScoringProposal(
+            stable_id="proposal_1",
+            output_name="b",
+            label_name="b",
+            proposal={"name": "b"},
+        ),
     ]
     parsed = {
         "scores": {

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_dispatch_params.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_dispatch_params.py
@@ -589,6 +589,76 @@ def test_research_specialist_without_needs_gpu_is_not_gated(orchestration_role):
     )
 
 
+def test_freeform_wave_mixed_valid_and_invalid_rejected(gate, orchestration_role):
+    with pytest.raises(PolicyDenied) as exc:
+        gate._validate_specialist_dispatch(
+            orchestration_role,
+            _dispatch(
+                {
+                    "scope": "freeform",
+                    "tasks": [
+                        {"task_description": "valid task"},
+                        {"task_description": ""},
+                    ],
+                }
+            ),
+        )
+    assert exc.value.rule == "specialist_freeform_empty_description"
+    assert "tasks[1]" in str(exc.value)
+
+
+def test_freeform_negative_max_turns_rejected(gate, orchestration_role):
+    with pytest.raises(PolicyDenied) as exc:
+        gate._validate_specialist_dispatch(
+            orchestration_role,
+            _dispatch({"scope": "freeform", "task_description": "probe", "max_turns": -1}),
+        )
+    assert "max_turns" in str(exc.value)
+
+
+def test_freeform_wave_task_negative_max_turns_rejected(gate, orchestration_role):
+    with pytest.raises(PolicyDenied) as exc:
+        gate._validate_specialist_dispatch(
+            orchestration_role,
+            _dispatch(
+                {
+                    "scope": "freeform",
+                    "tasks": [{"task_description": "probe", "max_turns": -1}],
+                }
+            ),
+        )
+    assert "tasks[0].max_turns" in str(exc.value)
+
+
+def test_freeform_max_turns_above_cap_rejected(gate, orchestration_role):
+    from hyperloom.orchestrator.specialists.domains import SPECIALIST_MAX_TURNS_HARD_CAP
+
+    with pytest.raises(PolicyDenied):
+        gate._validate_specialist_dispatch(
+            orchestration_role,
+            _dispatch(
+                {
+                    "scope": "freeform",
+                    "task_description": "probe",
+                    "max_turns": SPECIALIST_MAX_TURNS_HARD_CAP + 1,
+                }
+            ),
+        )
+
+
+def test_prepare_scoring_proposals_preserves_output_name_whitespace():
+    from hyperloom.orchestrator.scoring.proposal_scorer import (
+        _normalise_model_scores,
+        _prepare_scoring_proposals,
+    )
+
+    entries = _prepare_scoring_proposals([{"name": " x "}])
+    parsed = {"scores": {"proposal_0": {"score": 5, "reason": "ok"}}}
+    out = _normalise_model_scores(parsed, scoring_entries=entries)
+    assert " x " in out
+    assert "x" not in out
+
+
 def test_resolve_specialist_max_turns_zero_uses_default():
     from hyperloom.orchestrator.specialists.runner import resolve_specialist_max_turns
 

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_dispatch_params.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_dispatch_params.py
@@ -252,18 +252,33 @@ def test_freeform_wave_too_large_rejected(gate, orchestration_role):
     assert exc.value.rule == "specialist_freeform_wave_too_large"
 
 
-def test_freeform_wave_non_dict_task_skipped(gate, orchestration_role):
-    gate._validate_specialist_dispatch(
-        orchestration_role,
-        _dispatch({"scope": "freeform", "tasks": ["not a dict"]}),
-    )
+def test_freeform_wave_non_dict_task_rejected(gate, orchestration_role):
+    with pytest.raises(PolicyDenied) as exc:
+        gate._validate_specialist_dispatch(
+            orchestration_role,
+            _dispatch({"scope": "freeform", "tasks": ["not a dict"]}),
+        )
+    assert exc.value.rule == "specialist_freeform_wave_invalid_task"
+    assert "tasks[0]" in str(exc.value)
 
 
-def test_freeform_wave_empty_task_description_skipped(gate, orchestration_role):
-    gate._validate_specialist_dispatch(
-        orchestration_role,
-        _dispatch({"scope": "freeform", "tasks": [{"task_description": ""}]}),
-    )
+def test_freeform_wave_empty_task_description_rejected(gate, orchestration_role):
+    with pytest.raises(PolicyDenied) as exc:
+        gate._validate_specialist_dispatch(
+            orchestration_role,
+            _dispatch({"scope": "freeform", "tasks": [{"task_description": ""}]}),
+        )
+    assert exc.value.rule == "specialist_freeform_empty_description"
+    assert "tasks[0]" in str(exc.value)
+
+
+def test_freeform_wave_all_invalid_rejected(gate, orchestration_role):
+    with pytest.raises(PolicyDenied) as exc:
+        gate._validate_specialist_dispatch(
+            orchestration_role,
+            _dispatch({"scope": "freeform", "tasks": ["bad", {"task_description": ""}]}),
+        )
+    assert exc.value.rule == "specialist_freeform_wave_invalid_task"
 
 
 # --------------------------------------------------------------------------- #
@@ -572,6 +587,14 @@ def test_research_specialist_without_needs_gpu_is_not_gated(orchestration_role):
             }
         ),
     )
+
+
+def test_resolve_specialist_max_turns_zero_uses_default():
+    from hyperloom.orchestrator.specialists.runner import resolve_specialist_max_turns
+
+    assert resolve_specialist_max_turns(0, default=1000) == 1000
+    assert resolve_specialist_max_turns(None, default=42) == 42
+    assert resolve_specialist_max_turns(5, default=1000) == 5
 
 
 # --------------------------------------------------------------------------- #

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -2277,8 +2277,15 @@ class WritebackCollaborator:
                     tick=int(getattr(self.shared_state, "tick", 0) or 0),
                     phase=(getattr(self.shared_state, "phase", "") or "") or None,
                 )
-                if scores and scores.get("models"):
+                if scores and (scores.get("models") or scores.get("errors")):
                     round_entry["ensemble_scores"] = scores
+                    input_err = (scores.get("errors") or {}).get("input")
+                    if input_err and not scores.get("models"):
+                        log.warning(
+                            "specialist bookkeeping: proposal scoring skipped for task=%s: %s",
+                            task.task_id,
+                            input_err,
+                        )
             except Exception:  # noqa: BLE001 — advisory; never block
                 log.exception(
                     "specialist bookkeeping: proposal scoring failed for task=%s (continuing without scores)",

--- a/src/hyperloom/orchestrator/phases/explore.py
+++ b/src/hyperloom/orchestrator/phases/explore.py
@@ -17,6 +17,7 @@ from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
 from ..bus.message_bus import Message
 from ..policy.gate import (
     SPECIALIST_FROM_AGENT_PREFIX,
+    validate_freeform_wave_task,
 )
 from ..loop.maintenance import run_lease_and_db_reclaim
 from ..loop.sub_agent_runner import SubAgentResult
@@ -645,7 +646,8 @@ class ExplorePhase(PhaseHandler):
         standard free-form specialist dispatches (scope=freeform, lane=cpu,
         mode=research defaults). Each fanned task is re-dispatched through the
         normal ``_handle_delegate`` path. Per-task idempotency keys derive from
-        the wave key; non-dict / empty-description entries are skipped.
+        the wave key. Each entry must pass the same structural checks as
+        :func:`validate_freeform_wave_task` (the PolicyGate runs these first).
 
         Args:
             source: The agent issuing the wave delegate.
@@ -656,11 +658,7 @@ class ExplorePhase(PhaseHandler):
         shared = {k: v for k, v in params.items() if k != "tasks"}
         base_key = str(intent.payload.get("idempotency_key") or "").strip()
         for idx, task in enumerate(tasks):
-            if not isinstance(task, dict):
-                continue
-            desc = str(task.get("task_description") or task.get("task_summary") or "").strip()
-            if not desc:
-                continue
+            desc = validate_freeform_wave_task(task, index=idx)
             sub_params = dict(shared)
             sub_params["scope"] = "freeform"
             sub_params["task_description"] = desc

--- a/src/hyperloom/orchestrator/phases/explore.py
+++ b/src/hyperloom/orchestrator/phases/explore.py
@@ -17,6 +17,7 @@ from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
 from ..bus.message_bus import Message
 from ..policy.gate import (
     SPECIALIST_FROM_AGENT_PREFIX,
+    PolicyDenied,
     validate_freeform_wave_task,
 )
 from ..loop.maintenance import run_lease_and_db_reclaim
@@ -657,6 +658,7 @@ class ExplorePhase(PhaseHandler):
         tasks = params.get("tasks") or []
         shared = {k: v for k, v in params.items() if k != "tasks"}
         base_key = str(intent.payload.get("idempotency_key") or "").strip()
+        pending: list[Intent] = []
         for idx, task in enumerate(tasks):
             desc = validate_freeform_wave_task(task, index=idx)
             sub_params = dict(shared)
@@ -665,8 +667,6 @@ class ExplorePhase(PhaseHandler):
             summary = str(task.get("task_summary") or "").strip()
             if summary:
                 sub_params["task_summary"] = summary
-            # Per-task dial overrides take precedence over the shared params;
-            # then fall back to the freeform recon defaults.
             for carry in (
                 "mode",
                 "bench",
@@ -676,7 +676,7 @@ class ExplorePhase(PhaseHandler):
                 "timeout_minutes",
                 "max_turns",
             ):
-                if carry in task:
+                if isinstance(task, dict) and carry in task:
                     sub_params[carry] = task[carry]
             sub_params.setdefault("mode", "research")
             sub_params.setdefault("lane", "cpu")
@@ -686,10 +686,15 @@ class ExplorePhase(PhaseHandler):
                 sub_payload["idempotency_key"] = f"{base_key}-w{idx}"
             else:
                 sub_payload.pop("idempotency_key", None)
-            await self._handle_delegate(
-                source,
-                Intent(type=intent.type, payload=sub_payload),
-            )
+            sub_intent = Intent(type=intent.type, payload=sub_payload)
+            try:
+                self.policy.validate_intent(source, sub_intent)
+            except PolicyDenied as denied:
+                await self._record_policy_denied(source, sub_intent, denied)
+                raise
+            pending.append(sub_intent)
+        for sub_intent in pending:
+            await self._handle_delegate(source, sub_intent)
 
     async def _record_specialist_retry_exhausted(
         self,

--- a/src/hyperloom/orchestrator/policy/gate.py
+++ b/src/hyperloom/orchestrator/policy/gate.py
@@ -777,9 +777,7 @@ class PolicyGate:
             raise PolicyDenied("unknown agent 'orchestration'", rule="role")
         trusted_framework_targets: frozenset[str] = frozenset()
         if kind == _WARM_REPLAY_ACTION:
-            trusted_framework_targets = self._validate_warm_replay_targets(
-                params_dict
-            )
+            trusted_framework_targets = self._validate_warm_replay_targets(params_dict)
         self._validate_payload_paths(
             role,
             IntentType.DELEGATE,
@@ -1157,8 +1155,7 @@ class PolicyGate:
         owned_action = REQUEST_KIND_TO_OWNED_ACTION.get(kind, kind)
         if kind in COORDINATOR_OWNED_KERNEL_REQUEST_KINDS:
             raise PolicyDenied(
-                f"request kind {kind!r} is a Coordinator-owned kernel lane "
-                f"and not LLM-requestable ({role.name})",
+                f"request kind {kind!r} is a Coordinator-owned kernel lane and not LLM-requestable ({role.name})",
                 rule="phase_incompatible",
                 hint=(
                     "run_fusion / run_collective are dispatched by the "
@@ -1534,10 +1531,7 @@ class PolicyGate:
             raise PolicyDenied(
                 f"baseline: an enablement authoring round is currently in flight (task={inflight_tid})",
                 rule="enablement_round_in_flight",
-                hint=(
-                    "Wait for the enablement specialist to finish and rearm "
-                    "before re-running baseline."
-                ),
+                hint=("Wait for the enablement specialist to finish and rearm before re-running baseline."),
             )
         # Checked after the authoring round, which is a reason to wait whatever
         # the anchor says: a specialist rewriting the framework underneath a
@@ -1797,9 +1791,7 @@ class PolicyGate:
                 rule="specialist_gpu_request_invalid",
             )
         ceiling = gpu_specialist_ceiling(self.shared_state)
-        if ceiling <= 0 and not (
-            uses_whole_machine_gpu_lane(params) and _whole_machine_pool_size() > 0
-        ):
+        if ceiling <= 0 and not (uses_whole_machine_gpu_lane(params) and _whole_machine_pool_size() > 0):
             raise PolicyDenied(
                 "delegate{action='specialist'}: needs_gpu=true but the GPU specialist pool is disabled",
                 rule="specialist_gpu_pool_disabled",
@@ -2068,9 +2060,7 @@ class PolicyGate:
         if self.session_dir is None:
             return None
         try:
-            return self.session_dir.resolve().joinpath(
-                *_REMOTE_RECIPE_FILES_PARTS
-            )
+            return self.session_dir.resolve().joinpath(*_REMOTE_RECIPE_FILES_PARTS)
         except (OSError, RuntimeError):
             return None
 
@@ -2078,10 +2068,7 @@ class PolicyGate:
     def _patch_declared_targets(patch_path: Path) -> frozenset[str]:
         """Read safe relative targets from unified-diff headers."""
         try:
-            if (
-                not patch_path.is_file()
-                or patch_path.stat().st_size > _MAX_POLICY_PATCH_BYTES
-            ):
+            if not patch_path.is_file() or patch_path.stat().st_size > _MAX_POLICY_PATCH_BYTES:
                 return frozenset()
             text = patch_path.read_text(encoding="utf-8", errors="replace")
         except OSError:
@@ -2106,11 +2093,7 @@ class PolicyGate:
         except ValueError:
             return frozenset()
         relative_posix = relative.as_posix()
-        return (
-            frozenset({relative_posix})
-            if relative_posix and relative_posix != "."
-            else frozenset()
-        )
+        return frozenset({relative_posix}) if relative_posix and relative_posix != "." else frozenset()
 
     def _validate_warm_replay_targets(
         self,
@@ -2146,8 +2129,7 @@ class PolicyGate:
             if not raw_targets:
                 continue
             if not isinstance(raw_targets, list) or not all(
-                isinstance(target, str) and target.strip()
-                for target in raw_targets
+                isinstance(target, str) and target.strip() for target in raw_targets
             ):
                 raise PolicyDenied(
                     f"replay_warm_recipe warm_kernel_plan[{index}].resolved_patch_targets "
@@ -2158,14 +2140,12 @@ class PolicyGate:
             raw_patch = entry.get("patch_path")
             if not isinstance(raw_patch, str) or not raw_patch.strip():
                 raise PolicyDenied(
-                    f"replay_warm_recipe resolved_patch_targets={raw_targets!r} "
-                    "has no patch_path",
+                    f"replay_warm_recipe resolved_patch_targets={raw_targets!r} has no patch_path",
                     rule="warm_replay_patch_missing",
                 )
             if kb_root is None or not resolved_within(raw_patch, str(kb_root)):
                 raise PolicyDenied(
-                    f"replay_warm_recipe patch_path={raw_patch!r} is outside "
-                    f"the session KB download root={kb_root!s}",
+                    f"replay_warm_recipe patch_path={raw_patch!r} is outside the session KB download root={kb_root!s}",
                     rule="warm_replay_patch_outside_kb_download",
                 )
 
@@ -2190,14 +2170,11 @@ class PolicyGate:
                 active_root = resolve_session_framework_root()
                 if not active_root or not resolved_within(raw_target, active_root):
                     raise PolicyDenied(
-                        f"replay_warm_recipe target_file={raw_target!r} is outside "
-                        "the Session active framework root",
+                        f"replay_warm_recipe target_file={raw_target!r} is outside the Session active framework root",
                         rule="warm_replay_target_outside_framework_roots",
                     )
                 target_candidates = self._framework_relative_candidates(raw_target)
-                if not declared_targets or declared_targets.isdisjoint(
-                    target_candidates
-                ):
+                if not declared_targets or declared_targets.isdisjoint(target_candidates):
                     raise PolicyDenied(
                         f"replay_warm_recipe target_file={raw_target!r} does not "
                         f"match patch targets={sorted(declared_targets)!r}",
@@ -2358,8 +2335,7 @@ class PolicyGate:
             scope = str(payload.get("scope") or PRUNE_BRANCH_SCOPE_FAMILY).strip()
             if scope not in PRUNE_BRANCH_ALLOWED_SCOPES:
                 raise PolicyDenied(
-                    f"prune_branch scope={scope!r} not allowed "
-                    f"(allowed: {sorted(PRUNE_BRANCH_ALLOWED_SCOPES)!r})",
+                    f"prune_branch scope={scope!r} not allowed (allowed: {sorted(PRUNE_BRANCH_ALLOWED_SCOPES)!r})",
                     rule="prune_scope",
                     hint=(
                         f"{PRUNE_BRANCH_SCOPE_FAMILY!r} retires the action for "
@@ -2539,8 +2515,7 @@ def validate_freeform_wave_task(task: Any, *, index: int) -> str:
     desc = str(task.get("task_description") or task.get("task_summary") or "").strip()
     if not desc:
         raise PolicyDenied(
-            f"delegate{{action='specialist',scope='freeform'}}: "
-            f"tasks[{index}] task_description must be non-empty",
+            f"delegate{{action='specialist',scope='freeform'}}: tasks[{index}] task_description must be non-empty",
             rule="specialist_freeform_empty_description",
             hint=("Each freeform task needs a natural-language task_description (the whole mandate)."),
         )

--- a/src/hyperloom/orchestrator/policy/gate.py
+++ b/src/hyperloom/orchestrator/policy/gate.py
@@ -1729,37 +1729,7 @@ class PolicyGate:
                 ),
             )
         max_turns_raw = params.get("max_turns")
-        if max_turns_raw is not None:
-            try:
-                max_turns = int(max_turns_raw)
-            except (TypeError, ValueError) as exc:
-                raise PolicyDenied(
-                    f"delegate{{action='specialist'}}: max_turns must be int, got {max_turns_raw!r}",
-                    rule="specialist_dispatch_source",
-                ) from exc
-            # The in-process backend's turn loop has no wall-clock check, so this
-            # cap is the only bound on that path.
-            if max_turns < 0:
-                raise PolicyDenied(
-                    f"delegate{{action='specialist'}}: max_turns={max_turns} must be >= 0",
-                    rule="specialist_dispatch_source",
-                    hint=(
-                        "Use a non-negative integer. "
-                        "0 = unbounded (bounded by the wall-clock budget); "
-                        "omit max_turns to use the default turn cap."
-                    ),
-                )
-            if max_turns > SPECIALIST_MAX_TURNS_HARD_CAP:
-                raise PolicyDenied(
-                    f"delegate{{action='specialist'}}: max_turns={max_turns} "
-                    f"exceeds the hard cap {SPECIALIST_MAX_TURNS_HARD_CAP}",
-                    rule="specialist_dispatch_source",
-                    hint=(
-                        f"max_turns must be <= {SPECIALIST_MAX_TURNS_HARD_CAP} "
-                        "(0 = unbounded; depth is bounded by the wall-clock "
-                        "budget, so omit max_turns unless capping a probe early)."
-                    ),
-                )
+        validate_specialist_max_turns_raw(max_turns_raw, where="params.max_turns")
 
         self._validate_specialist_gpu_request(params)
 
@@ -1965,9 +1935,9 @@ class PolicyGate:
             PolicyDenied: when the GPU request fails, the wave is too large, or
                 a task description is empty / too long.
         """
-        # Freeform skips the domain-anchored max_turns gate (bounded by the task
-        # timeout instead), but a GPU request must still clear the same pool
-        # ceiling as a domain specialist.
+        # Freeform applies the same max_turns contract as domain dispatches.
+        # Per-task overrides in a wave are checked per entry below.
+        validate_specialist_max_turns_raw(params.get("max_turns"), where="params.max_turns")
         self._validate_specialist_gpu_request(params)
         wave = params.get("tasks")
         # A malformed or empty wave falls through to the single-task path in the
@@ -1983,6 +1953,11 @@ class PolicyGate:
                 )
             for i, task in enumerate(wave):
                 validate_freeform_wave_task(task, index=i)
+                if isinstance(task, dict):
+                    validate_specialist_max_turns_raw(
+                        task.get("max_turns"),
+                        where=f"tasks[{i}].max_turns",
+                    )
             return
         desc = str(params.get("task_description") or "").strip()
         self._check_freeform_task_description(desc, where="params")
@@ -2494,6 +2469,53 @@ def to_policy_denial_summary(state, *, top_k: int = 6) -> str:
     return "\n".join(lines)
 
 
+def validate_specialist_max_turns_raw(
+    max_turns_raw: Any,
+    *,
+    where: str,
+) -> None:
+    """Validate an optional specialist ``max_turns`` dial.
+
+    Args:
+        max_turns_raw: Raw ``max_turns`` value from dispatch params, or ``None``.
+        where: Label used in error messages (e.g. ``params.max_turns``).
+
+    Raises:
+        PolicyDenied: When the value is not an int, is negative, or exceeds
+            :data:`SPECIALIST_MAX_TURNS_HARD_CAP`.
+    """
+    if max_turns_raw is None:
+        return
+    try:
+        max_turns = int(max_turns_raw)
+    except (TypeError, ValueError) as exc:
+        raise PolicyDenied(
+            f"delegate{{action='specialist'}}: {where} max_turns must be int, got {max_turns_raw!r}",
+            rule="specialist_dispatch_source",
+        ) from exc
+    if max_turns < 0:
+        raise PolicyDenied(
+            f"delegate{{action='specialist'}}: {where} max_turns={max_turns} must be >= 0",
+            rule="specialist_dispatch_source",
+            hint=(
+                "Use a non-negative integer. "
+                "0 = unbounded (bounded by the wall-clock budget); "
+                "omit max_turns to use the default turn cap."
+            ),
+        )
+    if max_turns > SPECIALIST_MAX_TURNS_HARD_CAP:
+        raise PolicyDenied(
+            f"delegate{{action='specialist'}}: {where} max_turns={max_turns} "
+            f"exceeds the hard cap {SPECIALIST_MAX_TURNS_HARD_CAP}",
+            rule="specialist_dispatch_source",
+            hint=(
+                f"max_turns must be <= {SPECIALIST_MAX_TURNS_HARD_CAP} "
+                "(0 = unbounded; depth is bounded by the wall-clock "
+                "budget, so omit max_turns unless capping a probe early)."
+            ),
+        )
+
+
 def validate_freeform_wave_task(task: Any, *, index: int) -> str:
     """Validate one entry in a freeform specialist ``tasks`` wave.
 
@@ -2541,6 +2563,7 @@ __all__ = [
     "PolicyDenied",
     "PolicyGate",
     "validate_freeform_wave_task",
+    "validate_specialist_max_turns_raw",
     "REQUEST_ROUTING",
     "REVIEW_VERDICTS",
     "REVIEW_VERDICT_SOURCE_ALLOWLIST",

--- a/src/hyperloom/orchestrator/policy/gate.py
+++ b/src/hyperloom/orchestrator/policy/gate.py
@@ -1739,6 +1739,16 @@ class PolicyGate:
                 ) from exc
             # The in-process backend's turn loop has no wall-clock check, so this
             # cap is the only bound on that path.
+            if max_turns < 0:
+                raise PolicyDenied(
+                    f"delegate{{action='specialist'}}: max_turns={max_turns} must be >= 0",
+                    rule="specialist_dispatch_source",
+                    hint=(
+                        "Use a non-negative integer. "
+                        "0 = unbounded (bounded by the wall-clock budget); "
+                        "omit max_turns to use the default turn cap."
+                    ),
+                )
             if max_turns > SPECIALIST_MAX_TURNS_HARD_CAP:
                 raise PolicyDenied(
                     f"delegate{{action='specialist'}}: max_turns={max_turns} "
@@ -1972,11 +1982,7 @@ class PolicyGate:
                     hint=(f"Split the wave into batches of at most {SPECIALIST_FREEFORM_WAVE_MAX} tasks."),
                 )
             for i, task in enumerate(wave):
-                if not isinstance(task, dict):
-                    continue
-                desc = str(task.get("task_description") or task.get("task_summary") or "").strip()
-                if desc:
-                    self._check_freeform_task_description(desc, where=f"tasks[{i}]")
+                validate_freeform_wave_task(task, index=i)
             return
         desc = str(params.get("task_description") or "").strip()
         self._check_freeform_task_description(desc, where="params")
@@ -2488,6 +2494,38 @@ def to_policy_denial_summary(state, *, top_k: int = 6) -> str:
     return "\n".join(lines)
 
 
+def validate_freeform_wave_task(task: Any, *, index: int) -> str:
+    """Validate one entry in a freeform specialist ``tasks`` wave.
+
+    Args:
+        task: One wave entry; must be a dict with a non-empty description.
+        index: Zero-based index used in error messages.
+
+    Returns:
+        The normalized task description.
+
+    Raises:
+        PolicyDenied: When the entry is malformed or the description is
+            empty / too long.
+    """
+    if not isinstance(task, dict):
+        raise PolicyDenied(
+            f"delegate{{action='specialist',scope='freeform'}}: tasks[{index}] must be a dict",
+            rule="specialist_freeform_wave_invalid_task",
+            hint="Each wave entry must be an object with task_description.",
+        )
+    desc = str(task.get("task_description") or task.get("task_summary") or "").strip()
+    if not desc:
+        raise PolicyDenied(
+            f"delegate{{action='specialist',scope='freeform'}}: "
+            f"tasks[{index}] task_description must be non-empty",
+            rule="specialist_freeform_empty_description",
+            hint=("Each freeform task needs a natural-language task_description (the whole mandate)."),
+        )
+    PolicyGate._check_freeform_task_description(desc, where=f"tasks[{index}]")
+    return desc
+
+
 __all__ = [
     "CORE_STATE_FIELDS",
     "DELEGATE_ACTION_REQUIRED_PAYLOAD",
@@ -2502,6 +2540,7 @@ __all__ = [
     "PRUNE_BRANCH_SCOPE_QUEUED",
     "PolicyDenied",
     "PolicyGate",
+    "validate_freeform_wave_task",
     "REQUEST_ROUTING",
     "REVIEW_VERDICTS",
     "REVIEW_VERDICT_SOURCE_ALLOWLIST",

--- a/src/hyperloom/orchestrator/scoring/proposal_scorer.py
+++ b/src/hyperloom/orchestrator/scoring/proposal_scorer.py
@@ -11,6 +11,9 @@ Output schema (``score`` return value)::
 
     {"scale": "0-10", "models": {"<slug>": {"<name>": {"score": <0-10>, "reason": "<str>"}}}, "errors": {...}}
 
+Each proposal is scored under a stable ``proposal_<index>`` id in the model
+prompt; results are keyed by the proposal's display ``name`` in the output.
+
 Test seam: pass ``client_factory`` to bypass real client construction.
 """
 
@@ -32,7 +35,6 @@ from hyperloom.common.llm_config import (
     astream_chat_completion_text,
     get_async_openai_client,
 )
-from hyperloom.common.jsonio import extract_first_json_with_key
 from ..roles.base import parse_call_timeout_env
 from ..loop.coordinator_helpers import format_exc_brief
 from ..trace.conversation_trace import ConversationRecord, append_conversation
@@ -65,22 +67,81 @@ large win; 0 = irrelevant or likely harmful. Be calibrated, not generous.
 
 Output ONLY one compact JSON object, no prose, no markdown fence needed:
 
-{"scores": {"<proposal_name>": {"score": <0-10 number>, "reason": "<= 15 words"}}}
+{"scores": {"<proposal_id>": {"score": <0-10 number>, "reason": "<= 15 words"}}}
 
 Rules:
-- One entry per proposal, keyed by its exact "name".
+- One entry per proposal, keyed by its exact "id" (not the human-readable name).
 - "reason" MUST be <= 15 words. Keep it terse to keep the reply short.
 - Do not add keys other than "score" and "reason".
 """.strip()
 
 
-# Bare top-level "scores" object.
-_BARE_JSON_RE = re.compile(r"(\{.*?\"scores\".*\})", re.DOTALL)
+_SCORES_OBJECT_OPENER_RE = re.compile(r'\{\s*"scores"\s*:', re.DOTALL)
 
 
 def _extract_scores_json(text: str) -> dict[str, Any] | None:
-    """Pull the first valid ``{"scores": {...}}`` object out of a reply."""
-    return extract_first_json_with_key(text, "scores", _BARE_JSON_RE)
+    """Pull the last valid ``{"scores": {...}}`` object out of a reply."""
+    if not text:
+        return None
+    from hyperloom.common.jsonio import _FENCED_JSON_RE
+
+    found: dict[str, Any] | None = None
+    for m in _FENCED_JSON_RE.finditer(text):
+        try:
+            data = json.loads(m.group(1))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict) and "scores" in data:
+            found = data
+    for m in _SCORES_OBJECT_OPENER_RE.finditer(text):
+        candidate = text[m.start() :]
+        for end in range(len(candidate), 0, -1):
+            try:
+                data = json.loads(candidate[:end])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(data, dict) and "scores" in data:
+                found = data
+            break
+    return found
+
+
+@dataclass(frozen=True)
+class _ScoringProposal:
+    """One proposal prepared for multi-model scoring."""
+
+    stable_id: str
+    display_name: str
+    proposal: dict[str, Any]
+
+
+def _prepare_scoring_proposals(proposals: list[dict[str, Any]]) -> list[_ScoringProposal]:
+    """Assign stable ids and reject duplicate display names.
+
+    Args:
+        proposals: Candidate variants to score.
+
+    Returns:
+        Prepared scoring entries with stable ids and unique display names.
+
+    Raises:
+        ValueError: When two proposals share the same non-empty display name.
+    """
+    seen_names: set[str] = set()
+    out: list[_ScoringProposal] = []
+    for i, proposal in enumerate(proposals):
+        display_name = str(proposal.get("name") or f"proposal_{i}").strip() or f"proposal_{i}"
+        if display_name in seen_names:
+            raise ValueError(f"duplicate proposal name: {display_name!r}")
+        seen_names.add(display_name)
+        out.append(
+            _ScoringProposal(
+                stable_id=f"proposal_{i}",
+                display_name=display_name,
+                proposal=proposal,
+            )
+        )
+    return out
 
 
 def _clip(value: Any, *, limit: int = _MAX_FIELD_CHARS) -> str:
@@ -105,8 +166,11 @@ def _coerce_score(raw: Any) -> float | None:
 
     Returns:
         The score clamped to ``[0, 10]``, or ``None`` if ``raw`` is not numeric
-        or is NaN. Infinities are clamped to the bounds.
+        or is NaN. Infinities are clamped to the bounds. Boolean values are
+        rejected (they would otherwise coerce via ``float(True) == 1.0``).
     """
+    if isinstance(raw, bool):
+        return None
     try:
         val = float(raw)
     except (TypeError, ValueError):
@@ -119,31 +183,32 @@ def _coerce_score(raw: Any) -> float | None:
 def _normalise_model_scores(
     parsed: dict[str, Any],
     *,
-    proposal_names: list[str],
+    scoring_entries: list[_ScoringProposal],
 ) -> dict[str, dict[str, Any]]:
-    """Project parsed ``{"scores": {...}}`` onto known names (drop unknowns, clamp [0,10], truncate reasons).
+    """Project parsed ``{"scores": {...}}`` onto known stable ids.
 
     Args:
         parsed: A parsed ``{"scores": {...}}`` dict from a model reply.
-        proposal_names: Names of the proposals that were actually scored;
-            scores for any other name are discarded.
+        scoring_entries: Prepared proposals keyed by stable id in the prompt.
 
     Returns:
-        A mapping of proposal name to its clamped score and truncated reason.
+        A mapping of proposal display name to its clamped score and truncated
+        reason.
     """
     out: dict[str, dict[str, Any]] = {}
     scores = parsed.get("scores")
     if not isinstance(scores, dict):
         return out
-    known = set(proposal_names)
-    for name, entry in scores.items():
-        key = str(name)
+    id_to_name = {entry.stable_id: entry.display_name for entry in scoring_entries}
+    known = set(id_to_name)
+    for proposal_id, entry in scores.items():
+        key = str(proposal_id)
         if key not in known or not isinstance(entry, dict):
             continue
         score = _coerce_score(entry.get("score"))
         if score is None:
             continue
-        out[key] = {
+        out[id_to_name[key]] = {
             "score": score,
             "reason": _clip(entry.get("reason"), limit=160),
         }
@@ -184,6 +249,8 @@ class ProposalScorer:
         unconfigured environment degrades per-call rather than at boot.
         """
         self.models = tuple(m for m in (str(x).strip() for x in (self.models or ())) if m)
+        if len(self.models) != len(set(self.models)):
+            raise ValueError("duplicate scorer model slug(s) in models")
         if self.client_factory is not None:
             self._client = self.client_factory()
             return
@@ -215,13 +282,13 @@ class ProposalScorer:
         self,
         *,
         gap: dict[str, Any],
-        proposals: list[dict[str, Any]],
+        scoring_entries: list[_ScoringProposal],
     ) -> str:
         """Build ONE group-scoring prompt covering every proposal.
 
         Args:
             gap: The gap being addressed (domain, symptom, evidence, etc.).
-            proposals: Candidate variants to embed in the prompt.
+            scoring_entries: Prepared proposals with stable ids.
 
         Returns:
             The assembled prompt text describing the gap and proposals.
@@ -238,9 +305,10 @@ class ProposalScorer:
 
         lines.append("")
         lines.append("=== Proposals to score ===")
-        for i, p in enumerate(proposals):
-            name = str(p.get("name") or f"proposal_{i}")
-            lines.append(f"- name: {name}")
+        for entry in scoring_entries:
+            p = entry.proposal
+            lines.append(f"- id: {entry.stable_id}")
+            lines.append(f"  name: {entry.display_name}")
             if p.get("extra_args"):
                 lines.append(f"  extra_args: {_clip(p.get('extra_args'))}")
             if p.get("extra_envs"):
@@ -255,7 +323,7 @@ class ProposalScorer:
         self,
         model: str,
         prompt: str,
-        proposal_names: list[str],
+        scoring_entries: list[_ScoringProposal],
         *,
         task_id: str | None = None,
         tick: int | None = None,
@@ -266,7 +334,7 @@ class ProposalScorer:
         Args:
             model: The model slug to score with.
             prompt: The base scoring prompt (instructions are appended).
-            proposal_names: Names of the proposals being scored.
+            scoring_entries: Prepared proposals with stable ids.
 
         Returns:
             A mapping of proposal name to its normalised score and reason.
@@ -342,7 +410,7 @@ class ProposalScorer:
         parsed = _extract_scores_json(text)
         if parsed is None:
             raise RuntimeError(f"no parseable scores JSON (reply_chars={len(text)})")
-        return _normalise_model_scores(parsed, proposal_names=proposal_names)
+        return _normalise_model_scores(parsed, scoring_entries=scoring_entries)
 
     def _trace_scorer_llm_call(
         self,
@@ -526,15 +594,22 @@ class ProposalScorer:
             return {"scale": "0-10", "models": {}, "errors": {}}
         if len(proposals) > _MAX_PROPOSALS_SCORED:
             proposals = proposals[:_MAX_PROPOSALS_SCORED]
-        proposal_names = [str(p.get("name") or f"proposal_{i}") for i, p in enumerate(proposals)]
-        prompt = self._build_prompt(gap=gap, proposals=proposals)
+        try:
+            scoring_entries = _prepare_scoring_proposals(proposals)
+        except ValueError as exc:
+            return {
+                "scale": "0-10",
+                "models": {},
+                "errors": {"input": format_exc_brief(exc, limit=200)},
+            }
+        prompt = self._build_prompt(gap=gap, scoring_entries=scoring_entries)
 
         results = await asyncio.gather(
             *(
                 self._score_one_model(
                     m,
                     prompt,
-                    proposal_names,
+                    scoring_entries,
                     task_id=task_id,
                     tick=tick,
                     phase=phase,

--- a/src/hyperloom/orchestrator/scoring/proposal_scorer.py
+++ b/src/hyperloom/orchestrator/scoring/proposal_scorer.py
@@ -23,7 +23,6 @@ import asyncio
 import json
 import logging
 import math
-import re
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -76,34 +75,11 @@ Rules:
 """.strip()
 
 
-_SCORES_OBJECT_OPENER_RE = re.compile(r'\{\s*"scores"\s*:', re.DOTALL)
-
-
 def _extract_scores_json(text: str) -> dict[str, Any] | None:
     """Pull the last valid ``{"scores": {...}}`` object out of a reply."""
-    if not text:
-        return None
-    from hyperloom.common.jsonio import _FENCED_JSON_RE
+    from hyperloom.common.jsonio import extract_last_json_with_key
 
-    found: dict[str, Any] | None = None
-    for m in _FENCED_JSON_RE.finditer(text):
-        try:
-            data = json.loads(m.group(1))
-        except json.JSONDecodeError:
-            continue
-        if isinstance(data, dict) and "scores" in data:
-            found = data
-    for m in _SCORES_OBJECT_OPENER_RE.finditer(text):
-        candidate = text[m.start() :]
-        for end in range(len(candidate), 0, -1):
-            try:
-                data = json.loads(candidate[:end])
-            except json.JSONDecodeError:
-                continue
-            if isinstance(data, dict) and "scores" in data:
-                found = data
-            break
-    return found
+    return extract_last_json_with_key(text, "scores")
 
 
 @dataclass(frozen=True)
@@ -111,7 +87,8 @@ class _ScoringProposal:
     """One proposal prepared for multi-model scoring."""
 
     stable_id: str
-    display_name: str
+    output_name: str
+    label_name: str
     proposal: dict[str, Any]
 
 
@@ -122,22 +99,29 @@ def _prepare_scoring_proposals(proposals: list[dict[str, Any]]) -> list[_Scoring
         proposals: Candidate variants to score.
 
     Returns:
-        Prepared scoring entries with stable ids and unique display names.
+        Prepared scoring entries with stable ids and unique label names.
 
     Raises:
-        ValueError: When two proposals share the same non-empty display name.
+        ValueError: When two proposals share the same canonical display name.
     """
-    seen_names: set[str] = set()
+    seen_labels: set[str] = set()
     out: list[_ScoringProposal] = []
     for i, proposal in enumerate(proposals):
-        display_name = str(proposal.get("name") or f"proposal_{i}").strip() or f"proposal_{i}"
-        if display_name in seen_names:
-            raise ValueError(f"duplicate proposal name: {display_name!r}")
-        seen_names.add(display_name)
+        raw_name = proposal.get("name")
+        if raw_name is not None and str(raw_name).strip():
+            output_name = str(raw_name)
+            label_name = output_name.strip()
+        else:
+            output_name = f"proposal_{i}"
+            label_name = output_name
+        if label_name in seen_labels:
+            raise ValueError(f"duplicate proposal name: {label_name!r}")
+        seen_labels.add(label_name)
         out.append(
             _ScoringProposal(
                 stable_id=f"proposal_{i}",
-                display_name=display_name,
+                output_name=output_name,
+                label_name=label_name,
                 proposal=proposal,
             )
         )
@@ -199,7 +183,7 @@ def _normalise_model_scores(
     scores = parsed.get("scores")
     if not isinstance(scores, dict):
         return out
-    id_to_name = {entry.stable_id: entry.display_name for entry in scoring_entries}
+    id_to_name = {entry.stable_id: entry.output_name for entry in scoring_entries}
     known = set(id_to_name)
     for proposal_id, entry in scores.items():
         key = str(proposal_id)
@@ -308,7 +292,7 @@ class ProposalScorer:
         for entry in scoring_entries:
             p = entry.proposal
             lines.append(f"- id: {entry.stable_id}")
-            lines.append(f"  name: {entry.display_name}")
+            lines.append(f"  name: {entry.label_name}")
             if p.get("extra_args"):
                 lines.append(f"  extra_args: {_clip(p.get('extra_args'))}")
             if p.get("extra_envs"):

--- a/src/hyperloom/orchestrator/specialists/runner.py
+++ b/src/hyperloom/orchestrator/specialists/runner.py
@@ -59,6 +59,27 @@ from ..prompts.specialist_prompt_builder import (
 log = logging.getLogger(__name__)
 
 
+def resolve_specialist_max_turns(raw: Any, *, default: int) -> int:
+    """Resolve the specialist turn budget from dispatch params.
+
+    ``None`` and ``0`` both mean unbounded depth bounded by the wall-clock
+    budget, implemented as the configured default cap.
+
+    Args:
+        raw: The ``max_turns`` value from dispatch params, or ``None``.
+        default: The runner default when ``raw`` is omitted or zero.
+
+    Returns:
+        The resolved non-negative turn budget.
+    """
+    if raw is None:
+        return int(default)
+    max_turns = int(raw)
+    if max_turns == 0:
+        return int(default)
+    return max_turns
+
+
 def _extra_focus_tags(
     params: dict[str, Any],
     domain: "SpecialistDomain",
@@ -462,7 +483,7 @@ class SpecialistRunner:
             if resolved_tags:
                 domain_key = resolved_tags[0]
         gap = str(params.get("gap_canonical_id") or params.get("gap") or "").strip()
-        max_turns = int(params.get("max_turns") or self.default_max_turns)
+        max_turns = resolve_specialist_max_turns(params.get("max_turns"), default=self.default_max_turns)
         # Resolve by anchor first then key so a domain carrying the KB anchor matches its entry.
         domain = domain_for_tag(domain_key)
         profile = resolve_specialist_profile(params, domain=domain)


### PR DESCRIPTION
## Problem

PolicyGate's freeform `tasks[]` wave gate skipped non-dict entries and empty descriptions whenever any valid item remained, so partially invalid or entirely empty waves could pass validation without surfacing the failing index. ProposalScorer keyed results by display name (allowing silent overwrites), parsed the first `scores` JSON envelope in a reply, accepted boolean coercions as numeric scores, and could invoke duplicate model slugs on repeated API calls.

## Fix

Wave validation now rejects the entire dispatch on any malformed `tasks[i]` via a shared `validate_freeform_wave_task` helper used by PolicyGate and explore fan-out; domain dispatches also reject negative `max_turns`, and SpecialistRunner explicitly maps `max_turns=0` to the default unbounded cap. ProposalScorer assigns stable `proposal_<n>` IDs for prompting and parsing, rejects duplicate proposal names and model slugs plus boolean scores at input, and selects the last valid tail `scores` envelope while still emitting display-name keys for existing render paths.