### PR TITLE
fix(breakdown): make reported counts and evidence match their contracts

### DIFF
--- a/docs/reference/session-breakdown.md
+++ b/docs/reference/session-breakdown.md
@@ -445,10 +445,27 @@ T+90 min" charts.
 ## `capability_summary` — `CapabilitySummary`
 
 One card per live capability (`geak`, `forge`, `explore`, `sweep`,
-`specialist`) with: `status`, `attempts`, `keeps`, `tested`,
-`best_gain_pct`, `reason`. Legacy `backends`, `params`, and
-`validate_stack` rows can appear when archived sessions are rebuilt.
-Drives the per-session UI cards in Primus-Claw.
+`specialist`) with: `status`, `attempts`, `keeps`, `micro_only_keeps`,
+`pending_integrate`, `reverts`, `e2e_gain_pct`, `tested`, `best_gain_pct`,
+`reason`. Legacy `backends`, `params`, and `validate_stack` rows can appear
+when archived sessions are rebuilt. Drives the per-session UI cards in
+Primus-Claw.
+
+For the kernel lanes (`geak`, `forge`) these counts are not interchangeable:
+
+- `keeps` — **distinct kernels adopted at integrate**, i.e. end-to-end
+  verified. A kernel re-tried across runs counts once.
+- `micro_only_keeps` — kernels that cleared the micro benchmark but never
+  reached integrate. Not adoptions: a faster kernel in isolation does not
+  imply a faster service.
+- `pending_integrate` — kernels whose integrate verdict is `NEEDS_REVIEW` or
+  not yet recorded. Undecided, not successful.
+- `reverts` — kernels integrate rejected (end-to-end regression).
+- `attempts` — **invocation rows**, not distinct kernels: how many tries the
+  lane made. Deliberately a different unit from `keeps`.
+
+The `specialist` row uses `keeps` / `attempts` differently: see
+`CapabilitySummary` in `schema.py`.
 
 ---
 

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/__init__.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/__init__.py
@@ -75,6 +75,7 @@ from .sessions import (
 from .timeline import (
     _AUDIT_ACTIONS as _AUDIT_ACTIONS,
     _journal_entry_to_event as _journal_entry_to_event,
+    TimelineDedup as TimelineDedup,
     collect_phase_timeline as collect_phase_timeline,
     _capability_for_action as _capability_for_action,
     collect_capability_summary as collect_capability_summary,
@@ -200,6 +201,7 @@ __all__ = [
     "collect_collective",
     "collect_geak",
     "collect_phase_segments",
+    "TimelineDedup",
     "collect_phase_timeline",
     "collect_session",
     "collect_source_files",

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/timeline.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/timeline.py
@@ -41,6 +41,50 @@ _AUDIT_ACTIONS = (
 )
 
 
+class TimelineDedup:
+    """Decide which timeline rows describe an event already seen.
+
+    Rows collide on ``(action, ts-to-second, change)``. Rows that also carry
+    distinct task ids are distinct events and are all kept -- but only while
+    every row seen for that triple was itself task-tagged. An untagged row is
+    the same event observed from another source (journal vs audit list vs
+    recorder fragment), so it keeps the legacy fold rather than duplicating.
+
+    The collector and the exporter merge different mixes of those sources.
+    Sharing this decision is what stops them disagreeing about what one event
+    is: an exporter with a weaker identity silently drops rows the collector
+    would have kept, and nothing downstream can tell that happened.
+    """
+
+    def __init__(self) -> None:
+        """Start with no events seen."""
+        self._seen: dict[tuple[str, str, str], set[str]] = {}
+
+    def is_new(self, ev: dict[str, Any]) -> bool:
+        """Record ``ev`` and report whether it is an event not seen before.
+
+        Args:
+            ev (dict[str, Any]): One timeline event row.
+
+        Returns:
+            bool: ``True`` when the row should be kept.
+        """
+        base = (
+            str(ev.get("action") or ""),
+            iso_z(ev.get("ts"))[:19],
+            str(ev.get("change") or ev.get("task_id") or ""),
+        )
+        task_id = str(ev.get("task_id") or "")
+        prior = self._seen.get(base)
+        if prior is None:
+            self._seen[base] = {task_id}
+            return True
+        if task_id and task_id not in prior and all(prior):
+            prior.add(task_id)
+            return True
+        return False
+
+
 def _journal_entry_to_event(e: dict[str, Any]) -> dict[str, Any]:
     """Map one optimization_journal entry to a phase_timeline event.
 
@@ -227,29 +271,8 @@ def collect_phase_timeline(
         ev["ts"] = iso_z(ev.get("ts"))
 
     # De-dup: journal rows are appended first and win on collision.
-    #
-    # Rows collide on ``(action, ts-to-second, change)``. Rows that also carry
-    # distinct task ids are distinct events and are all kept -- but only while
-    # every row seen for that triple was itself task-tagged. An untagged row is
-    # the same event observed from the other source (journal vs audit list), so
-    # it keeps the legacy fold instead of being duplicated.
-    seen_tasks: dict[tuple[str, str, str], set[str]] = {}
-    deduped: list[dict[str, Any]] = []
-    for ev in events:
-        base = (
-            str(ev.get("action") or ""),
-            (str(ev.get("ts") or ""))[:19],
-            str(ev.get("change") or ev.get("task_id") or ""),
-        )
-        task_id = str(ev.get("task_id") or "")
-        prior = seen_tasks.get(base)
-        if prior is None:
-            seen_tasks[base] = {task_id}
-            deduped.append(ev)
-            continue
-        if task_id and task_id not in prior and all(prior):
-            prior.add(task_id)
-            deduped.append(ev)
+    dedup = TimelineDedup()
+    deduped = [ev for ev in events if dedup.is_new(ev)]
 
     deduped.sort(key=lambda e: e.get("ts") or "")
     return deduped
@@ -315,6 +338,30 @@ def _fold_search_ledger_keeps(row: dict[str, Any], search: dict[str, Any]) -> No
     row["status"] = "kept"
 
 
+# How decided a verdict is. One kernel can carry several integrate rows (the
+# ledger is keyed ``<kernel_id>|<patch_path>|<extra_args>``), and folding them
+# by kernel must not hand the outcome to whichever row is iterated last: an
+# adopted patch is not undone by a reverted sibling. Anything unlisted --
+# ``NEEDS_REVIEW``, or no decision recorded yet -- ranks lowest, because it is
+# the absence of a verdict rather than a verdict.
+_VERDICT_RANK = {"KEEP": 3, "REVERT": 2, "REJECT": 2}
+
+
+def _stronger_verdict(current: str, candidate: str) -> str:
+    """Return whichever of two integrate verdicts is more decided.
+
+    Args:
+        current (str): The verdict folded so far.
+        candidate (str): The verdict being folded in.
+
+    Returns:
+        str: The verdict that should represent the kernel.
+    """
+    if _VERDICT_RANK.get(candidate, 1) > _VERDICT_RANK.get(current, 1):
+        return candidate
+    return current
+
+
 def collect_capability_summary(
     state: dict[str, Any],
     geak_invocations: list[dict[str, Any]],
@@ -343,10 +390,17 @@ def collect_capability_summary(
             kid = str(ent.get("kernel_id") or "")
             if not kid:
                 continue
-            integ_by_kid[kid] = {
-                "decision": str(ent.get("last_decision") or "").upper(),
-                "e2e_gain_pct": _to_float(ent.get("best_gain_pct")),
-            }
+            decision = str(ent.get("last_decision") or "").upper()
+            gain = _to_float(ent.get("best_gain_pct"))
+            prior = integ_by_kid.get(kid)
+            if prior is None:
+                integ_by_kid[kid] = {"decision": decision, "e2e_gain_pct": gain}
+                continue
+            # Fold, never overwrite: several patches for one kernel each get
+            # their own row here.
+            prior["decision"] = _stronger_verdict(prior["decision"], decision)
+            if gain is not None and (prior["e2e_gain_pct"] is None or gain > prior["e2e_gain_pct"]):
+                prior["e2e_gain_pct"] = gain
 
     # Kernel backends from on-disk invocations, reconciled against the integrate verdict.
     def _from_invocations(invs: list[dict[str, Any]]) -> dict[str, Any]:
@@ -365,6 +419,7 @@ def collect_capability_summary(
         # across runs is still one kernel.
         adopted_kids: set[str] = set()
         reverted_kids: set[str] = set()
+        pending_kids: set[str] = set()
         micro_only_kids: set[str] = set()
         best_e2e: float | None = None
         for i, v in enumerate(invs):
@@ -380,18 +435,29 @@ def collect_capability_summary(
                 # ``keeps`` is "kernels adopted at integrate").
                 micro_only_kids.add(ident)
                 continue
-            g = outcome["e2e_gain_pct"]
-            if g is not None and (best_e2e is None or g > best_e2e):
-                best_e2e = g
-            if outcome["decision"] in ("REVERT", "REJECT"):
+            decision = outcome["decision"]
+            if decision == "KEEP":
+                adopted_kids.add(ident)
+                # Only an adoption contributes to "best gain": a reverted
+                # patch's number describes a regression, and an undecided
+                # one describes a measurement nobody has ruled on.
+                g = outcome["e2e_gain_pct"]
+                if g is not None and (best_e2e is None or g > best_e2e):
+                    best_e2e = g
+            elif decision in ("REVERT", "REJECT"):
                 reverted_kids.add(ident)
             else:
-                adopted_kids.add(ident)
-        # An adoption outranks a revert or a micro-only KEEP for the same kernel.
+                # NEEDS_REVIEW, or no decision recorded. The verdict is not in,
+                # and a gain <= 0 NEEDS_REVIEW never gets retried, so calling
+                # this an adoption misreports it for the rest of the session.
+                pending_kids.add(ident)
+        # A decided outcome outranks an undecided one for the same kernel.
         reverted_kids -= adopted_kids
-        micro_only_kids -= adopted_kids | reverted_kids
+        pending_kids -= adopted_kids | reverted_kids
+        micro_only_kids -= adopted_kids | reverted_kids | pending_kids
         adopted = len(adopted_kids)
         reverted = len(reverted_kids)
+        pending = len(pending_kids)
         micro_only = len(micro_only_kids)
         status = (
             "kept" if adopted > 0 else "reverted" if reverted > 0 else "attempted" if attempts > 0 else "not_attempted"
@@ -403,6 +469,8 @@ def collect_capability_summary(
         }
         if reverted:
             row["reverts"] = reverted
+        if pending:
+            row["pending_integrate"] = pending
         if micro_only:
             row["micro_only_keeps"] = micro_only
         if best_e2e is not None:

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/timeline.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/timeline.py
@@ -227,18 +227,29 @@ def collect_phase_timeline(
         ev["ts"] = iso_z(ev.get("ts"))
 
     # De-dup: journal rows are appended first and win on collision.
-    seen: set[tuple[str, str, str]] = set()
+    #
+    # Rows collide on ``(action, ts-to-second, change)``. Rows that also carry
+    # distinct task ids are distinct events and are all kept -- but only while
+    # every row seen for that triple was itself task-tagged. An untagged row is
+    # the same event observed from the other source (journal vs audit list), so
+    # it keeps the legacy fold instead of being duplicated.
+    seen_tasks: dict[tuple[str, str, str], set[str]] = {}
     deduped: list[dict[str, Any]] = []
     for ev in events:
-        key = (
+        base = (
             str(ev.get("action") or ""),
             (str(ev.get("ts") or ""))[:19],
             str(ev.get("change") or ev.get("task_id") or ""),
         )
-        if key in seen:
+        task_id = str(ev.get("task_id") or "")
+        prior = seen_tasks.get(base)
+        if prior is None:
+            seen_tasks[base] = {task_id}
+            deduped.append(ev)
             continue
-        seen.add(key)
-        deduped.append(ev)
+        if task_id and task_id not in prior and all(prior):
+            prior.add(task_id)
+            deduped.append(ev)
 
     deduped.sort(key=lambda e: e.get("ts") or "")
     return deduped
@@ -345,28 +356,43 @@ def collect_capability_summary(
             invs (list[dict[str, Any]]): A lane's invocation records.
 
         Returns:
-            dict[str, Any]: ``{"status", "attempts", "keeps"}`` where
-            ``keeps`` counts ``decision == "KEEP"`` entries.
+            dict[str, Any]: ``{"status", "attempts", "keeps"}`` where ``keeps``
+            counts distinct kernels an integrate verdict adopted, plus optional
+            ``reverts`` / ``micro_only_keeps`` / ``e2e_gain_pct``.
         """
         attempts = len(invs)
-        adopted = 0
-        reverted = 0
+        # Tally distinct kernels, not invocation rows: one kernel re-tried
+        # across runs is still one kernel.
+        adopted_kids: set[str] = set()
+        reverted_kids: set[str] = set()
+        micro_only_kids: set[str] = set()
         best_e2e: float | None = None
-        for v in invs:
+        for i, v in enumerate(invs):
             if v.get("decision") != "KEEP":
                 continue
-            outcome = integ_by_kid.get(str(v.get("kernel_id") or ""))
+            kid = str(v.get("kernel_id") or "")
+            # A row without a kernel id cannot be folded with any other row.
+            ident = kid or f"__row_{i}"
+            outcome = integ_by_kid.get(kid) if kid else None
             if outcome is None:
-                # micro-KEEP with no integrate record stands as kept.
-                adopted += 1
+                # A KEEP that never reached integrate cleared the micro
+                # benchmark only. It is not an adoption (see CapabilityEntry:
+                # ``keeps`` is "kernels adopted at integrate").
+                micro_only_kids.add(ident)
                 continue
             g = outcome["e2e_gain_pct"]
             if g is not None and (best_e2e is None or g > best_e2e):
                 best_e2e = g
             if outcome["decision"] in ("REVERT", "REJECT"):
-                reverted += 1
+                reverted_kids.add(ident)
             else:
-                adopted += 1
+                adopted_kids.add(ident)
+        # An adoption outranks a revert or a micro-only KEEP for the same kernel.
+        reverted_kids -= adopted_kids
+        micro_only_kids -= adopted_kids | reverted_kids
+        adopted = len(adopted_kids)
+        reverted = len(reverted_kids)
+        micro_only = len(micro_only_kids)
         status = (
             "kept" if adopted > 0 else "reverted" if reverted > 0 else "attempted" if attempts > 0 else "not_attempted"
         )
@@ -377,6 +403,8 @@ def collect_capability_summary(
         }
         if reverted:
             row["reverts"] = reverted
+        if micro_only:
+            row["micro_only_keeps"] = micro_only
         if best_e2e is not None:
             row["e2e_gain_pct"] = best_e2e
         return row

--- a/src/hyperloom/inference_optimizer/breakdown/exporter.py
+++ b/src/hyperloom/inference_optimizer/breakdown/exporter.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from typing import Any
 
 from hyperloom.common.jsonio import read_json
-from hyperloom.common.timeutil import iso_z
 
 from . import collectors
 from .schema import SCHEMA_VERSION_V5
@@ -29,26 +28,6 @@ log = logging.getLogger(__name__)
 
 EXPORTER_VERSION = "session-breakdown-1.0.0"
 BREAKDOWN_FILENAME = "session_breakdown.json"
-
-
-def _phase_event_key(ev: dict[str, Any]) -> tuple[str, str, str]:
-    """Dedupe key matching :func:`collectors.collect_phase_timeline`.
-
-    ``(action, ts-to-second, change|task_id)`` with the timestamp canonicalised
-    to ``...Z`` so a recorder fragment row and the collector's audit-list row
-    for the same attempt collapse to one event.
-
-    Args:
-        ev: A phase-timeline event dict.
-
-    Returns:
-        The ``(action, ts-to-second, change|task_id)`` dedupe key.
-    """
-    return (
-        str(ev.get("action") or ""),
-        iso_z(ev.get("ts"))[:19],
-        str(ev.get("change") or ev.get("task_id") or ""),
-    )
 
 
 def _merge_phase_timeline(
@@ -73,7 +52,12 @@ def _merge_phase_timeline(
     base: list[dict[str, Any]] = list(collector_value) if isinstance(collector_value, list) else []
     if not isinstance(fragment, list) or not fragment:
         return base
-    seen = {_phase_event_key(ev) for ev in base if isinstance(ev, dict)}
+    # Share the collector's identity rule rather than restating it: the two
+    # disagreeing is invisible downstream, and costs whole events.
+    dedup = collectors.TimelineDedup()
+    for ev in base:
+        if isinstance(ev, dict):
+            dedup.is_new(ev)
     for ev in fragment:
         if not isinstance(ev, dict):
             continue
@@ -82,11 +66,8 @@ def _merge_phase_timeline(
         norm.setdefault("kernel_id", None)
         norm.setdefault("phase", "")
         norm.setdefault("change", str(ev.get("action") or ""))
-        key = _phase_event_key(norm)
-        if key in seen:
-            continue
-        seen.add(key)
-        base.append(norm)
+        if dedup.is_new(norm):
+            base.append(norm)
     base.sort(key=lambda e: e.get("ts") or "")
     return base
 

--- a/src/hyperloom/inference_optimizer/breakdown/recorder/recorder.py
+++ b/src/hyperloom/inference_optimizer/breakdown/recorder/recorder.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import re
 import threading
@@ -143,6 +144,8 @@ def section_shape(section: str) -> SectionShape | None:
     """
     return SECTION_SHAPES.get(section)
 
+
+log = logging.getLogger(__name__)
 
 _SANITIZE = re.compile(r"[^A-Za-z0-9._-]+")
 _ENTITY_ID_FIELDS = (
@@ -360,7 +363,10 @@ class Recorder:
 
         Fragments written before this digest existed keep their old name: a
         resumed session must go on updating the file it already wrote, not
-        start a second one for the same key.
+        start a second one for the same key. That reuse is only safe when the
+        key survived sanitizing untouched -- otherwise the legacy file could
+        belong to any of the keys that fold onto that name, and adopting it
+        would merge two entities, which is the bug the digest exists to stop.
 
         Args:
             section (str): The breakdown section name.
@@ -369,11 +375,24 @@ class Recorder:
         Returns:
             str: The fragment filename to write within the spool directory.
         """
-        prefix = f"{_slug(section)}__{self._producer}__{_slug(key)}"
+        slug = _slug(key)
+        prefix = f"{_slug(section)}__{self._producer}__{slug}"
         digest = hashlib.sha256(key.encode("utf-8", errors="replace")).hexdigest()[:8]
         filename = f"{prefix}-{digest}.json"
-        if not (self._dir / filename).exists() and (self._dir / f"{prefix}.json").exists():
-            return f"{prefix}.json"
+        legacy = self._dir / f"{prefix}.json"
+        if slug != key:
+            if legacy.exists():
+                log.warning(
+                    "breakdown recorder: not reusing %s for key %r -- the name is "
+                    "ambiguous after sanitizing; writing %s instead. The legacy "
+                    "fragment stays on disk and may hold a different key.",
+                    legacy.name,
+                    key,
+                    filename,
+                )
+            return filename
+        if not (self._dir / filename).exists() and legacy.exists():
+            return legacy.name
         return filename
 
     def record_upsert_item(

--- a/src/hyperloom/inference_optimizer/breakdown/recorder/recorder.py
+++ b/src/hyperloom/inference_optimizer/breakdown/recorder/recorder.py
@@ -16,9 +16,15 @@ re-walk heterogeneous artifacts later. Each producer owns its own files:
   — the same, but merged into the prior fragment payload instead of replacing
   it, for producers that emit a fact in several partial updates.
 
-Writes are atomic (tmp + ``os.replace``) and filenames are unique per
-(section, producer), so this is safe across processes and on network
-filesystems (no shared-append dependency).
+Every write lands atomically (tmp + ``os.replace``) and filenames are unique
+per (section, producer), so :meth:`Recorder.record_item` and
+:meth:`Recorder.record_singleton` are safe across processes and on network
+filesystems (no shared-append dependency). The ``record_upsert_*`` methods are
+NOT: they read the current fragment, merge, and rewrite it under an in-process
+lock only, so two processes upserting the same (section, producer, key) can
+lose one side of the merge. Keep every upsert for a given fragment in one
+process -- today the coordinator is the only writer, and
+``test_breakdown_recorder_no_subprocess_writers`` keeps it that way.
 
 Every write funnels through :meth:`Recorder._write`, which is where the write
 trace is emitted; ``HYPERLOOM_BREAKDOWN_TRACE=1`` turns it on (see
@@ -27,6 +33,7 @@ trace is emitted; ``HYPERLOOM_BREAKDOWN_TRACE=1`` turns it on (see
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -332,12 +339,42 @@ class Recorder:
             The path of the written item fragment.
         """
         self._check_shape(section, "item")
+        seq: int | None = None
         if key:
-            filename = f"{_slug(section)}__{self._producer}__{_slug(key)}.json"
+            filename = self._stable_item_filename(section, key)
         else:
+            # One number serves both the filename and the envelope: someone
+            # reading ``seq=N`` in a trace line must be able to find the file
+            # that write produced.
             seq = self._next_seq()
             filename = f"{_slug(section)}__{self._producer}__{os.getpid()}-{seq:06d}.json"
-        return self._write(section, "item", payload, filename=filename)
+        return self._write(section, "item", payload, filename=filename, seq=seq)
+
+    def _stable_item_filename(self, section: str, key: str) -> str:
+        """Name the fragment file that holds ``key``'s item in ``section``.
+
+        ``_slug`` folds every character outside ``[A-Za-z0-9._-]`` to a dash, so
+        ``a/b``, ``a:b`` and ``a b`` all name the same file and the last writer
+        silently wins. A digest of the untouched key keeps the readable part
+        readable while making the name injective.
+
+        Fragments written before this digest existed keep their old name: a
+        resumed session must go on updating the file it already wrote, not
+        start a second one for the same key.
+
+        Args:
+            section (str): The breakdown section name.
+            key (str): The caller's stable item identity, unsanitized.
+
+        Returns:
+            str: The fragment filename to write within the spool directory.
+        """
+        prefix = f"{_slug(section)}__{self._producer}__{_slug(key)}"
+        digest = hashlib.sha256(key.encode("utf-8", errors="replace")).hexdigest()[:8]
+        filename = f"{prefix}-{digest}.json"
+        if not (self._dir / filename).exists() and (self._dir / f"{prefix}.json").exists():
+            return f"{prefix}.json"
+        return filename
 
     def record_upsert_item(
         self,
@@ -355,7 +392,7 @@ class Recorder:
         self._check_shape(section, "item")
         if not key:
             raise ValueError("upsert key must be non-empty")
-        filename = f"{_slug(section)}__{self._producer}__{_slug(key)}.json"
+        filename = self._stable_item_filename(section, key)
         target = self._dir / filename
         merged: dict[str, Any] = {}
         with self._lock:
@@ -403,6 +440,7 @@ class Recorder:
         filename: str,
         operation: str = "write",
         previous: Mapping[str, Any] | None = None,
+        seq: int | None = None,
     ) -> Path:
         """Atomically write one fragment record to ``filename`` in the spool dir.
 
@@ -424,6 +462,9 @@ class Recorder:
             previous (Mapping[str, Any] | None): the payload that was already on
                 disk, so the trace can report what this write changed. ``None``
                 when there was nothing to merge into.
+            seq (int | None): a sequence number already drawn by the caller,
+                for callers that also spend it on the filename. ``None`` draws
+                a fresh one.
 
         Returns:
             Path: the path of the written fragment.
@@ -435,7 +476,7 @@ class Recorder:
         record = {
             "section": section,
             "kind": kind,
-            "seq": self._next_seq(),
+            "seq": self._next_seq() if seq is None else seq,
             "ts": now_iso(timespec="microseconds"),
             "producer": self._producer,
             "payload": dict(payload) if isinstance(payload, Mapping) else payload,

--- a/src/hyperloom/inference_optimizer/breakdown/reporters/_renderers/capability_summary.py
+++ b/src/hyperloom/inference_optimizer/breakdown/reporters/_renderers/capability_summary.py
@@ -64,6 +64,17 @@ def render(breakdown: dict[str, Any]) -> RenderedSection:
             extras.append(f"validated_gain={fmt_pct(v['last_validated_gain_pct'])}")
         if "grid_size" in v and v["grid_size"] is not None:
             extras.append(f"grid={v['grid_size']}")
+        # Kernel-lane outcomes that ``keeps`` deliberately excludes. Without
+        # them a reader cannot tell a lane that failed from one whose wins are
+        # still waiting on integrate.
+        if v.get("micro_only_keeps"):
+            extras.append(f"micro_only={v['micro_only_keeps']}")
+        if v.get("pending_integrate"):
+            extras.append(f"pending_integrate={v['pending_integrate']}")
+        if v.get("reverts"):
+            extras.append(f"reverts={v['reverts']}")
+        if v.get("e2e_gain_pct") is not None:
+            extras.append(f"e2e_gain={fmt_pct(v['e2e_gain_pct'])}")
         # explore extras.
         if "keep_unstable_count" in v and v["keep_unstable_count"]:
             extras.append(f"keep_unstable={v['keep_unstable_count']}")

--- a/src/hyperloom/inference_optimizer/breakdown/reporters/base.py
+++ b/src/hyperloom/inference_optimizer/breakdown/reporters/base.py
@@ -45,8 +45,10 @@ class RenderedSection:
     """A single section's render output.
 
     ``markdown_block`` is preserved verbatim; the LLM only sees
-    ``key_facts`` / ``decisions`` / ``warnings``. ``skipped`` tells the
-    compose layer to emit a one-line "not run" note instead of the block.
+    ``key_facts`` / ``decisions`` / ``warnings``. ``skipped`` drops the section
+    from the report body entirely -- its ``warnings`` and ``key_facts`` still
+    reach the reader, through ``GlobalFacts.data_quality_flags``, so that a
+    section nobody ran cannot be mistaken for a section that ran clean.
     """
 
     section_id: str

--- a/src/hyperloom/inference_optimizer/breakdown/reporters/compose.py
+++ b/src/hyperloom/inference_optimizer/breakdown/reporters/compose.py
@@ -212,6 +212,14 @@ def _stitch(
     parts.append("## Executive Summary")
     if used_llm and llm_exec_summary:
         parts.append(llm_exec_summary)
+        # The system prompt asks the model to surface every data-quality flag,
+        # but a prompt is a request. These flags are where a skipped section's
+        # evidence ends up, so leaving them to the narrative is how "this was
+        # never measured" silently becomes "this came back clean".
+        flag_lines = _data_quality_flag_lines(global_facts)
+        if flag_lines:
+            parts.append("")
+            parts.extend(flag_lines)
     else:
         parts.append(_deterministic_exec_summary(global_facts))
     parts.append("")
@@ -273,11 +281,27 @@ def _deterministic_exec_summary(g: GlobalFacts) -> str:
     )
     if g.capabilities_not_attempted:
         out.append("- Capabilities never invoked: " + ", ".join(f"`{c}`" for c in g.capabilities_not_attempted) + ".")
-    if g.data_quality_flags:
-        out.append("- **Data quality flags**:")
-        for f in g.data_quality_flags:
-            out.append(f"  - {f}")
+    out.extend(_data_quality_flag_lines(g))
     return "\n".join(out)
+
+
+def _data_quality_flag_lines(g: GlobalFacts) -> list[str]:
+    """Render the data-quality flags as markdown bullets.
+
+    Shared by the deterministic summary and the LLM path so both report the
+    same facts in the same shape.
+
+    Args:
+        g (GlobalFacts): Global facts carrying the flags.
+
+    Returns:
+        list[str]: Markdown lines, empty when there are no flags.
+    """
+    if not g.data_quality_flags:
+        return []
+    lines = ["- **Data quality flags**:"]
+    lines.extend(f"  - {flag}" for flag in g.data_quality_flags)
+    return lines
 
 
 def _render_global_facts_block(g: GlobalFacts) -> str:

--- a/src/hyperloom/inference_optimizer/breakdown/reporters/compose.py
+++ b/src/hyperloom/inference_optimizer/breakdown/reporters/compose.py
@@ -53,6 +53,11 @@ SECTION_GROUPS: list[tuple[str, list[str]]] = [
         "Kernel Optimization",
         [
             "kernel_lifecycle",
+            # The per-backend invocation logs behind the capability-summary
+            # counts. Without them the report states how many kernels a lane
+            # adopted while showing none of the attempts behind the number.
+            "geak_invocations",
+            "forge_invocations",
             "kernel_profiling",
             "kernel_decision_path",
             "critic_robustness",

--- a/src/hyperloom/inference_optimizer/breakdown/reporters/cross_section.py
+++ b/src/hyperloom/inference_optimizer/breakdown/reporters/cross_section.py
@@ -179,6 +179,24 @@ def _kernel_funnel(breakdown: dict[str, Any]) -> dict[str, int]:
     }
 
 
+# Sections whose renderer is registered but whose data nothing produces: no
+# collector, exporter key or recorder fragment ever fills them. They are always
+# skipped, so surfacing that as a data-quality flag would tell the reader this
+# run came up short when the truth is that the feature was never wired up --
+# and four permanent flags would drown the ones that do describe the session.
+# ``test_breakdown_report_integrity`` recomputes this set from the real
+# exporter + recorder key space, so wiring a producer up (or adding another
+# dead section) fails the suite instead of silently drifting.
+_SECTIONS_WITHOUT_PRODUCER = frozenset(
+    {
+        "data_provenance",
+        "decision_journal",
+        "kernel_decision_path",
+        "kernel_profiling",
+    }
+)
+
+
 def _data_quality_flags(
     breakdown: dict[str, Any],
     rendered: list[RenderedSection],
@@ -207,8 +225,18 @@ def _data_quality_flags(
         flags.append(line)
 
     for sec in rendered:
-        # Skip dropped sections.
         if sec.skipped:
+            if sec.section_id in _SECTIONS_WITHOUT_PRODUCER:
+                continue
+            # A dropped section still carries evidence: "this never ran" is a
+            # data-quality fact, and discarding it lets a reader mistake an
+            # untested area for a clean one. Prefer the renderer's warnings,
+            # fall back to its key facts, and state the absence either way.
+            evidence = sec.warnings or sec.key_facts
+            for line in evidence:
+                _push(f"[{sec.section_id}] skipped: {line}")
+            if not evidence:
+                _push(f"[{sec.section_id}] skipped: no data recorded this session.")
             continue
         for w in sec.warnings:
             _push(f"[{sec.section_id}] {w}")

--- a/src/hyperloom/inference_optimizer/breakdown/reporters/cross_section.py
+++ b/src/hyperloom/inference_optimizer/breakdown/reporters/cross_section.py
@@ -232,7 +232,9 @@ def _data_quality_flags(
             # data-quality fact, and discarding it lets a reader mistake an
             # untested area for a clean one. Prefer the renderer's warnings,
             # fall back to its key facts, and state the absence either way.
-            evidence = sec.warnings or sec.key_facts
+            # Both, not either: a renderer that logged a warning may still
+            # carry the key fact that explains it, and ``or`` would drop it.
+            evidence = [*sec.warnings, *sec.key_facts]
             for line in evidence:
                 _push(f"[{sec.section_id}] skipped: {line}")
             if not evidence:

--- a/src/hyperloom/inference_optimizer/breakdown/reporters/llm_prompt.py
+++ b/src/hyperloom/inference_optimizer/breakdown/reporters/llm_prompt.py
@@ -125,53 +125,51 @@ def build_user_prompt(
 _MAX_EXEC_SUMMARY_CHARS = 1500
 _MAX_NARRATIVE_CHARS = 800
 
-# Narratives are pasted under a heading the composer owns -- the summary under
-# an H2, each section paragraph under an H3. A line that opens a heading, a
-# code fence or a block-level element re-parents every deterministic block that
-# follows it, turning a wrong paragraph into a wrong document.
-_STRUCTURAL_LINE = re.compile(
+# Narratives are pasted into a slot the composer owns -- the summary under an
+# H2, each section paragraph under an H3. Markdown that *opens a block* escapes
+# that slot and re-parents every deterministic block after it: an unterminated
+# HTML comment comments the rest of the report out, an odd code fence swallows
+# it. CommonMark has many ways to open a block, and a blacklist that misses one
+# fails silently and totally -- so match the act of opening a block, and treat
+# it as evidence the model ignored the brief.
+_BLOCK_OPENER = re.compile(
     r"""
     ^\s{0,3}(
-        \#{1,6}(\s|$)                                  # ATX heading
-      | (```|~~~)                                      # code fence
-      | (={3,}|-{3,}|\*{3,}|_{3,})\s*$                 # setext rule / thematic break
-      | </?(script|style|iframe|div|h[1-6]|table)\b    # block-level HTML
+        \#{1,6}(\s|$)                      # ATX heading
+      | (```|~~~)                          # fenced code
+      | (={3,}|-{3,}|\*{3,}|_{3,})\s*$     # setext underline / thematic break
+      | <                                  # any HTML block: tag, comment, PI, CDATA
     )
     """,
-    re.VERBOSE | re.IGNORECASE,
+    re.VERBOSE,
 )
 
 
 def _sanitize(text: str, *, max_chars: int) -> str:
-    """Strip model prose that would restructure the report instead of describing it.
+    """Return model prose only when it is safe to paste into the report.
 
-    Structural lines are dropped individually; output that is mostly structure
-    is dropped whole, as is output past ``max_chars`` -- half a truncated
-    sentence reads worse than the deterministic fallback. Callers treat ``""``
-    as "the model said nothing usable", which every consumer already handles.
+    Prose that opens a markdown block, or that ran past the length the prompt
+    asked for, is discarded whole rather than repaired: a partially stripped
+    paragraph is prose the model did not write, and half a truncated sentence
+    reads worse than the deterministic text. ``""`` means "nothing usable",
+    which every caller already treats as "fall back".
+
+    Note the anchor: only a line *starting* a block is rejected, so ordinary
+    prose containing ``<`` (``latency < 5ms``) passes untouched.
 
     Args:
         text (str): Raw narrative as the model wrote it.
-        max_chars (int): Length ceiling, applied after cleaning.
+        max_chars (int): Length ceiling for the whole narrative.
 
     Returns:
-        str: The cleaned narrative, or ``""`` when it is unusable.
+        str: The narrative, or ``""`` when it must not be used.
     """
-    kept: list[str] = []
-    dropped = 0
-    for line in (text or "").splitlines():
-        line = line.rstrip()
-        if _STRUCTURAL_LINE.match(line):
-            dropped += 1
-            continue
-        # Four leading spaces would render as an indented code block.
-        kept.append(re.sub(r"^\s{4,}", "", line))
-    # More structure than prose means the model wrote a document, and none of
-    # that document belongs inside a section someone else owns.
-    if dropped and dropped > sum(1 for line in kept if line.strip()):
+    cleaned = (text or "").strip()
+    if not cleaned or len(cleaned) > max_chars:
         return ""
-    cleaned = re.sub(r"\n{3,}", "\n\n", "\n".join(kept)).strip()
-    return "" if len(cleaned) > max_chars else cleaned
+    if any(_BLOCK_OPENER.match(line) for line in cleaned.splitlines()):
+        return ""
+    return cleaned
 
 
 def parse_llm_response(raw: str) -> dict[str, Any]:

--- a/src/hyperloom/inference_optimizer/breakdown/reporters/llm_prompt.py
+++ b/src/hyperloom/inference_optimizer/breakdown/reporters/llm_prompt.py
@@ -5,14 +5,20 @@
 
 The LLM writes only an executive summary plus one paragraph per
 non-skipped section; deterministic ``markdown_block``s are stitched in
-verbatim. Guard rails (enforced in the system prompt): no numbers outside
+verbatim. Guard rails asked for in the system prompt: no numbers outside
 ``key_facts``/``decisions``/``global_facts``, honest capability status,
 JSON output keyed by section so stitching stays clean.
+
+A prompt is a request, not a constraint, so :func:`parse_llm_response` also
+enforces the two guard rails that can corrupt the document rather than merely
+misinform: prose that would restructure the report, and prose that ignored the
+length brief. Claims about numbers remain the system prompt's problem.
 """
 
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 from .base import RenderedSection
@@ -113,11 +119,68 @@ def build_user_prompt(
     return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
 
 
+# The system prompt asks for "3-5 sentences" and "1 short paragraph"
+# (see SYSTEM_PROMPT). These ceilings are those shapes with generous room, so
+# they only catch output that ignored the brief outright.
+_MAX_EXEC_SUMMARY_CHARS = 1500
+_MAX_NARRATIVE_CHARS = 800
+
+# Narratives are pasted under a heading the composer owns -- the summary under
+# an H2, each section paragraph under an H3. A line that opens a heading, a
+# code fence or a block-level element re-parents every deterministic block that
+# follows it, turning a wrong paragraph into a wrong document.
+_STRUCTURAL_LINE = re.compile(
+    r"""
+    ^\s{0,3}(
+        \#{1,6}(\s|$)                                  # ATX heading
+      | (```|~~~)                                      # code fence
+      | (={3,}|-{3,}|\*{3,}|_{3,})\s*$                 # setext rule / thematic break
+      | </?(script|style|iframe|div|h[1-6]|table)\b    # block-level HTML
+    )
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+
+def _sanitize(text: str, *, max_chars: int) -> str:
+    """Strip model prose that would restructure the report instead of describing it.
+
+    Structural lines are dropped individually; output that is mostly structure
+    is dropped whole, as is output past ``max_chars`` -- half a truncated
+    sentence reads worse than the deterministic fallback. Callers treat ``""``
+    as "the model said nothing usable", which every consumer already handles.
+
+    Args:
+        text (str): Raw narrative as the model wrote it.
+        max_chars (int): Length ceiling, applied after cleaning.
+
+    Returns:
+        str: The cleaned narrative, or ``""`` when it is unusable.
+    """
+    kept: list[str] = []
+    dropped = 0
+    for line in (text or "").splitlines():
+        line = line.rstrip()
+        if _STRUCTURAL_LINE.match(line):
+            dropped += 1
+            continue
+        # Four leading spaces would render as an indented code block.
+        kept.append(re.sub(r"^\s{4,}", "", line))
+    # More structure than prose means the model wrote a document, and none of
+    # that document belongs inside a section someone else owns.
+    if dropped and dropped > sum(1 for line in kept if line.strip()):
+        return ""
+    cleaned = re.sub(r"\n{3,}", "\n\n", "\n".join(kept)).strip()
+    return "" if len(cleaned) > max_chars else cleaned
+
+
 def parse_llm_response(raw: str) -> dict[str, Any]:
     """Best-effort parse of the LLM's JSON output.
 
     Tolerates a code fence; on any failure returns empty fields so the
-    deterministic-only output path stays usable.
+    deterministic-only output path stays usable. Surviving values are passed
+    through :func:`_sanitize`, so a field may come back empty even when the
+    model filled it -- the composer already treats empty as "fall back".
 
     Args:
         raw: Raw text returned by the LLM, optionally wrapped in a code fence.
@@ -141,6 +204,9 @@ def parse_llm_response(raw: str) -> dict[str, Any]:
     if not isinstance(data, dict):
         return {"executive_summary": "", "section_narratives": {}}
     return {
-        "executive_summary": str(data.get("executive_summary") or "").strip(),
-        "section_narratives": {str(k): str(v).strip() for k, v in (data.get("section_narratives") or {}).items()},
+        "executive_summary": _sanitize(str(data.get("executive_summary") or ""), max_chars=_MAX_EXEC_SUMMARY_CHARS),
+        "section_narratives": {
+            str(k): _sanitize(str(v), max_chars=_MAX_NARRATIVE_CHARS)
+            for k, v in (data.get("section_narratives") or {}).items()
+        },
     }

--- a/src/hyperloom/inference_optimizer/breakdown/schema.py
+++ b/src/hyperloom/inference_optimizer/breakdown/schema.py
@@ -410,6 +410,7 @@ class CapabilityEntry(TypedDict, total=False):
     status: str  # kept / reverted / tried / attempted / not_attempted / not_configured / failed / completed
     attempts: int
     keeps: int  # kernels adopted at integrate (NOT micro-only KEEP)
+    micro_only_keeps: int  # micro-KEPT kernels that never reached integrate
     reverts: int  # micro-KEPT kernels reverted at integrate (e2e regressed)
     e2e_gain_pct: float | None  # best end-to-end integrate gain for this lane's kernel
     tested: int  # for backends/params/explore: distinct variants tested

--- a/src/hyperloom/inference_optimizer/breakdown/schema.py
+++ b/src/hyperloom/inference_optimizer/breakdown/schema.py
@@ -408,9 +408,10 @@ class PhaseEvent(TypedDict, total=False):
 # Capability summary — Capability cards in UI
 class CapabilityEntry(TypedDict, total=False):
     status: str  # kept / reverted / tried / attempted / not_attempted / not_configured / failed / completed
-    attempts: int
-    keeps: int  # kernels adopted at integrate (NOT micro-only KEEP)
+    attempts: int  # invocation rows, NOT distinct kernels: how many tries
+    keeps: int  # distinct kernels adopted at integrate (NOT micro-only KEEP)
     micro_only_keeps: int  # micro-KEPT kernels that never reached integrate
+    pending_integrate: int  # micro-KEPT kernels whose integrate verdict is undecided
     reverts: int  # micro-KEPT kernels reverted at integrate (e2e regressed)
     e2e_gain_pct: float | None  # best end-to-end integrate gain for this lane's kernel
     tested: int  # for backends/params/explore: distinct variants tested
@@ -433,8 +434,7 @@ class CapabilitySummary(TypedDict, total=False):
 
     Attributes:
         geak (CapabilityEntry): GEAK kernel-generation capability.
-        forge (CapabilityEntry): Forge kernel-generation capability; emitted by
-            the collector but not yet declared on this TypedDict.
+        forge (CapabilityEntry): Forge kernel-generation capability.
         explore (CapabilityEntry): Primary explore (param/backend search) row.
         backends (CapabilityEntry): Compatibility alias for backend exploration.
         params (CapabilityEntry): Compatibility alias for param exploration.
@@ -446,6 +446,7 @@ class CapabilitySummary(TypedDict, total=False):
     """
 
     geak: CapabilityEntry
+    forge: CapabilityEntry
     # primary explore row; backends/params/validate_stack are compat aliases.
     explore: CapabilityEntry
     backends: CapabilityEntry

--- a/src/hyperloom/inference_optimizer/tests/test_breakdown_recorder_no_subprocess_writers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_breakdown_recorder_no_subprocess_writers.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""The breakdown recorder has exactly one writer: the coordinator process.
+
+``Recorder.record_upsert_singleton`` / ``record_upsert_item`` read the current
+fragment, merge, and rewrite it while holding an in-process lock only. Two
+processes upserting the same (section, producer, key) would lose one side of
+the merge, and a file lock cannot fix it here -- the spool lives on a network
+filesystem, where advisory locks are unreliable.
+
+The recorder module docstring therefore promises that upserts stay inside one
+process. Agent packages and the multi-node helpers run as subprocesses, so this
+test fails the moment one of them starts recording fragments, before the
+promise silently becomes false.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import hyperloom.agents
+import hyperloom.inference_optimizer.multi_node
+
+# Matches the recorder package and its ``instrument`` facade, which is how a
+# caller would normally reach it.
+_FORBIDDEN_FRAGMENT = "breakdown.recorder"
+
+
+def _subprocess_package_roots() -> list[Path]:
+    """Return the package directories that must not write breakdown fragments.
+
+    Returns:
+        list[Path]: Absolute roots of the agent and multi-node packages.
+    """
+    return [
+        Path(hyperloom.agents.__file__).resolve().parent,
+        Path(hyperloom.inference_optimizer.multi_node.__file__).resolve().parent,
+    ]
+
+
+def _imports_recorder(path: Path) -> bool:
+    """Report whether ``path`` imports the breakdown recorder.
+
+    Relative imports are matched on their module suffix: a relative
+    ``from ....breakdown.recorder import x`` still carries the fragment.
+
+    Args:
+        path (Path): The Python source file to inspect.
+
+    Returns:
+        bool: ``True`` when the file imports the recorder in any form.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except SyntaxError:
+        # Not our contract to police; the syntax checkers own this.
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(_FORBIDDEN_FRAGMENT in alias.name for alias in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            if _FORBIDDEN_FRAGMENT in (node.module or ""):
+                return True
+    return False
+
+
+def test_subprocess_packages_do_not_write_breakdown_fragments() -> None:
+    """No agent or multi-node module may import the breakdown recorder."""
+    offenders: list[str] = []
+    for root in _subprocess_package_roots():
+        for path in sorted(root.rglob("*.py")):
+            # Tests may import anything; they do not run as the subprocesses.
+            if "tests" in path.parts:
+                continue
+            if _imports_recorder(path):
+                offenders.append(str(path))
+
+    assert not offenders, (
+        "breakdown recorder writes must stay in the coordinator process -- "
+        "record_upsert_* is not safe across processes (see the recorder module "
+        f"docstring). Offending modules: {offenders}"
+    )
+
+
+def test_the_detector_actually_detects(tmp_path: Path) -> None:
+    """Guard the guard: a rule that cannot fail protects nothing."""
+    absolute = tmp_path / "absolute.py"
+    absolute.write_text(
+        "from hyperloom.inference_optimizer.breakdown.recorder import instrument\n",
+        encoding="utf-8",
+    )
+    relative = tmp_path / "relative.py"
+    relative.write_text(
+        "from ...inference_optimizer.breakdown.recorder.recorder import Recorder\n",
+        encoding="utf-8",
+    )
+    plain_import = tmp_path / "plain.py"
+    plain_import.write_text(
+        "import hyperloom.inference_optimizer.breakdown.recorder as r\n",
+        encoding="utf-8",
+    )
+    innocent = tmp_path / "innocent.py"
+    innocent.write_text("from hyperloom.common import io\n", encoding="utf-8")
+
+    assert _imports_recorder(absolute)
+    assert _imports_recorder(relative)
+    assert _imports_recorder(plain_import)
+    assert not _imports_recorder(innocent)

--- a/src/hyperloom/inference_optimizer/tests/test_breakdown_recorder_no_subprocess_writers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_breakdown_recorder_no_subprocess_writers.py
@@ -62,7 +62,12 @@ def _imports_recorder(path: Path) -> bool:
             if any(_FORBIDDEN_FRAGMENT in alias.name for alias in node.names):
                 return True
         elif isinstance(node, ast.ImportFrom):
-            if _FORBIDDEN_FRAGMENT in (node.module or ""):
+            module = node.module or ""
+            if _FORBIDDEN_FRAGMENT in module:
+                return True
+            # ``from ...breakdown import recorder`` names the package in the
+            # alias rather than the module path, and reaches the same writers.
+            if module.endswith("breakdown") and any(alias.name == "recorder" for alias in node.names):
                 return True
     return False
 
@@ -86,26 +91,34 @@ def test_subprocess_packages_do_not_write_breakdown_fragments() -> None:
 
 
 def test_the_detector_actually_detects(tmp_path: Path) -> None:
-    """Guard the guard: a rule that cannot fail protects nothing."""
-    absolute = tmp_path / "absolute.py"
-    absolute.write_text(
-        "from hyperloom.inference_optimizer.breakdown.recorder import instrument\n",
-        encoding="utf-8",
-    )
-    relative = tmp_path / "relative.py"
-    relative.write_text(
-        "from ...inference_optimizer.breakdown.recorder.recorder import Recorder\n",
-        encoding="utf-8",
-    )
-    plain_import = tmp_path / "plain.py"
-    plain_import.write_text(
-        "import hyperloom.inference_optimizer.breakdown.recorder as r\n",
-        encoding="utf-8",
-    )
-    innocent = tmp_path / "innocent.py"
-    innocent.write_text("from hyperloom.common import io\n", encoding="utf-8")
+    """Guard the guard: a rule that cannot fail protects nothing.
 
-    assert _imports_recorder(absolute)
-    assert _imports_recorder(relative)
-    assert _imports_recorder(plain_import)
-    assert not _imports_recorder(innocent)
+    Every form below reaches ``recorder.get_recorder`` at runtime, so every one
+    has to trip the check. The parent-package forms are the ones the first
+    version of this guard missed: it inspected only the module path, and
+    ``from ...breakdown import recorder`` carries the package in the alias.
+    """
+    reaching = [
+        "from hyperloom.inference_optimizer.breakdown.recorder import instrument",
+        "from hyperloom.inference_optimizer.breakdown.recorder.recorder import Recorder",
+        "import hyperloom.inference_optimizer.breakdown.recorder as r",
+        "from hyperloom.inference_optimizer.breakdown import recorder",
+        "from hyperloom.inference_optimizer.breakdown import recorder as r",
+        "from ...inference_optimizer.breakdown import recorder",
+        "from ...breakdown.recorder import instrument",
+    ]
+    for index, source in enumerate(reaching):
+        path = tmp_path / f"reaching_{index}.py"
+        path.write_text(source + "\n", encoding="utf-8")
+        assert _imports_recorder(path), f"guard missed a real writer: {source}"
+
+    # Neighbouring modules under the same package must not trip it.
+    innocent = [
+        "from hyperloom.common import io",
+        "from hyperloom.inference_optimizer.breakdown import exporter",
+        "from hyperloom.inference_optimizer.breakdown import schema",
+    ]
+    for index, source in enumerate(innocent):
+        path = tmp_path / f"innocent_{index}.py"
+        path.write_text(source + "\n", encoding="utf-8")
+        assert not _imports_recorder(path), f"guard false-positived on: {source}"

--- a/src/hyperloom/inference_optimizer/tests/test_breakdown_report_integrity.py
+++ b/src/hyperloom/inference_optimizer/tests/test_breakdown_report_integrity.py
@@ -8,8 +8,13 @@ but never enforced:
 
 * ``CapabilityEntry.keeps`` counts kernels adopted at *integrate*. A KEEP that
   only cleared the micro benchmark is not an adoption and must not inflate it.
-* ``keeps`` / ``attempts`` count distinct kernels, not invocation rows, so a
-  kernel re-tried across runs is still one kernel.
+* ``keeps`` counts distinct kernels, so a kernel re-tried across runs is one
+  adoption. ``attempts`` deliberately stays a count of invocation rows -- "how
+  many tries did this take" is the question it answers -- so the two fields
+  carry different units on purpose.
+* Only a ``KEEP`` verdict is an adoption. ``NEEDS_REVIEW`` and a missing
+  decision mean the verdict is not in yet, and a lane holding one must not
+  read as ``kept``.
 * Timeline de-duplication must not fold two different tasks into one row just
   because they share an action and a wall-clock second.
 * A section skipped for lack of data still carries evidence ("this never ran");
@@ -119,6 +124,83 @@ def test_micro_only_and_adopted_kernels_are_tallied_separately() -> None:
     assert cap["forge"]["status"] == "kept"
 
 
+def test_needs_review_is_not_an_adoption() -> None:
+    """``NEEDS_REVIEW`` means the verdict is not in, not that it was a win."""
+    invs = [{"kernel_id": "k1", "decision": "KEEP"}]
+
+    cap = collectors.collect_capability_summary(_integrate_state("k1", "NEEDS_REVIEW"), [], [], forge_invocations=invs)
+
+    assert cap["forge"]["keeps"] == 0
+    assert cap["forge"]["status"] != "kept"
+    assert cap["forge"]["pending_integrate"] == 1
+
+
+def test_missing_integrate_decision_is_not_an_adoption() -> None:
+    """An empty decision is an undecided verdict, reachable on the fault path."""
+    invs = [{"kernel_id": "k1", "decision": "KEEP"}]
+
+    cap = collectors.collect_capability_summary(_integrate_state("k1", ""), [], [], forge_invocations=invs)
+
+    assert cap["forge"]["keeps"] == 0
+    assert cap["forge"]["pending_integrate"] == 1
+
+
+def test_adopted_patch_is_not_undone_by_a_reverted_sibling() -> None:
+    """``kernel_integrate_attempts`` is keyed by kernel|patch|args, so one
+    kernel holds several rows. Folding them by kernel id must not let whichever
+    row happens to be iterated last decide the outcome.
+    """
+    state = {
+        "kernel_integrate_attempts": {
+            # Ordered so the REVERT is visited last: overwriting loses the KEEP.
+            "k1|patchA|": {"kernel_id": "k1", "last_decision": "KEEP", "best_gain_pct": 9.0},
+            "k1|patchB|": {"kernel_id": "k1", "last_decision": "REVERT", "best_gain_pct": -5.0},
+        }
+    }
+
+    cap = collectors.collect_capability_summary(
+        state, [], [], forge_invocations=[{"kernel_id": "k1", "decision": "KEEP"}]
+    )
+
+    assert cap["forge"]["keeps"] == 1, "an adopted patch survives a reverted sibling"
+    assert cap["forge"]["status"] == "kept"
+    assert cap["forge"]["e2e_gain_pct"] == 9.0
+
+
+def test_kernel_with_only_reverted_patches_is_not_adopted() -> None:
+    """Folding must not manufacture an adoption out of two reverts."""
+    state = {
+        "kernel_integrate_attempts": {
+            "k1|patchA|": {"kernel_id": "k1", "last_decision": "REVERT", "best_gain_pct": -5.0},
+            "k1|patchB|": {"kernel_id": "k1", "last_decision": "REVERT", "best_gain_pct": -2.0},
+        }
+    }
+
+    cap = collectors.collect_capability_summary(
+        state, [], [], forge_invocations=[{"kernel_id": "k1", "decision": "KEEP"}]
+    )
+
+    assert cap["forge"]["keeps"] == 0
+    assert cap["forge"]["status"] == "reverted"
+
+
+def test_pending_verdict_loses_to_a_decided_one() -> None:
+    """A decided sibling outranks an undecided one."""
+    state = {
+        "kernel_integrate_attempts": {
+            "k1|patchA|": {"kernel_id": "k1", "last_decision": "NEEDS_REVIEW", "best_gain_pct": 1.0},
+            "k1|patchB|": {"kernel_id": "k1", "last_decision": "KEEP", "best_gain_pct": 4.0},
+        }
+    }
+
+    cap = collectors.collect_capability_summary(
+        state, [], [], forge_invocations=[{"kernel_id": "k1", "decision": "KEEP"}]
+    )
+
+    assert cap["forge"]["keeps"] == 1
+    assert cap["forge"].get("pending_integrate", 0) == 0
+
+
 # Fragment identity
 
 
@@ -173,6 +255,27 @@ def test_same_key_still_rewrites_one_fragment(tmp_path: Path) -> None:
     assert len(list(tmp_path.glob("measurements__*.json"))) == 1
 
 
+def test_legacy_reuse_does_not_resurrect_the_collision(tmp_path: Path) -> None:
+    """A legacy filename only belongs to a key that sanitizing left untouched.
+
+    ``a/b`` and ``a:b`` both sanitize to ``a-b``. Reusing a legacy ``a-b.json``
+    for either of them puts the digest back where it started: two entities
+    merged into one file.
+    """
+    rec = Recorder(tmp_path, producer="coordinator")
+    legacy = tmp_path / "measurements__coordinator__a-b.json"
+    legacy.write_text(
+        json.dumps({"section": "measurements", "kind": "item", "seq": 1, "payload": {"who": "a/b"}}),
+        encoding="utf-8",
+    )
+
+    written = rec.record_upsert_item("measurements", {"who": "a:b"}, key="a:b")
+
+    assert written != legacy, "a sanitized key must not claim an ambiguous legacy file"
+    assert json.loads(legacy.read_text(encoding="utf-8"))["payload"]["who"] == "a/b", "legacy left intact"
+    assert json.loads(written.read_text(encoding="utf-8"))["payload"]["who"] == "a:b"
+
+
 def test_fragment_written_under_the_old_name_keeps_that_name(tmp_path: Path) -> None:
     """A resumed session must update its fragment, not fork a second one."""
     rec = Recorder(tmp_path, producer="coordinator")
@@ -205,6 +308,57 @@ def test_distinct_tasks_in_the_same_second_are_not_folded() -> None:
 
     assert len(events) == 2, "task_id must participate in the de-dup key"
     assert {e["task_id"] for e in events} == {"task-1", "task-2"}
+
+
+def test_exporter_keeps_distinct_tasks_from_recorder_fragments() -> None:
+    """The exporter merges recorder fragments and must fold them as the collector does.
+
+    Recorder-only rows never pass through the collector, so an exporter with its
+    own weaker identity silently drops events the collector would have kept.
+    """
+    from hyperloom.inference_optimizer.breakdown.exporter import _merge_phase_timeline
+
+    fragment = [
+        {"ts": "2026-08-24T10:00:00Z", "action": "explore", "task_id": "task-1", "status": "succeeded"},
+        {"ts": "2026-08-24T10:00:00Z", "action": "explore", "task_id": "task-2", "status": "succeeded"},
+    ]
+
+    merged = _merge_phase_timeline(fragment, [])
+
+    assert len(merged) == 2, "exporter must not fold two tasks into one event"
+    assert {e.get("task_id") for e in merged} == {"task-1", "task-2"}
+
+
+def test_collector_and_exporter_agree_on_event_identity() -> None:
+    """The two paths must not disagree about what counts as the same event."""
+    from hyperloom.inference_optimizer.breakdown.exporter import _merge_phase_timeline
+
+    rows = [
+        {"ts": "2026-08-24T10:00:00Z", "task_id": "task-1", "status": "succeeded"},
+        {"ts": "2026-08-24T10:00:00Z", "task_id": "task-2", "status": "succeeded"},
+        {"ts": "2026-08-24T10:00:00Z", "task_id": "task-1", "status": "succeeded"},
+    ]
+    via_collector = collectors.collect_phase_timeline(None, {"explore_attempts": rows}, [])
+    via_exporter = _merge_phase_timeline([dict(r, action="explore") for r in rows], [])
+
+    assert len(via_collector) == len(via_exporter)
+
+
+def test_exporter_still_folds_a_fragment_echo_of_a_collector_row() -> None:
+    """The fold that exists for a reason must survive the fix."""
+    from hyperloom.inference_optimizer.breakdown.exporter import _merge_phase_timeline
+
+    row = {
+        "ts": "2026-08-24T10:00:00Z",
+        "action": "explore",
+        "task_id": "task-1",
+        "change": "explore",
+        "status": "succeeded",
+    }
+
+    merged = _merge_phase_timeline([dict(row)], [dict(row)])
+
+    assert len(merged) == 1
 
 
 def test_true_duplicate_rows_are_still_folded() -> None:
@@ -328,6 +482,66 @@ def test_live_section_warnings_are_unchanged() -> None:
     assert "[roofline] ceiling unavailable" in flags
 
 
+# Report output
+
+
+def test_data_quality_flags_survive_an_llm_summary() -> None:
+    """A model that ignores the flags must not be able to erase them.
+
+    The flags are where a skipped section's evidence ends up, and the LLM
+    summary replaces the deterministic one wholesale, so a narrative that never
+    mentions them would otherwise delete them from the report.
+    """
+    from hyperloom.inference_optimizer.breakdown.reporters.compose import render_session_report
+
+    class _SilentLLM:
+        """Answers well-formed JSON that never mentions a flag."""
+
+        def complete(self, *, system: str, user: str) -> str:
+            """Return a summary with no data-quality content.
+
+            Args:
+                system (str): System prompt (ignored).
+                user (str): User prompt (ignored).
+
+            Returns:
+                str: A valid response envelope.
+            """
+            return json.dumps({"executive_summary": "Everything went fine.", "section_narratives": {}})
+
+    result = render_session_report({}, llm_client=_SilentLLM())
+
+    assert result.used_llm
+    assert "Everything went fine." in result.markdown
+    assert "Data quality flags" in result.markdown, "flags must not depend on the model repeating them"
+
+
+def test_capability_table_shows_unadopted_outcomes() -> None:
+    """``keeps`` alone cannot distinguish a failed lane from a pending one."""
+    from hyperloom.inference_optimizer.breakdown.reporters._renderers import capability_summary as cap_renderer
+
+    rendered = cap_renderer.render(
+        {
+            "capability_summary": {
+                "forge": {
+                    "status": "attempted",
+                    "attempts": 3,
+                    "keeps": 0,
+                    "micro_only_keeps": 2,
+                    "pending_integrate": 1,
+                    "reverts": 1,
+                    "e2e_gain_pct": 4.5,
+                }
+            }
+        }
+    )
+
+    assert "micro_only=2" in rendered.markdown_block
+    assert "pending_integrate=1" in rendered.markdown_block
+    assert "reverts=1" in rendered.markdown_block
+    assert "e2e_gain" in rendered.markdown_block
+
+
 # LLM narrative guard rails
 
 
@@ -356,29 +570,45 @@ def test_ordinary_narrative_survives_untouched() -> None:
     assert out["section_narratives"]["sweep"] == prose
 
 
-def test_headings_are_stripped_from_narrative() -> None:
-    """A heading would re-parent every deterministic block that follows."""
-    out = _parse(sweep="## Injected Heading\nThe sweep found a better concurrency.")
+def test_prose_containing_an_inline_angle_bracket_survives() -> None:
+    """Only a line *opening* a block is a threat; ``<`` mid-sentence is prose."""
+    prose = "Tail latency stayed < 5ms while throughput rose."
 
-    assert "##" not in out["section_narratives"]["sweep"]
-    assert "better concurrency" in out["section_narratives"]["sweep"]
+    out = _parse(sweep=prose)
 
-
-def test_code_fence_is_stripped_from_narrative() -> None:
-    """An unbalanced fence swallows the rest of the document."""
-    out = _parse(sweep="Here is the config:\n```yaml\nkey: value\n```\nThat is all.")
-
-    assert "```" not in out["section_narratives"]["sweep"]
+    assert out["section_narratives"]["sweep"] == prose
 
 
-def test_thematic_break_and_block_html_are_stripped() -> None:
-    """Setext rules promote the previous line; block HTML escapes the slot."""
-    out = _parse(sweep="Summary line\n===\n<div>raw</div>\nreal prose here")
+def test_unterminated_html_comment_is_rejected() -> None:
+    """An unclosed comment comments out every section after this one."""
+    out = _parse(sweep="Looks fine.\n<!-- unterminated")
 
-    cleaned = out["section_narratives"]["sweep"]
-    assert "===" not in cleaned
-    assert "<div>" not in cleaned
-    assert "real prose here" in cleaned
+    assert out["section_narratives"]["sweep"] == ""
+
+
+def test_any_block_opener_rejects_the_whole_narrative() -> None:
+    """Repairing the prose would leave text the model never wrote.
+
+    Enumerating safe HTML was the wrong shape for this: CommonMark opens a
+    block many ways and missing one fails silently, so the rule matches the
+    act of opening a block instead.
+    """
+    openers = [
+        "## Injected Heading\nThe sweep found a better concurrency.",
+        "Here is the config:\n```yaml\nkey: value\n```",
+        "Summary line\n===",
+        "<div>raw</div>\nreal prose",
+        "<!DOCTYPE html>\nprose",
+        "<?php echo 1; ?>\nprose",
+        "<![CDATA[ raw ]]>\nprose",
+        "<p>paragraph</p>",
+        "<pre>fixed</pre>",
+        "<blockquote>quoted</blockquote>",
+    ]
+
+    for source in openers:
+        out = _parse(sweep=source)
+        assert out["section_narratives"]["sweep"] == "", f"block opener slipped through: {source!r}"
 
 
 def test_overlong_narrative_is_dropped_whole() -> None:
@@ -395,8 +625,10 @@ def test_overlong_executive_summary_is_dropped_whole() -> None:
     assert out["executive_summary"] == ""
 
 
-def test_mostly_structural_output_is_dropped_whole() -> None:
-    """A model that returned a document, not a paragraph, contributes nothing."""
-    out = _parse(sweep="# One\n## Two\n### Three\n```\n```\nstray")
+def test_multi_paragraph_prose_is_still_accepted() -> None:
+    """Rejecting block openers must not reject ordinary paragraph breaks."""
+    prose = "The sweep raised concurrency.\n\nNo accuracy regression was observed."
 
-    assert out["section_narratives"]["sweep"] == ""
+    out = _parse(sweep=prose)
+
+    assert out["section_narratives"]["sweep"] == prose

--- a/src/hyperloom/inference_optimizer/tests/test_breakdown_report_integrity.py
+++ b/src/hyperloom/inference_optimizer/tests/test_breakdown_report_integrity.py
@@ -1,0 +1,402 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Report integrity: reported counts must mean what the schema says they mean.
+
+These tests pin contracts the breakdown pipeline previously stated in comments
+but never enforced:
+
+* ``CapabilityEntry.keeps`` counts kernels adopted at *integrate*. A KEEP that
+  only cleared the micro benchmark is not an adoption and must not inflate it.
+* ``keeps`` / ``attempts`` count distinct kernels, not invocation rows, so a
+  kernel re-tried across runs is still one kernel.
+* Timeline de-duplication must not fold two different tasks into one row just
+  because they share an action and a wall-clock second.
+* A section skipped for lack of data still carries evidence ("this never ran");
+  that evidence must reach the reader instead of being dropped silently.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from hyperloom.inference_optimizer.breakdown import collectors
+from hyperloom.inference_optimizer.breakdown.recorder.recorder import Recorder
+from hyperloom.inference_optimizer.breakdown.reporters import cross_section, llm_prompt
+from hyperloom.inference_optimizer.breakdown.reporters.base import RenderedSection
+
+
+def _integrate_state(kernel_id: str, decision: str, gain: float | None = None) -> dict[str, Any]:
+    """Build a ``state`` carrying one integrate verdict for ``kernel_id``.
+
+    Args:
+        kernel_id (str): Kernel the integrate attempt refers to.
+        decision (str): Terminal integrate decision, e.g. ``"KEEP"`` / ``"REVERT"``.
+        gain (float | None): Best end-to-end gain percentage, if any.
+
+    Returns:
+        dict[str, Any]: A minimal ``state.json`` shaped mapping.
+    """
+    return {
+        "kernel_integrate_attempts": {
+            "attempt-1": {
+                "kernel_id": kernel_id,
+                "last_decision": decision,
+                "best_gain_pct": gain,
+            }
+        }
+    }
+
+
+# Capability counting
+
+
+def test_micro_only_keep_is_not_an_integrate_adoption() -> None:
+    """A KEEP with no integrate record is micro-only and must not count as adopted."""
+    invs = [{"kernel_id": "k1", "decision": "KEEP", "micro_speedup": 1.4}]
+
+    cap = collectors.collect_capability_summary({}, [], [], forge_invocations=invs)
+
+    assert cap["forge"]["attempts"] == 1
+    assert cap["forge"]["keeps"] == 0, "micro-only KEEP must not be reported as an integrate adoption"
+    assert cap["forge"]["micro_only_keeps"] == 1
+    # Not "kept": nothing was adopted end-to-end, so the executive summary must
+    # not advertise this lane as a capability that paid off.
+    assert cap["forge"]["status"] == "attempted"
+
+
+def test_integrate_adoption_is_counted_as_keep() -> None:
+    """A KEEP confirmed by an integrate verdict is a real adoption."""
+    invs = [{"kernel_id": "k1", "decision": "KEEP"}]
+
+    cap = collectors.collect_capability_summary(_integrate_state("k1", "KEEP", 7.5), [], [], forge_invocations=invs)
+
+    assert cap["forge"]["keeps"] == 1
+    assert cap["forge"]["status"] == "kept"
+    assert cap["forge"]["e2e_gain_pct"] == 7.5
+    assert cap["forge"].get("micro_only_keeps", 0) == 0
+
+
+def test_same_kernel_retried_across_runs_counts_once() -> None:
+    """One kernel stamped KEEP in several runs is one adoption, not several."""
+    invs = [
+        {"kernel_id": "k1", "decision": "KEEP", "run_id": "run-a"},
+        {"kernel_id": "k1", "decision": "KEEP", "run_id": "run-b"},
+    ]
+
+    cap = collectors.collect_capability_summary(_integrate_state("k1", "KEEP", 3.0), [], [], forge_invocations=invs)
+
+    assert cap["forge"]["keeps"] == 1, "distinct kernels, not invocation rows"
+
+
+def test_reverted_kernel_counted_once_across_runs() -> None:
+    """A kernel reverted at integrate stays a single revert across retries."""
+    invs = [
+        {"kernel_id": "k1", "decision": "KEEP", "run_id": "run-a"},
+        {"kernel_id": "k1", "decision": "KEEP", "run_id": "run-b"},
+    ]
+
+    cap = collectors.collect_capability_summary(_integrate_state("k1", "REVERT"), [], [], forge_invocations=invs)
+
+    assert cap["forge"]["keeps"] == 0
+    assert cap["forge"]["reverts"] == 1
+    assert cap["forge"]["status"] == "reverted"
+
+
+def test_micro_only_and_adopted_kernels_are_tallied_separately() -> None:
+    """Mixed lane: one adopted kernel, one micro-only, counted in their own buckets."""
+    invs = [
+        {"kernel_id": "k1", "decision": "KEEP"},
+        {"kernel_id": "k2", "decision": "KEEP"},
+    ]
+
+    cap = collectors.collect_capability_summary(_integrate_state("k1", "KEEP", 4.0), [], [], forge_invocations=invs)
+
+    assert cap["forge"]["keeps"] == 1
+    assert cap["forge"]["micro_only_keeps"] == 1
+    assert cap["forge"]["status"] == "kept"
+
+
+# Fragment identity
+
+
+def test_item_filename_seq_matches_envelope_seq(tmp_path: Path) -> None:
+    """A keyless item spends one sequence number, not two.
+
+    The filename and the envelope must agree, or a ``seq=N`` trace line points
+    at a file that does not exist.
+    """
+    rec = Recorder(tmp_path, producer="coordinator")
+
+    path = rec.record_item("measurements", {"value": 1})
+
+    envelope = json.loads(path.read_text(encoding="utf-8"))
+    filename_seq = int(path.stem.rsplit("-", 1)[-1])
+    assert filename_seq == envelope["seq"]
+
+
+def test_sequence_numbers_stay_monotonic_across_item_kinds(tmp_path: Path) -> None:
+    """Sharing a number must not break the ordering assembler sorts on."""
+    rec = Recorder(tmp_path, producer="coordinator")
+
+    first = rec.record_item("measurements", {"value": 1})
+    second = rec.record_item("measurements", {"value": 2}, key="keyed")
+    third = rec.record_item("measurements", {"value": 3})
+
+    seqs = [json.loads(p.read_text(encoding="utf-8"))["seq"] for p in (first, second, third)]
+    assert seqs == sorted(seqs)
+    assert len(set(seqs)) == len(seqs), "sequence numbers must stay unique"
+
+
+def test_keys_that_slugify_alike_get_distinct_fragments(tmp_path: Path) -> None:
+    """``ck#1`` and ``ck-1`` are different kernels and need different files."""
+    rec = Recorder(tmp_path, producer="coordinator")
+
+    first = rec.record_item("measurements", {"value": 1}, key="ck#1")
+    second = rec.record_item("measurements", {"value": 2}, key="ck-1")
+
+    assert first != second, "sanitizing must not fold two keys onto one file"
+    assert json.loads(first.read_text(encoding="utf-8"))["payload"]["value"] == 1
+    assert json.loads(second.read_text(encoding="utf-8"))["payload"]["value"] == 2
+
+
+def test_same_key_still_rewrites_one_fragment(tmp_path: Path) -> None:
+    """Idempotence across retries is the whole point of a stable key."""
+    rec = Recorder(tmp_path, producer="coordinator")
+
+    first = rec.record_item("measurements", {"value": 1}, key="k1")
+    second = rec.record_item("measurements", {"value": 2}, key="k1")
+
+    assert first == second
+    assert len(list(tmp_path.glob("measurements__*.json"))) == 1
+
+
+def test_fragment_written_under_the_old_name_keeps_that_name(tmp_path: Path) -> None:
+    """A resumed session must update its fragment, not fork a second one."""
+    rec = Recorder(tmp_path, producer="coordinator")
+    legacy = tmp_path / "measurements__coordinator__k1.json"
+    legacy.write_text(
+        json.dumps({"section": "measurements", "kind": "item", "seq": 1, "payload": {"value": 1}}),
+        encoding="utf-8",
+    )
+
+    written = rec.record_upsert_item("measurements", {"value": 2}, key="k1")
+
+    assert written == legacy
+    assert len(list(tmp_path.glob("measurements__*.json"))) == 1, "resume must not duplicate the fragment"
+    assert json.loads(written.read_text(encoding="utf-8"))["payload"]["value"] == 2
+
+
+# Timeline de-duplication
+
+
+def test_distinct_tasks_in_the_same_second_are_not_folded() -> None:
+    """Two tasks sharing an action and a second are two events, not one."""
+    state = {
+        "explore_attempts": [
+            {"ts": "2026-08-24T10:00:00Z", "task_id": "task-1", "status": "succeeded"},
+            {"ts": "2026-08-24T10:00:00Z", "task_id": "task-2", "status": "succeeded"},
+        ]
+    }
+
+    events = collectors.collect_phase_timeline(None, state, [])
+
+    assert len(events) == 2, "task_id must participate in the de-dup key"
+    assert {e["task_id"] for e in events} == {"task-1", "task-2"}
+
+
+def test_true_duplicate_rows_are_still_folded() -> None:
+    """De-dup still collapses rows that are genuinely the same event."""
+    state = {
+        "explore_attempts": [
+            {"ts": "2026-08-24T10:00:00Z", "task_id": "task-1", "status": "succeeded"},
+            {"ts": "2026-08-24T10:00:00Z", "task_id": "task-1", "status": "succeeded"},
+        ]
+    }
+
+    events = collectors.collect_phase_timeline(None, state, [])
+
+    assert len(events) == 1
+
+
+# Skipped-section evidence
+
+
+def test_skipped_section_evidence_is_not_dropped() -> None:
+    """A skipped section's warning still reaches ``data_quality_flags``."""
+    sec = RenderedSection(
+        section_id="sweep",
+        title="Sweep",
+        key_facts=["No sweep run this session."],
+        warnings=["sweep never ran this session"],
+        skipped=True,
+    )
+
+    flags = cross_section._data_quality_flags({}, [sec])
+
+    assert any("sweep" in f for f in flags), "skipped sections must not vanish silently"
+    assert any("never ran" in f for f in flags)
+
+
+def test_skipped_section_without_warnings_still_reports_absence() -> None:
+    """Absence itself is reportable even when the renderer logged no warning."""
+    sec = RenderedSection(
+        section_id="roofline",
+        title="Roofline",
+        key_facts=["No roofline snapshot recorded."],
+        skipped=True,
+    )
+
+    flags = cross_section._data_quality_flags({}, [sec])
+
+    assert any("roofline" in f for f in flags)
+
+
+def test_section_without_producer_is_not_a_data_quality_flag() -> None:
+    """A section nothing produces says nothing about this session."""
+    sec = RenderedSection(
+        section_id="data_provenance",
+        title="Data Provenance",
+        key_facts=["No provenance recorded."],
+        skipped=True,
+    )
+
+    flags = cross_section._data_quality_flags({}, [sec])
+
+    assert not any("data_provenance" in f for f in flags)
+
+
+def test_every_registered_section_reaches_the_report() -> None:
+    """A section that renders but is never grouped is invisible work.
+
+    ``geak_invocations`` / ``forge_invocations`` rendered for months without a
+    group entry, so the report quoted their adoption counts while showing none
+    of the attempts behind them.
+    """
+    from hyperloom.inference_optimizer.breakdown.reporters import compose
+    from hyperloom.inference_optimizer.breakdown.reporters.base import REGISTRY
+
+    grouped = {section_id for _, ids in compose.SECTION_GROUPS for section_id in ids}
+    registered = {section_id for section_id, _ in REGISTRY}
+
+    assert not (registered - grouped), "registered renderers missing from SECTION_GROUPS"
+    assert not (grouped - registered), "SECTION_GROUPS references sections nothing renders"
+
+
+def test_sections_without_producer_list_matches_reality(tmp_path: Path) -> None:
+    """Recompute the dead-section list; the constant must still match.
+
+    Wiring up a producer, or registering another section nothing fills, has to
+    fail here rather than silently drift. The scan reads ``breakdown.get("x")``
+    literals, so a renderer that computes its key at runtime would be missed --
+    none do today.
+    """
+    import re
+
+    from hyperloom.inference_optimizer.breakdown import exporter
+    from hyperloom.inference_optimizer.breakdown.recorder import recorder as recorder_mod
+
+    available = set(exporter.build(tmp_path).keys())
+    available |= set(getattr(recorder_mod, "SECTION_SHAPES", {}) or {})
+    available |= set(getattr(recorder_mod, "DERIVED_SECTIONS", ()) or ())
+
+    renderers_dir = Path(cross_section.__file__).resolve().parent / "_renderers"
+    without_producer: set[str] = set()
+    for path in sorted(renderers_dir.glob("*.py")):
+        if path.name.startswith("_"):
+            continue
+        keys = set(re.findall(r'breakdown\.get\("([a-z_]+)"', path.read_text(encoding="utf-8")))
+        if keys - available:
+            without_producer.add(path.stem)
+
+    assert without_producer == set(cross_section._SECTIONS_WITHOUT_PRODUCER)
+
+
+def test_live_section_warnings_are_unchanged() -> None:
+    """Non-skipped sections keep their existing flag format."""
+    sec = RenderedSection(
+        section_id="roofline",
+        title="Roofline",
+        warnings=["ceiling unavailable"],
+        skipped=False,
+    )
+
+    flags = cross_section._data_quality_flags({}, [sec])
+
+    assert "[roofline] ceiling unavailable" in flags
+
+
+# LLM narrative guard rails
+
+
+def _parse(exec_summary: str = "ok", **narratives: str) -> dict[str, Any]:
+    """Run ``parse_llm_response`` over a well-formed response envelope.
+
+    Args:
+        exec_summary (str): Executive summary the model supposedly returned.
+        **narratives (str): Section narratives keyed by section id.
+
+    Returns:
+        dict[str, Any]: The parsed and sanitized result.
+    """
+    return llm_prompt.parse_llm_response(
+        json.dumps({"executive_summary": exec_summary, "section_narratives": narratives})
+    )
+
+
+def test_ordinary_narrative_survives_untouched() -> None:
+    """Guard rails must not disturb prose that respected the brief."""
+    prose = "Throughput improved after the aiter variant was adopted. No regressions were seen."
+
+    out = _parse(exec_summary=prose, sweep=prose)
+
+    assert out["executive_summary"] == prose
+    assert out["section_narratives"]["sweep"] == prose
+
+
+def test_headings_are_stripped_from_narrative() -> None:
+    """A heading would re-parent every deterministic block that follows."""
+    out = _parse(sweep="## Injected Heading\nThe sweep found a better concurrency.")
+
+    assert "##" not in out["section_narratives"]["sweep"]
+    assert "better concurrency" in out["section_narratives"]["sweep"]
+
+
+def test_code_fence_is_stripped_from_narrative() -> None:
+    """An unbalanced fence swallows the rest of the document."""
+    out = _parse(sweep="Here is the config:\n```yaml\nkey: value\n```\nThat is all.")
+
+    assert "```" not in out["section_narratives"]["sweep"]
+
+
+def test_thematic_break_and_block_html_are_stripped() -> None:
+    """Setext rules promote the previous line; block HTML escapes the slot."""
+    out = _parse(sweep="Summary line\n===\n<div>raw</div>\nreal prose here")
+
+    cleaned = out["section_narratives"]["sweep"]
+    assert "===" not in cleaned
+    assert "<div>" not in cleaned
+    assert "real prose here" in cleaned
+
+
+def test_overlong_narrative_is_dropped_whole() -> None:
+    """Half a truncated sentence reads worse than the deterministic fallback."""
+    out = _parse(sweep="x" * (llm_prompt._MAX_NARRATIVE_CHARS + 1))
+
+    assert out["section_narratives"]["sweep"] == ""
+
+
+def test_overlong_executive_summary_is_dropped_whole() -> None:
+    """The summary has its own, larger ceiling."""
+    out = _parse(exec_summary="x" * (llm_prompt._MAX_EXEC_SUMMARY_CHARS + 1))
+
+    assert out["executive_summary"] == ""
+
+
+def test_mostly_structural_output_is_dropped_whole() -> None:
+    """A model that returned a document, not a paragraph, contributes nothing."""
+    out = _parse(sweep="# One\n## Two\n### Three\n```\n```\nstray")
+
+    assert out["section_narratives"]["sweep"] == ""

--- a/src/hyperloom/inference_optimizer/tests/test_forge_lane.py
+++ b/src/hyperloom/inference_optimizer/tests/test_forge_lane.py
@@ -23,8 +23,13 @@ def test_invocation_section_forge_is_own_lane() -> None:
 
 def test_capability_summary_has_distinct_forge_row() -> None:
     forge_invs = [{"kernel_id": "k1", "decision": "KEEP", "micro_speedup": 1.4}]
+    # The integrate verdict is what promotes a micro KEEP into a reported
+    # adoption; see test_breakdown_report_integrity for the micro-only lane.
+    state = {
+        "kernel_integrate_attempts": {"attempt-1": {"kernel_id": "k1", "last_decision": "KEEP", "best_gain_pct": 2.0}}
+    }
     cap = collectors.collect_capability_summary(
-        {},
+        state,
         [],
         [],
         forge_invocations=forge_invs,


### PR DESCRIPTION
Fixes P2-38, P2-39 (PR-4) and P2-42, P2-43, P2-44 (PR-5).

The breakdown pipeline stated four contracts in comments and enforced none of
them. Both ends leaked, each in its own way, and no test asserted any of the
four — which is how they survived.

| Contract, as written | What the code did |
|---|---|
| `schema.py`: `keeps` = "kernels adopted at integrate (NOT micro-only KEEP)" | counted exactly those |
| `recorder.py`: "safe across processes and on network filesystems" | `record_upsert_*` is read-merge-write under an in-process lock |
| `base.py`: skipped sections "emit a one-line not-run note" | never implemented |
| `llm_prompt.py` SYSTEM_PROMPT: "do not invent numbers" | plain prose, zero enforcement |

## What changed

**P2-42 — `collectors/timeline.py`, `schema.py`**
A lane could report `keeps=8, status=kept` for three kernels, none of which
ever passed integrate. Three separate faults: micro-only KEEPs counted as
adoptions; invocation rows counted instead of distinct kernels; `task_id` never
reached the de-dup key because `change` is always set, so two tasks sharing a
wall-clock second collapsed into one row. Micro-only KEEPs now have their own
tally and no longer make a lane read as `kept`.

**P2-43 — `reporters/cross_section.py`, `reporters/compose.py`**
A skipped section's key facts and warnings were discarded, making "this never
ran" indistinguishable from "this ran clean" — the reader sees no bad news and
concludes there is none. That evidence now reaches `data_quality_flags`.

Sections nothing produces (`decision_journal`, `kernel_profiling`,
`kernel_decision_path`, `data_provenance`) are held apart from sections with no
data *this session*: they are always skipped, so four permanent flags would
have drowned the ones that describe the run — and "no data recorded this
session" is the wrong explanation for a feature that was never wired up.

`geak_invocations` / `forge_invocations` rendered but had no `SECTION_GROUPS`
entry, so the report quoted their adoption counts while showing none of the
attempts behind them. Fixing the counts without this would have left the
corrected numbers invisible.

**P2-44 — `reporters/llm_prompt.py`**
Model prose was pasted verbatim beneath a heading the composer owns. A line
opening a heading, code fence or block element re-parents every deterministic
block that follows — a wrong paragraph becomes a wrong document. Such lines are
stripped; prose past the length the prompt asks for is dropped whole rather
than truncated (half a sentence reads worse than none). Both cases fall back to
the deterministic path that already existed, so no new code path was needed.
Number-checking is deliberately out of scope: it needs the response schema made
explicit first, and over-eager matching would flag ordinary phrasing.

**P2-38, P2-39 — `recorder/recorder.py`**
The docstring now names which methods are actually cross-process safe. No lock
was added: `agents/**` and `multi_node/**` contain no writers today, and an
advisory lock is unreliable on the network filesystem this spool lives on — a
guard test enforces that instead, so the promise cannot quietly become false.

Keyless items drew two sequence numbers, so a filename never matched its own
envelope and a `seq=N` trace line pointed at a file that did not exist. Stable
filenames now carry a digest of the untouched key, because sanitizing folded
`a/b`, `a:b` and `a b` onto one file. Fragments already written under the old
name keep it, so resuming a session updates its fragment instead of forking a
second one.

## Tests

26 new cases. Three guard against future drift rather than today's bug:

- the dead-section list is **recomputed** from the real exporter + recorder key
  space, so wiring up a producer (or adding another dead section) fails the suite
- registry and `SECTION_GROUPS` are compared **both ways**, so nothing can render
  without reaching the report again
- the import guard **ships with a test that it can fail** — a rule that cannot
  fail protects nothing

`test_forge_lane.py`'s capability assertion pinned the
micro-only-counts-as-adopted behaviour; it now supplies the integrate verdict
that makes its KEEP a real adoption.

## Verification

- breakdown suite: **158 passed, 2 failed**; both failures are pre-existing
  Windows path-separator assertions, reproduced on `main` at the same commit
- `ruff check` clean; `ruff format --check` clean **for the files this PR
  touches** — four files under `breakdown/` were already unformatted on `main`
  and were deliberately left alone rather than swept into this diff
- unit-level only: no end-to-end run against a real session breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)
