### PR TITLE
fix(integrate_patch, kb): persist optimization-only recipe deltas and preserve patch ownership

### DIFF
--- a/src/hyperloom/common/jsonio.py
+++ b/src/hyperloom/common/jsonio.py
@@ -207,10 +207,10 @@ def extract_last_json_with_key(
 ) -> dict[str, Any] | None:
     """Return the last JSON object in *text* (by start offset) that qualifies.
 
-    Scans fenced blocks and every bare ``{`` opener in document order so a
-    trailing fenced envelope wins over an earlier bare draft, and objects
-    whose first field is not *required_key* (e.g. ``{"meta": ..., "scores": ...}``)
-    still qualify when the key is present.
+    Uses one balanced-bracket scan to locate JSON object spans, then checks them
+    from the latest start offset backwards. Objects whose first field is not
+    *required_key* (e.g. ``{"meta": ..., "scores": ...}``) still qualify when
+    the key is present.
 
     Args:
         text: Raw model reply that may contain fenced or bare JSON objects.
@@ -226,30 +226,39 @@ def extract_last_json_with_key(
     def _qualifies(data: Any) -> bool:
         return isinstance(data, dict) and (required_key is None or required_key in data)
 
-    candidates: list[tuple[int, dict[str, Any]]] = []
-    for m in _FENCED_JSON_RE.finditer(text):
+    spans: list[tuple[int, int]] = []
+    stack: list[tuple[str, int]] = []
+    in_string = False
+    escaped = False
+    matching = {"}": "{", "]": "["}
+    for index, char in enumerate(text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char in "{[":
+            stack.append((char, index))
+        elif char in "}]":
+            if not stack or stack[-1][0] != matching[char]:
+                continue
+            opener, start = stack.pop()
+            if opener == "{":
+                spans.append((start, index + 1))
+
+    for start, end in sorted(spans, key=lambda span: span[0], reverse=True):
         try:
-            data = json.loads(m.group(1))
+            data = json.loads(text[start:end])
         except json.JSONDecodeError:
             continue
         if _qualifies(data):
-            candidates.append((m.start(), data))
-    for i, ch in enumerate(text):
-        if ch != "{":
-            continue
-        candidate = text[i:]
-        for end in range(len(candidate), 0, -1):
-            try:
-                data = json.loads(candidate[:end])
-            except json.JSONDecodeError:
-                continue
-            if _qualifies(data):
-                candidates.append((i, data))
-            break
-    if not candidates:
-        return None
-    candidates.sort(key=lambda item: item[0])
-    return candidates[-1][1]
+            return data
+    return None
 
 
 def iter_sse_objects(raw: str) -> Iterator[Any]:

--- a/src/hyperloom/inference_optimizer/breakdown/agent_ownership.py
+++ b/src/hyperloom/inference_optimizer/breakdown/agent_ownership.py
@@ -40,10 +40,7 @@ def agent_from_phase(value: Any) -> str:
 def patch_owner_phase(evidence: Mapping[str, Any] | None) -> str:
     """Resolve the immutable authoring phase from recorded ownership evidence."""
     evidence = evidence or {}
-    if (
-        evidence.get("framework_agent_authoring")
-        or evidence.get("framework_agent_candidate_id")
-    ):
+    if evidence.get("framework_agent_authoring") or evidence.get("framework_agent_candidate_id"):
         return "FRAMEWORK_AGENT"
     phase = str(evidence.get("source_phase") or "").strip().upper()
     if phase in {"FRAMEWORK", "FRAMEWORK_AGENT"}:

--- a/src/hyperloom/inference_optimizer/breakdown/agent_ownership.py
+++ b/src/hyperloom/inference_optimizer/breakdown/agent_ownership.py
@@ -37,6 +37,22 @@ def agent_from_phase(value: Any) -> str:
     return AGENT_BY_PHASE.get(str(value or "").strip().upper(), "")
 
 
+def patch_owner_phase(evidence: Mapping[str, Any] | None) -> str:
+    """Resolve the immutable authoring phase from recorded ownership evidence."""
+    evidence = evidence or {}
+    if (
+        evidence.get("framework_agent_authoring")
+        or evidence.get("framework_agent_candidate_id")
+    ):
+        return "FRAMEWORK_AGENT"
+    phase = str(evidence.get("source_phase") or "").strip().upper()
+    if phase in {"FRAMEWORK", "FRAMEWORK_AGENT"}:
+        return "FRAMEWORK_AGENT"
+    if phase == "EXPLORE":
+        return "EXPLORE"
+    return ""
+
+
 def patch_author(evidence: Mapping[str, Any] | None) -> str:
     """Name who wrote a patch, from the markers its applier left behind.
 
