### PR TITLE
Raise 12h demo target gain from 30% to 50%

### DIFF
--- a/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
+++ b/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
@@ -75,7 +75,7 @@ Required optimize CLI flags:
 - `--isl 1024`
 - `--osl 1024`
 - `--precision fp8`
-- `--target-gain 30`
+- `--target-gain 50`
 - `--max-hours 12`
 - `--max-minutes-framework-pct 0.01`
 - `--max-minutes-explore-pct 0.42`


### PR DESCRIPTION
## Summary
- Update the Qwen3-14B-FP8 12-hour demo preset to use `--target-gain 50` instead of `--target-gain 30`.
- Aligns the example skill with the updated optimization goal for medium-length FP8 runs.

## Test plan
- [ ] Verify `examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md` lists `--target-gain 50` under required optimize CLI flags
- [ ] Confirm the 3h demo preset remains unchanged at `--target-gain 30`