@@ -53,13 +69,7 @@ def patch_author(evidence: Mapping[str, Any] | None) -> str:
     Returns:
         The owning agent, or :data:`UNATTRIBUTED`.
     """
-    evidence = evidence or {}
-    if evidence.get("framework_agent_authoring") or evidence.get("framework_agent_candidate_id"):
-        return "framework_agent"
-    provenance = str(evidence.get("provenance") or "").strip().lower()
-    if evidence.get("domain") or provenance.startswith("specialist:"):
-        return "explore"
-    return agent_from_phase(evidence.get("source_phase")) or UNATTRIBUTED
+    return agent_from_phase(patch_owner_phase(evidence)) or UNATTRIBUTED
 
 
 __all__ = [
@@ -67,4 +77,5 @@ __all__ = [
     "UNATTRIBUTED",
     "agent_from_phase",
     "patch_author",
+    "patch_owner_phase",
 ]

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/attribution.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/attribution.py
@@ -15,7 +15,7 @@ from collections.abc import Callable
 from datetime import datetime
 from typing import Any
 
-
+from ..agent_ownership import patch_author
 from ._common import (
     _to_float,
     phase_at,
@@ -322,16 +322,10 @@ def _entry_family(entry: dict[str, Any]) -> str:
         return _action_family(action)
     if entry.get("attribution_eligible") is False or entry.get("baseline_enablement"):
         return "unattributed"
-    if entry.get("framework_agent_authoring"):
-        return "framework"
-    phase = str(entry.get("source_phase") or entry.get("phase") or "").strip().upper()
-    provenance = str(entry.get("provenance") or "").strip().lower()
-    specialist_owned = bool(entry.get("domain")) or provenance.startswith("specialist:")
-    if phase in {"FRAMEWORK", "FRAMEWORK_AGENT"}:
-        return "framework"
-    if phase == "EXPLORE" or specialist_owned:
-        return "explore"
-    return "unattributed"
+    return {
+        "framework_agent": "framework",
+        "explore": "explore",
+    }.get(patch_author(entry), "unattributed")
 
 
 def _promote_legacy_gain_entries(

--- a/src/hyperloom/inference_optimizer/tests/test_common_jsonio.py
+++ b/src/hyperloom/inference_optimizer/tests/test_common_jsonio.py
@@ -181,3 +181,12 @@ class TestExtractLastJson:
         )
         out = extract_last_json_with_key(text, "scores")
         assert out["scores"]["proposal_0"]["score"] == 8
+
+    def test_many_braces_and_braces_inside_strings(self):
+        drafts = " ".join(f'{{"meta": {index}, "reason": "literal {{ brace }}"}}' for index in range(800))
+        final = '{"meta": "final", "scores": {"proposal_0": {"score": 7}}}'
+
+        assert extract_last_json_with_key(f"{drafts} {final}", "scores") == {
+            "meta": "final",
+            "scores": {"proposal_0": {"score": 7}},
+        }

--- a/src/hyperloom/inference_optimizer/tests/test_config_patch_agent_kb.py
+++ b/src/hyperloom/inference_optimizer/tests/test_config_patch_agent_kb.py
@@ -29,8 +29,27 @@ from hyperloom.orchestrator.phases.prelude import _merge_current_recipe_configs
 
 
 def _state(stack: list[dict]) -> SimpleNamespace:
+    normalized_stack = []
+    for raw in stack:
+        row = dict(raw)
+        if (
+            str(row.get("action") or "").lower() == "replay_warm_recipe"
+            and "recipe_delta" not in row
+        ):
+            row["recipe_delta"] = {
+                "extra_server_args": str(
+                    row.get("candidate_extra_server_args")
+                    or row.get("extra_server_args")
+                    or ""
+                ),
+                "extra_envs": dict(row.get("extra_envs") or {}),
+                "remove_args": [],
+                "unset_envs": [],
+                "args_mode": "replace",
+            }
+        normalized_stack.append(row)
     return SimpleNamespace(
-        optimization_stack=stack,
+        optimization_stack=normalized_stack,
         current_best={"tput": 130.0},
         cumulative_gain_validated=30.0,
         gain_per_stack_entry=[],
@@ -236,12 +255,22 @@ def test_current_contract_persists_one_final_config(
             {
                 "action": "explore",
                 "source_phase": "EXPLORE",
+                "recipe_delta": {
+                    "extra_server_args": "--explore-old",
+                    "extra_envs": {"VLLM_OWNER": "explore"},
+                    "args_mode": "append",
+                },
                 "extra_server_args": "--explore-old",
                 "extra_envs": {"VLLM_OWNER": "explore"},
             },
             {
                 "action": "framework",
                 "source_phase": "FRAMEWORK_AGENT",
+                "recipe_delta": {
+                    "extra_server_args": "--framework-final",
+                    "extra_envs": {"VLLM_OWNER": "framework"},
+                    "args_mode": "replace",
+                },
                 "extra_server_args": "--framework-final",
                 "extra_envs": {"VLLM_OWNER": "framework"},
             },

--- a/src/hyperloom/inference_optimizer/tests/test_config_patch_agent_kb.py
+++ b/src/hyperloom/inference_optimizer/tests/test_config_patch_agent_kb.py
@@ -32,16 +32,9 @@ def _state(stack: list[dict]) -> SimpleNamespace:
     normalized_stack = []
     for raw in stack:
         row = dict(raw)
-        if (
-            str(row.get("action") or "").lower() == "replay_warm_recipe"
-            and "recipe_delta" not in row
-        ):
+        if str(row.get("action") or "").lower() == "replay_warm_recipe" and "recipe_delta" not in row:
             row["recipe_delta"] = {
-                "extra_server_args": str(
-                    row.get("candidate_extra_server_args")
-                    or row.get("extra_server_args")
-                    or ""
-                ),
+                "extra_server_args": str(row.get("candidate_extra_server_args") or row.get("extra_server_args") or ""),
                 "extra_envs": dict(row.get("extra_envs") or {}),
                 "remove_args": [],
                 "unset_envs": [],

--- a/src/hyperloom/inference_optimizer/tests/test_config_patch_agent_kb.py
+++ b/src/hyperloom/inference_optimizer/tests/test_config_patch_agent_kb.py
@@ -271,7 +271,7 @@ def test_current_contract_persists_one_final_config(
     )
     state.current_best = {
         "tput": 150.0,
-        "extra_server_args": "--framework-final",
+        "extra_server_args": "--explore-old --framework-final",
         "extra_envs": {"VLLM_OWNER": "framework"},
     }
     bundle = build_remote_knowledge(
@@ -282,7 +282,7 @@ def test_current_contract_persists_one_final_config(
 
     assert "replay_config" not in bundle.knowledge["value"]
     assert bundle.knowledge["value"]["config"] == {
-        "extra_server_args": "--framework-final",
+        "extra_server_args": "--explore-old --framework-final",
         "extra_envs": {"VLLM_OWNER": "framework"},
     }
     assert set(bundle.knowledge["value"]["explore"]) == {"patches", "artifacts"}

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_async_batch2_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_async_batch2_unit.py
@@ -2264,6 +2264,25 @@ async def test_direct_integrate_proposal_inherits_specialist_owner(
     assert params["gap_layer"] == "framework"
 
 
+def test_specialist_owner_is_frozen_at_creation_outside_agent_phases(
+    coord: Coordinator,
+) -> None:
+    coord.shared_state.phase = "KERNEL_AGENT"
+    explore_params = {
+        "domain": "serving_specialist",
+        "gap_layer": "perf_explore",
+    }
+    framework_params = {
+        "domain": "serving_specialist",
+        "gap_layer": "framework",
+    }
+
+    assert coord.router._stamp_specialist_owner(explore_params) == "EXPLORE"
+    assert explore_params["source_phase"] == "EXPLORE"
+    assert coord.router._stamp_specialist_owner(framework_params) == "FRAMEWORK_AGENT"
+    assert framework_params["source_phase"] == "FRAMEWORK_AGENT"
+
+
 def test_forward_integrate_source_has_no_current_phase_fallback() -> None:
     from hyperloom.orchestrator.phases.explore import _forward_integrate_source
 
@@ -2305,10 +2324,13 @@ async def test_materialize_integrate_patch_rejects_missing_owner(
         {"params": {"specialist_task_id": "missing-specialist"}},
         msg_id="prop-ownerless",
     )
+    coord.state.pending_proposals[pending.proposal_msg_id] = pending
 
     await coord._materialize_approved_proposal(pending)
 
     assert not [task for task in await coord.tasks.queued() if task.kind == "integrate_patch"]
+    assert pending.proposal_msg_id not in coord.state.pending_proposals
+    assert coord.shared_state.get_specialist_patch_verdict("missing-specialist") == "owner_missing"
     observations = await coord.bus.tail(topic="observation", n=10)
     assert any(message.payload.get("reason") == "integrate_patch_owner_missing" for message in observations)
 

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_async_batch2_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_async_batch2_unit.py
@@ -2308,14 +2308,9 @@ async def test_materialize_integrate_patch_rejects_missing_owner(
 
     await coord._materialize_approved_proposal(pending)
 
-    assert not [
-        task for task in await coord.tasks.queued() if task.kind == "integrate_patch"
-    ]
+    assert not [task for task in await coord.tasks.queued() if task.kind == "integrate_patch"]
     observations = await coord.bus.tail(topic="observation", n=10)
-    assert any(
-        message.payload.get("reason") == "integrate_patch_owner_missing"
-        for message in observations
-    )
+    assert any(message.payload.get("reason") == "integrate_patch_owner_missing" for message in observations)
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_async_batch2_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_async_batch2_unit.py
@@ -420,6 +420,7 @@ async def test_resume_consistency_replays_pending_integrate_keep(coord: Coordina
     assert "source_phase" not in coord.shared_state.optimization_stack[-1]
     assert "domain" not in coord.shared_state.optimization_stack[-1]
     assert "framework_agent_authoring" not in coord.shared_state.optimization_stack[-1]
+    assert coord.shared_state.optimization_stack[-1]["recipe_publishable"] is False
     assert coord.shared_state.resume_pending_revalidation is True
 
 
@@ -2227,6 +2228,51 @@ def _pending(action_name: str, payload: dict, msg_id: str = "prop-1"):
 
 
 @pytest.mark.asyncio
+async def test_direct_integrate_proposal_inherits_specialist_owner(
+    coord: Coordinator,
+    monkeypatch,
+) -> None:
+    specialist = await coord.tasks.create(
+        kind="specialist",
+        params={
+            "source_phase": "FRAMEWORK_AGENT",
+            "domain": "serving_specialist",
+            "gap_layer": "framework",
+        },
+        idempotency_key="owner-source",
+    )
+    monkeypatch.setattr(
+        coord.router,
+        "_admission_denial_for_action",
+        lambda _action: None,
+    )
+    await coord._handle_propose_action(
+        "orchestration",
+        Intent(
+            type=IntentType.PROPOSE_ACTION,
+            payload={
+                "action_name": "integrate_patch",
+                "params": {"specialist_task_id": specialist.task_id},
+            },
+        ),
+    )
+
+    pending = next(iter(coord.state.pending_proposals.values()))
+    params = pending.payload["params"]
+    assert params["source_phase"] == "FRAMEWORK_AGENT"
+    assert params["domain"] == "serving_specialist"
+    assert params["gap_layer"] == "framework"
+
+
+def test_forward_integrate_source_has_no_current_phase_fallback() -> None:
+    from hyperloom.orchestrator.phases.explore import _forward_integrate_source
+
+    forwarded: dict = {}
+    _forward_integrate_source({}, forwarded)
+    assert "source_phase" not in forwarded
+
+
+@pytest.mark.asyncio
 async def test_materialize_explore_filters_grid(coord: Coordinator) -> None:
     coord.shared_state.baseline_tput = 800.0
     pending = _pending(
@@ -2247,6 +2293,29 @@ async def test_materialize_explore_filters_grid(coord: Coordinator) -> None:
     )
     tail = await coord.bus.tail(topic="decision", n=10)
     assert any(m.payload.get("kind") == "approved_proposal" for m in tail)
+
+
+@pytest.mark.asyncio
+async def test_materialize_integrate_patch_rejects_missing_owner(
+    coord: Coordinator,
+) -> None:
+    coord.shared_state.baseline_tput = 800.0
+    pending = _pending(
+        "integrate_patch",
+        {"params": {"specialist_task_id": "missing-specialist"}},
+        msg_id="prop-ownerless",
+    )
+
+    await coord._materialize_approved_proposal(pending)
+
+    assert not [
+        task for task in await coord.tasks.queued() if task.kind == "integrate_patch"
+    ]
+    observations = await coord.bus.tail(topic="observation", n=10)
+    assert any(
+        message.payload.get("reason") == "integrate_patch_owner_missing"
+        for message in observations
+    )
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_authoring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_authoring.py
@@ -1467,3 +1467,21 @@ def test_empty_outcome_stamps_when_artifacts_source_outside_sandbox(tmp_path: Pa
     assert len(rows) == 1
     assert rows[0]["status"] == "not_applicable"
     assert rows[0]["kept"] is False
+
+
+@pytest.mark.asyncio
+async def test_perf_explore_retry_stamps_immutable_explore_owner(
+    tmp_path: Path,
+) -> None:
+    stub = _Stub(tmp_path, authoring=True)
+
+    task_id = await FrameworkPhase._enqueue_author_specialist(  # type: ignore[arg-type]
+        stub,
+        lane="perf_explore",
+        attempt=1,
+    )
+
+    assert task_id
+    params = stub.tasks.created[-1]["params"]
+    assert params["source_phase"] == "EXPLORE"
+    assert params["gap_layer"] == "perf_explore"

--- a/src/hyperloom/inference_optimizer/tests/test_framework_config_exploration.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_config_exploration.py
@@ -453,6 +453,7 @@ def test_dispatch_generation_specialist_params_and_marker():
     assert p["framework_config_generation"] is True
     assert p["mode"] == "research"
     assert p["gap_layer"] == "framework"
+    assert p["source_phase"] == "FRAMEWORK_AGENT"
     assert p["framework"] == "sglang"
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_promote_shared_state_lock.py
+++ b/src/hyperloom/inference_optimizer/tests/test_promote_shared_state_lock.py
@@ -22,6 +22,7 @@ from hyperloom.orchestrator.loop.writeback import WritebackCollaborator
 from hyperloom.orchestrator.knowledge.remote_recipe._vendor.kb_store_client import (
     KnowledgeSections,
 )
+from hyperloom.orchestrator.knowledge.remote_recipe.values import has_new_keep
 from hyperloom.orchestrator.state.shared_state import _AUDIT_ACTIONS
 from hyperloom.inference_optimizer.session.paths import make_session_dir
 from hyperloom.orchestrator.state.task_registry import Task
@@ -617,9 +618,39 @@ async def test_prebaseline_enablement_patch_is_config_only_not_gain(session_dir)
     assert entry["action"] == "integrate_patch"
     assert entry["baseline_enablement"] is True
     assert entry["attribution_eligible"] is False
+    assert entry["recipe_publishable"] is False
     assert s.gain_per_stack_entry == [None]
     assert s.cumulative_gain_validated == 0.0
     assert s.pending_integrate == {}
+
+
+@pytest.mark.asyncio
+async def test_postbaseline_enablement_config_is_not_recipe_publishable(
+    session_dir,
+):
+    coord = _coord(session_dir)
+    state = coord.shared_state
+    state.baseline_tput = 100.0
+    state.current_best = {"action": "baseline", "tput": 100.0}
+
+    await coord._promote_to_shared_state(
+        "integrate_patch",
+        {
+            "status": "kept",
+            "enablement": True,
+            "output_throughput": 110.0,
+            "specialist_task_id": "spec-enable-late",
+            "extra_envs_applied": {"SGLANG_ENABLEMENT_ONLY": "1"},
+        },
+        task=_task(
+            "integrate_patch",
+            task_id="t-enable-late",
+            params={"enablement": True, "source_phase": "FRAMEWORK_AGENT"},
+        ),
+    )
+
+    assert state.optimization_stack[-1]["recipe_publishable"] is False
+    assert has_new_keep(state) is False
 
 
 @pytest.mark.asyncio
@@ -1214,6 +1245,49 @@ def test_lift_applies_unset_envs_before_new_envs(session_dir):
         "KEEP": "new",
         "RESTORE": "new",
     }
+
+
+def test_lift_persists_recipe_delta_separately_from_runtime_config(session_dir):
+    coord = _coord(session_dir)
+    coord.shared_state.current_best = {
+        "action": "baseline",
+        "tput": 1000.0,
+        "extra_server_args": "--hld-only",
+        "extra_envs": {"SGLANG_ENABLEMENT_ONLY": "1"},
+    }
+
+    coord._lift_to_current_best(
+        "explore",
+        1100.0,
+        {
+            "name": "optimized",
+            "candidate_extra_server_args": "--page-size 64",
+            "candidate_extra_envs": {"VLLM_OPTIMIZED": "1"},
+            "recipe_delta": {
+                "extra_server_args": "--page-size 64",
+                "extra_envs": {"VLLM_OPTIMIZED": "1"},
+                "remove_args": [],
+                "unset_envs": [],
+                "args_mode": "append",
+            },
+            "extra_server_args": "--hld-only --page-size 64",
+            "extra_envs": {
+                "SGLANG_ENABLEMENT_ONLY": "1",
+                "VLLM_OPTIMIZED": "1",
+            },
+        },
+    )
+
+    top = coord.shared_state.optimization_stack[-1]
+    assert top["recipe_delta"] == {
+        "extra_server_args": "--page-size 64",
+        "extra_envs": {"VLLM_OPTIMIZED": "1"},
+        "remove_args": [],
+        "unset_envs": [],
+        "args_mode": "append",
+    }
+    assert "--hld-only" in coord.shared_state.current_best["extra_server_args"]
+    assert "--hld-only" not in top["recipe_delta"]["extra_server_args"]
 
 
 def test_lift_is_the_only_writer_so_an_ablated_env_stays_gone(session_dir):

--- a/src/hyperloom/inference_optimizer/tests/test_remote_recipe_v2.py
+++ b/src/hyperloom/inference_optimizer/tests/test_remote_recipe_v2.py
@@ -52,7 +52,10 @@ from hyperloom.orchestrator.knowledge.remote_recipe.sanitize import (
     sanitize_publish_server_args,
     sanitize_shared_knowledge,
 )
-from hyperloom.orchestrator.knowledge.remote_recipe.values import _Files
+from hyperloom.orchestrator.knowledge.remote_recipe.values import (
+    _Files,
+    build_publishable_recipe_config,
+)
 from hyperloom.orchestrator.loop.writeback import WritebackCollaborator
 
 _DOWNLOAD_BYTES = b"verified artifact"
@@ -102,6 +105,15 @@ def _state(tmp_path: Path) -> SimpleNamespace:
             {
                 "action": "explore",
                 "source_phase": "EXPLORE",
+                "candidate_extra_server_args": "--page-size 32",
+                "candidate_extra_envs": {"VLLM_EXPLORE_TEST": "1"},
+                "recipe_delta": {
+                    "extra_server_args": "--page-size 32",
+                    "extra_envs": {"VLLM_EXPLORE_TEST": "1"},
+                    "remove_args": [],
+                    "unset_envs": [],
+                    "args_mode": "append",
+                },
                 "extra_server_args": "--page-size 32",
                 "extra_envs": {"VLLM_EXPLORE_TEST": "1"},
                 "patch_path": str(explore_patch),
@@ -110,6 +122,15 @@ def _state(tmp_path: Path) -> SimpleNamespace:
             {
                 "action": "integrate_patch",
                 "source_phase": "FRAMEWORK_AGENT",
+                "candidate_extra_server_args": "--enable-foo",
+                "candidate_extra_envs": {"VLLM_FRAMEWORK_TEST": "1"},
+                "recipe_delta": {
+                    "extra_server_args": "--enable-foo",
+                    "extra_envs": {"VLLM_FRAMEWORK_TEST": "1"},
+                    "remove_args": [],
+                    "unset_envs": [],
+                    "args_mode": "append",
+                },
                 "extra_server_args": "--page-size 32 --enable-foo",
                 "extra_envs": {"VLLM_FRAMEWORK_TEST": "1"},
                 "patch_path": str(framework_patch),
@@ -176,6 +197,13 @@ def test_build_remote_knowledge_partitions_origins_and_files(tmp_path: Path) -> 
     assert bundle.knowledge["record_kind"] == RECORD_KIND_HYPERLOOM_RECIPE
     assert bundle.knowledge["validated_e2e_gain"] == 30.0
     value = bundle.knowledge["value"]
+    assert value["config"] == {
+        "extra_server_args": "--page-size 32 --enable-foo",
+        "extra_envs": {
+            "VLLM_EXPLORE_TEST": "1",
+            "VLLM_FRAMEWORK_TEST": "1",
+        },
+    }
     assert value["explore"]["extra_envs"] == {"VLLM_EXPLORE_TEST": "1"}
     assert value["framework"]["extra_envs"] == {"VLLM_FRAMEWORK_TEST": "1"}
     assert "config" not in value["explore"]
@@ -203,6 +231,128 @@ def test_build_remote_knowledge_partitions_origins_and_files(tmp_path: Path) -> 
     assert "object_id" not in serialized
     assert "bucket" not in serialized
     assert '"files": [' not in serialized
+
+
+def test_publishable_config_excludes_runtime_and_enablement_bases() -> None:
+    state = SimpleNamespace(
+        current_best={
+            "effective_extra_server_args": "--hld-only --baseline-only",
+            "extra_envs": {"SGLANG_ENABLEMENT_ONLY": "1"},
+        },
+        warm_replay_outcome={},
+        optimization_stack=[
+            {
+                "action": "integrate_patch",
+                "baseline_enablement": True,
+                "attribution_eligible": False,
+                "recipe_delta": {
+                    "extra_server_args": "--enablement-only",
+                    "extra_envs": {"SGLANG_ENABLEMENT_ONLY": "1"},
+                },
+            },
+            {
+                "action": "explore",
+                "variant_name": "optimized",
+                "candidate_extra_server_args": "--page-size 64",
+                "candidate_extra_envs": {"VLLM_OPTIMIZED": "1"},
+                "recipe_delta": {
+                    "extra_server_args": "--page-size 64",
+                    "extra_envs": {"VLLM_OPTIMIZED": "1"},
+                    "args_mode": "append",
+                },
+            },
+        ],
+    )
+
+    assert build_publishable_recipe_config(state) == {
+        "extra_server_args": "--page-size 64",
+        "extra_envs": {"VLLM_OPTIMIZED": "1"},
+    }
+
+
+def test_publishable_config_flattens_replayed_base_and_new_delta() -> None:
+    state = SimpleNamespace(
+        warm_replay_outcome={"status": "reproduced"},
+        optimization_stack=[
+            {
+                "action": "replay_warm_recipe",
+                "recipe_delta": {
+                    "extra_server_args": "--page-size 32",
+                    "extra_envs": {"VLLM_PRIOR": "1"},
+                    "args_mode": "replace",
+                },
+            },
+            {
+                "action": "explore",
+                "variant_name": "new-keep",
+                "candidate_extra_server_args": "--enable-foo",
+                "candidate_extra_envs": {"VLLM_NEW": "1"},
+                "recipe_delta": {
+                    "extra_server_args": "--enable-foo",
+                    "extra_envs": {"VLLM_NEW": "1"},
+                    "args_mode": "append",
+                },
+            },
+        ],
+    )
+
+    assert build_publishable_recipe_config(state) == {
+        "extra_server_args": "--page-size 32 --enable-foo",
+        "extra_envs": {"VLLM_PRIOR": "1", "VLLM_NEW": "1"},
+    }
+
+
+def test_publishable_config_applies_remove_and_unset_without_dropping_base() -> None:
+    state = SimpleNamespace(
+        warm_replay_outcome={},
+        optimization_stack=[
+            {
+                "action": "explore",
+                "recipe_delta": {
+                    "extra_server_args": "--keep 1 --drop 2",
+                    "extra_envs": {"VLLM_KEEP": "1", "VLLM_DROP": "1"},
+                    "args_mode": "append",
+                },
+            },
+            {
+                "action": "explore",
+                "recipe_delta": {
+                    "extra_server_args": "--new 3",
+                    "extra_envs": {"VLLM_NEW": "1"},
+                    "remove_args": ["--drop"],
+                    "unset_envs": ["VLLM_DROP"],
+                    "args_mode": "append",
+                },
+            },
+        ],
+    )
+
+    assert build_publishable_recipe_config(state) == {
+        "extra_server_args": "--keep 1 --new 3",
+        "extra_envs": {"VLLM_KEEP": "1", "VLLM_NEW": "1"},
+    }
+
+
+def test_publishable_config_rejects_unstructured_framework_args_env() -> None:
+    state = SimpleNamespace(
+        warm_replay_outcome={},
+        optimization_stack=[
+            {
+                "action": "explore",
+                "variant_name": "bad-delta",
+                "recipe_delta": {
+                    "extra_server_args": "",
+                    "extra_envs": {"EXTRA_SGLANG_ARGS": "--page-size 64"},
+                },
+            }
+        ],
+    )
+
+    with pytest.raises(
+        RemoteRecipeValidationError,
+        match="extra_server_args, not envs",
+    ):
+        build_publishable_recipe_config(state)
 
 
 def test_fusion_writer_accepts_multi_file_patch(tmp_path: Path) -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_remote_recipe_v2.py
+++ b/src/hyperloom/inference_optimizer/tests/test_remote_recipe_v2.py
@@ -302,6 +302,35 @@ def test_publishable_config_flattens_replayed_base_and_new_delta() -> None:
     }
 
 
+def test_publishable_config_replace_keeps_accumulated_recipe_stack() -> None:
+    state = SimpleNamespace(
+        warm_replay_outcome={"status": "reproduced"},
+        optimization_stack=[
+            {
+                "action": "replay_warm_recipe",
+                "recipe_delta": {
+                    "extra_server_args": "--page-size 32",
+                    "extra_envs": {"VLLM_PRIOR": "1"},
+                    "args_mode": "replace",
+                },
+            },
+            {
+                "action": "explore",
+                "recipe_delta": {
+                    "extra_server_args": "--enable-foo",
+                    "extra_envs": {"VLLM_NEW": "1"},
+                    "args_mode": "replace",
+                },
+            },
+        ],
+    )
+
+    assert build_publishable_recipe_config(state) == {
+        "extra_server_args": "--page-size 32 --enable-foo",
+        "extra_envs": {"VLLM_PRIOR": "1", "VLLM_NEW": "1"},
+    }
+
+
 def test_publishable_config_applies_remove_and_unset_without_dropping_base() -> None:
     state = SimpleNamespace(
         warm_replay_outcome={},

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py
@@ -785,9 +785,17 @@ def test_both_sides_of_the_record_name_a_patch_author_the_same_way():
 
     cases = [
         ({"framework_agent_authoring": True, "source_phase": "KERNEL_AGENT"}, "framework_agent"),
-        ({"provenance": "specialist:latency", "source_phase": "KERNEL_AGENT"}, "explore"),
-        ({"domain": "attention"}, "explore"),
-        ({"source_phase": "KERNEL_AGENT"}, "kernel_agent"),
+        (
+            {
+                "provenance": "specialist:serving",
+                "domain": "serving_specialist",
+                "source_phase": "FRAMEWORK_AGENT",
+            },
+            "framework_agent",
+        ),
+        ({"provenance": "specialist:latency", "source_phase": "KERNEL_AGENT"}, "unattributed"),
+        ({"domain": "attention"}, "unattributed"),
+        ({"source_phase": "KERNEL_AGENT"}, "unattributed"),
         ({}, "unattributed"),
     ]
     for evidence, expected in cases:

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_dispatch_params.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_dispatch_params.py
@@ -663,6 +663,7 @@ def test_resolve_specialist_max_turns_zero_uses_default():
 
     assert resolve_specialist_max_turns(0, default=1000) == 1000
     assert resolve_specialist_max_turns(None, default=42) == 42
+    assert resolve_specialist_max_turns("", default=42) == 42
     assert resolve_specialist_max_turns(5, default=1000) == 5
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
+++ b/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
@@ -1983,6 +1983,18 @@ async def test_low_confidence_recipe_does_not_suppress_kernel(tmp_path):
     assert task.params["recipe_extra_envs"] == {}
     assert task.params["extra_server_args"] == "--kernel"
     assert coord.shared_state.warm_replay_outcome["recipe_suppressed"] is True
+    coord._promote_warm_replay(
+        {"status": "succeeded", "output_throughput": 612.0},
+        task=task,
+    )
+    assert coord.shared_state.optimization_stack[-1]["recipe_delta"] == {
+        "extra_server_args": "",
+        "extra_envs": {},
+        "remove_args": [],
+        "unset_envs": [],
+        "args_mode": "replace",
+    }
+    assert coord.shared_state.current_best["extra_server_args"] == "--kernel"
 
 
 def _git_repo_for_required_patch(tmp_path: Path) -> tuple[Path, str]:
@@ -2049,8 +2061,10 @@ def test_combined_keep_retains_validated_framework_root_without_reapply(
                     "patch_content": patch_content,
                 }
             ],
-            "extra_server_args": "",
-            "extra_envs": {},
+            "extra_server_args": "--recipe --kernel",
+            "extra_envs": {"VLLM_RECIPE": "1", "KERNEL_ONLY": "1"},
+            "recipe_extra_server_args": "--recipe",
+            "recipe_extra_envs": {"VLLM_RECIPE": "1"},
             "warm_kernel_plan": [],
             "warm_kernel_apply_results": [],
         }
@@ -2078,8 +2092,22 @@ def test_combined_keep_retains_validated_framework_root_without_reapply(
 
     assert "persisted = True" in (checkout / "vllm" / "fp8.py").read_text()
     assert coord.shared_state.warm_replay_outcome["status"] == "reproduced"
-    assert coord.shared_state.warm_replay_outcome["active_framework_root"] == str(checkout.resolve())
-    assert coord.shared_state.optimization_stack[-1]["framework_source_root"] == str(checkout.resolve())
+    assert coord.shared_state.warm_replay_outcome["active_framework_root"] == str(
+        checkout.resolve()
+    )
+    assert coord.shared_state.optimization_stack[-1]["framework_source_root"] == str(
+        checkout.resolve()
+    )
+    entry = coord.shared_state.optimization_stack[-1]
+    assert entry["recipe_delta"] == {
+        "extra_server_args": "--recipe",
+        "extra_envs": {"VLLM_RECIPE": "1"},
+        "remove_args": [],
+        "unset_envs": [],
+        "args_mode": "replace",
+    }
+    assert entry["candidate_extra_server_args"] == "--recipe --kernel"
+    assert coord.shared_state.current_best["extra_envs"]["KERNEL_ONLY"] == "1"
     assert coord.shared_state.warm_replay_pending == {}
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
+++ b/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
@@ -2092,12 +2092,8 @@ def test_combined_keep_retains_validated_framework_root_without_reapply(
 
     assert "persisted = True" in (checkout / "vllm" / "fp8.py").read_text()
     assert coord.shared_state.warm_replay_outcome["status"] == "reproduced"
-    assert coord.shared_state.warm_replay_outcome["active_framework_root"] == str(
-        checkout.resolve()
-    )
-    assert coord.shared_state.optimization_stack[-1]["framework_source_root"] == str(
-        checkout.resolve()
-    )
+    assert coord.shared_state.warm_replay_outcome["active_framework_root"] == str(checkout.resolve())
+    assert coord.shared_state.optimization_stack[-1]["framework_source_root"] == str(checkout.resolve())
     entry = coord.shared_state.optimization_stack[-1]
     assert entry["recipe_delta"] == {
         "extra_server_args": "--recipe",

--- a/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
+++ b/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
@@ -2103,6 +2103,10 @@ def test_combined_keep_retains_validated_framework_root_without_reapply(
         "args_mode": "replace",
     }
     assert entry["candidate_extra_server_args"] == "--recipe --kernel"
+    assert entry["candidate_extra_envs"] == {
+        "VLLM_RECIPE": "1",
+        "KERNEL_ONLY": "1",
+    }
     assert coord.shared_state.current_best["extra_envs"]["KERNEL_ONLY"] == "1"
     assert coord.shared_state.warm_replay_pending == {}
 

--- a/src/hyperloom/orchestrator/actions/executors/explore.py
+++ b/src/hyperloom/orchestrator/actions/executors/explore.py
@@ -1637,6 +1637,16 @@ class ExploreExecutor:
                             "fingerprint": fp,
                             "name": gv.name,
                             "candidate_extra_server_args": gv.extra_server_args,
+                            "candidate_extra_envs": dict(gv.extra_envs or {}),
+                            "recipe_delta": {
+                                "extra_server_args": gv.extra_server_args,
+                                "extra_envs": dict(gv.extra_envs or {}),
+                                **{
+                                    key: value
+                                    for key, value in control_fields.items()
+                                    if value not in (None, "", [], {})
+                                },
+                            },
                             "extra_server_args": next_effective_args if persist_effective_args else next_stack_args,
                             "effective_extra_server_args": next_effective_args,
                             "extra_envs": dict(next_envs),

--- a/src/hyperloom/orchestrator/actions/executors/explore.py
+++ b/src/hyperloom/orchestrator/actions/executors/explore.py
@@ -1641,11 +1641,7 @@ class ExploreExecutor:
                             "recipe_delta": {
                                 "extra_server_args": gv.extra_server_args,
                                 "extra_envs": dict(gv.extra_envs or {}),
-                                **{
-                                    key: value
-                                    for key, value in control_fields.items()
-                                    if value not in (None, "", [], {})
-                                },
+                                **control_fields,
                             },
                             "extra_server_args": next_effective_args if persist_effective_args else next_stack_args,
                             "effective_extra_server_args": next_effective_args,

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
@@ -15,6 +15,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Collection, Mapping
 
+from hyperloom.inference_optimizer.breakdown.agent_ownership import (
+    patch_owner_phase,
+)
 from .models import (
     MAX_FILE_BYTES,
     Artifact,
@@ -250,8 +253,12 @@ class _Files:
 
 
 def _entry_origin(entry: Mapping[str, Any]) -> str:
-    phase = str(entry.get("source_phase") or "").strip().upper()
     action = str(entry.get("action") or "").strip().lower()
+    phase = (
+        patch_owner_phase(entry)
+        if action.startswith("integrate_patch")
+        else str(entry.get("source_phase") or "").strip().upper()
+    )
     if phase == "FRAMEWORK_AGENT" or action == "framework":
         return "framework"
     if phase == "EXPLORE" or action == "explore":

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
@@ -306,9 +306,7 @@ def _apply_recipe_delta(
 
     mode = str(delta.get("args_mode") or "append").strip().lower()
     if mode not in {"append", "replace"}:
-        raise RemoteRecipeValidationError(
-            f"unsupported recipe args_mode: {mode!r}"
-        )
+        raise RemoteRecipeValidationError(f"unsupported recipe args_mode: {mode!r}")
     args = compose_server_args(
         inherited_args=str(config.get("extra_server_args") or ""),
         variant_extra_args=str(delta.get("extra_server_args") or ""),
@@ -319,15 +317,10 @@ def _apply_recipe_delta(
     for key in delta.get("unset_envs") or []:
         envs.pop(str(key), None)
     raw_envs = _mapping(delta.get("extra_envs"))
-    framework_arg_envs = sorted(
-        key
-        for key in raw_envs
-        if key.startswith("EXTRA_") and key.endswith("_ARGS")
-    )
+    framework_arg_envs = sorted(key for key in raw_envs if key.startswith("EXTRA_") and key.endswith("_ARGS"))
     if framework_arg_envs:
         raise RemoteRecipeValidationError(
-            "recipe_delta must carry framework arguments in "
-            f"extra_server_args, not envs: {framework_arg_envs!r}"
+            f"recipe_delta must carry framework arguments in extra_server_args, not envs: {framework_arg_envs!r}"
         )
     envs.update(raw_envs)
     return {
@@ -350,14 +343,10 @@ def build_publishable_recipe_config(state: Any) -> dict[str, Any]:
         action = str(entry.get("action") or "").strip().lower()
         if action == "replay_warm_recipe":
             if str(outcome.get("status") or "") != "reproduced":
-                raise RemoteRecipeValidationError(
-                    "replay_warm_recipe stack entry was not reproduced"
-                )
+                raise RemoteRecipeValidationError("replay_warm_recipe stack entry was not reproduced")
             raw_delta = entry.get("recipe_delta")
             if not isinstance(raw_delta, Mapping):
-                raise RemoteRecipeValidationError(
-                    "reproduced warm replay is missing recipe_delta"
-                )
+                raise RemoteRecipeValidationError("reproduced warm replay is missing recipe_delta")
             delta = dict(raw_delta)
             config = _apply_recipe_delta(
                 {"extra_server_args": "", "extra_envs": {}},
@@ -389,12 +378,8 @@ def build_publishable_recipe_config(state: Any) -> dict[str, Any]:
             continue
         config = _apply_recipe_delta(config, delta)
     return {
-        "extra_server_args": sanitize_publish_server_args(
-            str(config.get("extra_server_args") or "")
-        ),
-        "extra_envs": sanitize_publish_env_mapping(
-            _mapping(config.get("extra_envs"))
-        ),
+        "extra_server_args": sanitize_publish_server_args(str(config.get("extra_server_args") or "")),
+        "extra_envs": sanitize_publish_env_mapping(_mapping(config.get("extra_envs"))),
     }
 
 

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
@@ -308,7 +308,8 @@ def _apply_recipe_delta(
     if mode not in {"append", "replace"}:
         raise RemoteRecipeValidationError(f"unsupported recipe args_mode: {mode!r}")
     args = compose_server_args(
-        inherited_args=str(config.get("extra_server_args") or ""),
+        inherited_args="",
+        base_extra_args=str(config.get("extra_server_args") or ""),
         variant_extra_args=str(delta.get("extra_server_args") or ""),
         remove_args=delta.get("remove_args"),
         args_mode=mode,

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
@@ -290,12 +290,104 @@ def _config_from(entries: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _config_from_current_best(state: Any) -> dict[str, Any]:
-    current = _mapping(getattr(state, "current_best", {}))
-    args = str(current.get("effective_extra_server_args") or current.get("extra_server_args") or "").strip()
+def _apply_recipe_delta(
+    config: dict[str, Any],
+    delta: Mapping[str, Any],
+) -> dict[str, Any]:
+    from ...actions.executors._grid_server_args import compose_server_args
+    from ...loop.coordinator_helpers import _dedupe_extra_server_args
+
+    mode = str(delta.get("args_mode") or "append").strip().lower()
+    if mode not in {"append", "replace"}:
+        raise RemoteRecipeValidationError(
+            f"unsupported recipe args_mode: {mode!r}"
+        )
+    args = compose_server_args(
+        inherited_args=str(config.get("extra_server_args") or ""),
+        variant_extra_args=str(delta.get("extra_server_args") or ""),
+        remove_args=delta.get("remove_args"),
+        args_mode=mode,
+    )
+    envs = dict(_mapping(config.get("extra_envs")))
+    for key in delta.get("unset_envs") or []:
+        envs.pop(str(key), None)
+    raw_envs = _mapping(delta.get("extra_envs"))
+    framework_arg_envs = sorted(
+        key
+        for key in raw_envs
+        if key.startswith("EXTRA_") and key.endswith("_ARGS")
+    )
+    if framework_arg_envs:
+        raise RemoteRecipeValidationError(
+            "recipe_delta must carry framework arguments in "
+            f"extra_server_args, not envs: {framework_arg_envs!r}"
+        )
+    envs.update(raw_envs)
     return {
-        "extra_server_args": sanitize_publish_server_args(args),
-        "extra_envs": sanitize_publish_env_mapping(_mapping(current.get("extra_envs"))),
+        "extra_server_args": _dedupe_extra_server_args(args),
+        "extra_envs": envs,
+    }
+
+
+def build_publishable_recipe_config(state: Any) -> dict[str, Any]:
+    """Build the cross-session optimization layer, excluding runtime bases."""
+    config: dict[str, Any] = {
+        "extra_server_args": "",
+        "extra_envs": {},
+    }
+    outcome = _mapping(getattr(state, "warm_replay_outcome", {}))
+    for raw in getattr(state, "optimization_stack", []) or []:
+        entry = _mapping(raw)
+        if not entry:
+            continue
+        action = str(entry.get("action") or "").strip().lower()
+        if action == "replay_warm_recipe":
+            if str(outcome.get("status") or "") != "reproduced":
+                raise RemoteRecipeValidationError(
+                    "replay_warm_recipe stack entry was not reproduced"
+                )
+            raw_delta = entry.get("recipe_delta")
+            if not isinstance(raw_delta, Mapping):
+                raise RemoteRecipeValidationError(
+                    "reproduced warm replay is missing recipe_delta"
+                )
+            delta = dict(raw_delta)
+            config = _apply_recipe_delta(
+                {"extra_server_args": "", "extra_envs": {}},
+                delta,
+            )
+            continue
+        if (
+            action in _IGNORED_ACTIONS
+            or entry.get("baseline_enablement")
+            or entry.get("attribution_eligible") is False
+            or entry.get("recipe_publishable") is False
+            or _entry_origin(entry) == "kernel"
+        ):
+            continue
+        delta = _mapping(entry.get("recipe_delta"))
+        config_signal = bool(
+            str(entry.get("candidate_extra_server_args") or "").strip()
+            or _mapping(entry.get("candidate_extra_envs"))
+            or entry.get("remove_args")
+            or entry.get("unset_envs")
+            or str(entry.get("args_mode") or "").strip().lower() == "replace"
+        )
+        if not delta:
+            if config_signal:
+                raise RemoteRecipeValidationError(
+                    "publishable config KEEP is missing recipe_delta: "
+                    f"action={action!r} variant={entry.get('variant_name')!r}"
+                )
+            continue
+        config = _apply_recipe_delta(config, delta)
+    return {
+        "extra_server_args": sanitize_publish_server_args(
+            str(config.get("extra_server_args") or "")
+        ),
+        "extra_envs": sanitize_publish_env_mapping(
+            _mapping(config.get("extra_envs"))
+        ),
     }
 
 
@@ -657,6 +749,8 @@ def has_new_keep(state: Any) -> bool:
         if action in _IGNORED_ACTIONS:
             continue
         if raw.get("baseline_enablement"):
+            continue
+        if raw.get("recipe_publishable") is False:
             continue
         return True
     return False
@@ -1030,7 +1124,7 @@ def build_remote_knowledge(
         explore_value = {"patches": [], "artifacts": []}
         framework_value = {"patches": [], "artifacts": []}
     value = {
-        "config": _config_from_current_best(state),
+        "config": build_publishable_recipe_config(state),
         "explore": explore_value,
         "framework": framework_value,
         "kernel": {
@@ -1191,6 +1285,7 @@ __all__ = [
     "build_kernel_fusion_value",
     "build_kernel_gemm_value",
     "build_kernel_rewrite_value",
+    "build_publishable_recipe_config",
     "build_remote_knowledge",
     "has_replay_material",
     "knowledge_to_warm_recipe",

--- a/src/hyperloom/orchestrator/loop/intent_router.py
+++ b/src/hyperloom/orchestrator/loop/intent_router.py
@@ -21,8 +21,11 @@ import json
 import time
 from contextlib import asynccontextmanager, suppress
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from hyperloom.inference_optimizer.breakdown.agent_ownership import (
+    patch_owner_phase,
+)
 from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
 from .coordinator_helpers import (
     _parse_iso_unix,
@@ -46,6 +49,9 @@ from ..policy.gate import (
 from ..state.shared_state import inject_stack_base_params
 from ..state.task_registry import IllegalTransition, TaskNotFound
 from ..kernel.request_handlers import KERNEL_REQUEST_HANDLERS, get_handler
+
+if TYPE_CHECKING:
+    from .coordinator import Coordinator, PendingProposal
 
 # ``Coordinator`` is intentionally NOT imported (avoids a module-level import
 # cycle with coordinator.py); it is held as a back-reference and the annotation
@@ -85,6 +91,41 @@ class IntentRouter:
     def __getattr__(self, name: str) -> Any:
         # Attributes not defined on the router resolve onto the coordinator.
         return getattr(object.__getattribute__(self, "_coord"), name)
+
+    async def _stamp_integrate_patch_owner(
+        self,
+        params: dict[str, Any],
+    ) -> str:
+        """Copy immutable author ownership from the originating specialist."""
+        owner = patch_owner_phase(params)
+        if owner:
+            params["source_phase"] = owner
+            return owner
+        specialist_task_id = str(params.get("specialist_task_id") or "").strip()
+        if not specialist_task_id:
+            return ""
+        try:
+            specialist = await self.tasks.get(specialist_task_id)
+        except TaskNotFound:
+            return ""
+        specialist_params = dict(getattr(specialist, "params", None) or {})
+        owner = patch_owner_phase(specialist_params)
+        if not owner:
+            return ""
+        for key in (
+            "domain",
+            "source_domain",
+            "provenance",
+            "gap_canonical_id",
+            "gap_layer",
+            "framework_agent_authoring",
+            "framework_agent_candidate_id",
+        ):
+            value = specialist_params.get(key)
+            if value not in (None, "", [], {}):
+                params.setdefault(key, value)
+        params["source_phase"] = owner
+        return owner
 
     async def _handle_intent(self, source: str, intent: Intent) -> None:
         """Validate an emitted intent through PolicyGate, then route it.
@@ -174,11 +215,30 @@ class IntentRouter:
         if denied is not None:
             await self._record_policy_denied(source, intent, denied)
             return
+        payload = dict(intent.payload)
+        if action_name == "integrate_patch":
+            params = dict(payload.get("params") or {})
+            if not await self._stamp_integrate_patch_owner(params):
+                await self._record_observation(
+                    "coordinator",
+                    "observation",
+                    {
+                        "kind": "proposal_rejected",
+                        "reason": "integrate_patch_owner_missing",
+                        "from_agent": source,
+                        "action_name": action_name,
+                        "specialist_task_id": str(
+                            params.get("specialist_task_id") or ""
+                        ),
+                    },
+                )
+                return
+            payload["params"] = params
         msg = Message.new(
             source,
             "*",
             "proposal",
-            {**intent.payload, "needs_review": True},
+            {**payload, "needs_review": True},
             priority=1,
         )
         await self.bus.append_and_seq(msg)
@@ -189,7 +249,7 @@ class IntentRouter:
             from_agent=source,
             action_name=action_name,
             predicted_gain_pct=float(intent.payload.get("predicted_gain_pct", 0.0)),
-            payload=dict(intent.payload),
+            payload=payload,
         )
         self.state.pending_proposals[msg.msg_id] = pending
 
@@ -519,6 +579,22 @@ class IntentRouter:
             return
         # delegate explore runs variants directly (no Critic pre-review).
         params = dict(intent.payload.get("params") or {})
+        if action_name == "integrate_patch":
+            if not await self._stamp_integrate_patch_owner(params):
+                await self._record_observation(
+                    "coordinator",
+                    "observation",
+                    {
+                        "kind": "delegate_rejected",
+                        "reason": "integrate_patch_owner_missing",
+                        "from_agent": source,
+                        "action_name": action_name,
+                        "specialist_task_id": str(
+                            params.get("specialist_task_id") or ""
+                        ),
+                    },
+                )
+                return
         if action_name == "specialist":
             # Capture proposal ownership at dispatch. Specialist work can finish
             # after the state machine advances, so completion-time phase is not

--- a/src/hyperloom/orchestrator/loop/intent_router.py
+++ b/src/hyperloom/orchestrator/loop/intent_router.py
@@ -89,6 +89,24 @@ class IntentRouter:
         # Attributes not defined on the router resolve onto the coordinator.
         return getattr(object.__getattribute__(self, "_coord"), name)
 
+    def _stamp_specialist_owner(self, params: dict[str, Any]) -> str:
+        """Freeze patch ownership when a specialist task is created."""
+        owner = patch_owner_phase(params)
+        if not owner:
+            gap_layer = str(params.get("gap_layer") or "").strip().lower()
+            active_phase = str(getattr(self.shared_state, "phase", "") or "").strip().upper()
+            if gap_layer == "framework":
+                owner = "FRAMEWORK_AGENT"
+            elif active_phase in {"FRAMEWORK", "FRAMEWORK_AGENT"}:
+                owner = "FRAMEWORK_AGENT"
+            elif active_phase == "EXPLORE":
+                owner = "EXPLORE"
+            elif gap_layer in {"explore", "perf_explore"} or params.get("domain"):
+                owner = "EXPLORE"
+        if owner:
+            params["source_phase"] = owner
+        return owner
+
     async def _stamp_integrate_patch_owner(
         self,
         params: dict[str, Any],
@@ -592,10 +610,7 @@ class IntentRouter:
             # Capture proposal ownership at dispatch. Specialist work can finish
             # after the state machine advances, so completion-time phase is not
             # a reliable source for a later integrate_patch KEEP.
-            params.setdefault(
-                "source_phase",
-                str(getattr(self.shared_state, "phase", "") or ""),
-            )
+            self._stamp_specialist_owner(params)
         # idempotency_key is top-level per schema; strip a nested compat alias.
         nested_idempotency_key = params.pop("idempotency_key", None)
         # Plumb baseline's materialized YAML into grid-style tasks (delegator may override).

--- a/src/hyperloom/orchestrator/loop/intent_router.py
+++ b/src/hyperloom/orchestrator/loop/intent_router.py
@@ -227,9 +227,7 @@ class IntentRouter:
                         "reason": "integrate_patch_owner_missing",
                         "from_agent": source,
                         "action_name": action_name,
-                        "specialist_task_id": str(
-                            params.get("specialist_task_id") or ""
-                        ),
+                        "specialist_task_id": str(params.get("specialist_task_id") or ""),
                     },
                 )
                 return
@@ -589,9 +587,7 @@ class IntentRouter:
                         "reason": "integrate_patch_owner_missing",
                         "from_agent": source,
                         "action_name": action_name,
-                        "specialist_task_id": str(
-                            params.get("specialist_task_id") or ""
-                        ),
+                        "specialist_task_id": str(params.get("specialist_task_id") or ""),
                     },
                 )
                 return

--- a/src/hyperloom/orchestrator/loop/intent_router.py
+++ b/src/hyperloom/orchestrator/loop/intent_router.py
@@ -21,7 +21,7 @@ import json
 import time
 from contextlib import asynccontextmanager, suppress
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from hyperloom.inference_optimizer.breakdown.agent_ownership import (
     patch_owner_phase,
@@ -49,9 +49,6 @@ from ..policy.gate import (
 from ..state.shared_state import inject_stack_base_params
 from ..state.task_registry import IllegalTransition, TaskNotFound
 from ..kernel.request_handlers import KERNEL_REQUEST_HANDLERS, get_handler
-
-if TYPE_CHECKING:
-    from .coordinator import Coordinator, PendingProposal
 
 # ``Coordinator`` is intentionally NOT imported (avoids a module-level import
 # cycle with coordinator.py); it is held as a back-reference and the annotation
@@ -85,7 +82,7 @@ _KERNEL_HEARTBEAT_SEC: float = 150.0
 class IntentRouter:
     """Validates and dispatches agent-emitted intents on behalf of a Coordinator."""
 
-    def __init__(self, coordinator: "Coordinator") -> None:  # noqa: F821 - deferred ref, not imported to avoid an import cycle (see note above)
+    def __init__(self, coordinator: Any) -> None:
         self._coord = coordinator
 
     def __getattr__(self, name: str) -> Any:
@@ -415,7 +412,7 @@ class IntentRouter:
         self,
         *,
         source: str,
-        pending: "PendingProposal",  # noqa: F821 - deferred ref; imported lazily in handlers to avoid import cycle.
+        pending: Any,
         verdict: str,
         reasoning: str,
         authored_verdict: str = "",

--- a/src/hyperloom/orchestrator/loop/proposals.py
+++ b/src/hyperloom/orchestrator/loop/proposals.py
@@ -6,6 +6,9 @@
 from __future__ import annotations
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Mapping
+from hyperloom.inference_optimizer.breakdown.agent_ownership import (
+    patch_owner_phase,
+)
 from hyperloom.orchestrator.knowledge.recipe_kb import recipe_canonical_id
 from hyperloom.inference_optimizer.recipe_snapshot_constants import detect_framework_version
 from ..phases import machine_state as _phase_state
@@ -477,6 +480,24 @@ class ProposalsCollaborator:
             self._inject_explore_runtime_params(params)
             inject_stack_base_params(params, self.shared_state, anchor=True)
         if pending.action_name == "integrate_patch":
+            owner = patch_owner_phase(params)
+            if not owner:
+                await self._record_observation(
+                    "coordinator",
+                    "observation",
+                    {
+                        "kind": "proposal_materialize_skipped",
+                        "reason": "integrate_patch_owner_missing",
+                        "proposal_msg_id": pending.proposal_msg_id,
+                        "action_name": pending.action_name,
+                        "from_agent": pending.from_agent,
+                        "specialist_task_id": str(
+                            params.get("specialist_task_id") or ""
+                        ),
+                    },
+                )
+                return
+            params["source_phase"] = owner
             params.setdefault("keep_threshold_pct", _phase_state.resolve_keep_threshold(self.shared_state))
             # Seed the patched-eval server with the same base args/config every
             # other eval server uses, else it launches on bare framework defaults

--- a/src/hyperloom/orchestrator/loop/proposals.py
+++ b/src/hyperloom/orchestrator/loop/proposals.py
@@ -482,6 +482,23 @@ class ProposalsCollaborator:
         if pending.action_name == "integrate_patch":
             owner = patch_owner_phase(params)
             if not owner:
+                specialist_task_id = str(params.get("specialist_task_id") or "")
+                self.state.pending_proposals.pop(
+                    pending.proposal_msg_id,
+                    None,
+                )
+                if specialist_task_id:
+                    self.shared_state.record_specialist_patch_verdict(
+                        specialist_task_id,
+                        "owner_missing",
+                    )
+                    try:
+                        self.shared_state.save(self.session_dir)
+                    except Exception:  # noqa: BLE001
+                        log.exception(
+                            "failed to persist terminal owner-missing verdict for specialist=%s",
+                            specialist_task_id,
+                        )
                 await self._record_observation(
                     "coordinator",
                     "observation",
@@ -491,7 +508,7 @@ class ProposalsCollaborator:
                         "proposal_msg_id": pending.proposal_msg_id,
                         "action_name": pending.action_name,
                         "from_agent": pending.from_agent,
-                        "specialist_task_id": str(params.get("specialist_task_id") or ""),
+                        "specialist_task_id": specialist_task_id,
                     },
                 )
                 return

--- a/src/hyperloom/orchestrator/loop/proposals.py
+++ b/src/hyperloom/orchestrator/loop/proposals.py
@@ -491,9 +491,7 @@ class ProposalsCollaborator:
                         "proposal_msg_id": pending.proposal_msg_id,
                         "action_name": pending.action_name,
                         "from_agent": pending.from_agent,
-                        "specialist_task_id": str(
-                            params.get("specialist_task_id") or ""
-                        ),
+                        "specialist_task_id": str(params.get("specialist_task_id") or ""),
                     },
                 )
                 return

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -13,6 +13,9 @@ from types import SimpleNamespace
 from typing import Any, Mapping
 from hyperloom.common.coerce import to_float, to_str_list
 from hyperloom.common.io import append_jsonl
+from hyperloom.inference_optimizer.breakdown.agent_ownership import (
+    patch_owner_phase,
+)
 from ..kernel._recorder_trace import trace_recording_skipped
 from ..state.optimization_journal import (
     Journal,
@@ -4604,10 +4607,12 @@ class WritebackCollaborator:
                 "framework_root": result.get("framework_root") or "",
                 "base_sha": result.get("base_sha") or "",
             }
-            source_phase = str(result.get("source_phase") or "").strip()
+            source_phase = patch_owner_phase(result)
             gap_layer = str(result.get("gap_layer") or "").strip()
             if source_phase:
                 bv["source_phase"] = source_phase
+            else:
+                bv["recipe_publishable"] = False
             if domain:
                 bv["domain"] = domain
             if gap_layer:

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -2625,6 +2625,11 @@ class WritebackCollaborator:
                     "action": task_kind,
                     "variant_name": variant_name,
                     "candidate_extra_server_args": candidate_args,
+                    "candidate_extra_envs": (
+                        dict(bv.get("candidate_extra_envs") or {})
+                        if isinstance(bv, dict)
+                        else {}
+                    ),
                     "extra_server_args": full_args,
                     "extra_envs": (dict(bv.get("extra_envs") or {}) if isinstance(bv, dict) else {}),
                     # Carry the promoting lane's accuracy verdict onto the stack
@@ -2670,6 +2675,25 @@ class WritebackCollaborator:
                     if _stack_kernels:
                         stack_entry["accepted_kernels"] = _stack_kernels
                 if isinstance(bv, dict):
+                    recipe_delta = bv.get("recipe_delta")
+                    if isinstance(recipe_delta, Mapping):
+                        stack_entry["recipe_delta"] = {
+                            "extra_server_args": str(
+                                recipe_delta.get("extra_server_args") or ""
+                            ).strip(),
+                            "extra_envs": dict(
+                                recipe_delta.get("extra_envs") or {}
+                            ),
+                            "remove_args": to_str_list(
+                                recipe_delta.get("remove_args")
+                            ),
+                            "unset_envs": to_str_list(
+                                recipe_delta.get("unset_envs")
+                            ),
+                            "args_mode": str(
+                                recipe_delta.get("args_mode") or "append"
+                            ).strip().lower(),
+                        }
                     for _ctrl_key in ("remove_args", "unset_envs", "args_mode"):
                         if bv.get(_ctrl_key):
                             stack_entry[_ctrl_key] = bv.get(_ctrl_key)
@@ -2708,6 +2732,10 @@ class WritebackCollaborator:
                     for _attr_key in ("baseline_enablement", "attribution_eligible"):
                         if _attr_key in bv:
                             stack_entry[_attr_key] = bool(bv.get(_attr_key))
+                    if "recipe_publishable" in bv:
+                        stack_entry["recipe_publishable"] = bool(
+                            bv.get("recipe_publishable")
+                        )
                     if "framework_agent_authoring" in bv:
                         stack_entry["framework_agent_authoring"] = bool(bv.get("framework_agent_authoring"))
                     for _origin_key in ("domain", "gap_layer"):
@@ -3844,10 +3872,15 @@ class WritebackCollaborator:
             audit_extras["framework_levers"] = [str(row.get("switch") or "") for row in levers]
             audit_extras["framework_lever_outcome"] = lever_outcome
         task_params = (getattr(task, "params", None) or {}) if task is not None else {}
+        enablement_landing = bool(
+            result.get("enablement")
+            or task_params.get("enablement")
+            or task_params.get("enablement_landing")
+        )
         prebaseline_enablement = bool(
             kept_flag
             and float(getattr(self.shared_state, "baseline_tput", 0.0) or 0.0) <= 0.0
-            and (result.get("enablement") or task_params.get("enablement") or task_params.get("enablement_landing"))
+            and enablement_landing
         )
         lifted = False
         if kept_flag:
@@ -3864,7 +3897,39 @@ class WritebackCollaborator:
                 "name": specialist_task_id or "integrate_patch_keep",
                 "task_id": getattr(task, "task_id", "") if task is not None else "",
                 "candidate_extra_server_args": str(result.get("extra_server_args_applied") or ""),
-                "extra_envs": dict(result.get("extra_envs_applied") or result.get("config_changes_applied") or {}),
+                "candidate_extra_envs": dict(
+                    result.get("extra_envs_applied")
+                    or result.get("config_changes_applied")
+                    or {}
+                ),
+                "recipe_delta": {
+                    "extra_server_args": str(
+                        result.get("extra_server_args_applied") or ""
+                    ),
+                    "extra_envs": dict(
+                        result.get("extra_envs_applied")
+                        or result.get("config_changes_applied")
+                        or {}
+                    ),
+                    "remove_args": to_str_list(
+                        result.get("remove_args_applied")
+                        or task_params.get("remove_args")
+                    ),
+                    "unset_envs": to_str_list(
+                        result.get("unset_envs_applied")
+                        or task_params.get("unset_envs")
+                    ),
+                    "args_mode": str(
+                        result.get("args_mode")
+                        or task_params.get("args_mode")
+                        or "append"
+                    ).strip().lower(),
+                },
+                "extra_envs": dict(
+                    result.get("extra_envs_applied")
+                    or result.get("config_changes_applied")
+                    or {}
+                ),
                 "tput": float(new_tput),
                 "workspace": result.get("workspace"),
                 "provenance": origin_provenance or "integrate_patch",
@@ -3885,6 +3950,8 @@ class WritebackCollaborator:
                 lift["gap_layer"] = str(task_params.get("gap_layer"))
             if task_params.get("framework_agent_authoring"):
                 lift["framework_agent_authoring"] = True
+            if enablement_landing:
+                lift["recipe_publishable"] = False
             if prebaseline_enablement:
                 lift["baseline_enablement"] = True
                 lift["attribution_eligible"] = False
@@ -3957,8 +4024,16 @@ class WritebackCollaborator:
             "enablement_observed_accuracy": result.get("enablement_observed_accuracy"),
             "provisional": result.get("provisional"),
         }
-        if lifted and len(self.shared_state.optimization_stack or []) > stack_len_before:
-            owner = str(task_params.get("source_phase") or result.get("source_phase") or "").strip().upper()
+        if (
+            lifted
+            and not enablement_landing
+            and len(self.shared_state.optimization_stack or []) > stack_len_before
+        ):
+            owner = str(
+                task_params.get("source_phase")
+                or result.get("source_phase")
+                or ""
+            ).strip().upper()
             if owner in {"EXPLORE", "FRAMEWORK_AGENT"}:
                 self._enqueue_agent_keep_outbox(
                     owner=owner,
@@ -4485,7 +4560,37 @@ class WritebackCollaborator:
             bv = {
                 "name": sid,
                 "candidate_extra_server_args": str(result.get("extra_server_args_applied") or ""),
-                "extra_envs": dict(result.get("extra_envs_applied") or result.get("config_changes_applied") or {}),
+                "candidate_extra_envs": dict(
+                    result.get("extra_envs_applied")
+                    or result.get("config_changes_applied")
+                    or {}
+                ),
+                "recipe_delta": {
+                    "extra_server_args": str(
+                        result.get("extra_server_args_applied") or ""
+                    ),
+                    "extra_envs": dict(
+                        result.get("extra_envs_applied")
+                        or result.get("config_changes_applied")
+                        or {}
+                    ),
+                    "remove_args": to_str_list(
+                        result.get("remove_args_applied")
+                        or result.get("remove_args")
+                    ),
+                    "unset_envs": to_str_list(
+                        result.get("unset_envs_applied")
+                        or result.get("unset_envs")
+                    ),
+                    "args_mode": str(
+                        result.get("args_mode") or "append"
+                    ).strip().lower(),
+                },
+                "extra_envs": dict(
+                    result.get("extra_envs_applied")
+                    or result.get("config_changes_applied")
+                    or {}
+                ),
                 "tput": float(tput),
                 "workspace": result.get("workspace"),
                 "provenance": provenance or "integrate_patch",
@@ -4509,6 +4614,8 @@ class WritebackCollaborator:
                 bv["gap_layer"] = gap_layer
             if result.get("framework_agent_authoring"):
                 bv["framework_agent_authoring"] = True
+            if result.get("enablement") or result.get("enablement_landing"):
+                bv["recipe_publishable"] = False
         else:
             return False
         before = len(self.shared_state.optimization_stack or [])

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -2629,9 +2629,7 @@ class WritebackCollaborator:
                     "variant_name": variant_name,
                     "candidate_extra_server_args": candidate_args,
                     "candidate_extra_envs": (
-                        dict(bv.get("candidate_extra_envs") or {})
-                        if isinstance(bv, dict)
-                        else {}
+                        dict(bv.get("candidate_extra_envs") or {}) if isinstance(bv, dict) else {}
                     ),
                     "extra_server_args": full_args,
                     "extra_envs": (dict(bv.get("extra_envs") or {}) if isinstance(bv, dict) else {}),
@@ -2681,21 +2679,11 @@ class WritebackCollaborator:
                     recipe_delta = bv.get("recipe_delta")
                     if isinstance(recipe_delta, Mapping):
                         stack_entry["recipe_delta"] = {
-                            "extra_server_args": str(
-                                recipe_delta.get("extra_server_args") or ""
-                            ).strip(),
-                            "extra_envs": dict(
-                                recipe_delta.get("extra_envs") or {}
-                            ),
-                            "remove_args": to_str_list(
-                                recipe_delta.get("remove_args")
-                            ),
-                            "unset_envs": to_str_list(
-                                recipe_delta.get("unset_envs")
-                            ),
-                            "args_mode": str(
-                                recipe_delta.get("args_mode") or "append"
-                            ).strip().lower(),
+                            "extra_server_args": str(recipe_delta.get("extra_server_args") or "").strip(),
+                            "extra_envs": dict(recipe_delta.get("extra_envs") or {}),
+                            "remove_args": to_str_list(recipe_delta.get("remove_args")),
+                            "unset_envs": to_str_list(recipe_delta.get("unset_envs")),
+                            "args_mode": str(recipe_delta.get("args_mode") or "append").strip().lower(),
                         }
                     for _ctrl_key in ("remove_args", "unset_envs", "args_mode"):
                         if bv.get(_ctrl_key):
@@ -2736,9 +2724,7 @@ class WritebackCollaborator:
                         if _attr_key in bv:
                             stack_entry[_attr_key] = bool(bv.get(_attr_key))
                     if "recipe_publishable" in bv:
-                        stack_entry["recipe_publishable"] = bool(
-                            bv.get("recipe_publishable")
-                        )
+                        stack_entry["recipe_publishable"] = bool(bv.get("recipe_publishable"))
                     if "framework_agent_authoring" in bv:
                         stack_entry["framework_agent_authoring"] = bool(bv.get("framework_agent_authoring"))
                     for _origin_key in ("domain", "gap_layer"):
@@ -3876,14 +3862,10 @@ class WritebackCollaborator:
             audit_extras["framework_lever_outcome"] = lever_outcome
         task_params = (getattr(task, "params", None) or {}) if task is not None else {}
         enablement_landing = bool(
-            result.get("enablement")
-            or task_params.get("enablement")
-            or task_params.get("enablement_landing")
+            result.get("enablement") or task_params.get("enablement") or task_params.get("enablement_landing")
         )
         prebaseline_enablement = bool(
-            kept_flag
-            and float(getattr(self.shared_state, "baseline_tput", 0.0) or 0.0) <= 0.0
-            and enablement_landing
+            kept_flag and float(getattr(self.shared_state, "baseline_tput", 0.0) or 0.0) <= 0.0 and enablement_landing
         )
         lifted = False
         if kept_flag:
@@ -3901,38 +3883,18 @@ class WritebackCollaborator:
                 "task_id": getattr(task, "task_id", "") if task is not None else "",
                 "candidate_extra_server_args": str(result.get("extra_server_args_applied") or ""),
                 "candidate_extra_envs": dict(
-                    result.get("extra_envs_applied")
-                    or result.get("config_changes_applied")
-                    or {}
+                    result.get("extra_envs_applied") or result.get("config_changes_applied") or {}
                 ),
                 "recipe_delta": {
-                    "extra_server_args": str(
-                        result.get("extra_server_args_applied") or ""
-                    ),
-                    "extra_envs": dict(
-                        result.get("extra_envs_applied")
-                        or result.get("config_changes_applied")
-                        or {}
-                    ),
-                    "remove_args": to_str_list(
-                        result.get("remove_args_applied")
-                        or task_params.get("remove_args")
-                    ),
-                    "unset_envs": to_str_list(
-                        result.get("unset_envs_applied")
-                        or task_params.get("unset_envs")
-                    ),
-                    "args_mode": str(
-                        result.get("args_mode")
-                        or task_params.get("args_mode")
-                        or "append"
-                    ).strip().lower(),
+                    "extra_server_args": str(result.get("extra_server_args_applied") or ""),
+                    "extra_envs": dict(result.get("extra_envs_applied") or result.get("config_changes_applied") or {}),
+                    "remove_args": to_str_list(result.get("remove_args_applied") or task_params.get("remove_args")),
+                    "unset_envs": to_str_list(result.get("unset_envs_applied") or task_params.get("unset_envs")),
+                    "args_mode": str(result.get("args_mode") or task_params.get("args_mode") or "append")
+                    .strip()
+                    .lower(),
                 },
-                "extra_envs": dict(
-                    result.get("extra_envs_applied")
-                    or result.get("config_changes_applied")
-                    or {}
-                ),
+                "extra_envs": dict(result.get("extra_envs_applied") or result.get("config_changes_applied") or {}),
                 "tput": float(new_tput),
                 "workspace": result.get("workspace"),
                 "provenance": origin_provenance or "integrate_patch",
@@ -4027,16 +3989,8 @@ class WritebackCollaborator:
             "enablement_observed_accuracy": result.get("enablement_observed_accuracy"),
             "provisional": result.get("provisional"),
         }
-        if (
-            lifted
-            and not enablement_landing
-            and len(self.shared_state.optimization_stack or []) > stack_len_before
-        ):
-            owner = str(
-                task_params.get("source_phase")
-                or result.get("source_phase")
-                or ""
-            ).strip().upper()
+        if lifted and not enablement_landing and len(self.shared_state.optimization_stack or []) > stack_len_before:
+            owner = str(task_params.get("source_phase") or result.get("source_phase") or "").strip().upper()
             if owner in {"EXPLORE", "FRAMEWORK_AGENT"}:
                 self._enqueue_agent_keep_outbox(
                     owner=owner,
@@ -4564,36 +4518,16 @@ class WritebackCollaborator:
                 "name": sid,
                 "candidate_extra_server_args": str(result.get("extra_server_args_applied") or ""),
                 "candidate_extra_envs": dict(
-                    result.get("extra_envs_applied")
-                    or result.get("config_changes_applied")
-                    or {}
+                    result.get("extra_envs_applied") or result.get("config_changes_applied") or {}
                 ),
                 "recipe_delta": {
-                    "extra_server_args": str(
-                        result.get("extra_server_args_applied") or ""
-                    ),
-                    "extra_envs": dict(
-                        result.get("extra_envs_applied")
-                        or result.get("config_changes_applied")
-                        or {}
-                    ),
-                    "remove_args": to_str_list(
-                        result.get("remove_args_applied")
-                        or result.get("remove_args")
-                    ),
-                    "unset_envs": to_str_list(
-                        result.get("unset_envs_applied")
-                        or result.get("unset_envs")
-                    ),
-                    "args_mode": str(
-                        result.get("args_mode") or "append"
-                    ).strip().lower(),
+                    "extra_server_args": str(result.get("extra_server_args_applied") or ""),
+                    "extra_envs": dict(result.get("extra_envs_applied") or result.get("config_changes_applied") or {}),
+                    "remove_args": to_str_list(result.get("remove_args_applied") or result.get("remove_args")),
+                    "unset_envs": to_str_list(result.get("unset_envs_applied") or result.get("unset_envs")),
+                    "args_mode": str(result.get("args_mode") or "append").strip().lower(),
                 },
-                "extra_envs": dict(
-                    result.get("extra_envs_applied")
-                    or result.get("config_changes_applied")
-                    or {}
-                ),
+                "extra_envs": dict(result.get("extra_envs_applied") or result.get("config_changes_applied") or {}),
                 "tput": float(tput),
                 "workspace": result.get("workspace"),
                 "provenance": provenance or "integrate_patch",

--- a/src/hyperloom/orchestrator/phases/explore.py
+++ b/src/hyperloom/orchestrator/phases/explore.py
@@ -13,6 +13,9 @@ from pathlib import Path
 from typing import Any
 from . import machine_state as _phase_state
 from hyperloom.common.coerce import to_float
+from hyperloom.inference_optimizer.breakdown.agent_ownership import (
+    patch_owner_phase,
+)
 from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
 from ..bus.message_bus import Message
 from ..policy.gate import (
@@ -66,32 +69,11 @@ def _forward_enablement_carriers(src: dict[str, Any], dst: dict[str, Any]) -> No
 def _forward_integrate_source(
     src: dict[str, Any],
     dst: dict[str, Any],
-    *,
-    current_phase: str,
 ) -> None:
     """Preserve proposal ownership across delayed ``integrate_patch`` execution."""
 
     domain = str(src.get("domain") or src.get("source_domain") or "").strip()
-    gap_layer = str(src.get("gap_layer") or "").strip().lower()
-    recorded_phase = str(src.get("source_phase") or "").strip().upper()
-    if bool(src.get("framework_agent_authoring")) or gap_layer == "framework":
-        source_phase = "FRAMEWORK_AGENT"
-    elif recorded_phase in {"FRAMEWORK", "FRAMEWORK_AGENT", "EXPLORE"}:
-        source_phase = recorded_phase
-    elif gap_layer in {"explore", "perf_explore"} or domain:
-        # Specialist-produced runtime/source candidates are EXPLORE-owned unless
-        # explicit framework-authoring metadata says otherwise. In particular,
-        # never inherit a later KERNEL_AGENT completion phase.
-        source_phase = "EXPLORE"
-    elif str(current_phase or "").strip().upper() in {
-        "FRAMEWORK",
-        "FRAMEWORK_AGENT",
-        "EXPLORE",
-    }:
-        source_phase = str(current_phase).strip().upper()
-    else:
-        source_phase = ""
-
+    source_phase = patch_owner_phase(src)
     if source_phase:
         dst["source_phase"] = source_phase
     if domain:
@@ -1580,7 +1562,6 @@ class ExplorePhase(PhaseHandler):
         _forward_integrate_source(
             spec_params,
             integrate_params,
-            current_phase=str(getattr(self.shared_state, "phase", "") or ""),
         )
         # FRAMEWORK authoring provenance passthrough: propagate the PR
         # candidate/batch id onto the synthetic integrate_patch task so the
@@ -1747,7 +1728,6 @@ class ExplorePhase(PhaseHandler):
         _forward_integrate_source(
             spec_params,
             integrate_params,
-            current_phase=str(getattr(self.shared_state, "phase", "") or ""),
         )
         # FRAMEWORK authoring provenance passthrough for the authored-outcome bridge.
         fa_cand = str(spec_params.get("framework_agent_candidate_id") or "")

--- a/src/hyperloom/orchestrator/phases/framework.py
+++ b/src/hyperloom/orchestrator/phases/framework.py
@@ -2495,6 +2495,7 @@ class FrameworkPhase(PhaseHandler):
             pass
         params: dict[str, Any] = {
             "domain": domain,
+            "source_phase": "FRAMEWORK_AGENT",
             "gap_canonical_id": gap_cid,
             "gap_symptom": (gap or "Author a framework source patch from live source + profile evidence"),
             "gap_layer": "framework",
@@ -5493,6 +5494,7 @@ class FrameworkPhase(PhaseHandler):
         notes = "\n".join(context_lines).strip()
         params: dict[str, Any] = {
             "domain": domain,
+            "source_phase": "FRAMEWORK_AGENT",
             "gap_canonical_id": gap_cid,
             "gap_symptom": ("Propose runtime config variants (server args / env) for a throughput grid"),
             "gap_layer": "framework",

--- a/src/hyperloom/orchestrator/phases/framework.py
+++ b/src/hyperloom/orchestrator/phases/framework.py
@@ -2047,6 +2047,7 @@ class FrameworkPhase(PhaseHandler):
         notes = "\n".join(notes_lines).strip()
         params: dict[str, Any] = {
             "domain": "serving_specialist",
+            "source_phase": "EXPLORE",
             "gap_canonical_id": gap_cid,
             "gap_symptom": gap_symptom or f"Retry apply-failed patch for {gap_cid}",
             "gap_layer": "perf_explore",

--- a/src/hyperloom/orchestrator/phases/prelude.py
+++ b/src/hyperloom/orchestrator/phases/prelude.py
@@ -2188,7 +2188,7 @@ class PreludePhase(PhaseHandler):
                 {
                     "name": "warm_replay",
                     "candidate_extra_server_args": warm_args,
-                    "candidate_extra_envs": recipe_envs,
+                    "candidate_extra_envs": warm_envs,
                     "recipe_delta": {
                         "extra_server_args": recipe_args,
                         "extra_envs": recipe_envs,

--- a/src/hyperloom/orchestrator/phases/prelude.py
+++ b/src/hyperloom/orchestrator/phases/prelude.py
@@ -2178,12 +2178,30 @@ class PreludePhase(PhaseHandler):
                 state.warm_replay_outcome = outcome
                 state.save(self.session_dir)
                 return
+            recipe_args = str(
+                params["recipe_extra_server_args"]
+                if "recipe_extra_server_args" in params
+                else warm_args
+            ).strip()
+            recipe_envs = dict(
+                params["recipe_extra_envs"]
+                if "recipe_extra_envs" in params
+                else warm_envs
+            )
             self._lift_to_current_best(
                 "replay_warm_recipe",
                 float(single_round_tput),
                 {
                     "name": "warm_replay",
                     "candidate_extra_server_args": warm_args,
+                    "candidate_extra_envs": recipe_envs,
+                    "recipe_delta": {
+                        "extra_server_args": recipe_args,
+                        "extra_envs": recipe_envs,
+                        "remove_args": [],
+                        "unset_envs": [],
+                        "args_mode": "replace",
+                    },
                     "extra_envs": warm_envs,
                     "source_phase": "PRELUDE",
                     "task_id": str(getattr(task, "task_id", "") or ""),

--- a/src/hyperloom/orchestrator/phases/prelude.py
+++ b/src/hyperloom/orchestrator/phases/prelude.py
@@ -2179,15 +2179,9 @@ class PreludePhase(PhaseHandler):
                 state.save(self.session_dir)
                 return
             recipe_args = str(
-                params["recipe_extra_server_args"]
-                if "recipe_extra_server_args" in params
-                else warm_args
+                params["recipe_extra_server_args"] if "recipe_extra_server_args" in params else warm_args
             ).strip()
-            recipe_envs = dict(
-                params["recipe_extra_envs"]
-                if "recipe_extra_envs" in params
-                else warm_envs
-            )
+            recipe_envs = dict(params["recipe_extra_envs"] if "recipe_extra_envs" in params else warm_envs)
             self._lift_to_current_best(
                 "replay_warm_recipe",
                 float(single_round_tput),

--- a/src/hyperloom/orchestrator/policy/gate.py
+++ b/src/hyperloom/orchestrator/policy/gate.py
@@ -2513,12 +2513,6 @@ def validate_freeform_wave_task(task: Any, *, index: int) -> str:
             hint="Each wave entry must be an object with task_description.",
         )
     desc = str(task.get("task_description") or task.get("task_summary") or "").strip()
-    if not desc:
-        raise PolicyDenied(
-            f"delegate{{action='specialist',scope='freeform'}}: tasks[{index}] task_description must be non-empty",
-            rule="specialist_freeform_empty_description",
-            hint=("Each freeform task needs a natural-language task_description (the whole mandate)."),
-        )
     PolicyGate._check_freeform_task_description(desc, where=f"tasks[{index}]")
     return desc
 

--- a/src/hyperloom/orchestrator/specialists/runner.py
+++ b/src/hyperloom/orchestrator/specialists/runner.py
@@ -72,7 +72,7 @@ def resolve_specialist_max_turns(raw: Any, *, default: int) -> int:
     Returns:
         The resolved non-negative turn budget.
     """
-    if raw is None:
+    if raw in (None, ""):
         return int(default)
     max_turns = int(raw)
     if max_turns == 0:


### PR DESCRIPTION
## Summary
- persist optimization-only Recipe deltas for Explore, IntegratePatch, and warm replay while excluding HLD, baseline, kernel runtime, and enablement configuration
- rebuild cold Recipes from an empty base and warm Recipes from the reproduced donor config with append/replace/remove/unset semantics
- preserve immutable Framework/Explore patch ownership from specialist creation through integration, fail closed on missing owners, and keep perf-explore retries attributable

## Test plan
- [x] `PYTHONPATH=/tmp/hyperloom-testdeps:src USER_DATA_PATH=/tmp/hyperloom-owner-tests python3 -m pytest -q src/hyperloom/inference_optimizer/tests/test_framework_agent_authoring.py src/hyperloom/inference_optimizer/tests/test_sbd_optimizations.py src/hyperloom/inference_optimizer/tests/test_coordinator_async_batch2_unit.py src/hyperloom/inference_optimizer/tests/test_config_patch_agent_kb.py src/hyperloom/inference_optimizer/tests/test_promote_shared_state_lock.py src/hyperloom/inference_optimizer/tests/test_remote_recipe_v2.py src/hyperloom/inference_optimizer/tests/test_warm_replay.py` (499 passed)
- [x] `git diff --check origin/main...HEAD`
- [x] IDE diagnostics on changed files


Made with [Cursor](https://cursor.com)