### PR TITLE
Add torch soname aliases and --verify-hotfix for ROCm profiler hotfix

### DIFF
--- a/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
+++ b/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
@@ -1401,10 +1401,10 @@ restore_torch_soname_aliases() {
   [ -f "$marker" ] || return 0
   while read -r soname; do
     [ -n "$soname" ] || continue
+    # The alias we installed is a symlink, and cp would write through it.
+    rm -f "${torch_lib_dir}/${soname}" || return 1
     if [ -e "${backup_dir}/${soname}" ]; then
       cp -a "${backup_dir}/${soname}" "${torch_lib_dir}/${soname}" || return 1
-    else
-      rm -f "${torch_lib_dir}/${soname}" || return 1
     fi
   done < "$marker"
   rm -f "$marker"

--- a/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
+++ b/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
@@ -1352,10 +1352,10 @@ ensure_torch_lib_backup() {
 restore_torch_libs() {
   local backup_dir="$1" torch_lib_dir="$2" name
   for name in $ROCM_PROFILER_HOTFIX_TORCH_LIBS; do
+    # What we installed is a symlink, and cp would write through it.
+    rm -f "${torch_lib_dir}/${name}" || return 1
     if [ -e "${backup_dir}/${name}" ]; then
       cp -a "${backup_dir}/${name}" "${torch_lib_dir}/${name}" || return 1
-    else
-      rm -f "${torch_lib_dir}/${name}" || return 1
     fi
   done
 }
@@ -1413,7 +1413,7 @@ restore_torch_soname_aliases() {
 sync_one_torch_lib() {
   local rocm_lib_dir="$1" py="$2" torch_lib_dir="$3"
   local backup_dir="${torch_lib_dir}/${ROCM_PROFILER_HOTFIX_TORCH_BACKUP_DIR}"
-  local name src dst tmp mode pending=""
+  local name src dst pending=""
 
   for name in $ROCM_PROFILER_HOTFIX_TORCH_LIBS; do
     src="$(readlink -f "${rocm_lib_dir}/${name}" 2>/dev/null)" || src=""
@@ -1425,7 +1425,10 @@ sync_one_torch_lib() {
       warn "${name} unresolved under ${rocm_lib_dir}"
       return 1
     fi
-    cmp -s "$src" "${torch_lib_dir}/${name}" || pending="${pending:+${pending} }${name}"
+    if [ ! -L "${torch_lib_dir}/${name}" ] \
+        || [ "$(readlink -f "${torch_lib_dir}/${name}" 2>/dev/null)" != "$src" ]; then
+      pending="${pending:+${pending} }${name}"
+    fi
   done
   if [ -z "$pending" ] && _torch_soname_aliases_ok "$torch_lib_dir" "$rocm_lib_dir"; then
     log "torch profiler libs already in sync (${torch_lib_dir})"
@@ -1433,7 +1436,7 @@ sync_one_torch_lib() {
   fi
 
   if [ "$CHECK_ONLY" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then
-    log "would sync ${pending:-<no file changes>} from ${rocm_lib_dir} into ${torch_lib_dir}"
+    log "would link ${pending:-<no file changes>} from ${rocm_lib_dir} into ${torch_lib_dir}"
     log "would link versioned soname aliases in ${torch_lib_dir}"
     return 0
   fi
@@ -1441,16 +1444,14 @@ sync_one_torch_lib() {
   ensure_torch_lib_backup "$backup_dir" "$torch_lib_dir" "$rocm_lib_dir" \
     || { warn "cannot back up ${torch_lib_dir}"; return 1; }
 
-  [ -n "$pending" ] && log "syncing ${pending} into torch lib (${torch_lib_dir})"
+  [ -n "$pending" ] && log "linking ${pending} into torch lib (${torch_lib_dir})"
   for name in $pending; do
     src="$(readlink -f "${rocm_lib_dir}/${name}")"
     dst="${torch_lib_dir}/${name}"
-    tmp="${torch_lib_dir}/.${name}.hotfix-tmp.$$"
-    mode=0644
-    [ -e "$dst" ] && mode="$(stat -c '%a' "$dst")"
-    if ! cp -f "$src" "$tmp" || ! chmod "$mode" "$tmp" || ! mv -f "$tmp" "$dst"; then
-      rm -f "$tmp"
-      warn "failed to write ${dst}"
+    # Link rather than copy: a byte-identical copy is a second inode, so glibc
+    # maps both it and the ROCm original and each gets its own HIP runtime.
+    if ! ln -sfnT "$src" "$dst"; then
+      warn "failed to link ${dst} -> ${src}"
       restore_torch_libs "$backup_dir" "$torch_lib_dir" \
         || die "cannot restore ${torch_lib_dir} from ${backup_dir}"
       return 1

--- a/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
+++ b/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
@@ -124,7 +124,7 @@ Env overrides honored: REPO_ROOT,
 USER_DATA_PATH, HYPERLOOM_DEPS_ROOT / HYPERLOOM_CACHE_DIR,
 PYTHON, INFERENCE_OPTIMIZER_FORCE_PYTHON,
 SGLANG_REPO, SGLANG_REF, SGLANG_ROOT, SGLANG_ROCM_PYPI_VERSION,
-SGLANG_ROCM_EXTRA, AITER_REPO, AITER_REF, AITER_ROOT, ROCM_PATH, HIP_PATH,
+SGLANG_ROCM_EXTRA, SGLANG_BUILD_RUST_EXTS, AITER_REPO, AITER_REF, AITER_ROOT, ROCM_PATH, HIP_PATH,
 LD_LIBRARY_PATH, VLLM_VERSION, VLLM_ROCM_VARIANT, VLLM_ROCM_INDEX,
 VLLM_VENV_ROOT, HYPERLOOM_WHEEL_REPO, HYPERLOOM_WHEEL_TAG.
 EOF
@@ -552,6 +552,9 @@ install_sglang_from_source() {
   fi
   constraint_file="$(mktemp)"
   write_rocm_torch_constraints "$py" "$constraint_file"
+  # ROCm editable installs only need multimodal Rust crates for VLM serving.
+  export SGLANG_BUILD_RUST_EXTS="${SGLANG_BUILD_RUST_EXTS:-none}"
+  log "SGLANG_BUILD_RUST_EXTS=${SGLANG_BUILD_RUST_EXTS}"
   "$py" -m pip install --constraint "$constraint_file" -e "${sglang_root}/python[srt_hip]"
   rm -f "$constraint_file"
 }
@@ -689,6 +692,7 @@ PY
         log "would build in-tree ROCm kernel via setup_rocm.py after clone (sgl-kernel/ legacy or python/sglang/kernels/aot/ for v0.5.17+)"
       fi
       log "would install SGLang source with [srt_hip] runtime dependencies under current torch/triton constraints"
+      log "would set SGLANG_BUILD_RUST_EXTS=${SGLANG_BUILD_RUST_EXTS:-none} (editable install; override to build multimodal Rust crates)"
     fi
     if [ -n "$AITER_REF" ]; then
       log "would clone/update ${AITER_REPO}@${AITER_REF} at ${aiter_root} and install it with current torch/triton constraints"

--- a/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
+++ b/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
@@ -31,6 +31,8 @@ HYPERLOOM_WHEEL_REPO="${HYPERLOOM_WHEEL_REPO:-AMD-AGI/Hyperloom}"
 HYPERLOOM_WHEEL_TAG="${HYPERLOOM_WHEEL_TAG:-v1.0.0b2}"
 ROCM_PROFILER_HOTFIX_TARGET_LIB_DIR="${ROCM_PROFILER_HOTFIX_TARGET_LIB_DIR:-/opt/rocm/lib}"
 ROCM_PROFILER_HOTFIX_ASSET="${ROCM_PROFILER_HOTFIX_ASSET:-rocm-profiler-hotfix-libs.tar.gz}"
+# Installed name must outrank the vendor library in ldconfig's ordering.
+ROCM_PROFILER_HOTFIX_SUFFIX="${ROCM_PROFILER_HOTFIX_SUFFIX:--hotfix}"
 
 DEFAULT_OPENAI_BASE_URL="${DEFAULT_OPENAI_BASE_URL:-https://your-openai-compatible-gateway.example.com/v1}"
 OPENAI_API_KEY_PLACEHOLDER="ak-your-api-key-here"
@@ -75,6 +77,7 @@ REQUIRE_FRAMEWORKS=0
 SKIP_BASE_CHECK=0
 DRY_RUN=0
 CHECK_ONLY=0
+VERIFY_HOTFIX_ONLY=0
 ASSUME_YES=0
 USER_DATA_PATH_ARG=""
 DEPS_ROOT_ARG=""
@@ -105,6 +108,8 @@ Options:
   --skip-base-check      Skip Phase 1 base preflight
   --check-only           Verify only; do not clone/install/mutate
   --dry-run              Print planned actions without cloning/installing/writing
+  --verify-hotfix        Re-check the ROCm profiler hotfix only; exits non-zero
+                         when the loader or torch/lib no longer resolves to it
   --yes, -y              Non-interactive; fail fast on missing credentials
   -h, --help             Show this help
 
@@ -159,6 +164,7 @@ while [ "$#" -gt 0 ]; do
     --skip-base-check)  SKIP_BASE_CHECK=1 ;;
     --check-only)       CHECK_ONLY=1 ;;
     --dry-run)          DRY_RUN=1 ;;
+    --verify-hotfix)    VERIFY_HOTFIX_ONLY=1 ;;
     --yes|-y)           ASSUME_YES=1 ;;
     -h|--help)          usage; exit 0 ;;
     *) echo "[install-baremetal] ERROR: unknown option '$1'" >&2; usage >&2; exit 2 ;;
@@ -226,7 +232,6 @@ resolve_installed_framework() {
   done
   return 0
 }
-
 
 python_venv_root() {
   local py="$1" bin_dir venv_dir
@@ -914,12 +919,6 @@ install_requested_framework() {
   esac
 }
 
-rocm_profiler_hotfix_applied() {
-  local target_dir="$1" hip_lib="$2" tracer_lib="$3"
-  [ "$(basename "$(readlink -f "${target_dir}/libamdhip64.so" 2>/dev/null || true)")" = "$hip_lib" ] \
-    && [ "$(basename "$(readlink -f "${target_dir}/libroctracer64.so" 2>/dev/null || true)")" = "$tracer_lib" ]
-}
-
 rocm_profiler_hotfix_compatible() {
   local py hip
   py="$(resolve_python 2>/dev/null)" || { warn "cannot resolve Python; skipping ROCm profiler hotfix"; return 1; }
@@ -956,6 +955,11 @@ PY
       *" sglang "*) log "container run with sglang; ROCm profiler hotfix is eligible" ;;
       *) warn "container run without sglang (found: ${found}); skipping ROCm profiler hotfix" ; return 1 ;;
     esac
+  else
+    case " ${found} " in
+      *" sglang "*) ;;
+      *) warn "bare-metal run without sglang (found: ${found}); applying the hotfix anyway, unlike the container path" ;;
+    esac
   fi
 }
 
@@ -990,75 +994,197 @@ download_rocm_profiler_hotfix_libs() {
   printf '%s\n' "$tmp_dir"
 }
 
-backup_rocm_profiler_hotfix_targets() {
-  local target_dir="$1" backup_dir="$2" path real
-  install -d "$backup_dir"
+# The loader looks up the versioned SONAME, not the plain file name.
+_soname_of() {
+  local f="$1" s=""
+  [ -f "$f" ] || return 1
+  if command -v readelf >/dev/null 2>&1; then
+    s="$(readelf -d "$f" 2>/dev/null | sed -n 's/.*SONAME.*\[\(.*\)\].*/\1/p' | head -n 1)"
+  fi
+  if [ -z "$s" ] && command -v objdump >/dev/null 2>&1; then
+    s="$(objdump -p "$f" 2>/dev/null | awk '/SONAME/ {print $2; exit}')"
+  fi
+  [ -n "$s" ] || return 1
+  printf '%s\n' "$s"
+}
+
+# Base is the highest-versioned non-hotfix file, i.e. the vendor library. Reading
+# it from the soname link instead would rank against an already-installed hotfix.
+_hotfix_installed_name() {
+  local target_dir="$1" soname="$2" asset="$3" base tail
+  base="$(find "$target_dir" -maxdepth 1 -type f -name "${soname}.*" -printf '%f\n' 2>/dev/null \
+    | grep -v -- "$ROCM_PROFILER_HOTFIX_SUFFIX" | sort -V | tail -n 1)"
+  [ -n "$base" ] || return 1
+  tail="$(basename "$asset")"
+  printf '%s%s.%s\n' "$base" "$ROCM_PROFILER_HOTFIX_SUFFIX" "${tail#"${soname%%.so.*}.so."}"
+}
+
+install_rocm_profiler_hotfix_ranked() {
+  local source_dir="$1" target_dir="$2" hip_lib="$3" tracer_lib="$4"
+  local name soname installed unversioned
+
+  for name in "$hip_lib" "$tracer_lib"; do
+    soname="$(_soname_of "${source_dir}/${name}")" \
+      || { warn "cannot read SONAME of ${name}"; return 1; }
+    installed="$(_hotfix_installed_name "$target_dir" "$soname" "${source_dir}/${name}")" \
+      || { warn "cannot derive a ranked name for ${soname}"; return 1; }
+    log "installing ${name} as ${installed}"
+    install -m 0644 "${source_dir}/${name}" "${target_dir}/${installed}" || return 1
+    unversioned="${soname%%.so.*}.so"
+    ln -sfnT "$installed" "${target_dir}/${soname}" || return 1
+    ln -sfnT "$soname" "${target_dir}/${unversioned}" || return 1
+  done
+  command -v ldconfig >/dev/null 2>&1 && { ldconfig || return 1; }
+  return 0
+}
+
+rocm_profiler_hotfix_ranked_applied() {
+  local target_dir="$1" source_dir="$2" hip_lib="$3" tracer_lib="$4"
+  local name soname resolved expected
+  for name in "$hip_lib" "$tracer_lib"; do
+    soname="$(_soname_of "${source_dir}/${name}")" || return 1
+    expected="$(_hotfix_installed_name "$target_dir" "$soname" "${source_dir}/${name}")" || return 1
+    resolved="$(readlink -f "${target_dir}/${soname}" 2>/dev/null || true)"
+    [ "$(basename "$resolved")" = "$expected" ] || return 1
+    cmp -s "${source_dir}/${name}" "$resolved" || return 1
+  done
+}
+
+backup_rocm_profiler_hotfix_links() {
+  local target_dir="$1" backup_dir="$2" path
+  install -d "$backup_dir" || return 1
   for path in \
     "${target_dir}/libamdhip64.so" \
     "${target_dir}/libamdhip64.so.7" \
     "${target_dir}/libroctracer64.so" \
     "${target_dir}/libroctracer64.so.4"; do
     [ -e "$path" ] || [ -L "$path" ] || continue
-    cp -a "$path" "$backup_dir"/
-    real="$(readlink -f "$path" 2>/dev/null || true)"
-    if [ -n "$real" ] && [ -e "$real" ]; then
-      cp -a "$real" "$backup_dir"/
-    fi
+    cp -a "$path" "$backup_dir"/ || return 1
   done
 }
 
-install_rocm_profiler_hotfix_libs() {
-  local source_dir="$1" target_dir="$2" hip_lib="$3" tracer_lib="$4"
-  install -m 0644 "${source_dir}/${hip_lib}" "${target_dir}/${hip_lib}" || return 1
-  install -m 0644 "${source_dir}/${tracer_lib}" "${target_dir}/${tracer_lib}" || return 1
-  ln -sfnT "$hip_lib" "${target_dir}/libamdhip64.so.7" || return 1
-  ln -sfnT libamdhip64.so.7 "${target_dir}/libamdhip64.so" || return 1
-  ln -sfnT "$tracer_lib" "${target_dir}/libroctracer64.so.4" || return 1
-  ln -sfnT libroctracer64.so.4 "${target_dir}/libroctracer64.so" || return 1
-}
-
-rollback_rocm_profiler_hotfix_targets() {
-  local backup_dir="$1" target_dir="$2"
+rollback_rocm_profiler_hotfix_ranked() {
+  local backup_dir="$1" target_dir="$2" path
   [ -d "$backup_dir" ] || return 1
-  if compgen -G "${backup_dir}/libamdhip64.so*" >/dev/null; then
-    cp -a "${backup_dir}"/libamdhip64.so* "$target_dir"/ || return 1
-  fi
-  if compgen -G "${backup_dir}/libroctracer64.so*" >/dev/null; then
-    cp -a "${backup_dir}"/libroctracer64.so* "$target_dir"/ || return 1
-  fi
+  for path in "${target_dir}"/*"${ROCM_PROFILER_HOTFIX_SUFFIX}"*; do
+    [ -e "$path" ] && rm -f "$path"
+  done
+  cp -a "${backup_dir}"/. "$target_dir"/ || return 1
+  command -v ldconfig >/dev/null 2>&1 && { ldconfig || return 1; }
   return 0
 }
 
-verify_rocm_profiler_hotfix() {
-  local target_dir="$1" hip_lib="$2" tracer_lib="$3" py
-  log "verifying ROCm profiler hotfix links"
-  ls -l "${target_dir}/libamdhip64.so" "${target_dir}/libamdhip64.so.7" \
-        "${target_dir}/libroctracer64.so" "${target_dir}/libroctracer64.so.4" || return 1
-  [ "$(basename "$(readlink -f "${target_dir}/libamdhip64.so")")" = "$hip_lib" ] \
-    || { warn "libamdhip64.so does not point to ${hip_lib}"; return 1; }
-  [ "$(basename "$(readlink -f "${target_dir}/libroctracer64.so")")" = "$tracer_lib" ] \
-    || { warn "libroctracer64.so does not point to ${tracer_lib}"; return 1; }
+# Compares content, not paths: /opt/rocm is itself a symlink.
+verify_rocm_profiler_hotfix_links() {
+  local target_dir="$1" source_dir="$2" hip_lib="$3" tracer_lib="$4"
+  local name soname resolved py args=""
+
+  log "verifying ROCm profiler hotfix links in ${target_dir}"
+  for name in "$hip_lib" "$tracer_lib"; do
+    soname="$(_soname_of "${source_dir}/${name}")" || { warn "cannot read SONAME of ${name}"; return 1; }
+    resolved="$(readlink -f "${target_dir}/${soname}" 2>/dev/null || true)"
+    log "${soname} -> ${resolved:-<unresolved>}"
+    cmp -s "${source_dir}/${name}" "$resolved" \
+      || { warn "${soname} does not resolve to the hotfix build"; return 1; }
+    log "ldconfig: $(ldconfig -p 2>/dev/null | awk -v s="$soname" '$1 == s {print $NF; exit}')"
+    args="${args:+${args} }${soname}=${source_dir}/${name}"
+  done
 
   py="$(resolve_python)" || return 1
-  "$py" - "$target_dir" <<'PY'
+  # shellcheck disable=SC2086
+  "$py" - $args <<'PY'
 import ctypes
-import os
+import hashlib
+import pathlib
 import sys
 
-target_dir = sys.argv[1]
-for name in ("libamdhip64.so", "libroctracer64.so"):
-    path = os.path.join(target_dir, name)
-    print(f"{path} -> {os.path.realpath(path)}")
-    ctypes.CDLL(path)
-    print(f"loaded: {path}")
+wanted = dict(arg.split("=", 1) for arg in sys.argv[1:])
+digests = {
+    soname: hashlib.sha256(pathlib.Path(ref).read_bytes()).hexdigest()
+    for soname, ref in wanted.items()
+}
+for soname in wanted:
+    ctypes.CDLL(soname)
+    print(f"loaded by soname: {soname}")
 
-import torch
+stems = {soname.split(".so")[0]: soname for soname in wanted}
+mapped = {}
+with open("/proc/self/maps", encoding="utf-8") as fh:
+    for line in fh:
+        path = line.rstrip("\n").rsplit(" ", 1)[-1]
+        if not path.startswith("/"):
+            continue
+        base = path.rsplit("/", 1)[-1]
+        for stem, soname in stems.items():
+            if base.startswith(stem):
+                mapped.setdefault(soname, path)
 
-hip = getattr(torch.version, "hip", None)
-print(f"torch.version.hip={hip}")
-if not hip:
-    raise SystemExit("torch.version.hip is empty after ROCm profiler hotfix")
+failed = []
+for soname, path in mapped.items():
+    got = hashlib.sha256(pathlib.Path(path).read_bytes()).hexdigest()
+    ok = got == digests[soname]
+    print(f"{soname}: mapped {path} -> {'hotfix' if ok else 'NOT the hotfix'}")
+    if not ok:
+        failed.append(soname)
+missing = sorted(set(wanted) - set(mapped))
+if missing:
+    print("not mapped: " + ", ".join(missing))
+if failed:
+    raise SystemExit("the loader picked a non-hotfix library: " + ", ".join(failed))
 PY
+}
+
+# Confirms which profiler libs the framework interpreter actually mapped.
+verify_rocm_profiler_hotfix_loaded() {
+  local source_dir="$1" hip_lib="$2" tracer_lib="$3"
+  local default_py pairs py torch_dir rc=0
+
+  default_py="$(resolve_python)" || return 1
+  pairs="$(collect_framework_torch_lib_dirs "$default_py")"
+  [ -n "$pairs" ] || { log "no framework torch/lib to check"; return 0; }
+
+  while IFS="$(printf '\t')" read -r py torch_dir; do
+    log "checking mapped profiler libs for ${py}"
+    "$py" - "${source_dir}/${hip_lib}" "${source_dir}/${tracer_lib}" <<'PY' || rc=1
+import hashlib
+import pathlib
+import sys
+
+refs = [pathlib.Path(p) for p in sys.argv[1:]]
+expected = {}
+for ref in refs:
+    stem = ref.name.split(".so")[0]
+    expected[stem] = hashlib.sha256(ref.read_bytes()).hexdigest()
+
+import torch  # noqa: E402
+
+torch.zeros(1)
+mapped = {}
+with open("/proc/self/maps", encoding="utf-8") as fh:
+    for line in fh:
+        path = line.rstrip("\n").rsplit(" ", 1)[-1]
+        if not path.startswith("/"):
+            continue
+        name = path.rsplit("/", 1)[-1]
+        for stem in expected:
+            if name.startswith(stem):
+                mapped.setdefault(stem, path)
+
+failed = []
+for stem, want in expected.items():
+    path = mapped.get(stem)
+    if path is None:
+        print(f"{stem}: not mapped (framework may load it lazily)")
+        continue
+    got = hashlib.sha256(pathlib.Path(path).read_bytes()).hexdigest()
+    print(f"{stem}: {path} -> {'hotfix' if got == want else 'NOT the hotfix'}")
+    if got != want:
+        failed.append(stem)
+if failed:
+    raise SystemExit("mapped profiler libs are not the hotfix: " + ", ".join(failed))
+PY
+  done <<< "$pairs"
+  return "$rc"
 }
 
 resolve_torch_lib_dir() {
@@ -1079,6 +1205,7 @@ ROCM_PROFILER_HOTFIX_TORCH_LIBS="libamdhip64.so libroctracer64.so"
 ROCM_PROFILER_HOTFIX_SYNC_FRAMEWORKS="sglang vllm"
 ROCM_PROFILER_HOTFIX_TORCH_BACKUP_DIR=".profiler_hotfix_backup"
 ROCM_PROFILER_HOTFIX_FINGERPRINT=".fingerprint"
+ROCM_PROFILER_HOTFIX_SONAME_MARKER=".hotfix_soname_links"
 
 _sha256_file() {
   local f="$1"
@@ -1233,6 +1360,56 @@ restore_torch_libs() {
   done
 }
 
+# torch/lib is outside every ldconfig search path, so aliases here survive apt.
+link_torch_soname_aliases() {
+  local torch_lib_dir="$1" src_dir="$2"
+  local backup_dir="${torch_lib_dir}/${ROCM_PROFILER_HOTFIX_TORCH_BACKUP_DIR}"
+  local marker="${backup_dir}/${ROCM_PROFILER_HOTFIX_SONAME_MARKER}"
+  local name src soname target
+
+  for name in $ROCM_PROFILER_HOTFIX_TORCH_LIBS; do
+    src="$(readlink -f "${src_dir}/${name}" 2>/dev/null)" || src=""
+    [ -f "$src" ] || continue
+    soname="$(_soname_of "$src")" || continue
+    [ "$soname" = "$name" ] && continue
+    target="${torch_lib_dir}/${soname}"
+    install -d "$backup_dir" || return 1
+    # A real file here was shipped by torch; keep it before shadowing.
+    if [ -e "$target" ] && [ ! -L "$target" ] && [ ! -e "${backup_dir}/${soname}" ]; then
+      cp -a "$target" "${backup_dir}/${soname}" || return 1
+    fi
+    ln -sfnT "$name" "$target" || return 1
+    grep -qxF "$soname" "$marker" 2>/dev/null || printf '%s\n' "$soname" >> "$marker"
+    log "torch soname alias ${soname} -> ${name} (${torch_lib_dir})"
+  done
+}
+
+_torch_soname_aliases_ok() {
+  local torch_lib_dir="$1" src_dir="$2" name src soname
+  for name in $ROCM_PROFILER_HOTFIX_TORCH_LIBS; do
+    src="$(readlink -f "${src_dir}/${name}" 2>/dev/null)" || src=""
+    [ -f "$src" ] || continue
+    soname="$(_soname_of "$src")" || continue
+    [ "$soname" = "$name" ] && continue
+    [ "$(readlink "${torch_lib_dir}/${soname}" 2>/dev/null || true)" = "$name" ] || return 1
+  done
+}
+
+restore_torch_soname_aliases() {
+  local backup_dir="$1" torch_lib_dir="$2"
+  local marker="${backup_dir}/${ROCM_PROFILER_HOTFIX_SONAME_MARKER}" soname
+  [ -f "$marker" ] || return 0
+  while read -r soname; do
+    [ -n "$soname" ] || continue
+    if [ -e "${backup_dir}/${soname}" ]; then
+      cp -a "${backup_dir}/${soname}" "${torch_lib_dir}/${soname}" || return 1
+    else
+      rm -f "${torch_lib_dir}/${soname}" || return 1
+    fi
+  done < "$marker"
+  rm -f "$marker"
+}
+
 sync_one_torch_lib() {
   local rocm_lib_dir="$1" py="$2" torch_lib_dir="$3"
   local backup_dir="${torch_lib_dir}/${ROCM_PROFILER_HOTFIX_TORCH_BACKUP_DIR}"
@@ -1240,20 +1417,31 @@ sync_one_torch_lib() {
 
   for name in $ROCM_PROFILER_HOTFIX_TORCH_LIBS; do
     src="$(readlink -f "${rocm_lib_dir}/${name}" 2>/dev/null)" || src=""
-    [ -f "$src" ] || { warn "${name} unresolved under ${rocm_lib_dir}"; return 1; }
+    if [ ! -f "$src" ]; then
+      if [ "$CHECK_ONLY" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then
+        log "${name} not installed under ${rocm_lib_dir} yet; nothing to sync in this mode"
+        return 0
+      fi
+      warn "${name} unresolved under ${rocm_lib_dir}"
+      return 1
+    fi
     cmp -s "$src" "${torch_lib_dir}/${name}" || pending="${pending:+${pending} }${name}"
   done
-  [ -n "$pending" ] || { log "torch profiler libs already in sync (${torch_lib_dir})"; return 0; }
+  if [ -z "$pending" ] && _torch_soname_aliases_ok "$torch_lib_dir" "$rocm_lib_dir"; then
+    log "torch profiler libs already in sync (${torch_lib_dir})"
+    return 0
+  fi
 
   if [ "$CHECK_ONLY" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then
-    log "would sync ${pending} from ${rocm_lib_dir} into ${torch_lib_dir}"
+    log "would sync ${pending:-<no file changes>} from ${rocm_lib_dir} into ${torch_lib_dir}"
+    log "would link versioned soname aliases in ${torch_lib_dir}"
     return 0
   fi
 
   ensure_torch_lib_backup "$backup_dir" "$torch_lib_dir" "$rocm_lib_dir" \
     || { warn "cannot back up ${torch_lib_dir}"; return 1; }
 
-  log "syncing ${pending} into torch lib (${torch_lib_dir})"
+  [ -n "$pending" ] && log "syncing ${pending} into torch lib (${torch_lib_dir})"
   for name in $pending; do
     src="$(readlink -f "${rocm_lib_dir}/${name}")"
     dst="${torch_lib_dir}/${name}"
@@ -1269,8 +1457,17 @@ sync_one_torch_lib() {
     fi
   done
 
+  link_torch_soname_aliases "$torch_lib_dir" "$rocm_lib_dir" || {
+    warn "failed to link soname aliases in ${torch_lib_dir}"
+    restore_torch_soname_aliases "$backup_dir" "$torch_lib_dir" || true
+    restore_torch_libs "$backup_dir" "$torch_lib_dir" \
+      || die "cannot restore ${torch_lib_dir} from ${backup_dir}"
+    return 1
+  }
+
   if ! verify_torch_runtime "$py"; then
     warn "torch did not come up after the sync; restoring ${torch_lib_dir}"
+    restore_torch_soname_aliases "$backup_dir" "$torch_lib_dir" || true
     restore_torch_libs "$backup_dir" "$torch_lib_dir" \
       || die "cannot restore ${torch_lib_dir} from ${backup_dir}"
     for name in $ROCM_PROFILER_HOTFIX_TORCH_LIBS; do
@@ -1285,7 +1482,7 @@ sync_one_torch_lib() {
   log "torch profiler libs synced into ${torch_lib_dir}"
 }
 
-# torch loads profiler libs from its bundled torch/lib (DT_RPATH=$ORIGIN).
+# torch searches its bundled torch/lib first, but only for the versioned soname.
 sync_rocm_profiler_libs_to_torch_lib() {
   local rocm_lib_dir="${1:-${ROCM_PROFILER_HOTFIX_TARGET_LIB_DIR}}"
   local default_py pairs py dir rc=0
@@ -1321,6 +1518,8 @@ verify_rocm_profiler_torch_lib_sync() {
       [ -f "$src" ] || continue
       cmp -s "$src" "${dir}/${name}" || { warn "torch ${name} differs in ${dir}"; rc=1; }
     done
+    _torch_soname_aliases_ok "$dir" "$rocm_lib_dir" \
+      || { warn "versioned soname aliases missing in ${dir}"; rc=1; }
   done <<< "$pairs"
   return "$rc"
 }
@@ -1356,8 +1555,8 @@ apply_rocm_profiler_hotfix() {
 
   if [ "$DRY_RUN" -eq 1 ]; then
     log "would download ${ROCM_PROFILER_HOTFIX_ASSET} from ${HYPERLOOM_WHEEL_REPO}@${HYPERLOOM_WHEEL_TAG}"
-    log "would back up current ROCm libraries under ${target_dir}/.profiler_hotfix_backup_<timestamp>"
-    log "would install hotfix libraries and update /opt/rocm libamdhip64/libroctracer64 symlinks"
+    log "would back up current ROCm profiler links under ${target_dir}/.profiler_hotfix_backup_<timestamp>"
+    log "would install the hotfix as <current version>${ROCM_PROFILER_HOTFIX_SUFFIX} and run ldconfig"
     sync_torch_profiler_libs "$target_dir" || true
     return 0
   fi
@@ -1366,20 +1565,25 @@ apply_rocm_profiler_hotfix() {
     || { warn "could not obtain ROCm profiler hotfix libraries; skipping"; return 0; }
   hip_lib="$(basename "$(find "$extract_dir" -maxdepth 1 -type f -name 'libamdhip64.so.*' | sort | tail -n 1)")"
   tracer_lib="$(basename "$(find "$extract_dir" -maxdepth 1 -type f -name 'libroctracer64.so.*' | sort | tail -n 1)")"
-  if rocm_profiler_hotfix_applied "$target_dir" "$hip_lib" "$tracer_lib"; then
+  if rocm_profiler_hotfix_ranked_applied "$target_dir" "$extract_dir" "$hip_lib" "$tracer_lib"; then
     log "ROCm profiler hotfix already applied (${hip_lib}, ${tracer_lib})"
-    verify_rocm_profiler_hotfix "$target_dir" "$hip_lib" "$tracer_lib" || warn "existing ROCm profiler hotfix verification reported issues"
+    verify_rocm_profiler_hotfix_links "$target_dir" "$extract_dir" "$hip_lib" "$tracer_lib" \
+      || warn "existing ROCm profiler hotfix verification reported issues"
     sync_torch_profiler_libs "$target_dir" 1 || true
+    verify_rocm_profiler_hotfix_loaded "$extract_dir" "$hip_lib" "$tracer_lib" \
+      || warn "mapped profiler libs are not the hotfix"
     rm -rf "$extract_dir"
     return 0
   fi
+
   backup_dir="${target_dir}/.profiler_hotfix_backup_$(date -u +%Y%m%dT%H%M%SZ)"
-  backup_rocm_profiler_hotfix_targets "$target_dir" "$backup_dir"
-  log "backed up current ROCm profiler libraries to ${backup_dir}"
-  if ! install_rocm_profiler_hotfix_libs "$extract_dir" "$target_dir" "$hip_lib" "$tracer_lib" \
-     || ! verify_rocm_profiler_hotfix "$target_dir" "$hip_lib" "$tracer_lib"; then
+  backup_rocm_profiler_hotfix_links "$target_dir" "$backup_dir" \
+    || { rm -rf "$extract_dir"; die "cannot back up ${target_dir} profiler links"; }
+  log "backed up current ROCm profiler links to ${backup_dir}"
+  if ! install_rocm_profiler_hotfix_ranked "$extract_dir" "$target_dir" "$hip_lib" "$tracer_lib" \
+     || ! verify_rocm_profiler_hotfix_links "$target_dir" "$extract_dir" "$hip_lib" "$tracer_lib"; then
     warn "ROCm profiler hotfix failed; attempting rollback from ${backup_dir}"
-    if rollback_rocm_profiler_hotfix_targets "$backup_dir" "$target_dir"; then
+    if rollback_rocm_profiler_hotfix_ranked "$backup_dir" "$target_dir"; then
       warn "rollback succeeded; continuing without ROCm profiler hotfix"
       rm -rf "$extract_dir"
       return 0
@@ -1387,12 +1591,38 @@ apply_rocm_profiler_hotfix() {
     rm -rf "$extract_dir"
     die "ROCm profiler hotfix failed and rollback did not complete"
   fi
-  rm -rf "$extract_dir"
   if sync_torch_profiler_libs "$target_dir"; then
     log "ROCm profiler hotfix applied"
   else
-    warn "ROCm profiler hotfix partially applied (/opt/rocm overlay only; torch/lib sync failed)"
+    warn "ROCm profiler hotfix partially applied (ROCm links only; torch/lib sync failed)"
   fi
+  verify_rocm_profiler_hotfix_loaded "$extract_dir" "$hip_lib" "$tracer_lib" \
+    || warn "mapped profiler libs are not the hotfix; profiling runs on the vendor libraries"
+  rm -rf "$extract_dir"
+}
+
+verify_rocm_profiler_hotfix_only() {
+  local target_dir="${ROCM_PROFILER_HOTFIX_TARGET_LIB_DIR}" hip_lib tracer_lib rc=0
+
+  log "verifying ROCm profiler hotfix state"
+  hip_lib="$(basename "$(find "$target_dir" -maxdepth 1 -type f \
+    -name "libamdhip64.so.*${ROCM_PROFILER_HOTFIX_SUFFIX}*" 2>/dev/null | sort -V | tail -n 1)")"
+  tracer_lib="$(basename "$(find "$target_dir" -maxdepth 1 -type f \
+    -name "libroctracer64.so.*${ROCM_PROFILER_HOTFIX_SUFFIX}*" 2>/dev/null | sort -V | tail -n 1)")"
+  if [ -z "$hip_lib" ] || [ -z "$tracer_lib" ]; then
+    warn "no ${ROCM_PROFILER_HOTFIX_SUFFIX} libraries under ${target_dir}; run setup without --verify-hotfix first"
+    return 1
+  fi
+
+  verify_rocm_profiler_hotfix_links "$target_dir" "$target_dir" "$hip_lib" "$tracer_lib" || rc=1
+  verify_rocm_profiler_torch_lib_sync "$target_dir" || rc=1
+  verify_rocm_profiler_hotfix_loaded "$target_dir" "$hip_lib" "$tracer_lib" || rc=1
+  if [ "$rc" -eq 0 ]; then
+    log "ROCm profiler hotfix verified"
+  else
+    warn "ROCm profiler hotfix verification failed; re-run setup to repair it"
+  fi
+  return "$rc"
 }
 
 # Re-read framework env persisted by a prior setup run so Phase 3 targets the
@@ -1842,6 +2072,11 @@ _default_workspace_root() {
   local py_for_env
   if py_for_env="$(resolve_python 2>/dev/null)"; then
     export_virtualenv_for_python "$py_for_env"
+  fi
+
+  if [ "$VERIFY_HOTFIX_ONLY" -eq 1 ]; then
+    verify_rocm_profiler_hotfix_only
+    return $?
   fi
 
   if [ "$SKIP_BASE_CHECK" -eq 1 ]; then

--- a/src/hyperloom/inference_optimizer/tests/test_geak_revalidation_dispatch.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_revalidation_dispatch.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from hyperloom.orchestrator.actions.executors._grid_runner import GridVariant
 from hyperloom.orchestrator.bus.message_bus import Message
 from hyperloom.orchestrator.phases import geak_rebench as gr
 from hyperloom.orchestrator.phases import machine_state as ps
@@ -216,6 +217,44 @@ async def test_enqueue_internal_stack_rebench_uses_macro_cycle_idempotency_key(
     row1 = await c.tasks.get(str(second["task_id"]))
     assert row1.idempotency_key == "geak-revalidate-c1"
     assert row1.task_id != row0.task_id
+
+
+@pytest.mark.asyncio
+async def test_expected_cfg_hash_matches_the_variant_the_executor_builds(
+    coordinator,
+) -> None:
+    """The pinned hash must describe the config the grid executor actually runs.
+
+    ``accepted_config`` carries PATH so the benchmark resolves its own
+    interpreter, but ``GridVariant`` drops shell/loader keys before it
+    fingerprints. Hashing the unfiltered mapping made the 2b identity check miss
+    on every GEAK win that shipped one, replaying a measured gain as
+    inconclusive.
+    """
+    c = coordinator
+    st = c.shared_state
+    st.baseline_tput = 100.0
+    st.macro_cycle = 0
+    st.geak_result = {
+        "status": "ok",
+        "accepted_config": {
+            "flags": "--fp8-gemm-backend aiter",
+            "env": "PATH=/opt/venv/bin:/usr/bin SGLANG_USE_AITER=1 TP=1",
+        },
+    }
+
+    enqueued = await c._enqueue_internal_stack_rebench(reason="geak_e2e_win")
+    row = await c.tasks.get(str(enqueued["task_id"]))
+    entry = row.params["grid"][0]
+    ran = GridVariant(
+        str(entry["name"]),
+        str(entry["extra_args"]),
+        dict(entry["extra_envs"]),
+    )
+
+    assert "PATH" not in ran.extra_envs
+    assert ran.extra_envs == {"SGLANG_USE_AITER": "1", "TP": "1"}
+    assert row.params["expected_cfg_hash"] == ran.fingerprint
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/inference_optimizer/tests/test_geak_revalidation_dispatch.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_revalidation_dispatch.py
@@ -257,6 +257,36 @@ async def test_expected_cfg_hash_matches_the_variant_the_executor_builds(
     assert row.params["expected_cfg_hash"] == ran.fingerprint
 
 
+def test_material_check_ignores_untrusted_env_names() -> None:
+    """An untrusted key on one side only must not read as a config difference.
+
+    ``accepted_config`` is a harness snapshot and carries PATH; ``current_best``
+    holds the executor-filtered mapping. Comparing them raw made every echoed
+    config look material, which is exactly the passthrough noise the gate exists
+    to reject.
+    """
+    from hyperloom.orchestrator.loop.coordinator_helpers import _geak_result_has_material
+
+    echoed = {
+        "status": "ok",
+        "accepted_config": {
+            "flags": "--fp8-gemm-backend aiter",
+            "env": "PATH=/opt/venv/bin SGLANG_USE_AITER=1",
+        },
+    }
+    assert not _geak_result_has_material(
+        echoed,
+        prev_best_flags="--fp8-gemm-backend aiter",
+        prev_best_envs={"SGLANG_USE_AITER": "1"},
+    )
+    # A real config delta still registers.
+    assert _geak_result_has_material(
+        echoed,
+        prev_best_flags="--fp8-gemm-backend triton",
+        prev_best_envs={"SGLANG_USE_AITER": "1"},
+    )
+
+
 @pytest.mark.asyncio
 async def test_rebench_can_be_rebuilt_after_cancel_within_same_cycle(coordinator) -> None:
     """A cancelled rebench must not block a fresh one in the same macro-cycle.

--- a/src/hyperloom/inference_optimizer/tests/test_policy_source_file_from_trace.py
+++ b/src/hyperloom/inference_optimizer/tests/test_policy_source_file_from_trace.py
@@ -151,3 +151,62 @@ def test_sentinel_pass_through_is_logged(tmp_path, monkeypatch, caplog):
     with caplog.at_level("INFO", logger="hyperloom.orchestrator.policy.gate"):
         _gate(tmp_path).validate_intent("orchestration", _dispatch_intent("Not found"))
     assert any("absent-value sentinel" in record.message and "Not found" in record.message for record in caplog.records)
+
+
+# A pip-installed framework has no checkout, so resolve_session_framework_root()
+# is empty and the join above never fires -- yet the frame's file really does sit
+# under an allowlist root. The package name is synthetic so a host that ships the
+# real package cannot make these pass for the wrong reason.
+INSTALLED_FRAME = "hlfixture_aiter/ops/gemm_op_a8w8.py"
+
+
+def _installed_package_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Model a pip install: an allowlisted package root and no checkout to name."""
+    root = tmp_path / "site-packages"
+    (root / "hlfixture_aiter" / "ops").mkdir(parents=True)
+    (root / "hlfixture_aiter" / "ops" / "gemm_op_a8w8.py").write_text(
+        "def gemm_a8w8_blockscale():\n    pass\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_FRAMEWORK_SOURCE_ROOTS", str(root))
+    monkeypatch.setenv("FRAMEWORK", "vllm")
+    for var in ("FRAMEWORK_REPO_PATH", "VLLM_REPO_PATH", "VLLM_DIR"):
+        monkeypatch.delenv(var, raising=False)
+    return root
+
+
+def test_relative_frame_under_an_installed_package_root_is_accepted(tmp_path, monkeypatch):
+    """The bare relative form a roofline row records for a pip-installed framework."""
+    _installed_package_root(tmp_path, monkeypatch)
+    _gate(tmp_path).validate_intent("orchestration", _dispatch_intent(INSTALLED_FRAME))
+
+
+def test_annotated_frame_under_an_installed_package_root_is_accepted(tmp_path, monkeypatch):
+    """Same frame carrying the trace's ``(line): function`` annotation."""
+    _installed_package_root(tmp_path, monkeypatch)
+    _gate(tmp_path).validate_intent(
+        "orchestration",
+        _dispatch_intent(f"{INSTALLED_FRAME}(214): gemm_a8w8_blockscale"),
+    )
+
+
+def test_relative_frame_absent_from_every_installed_root_is_denied(tmp_path, monkeypatch):
+    """Joining against a root is not a licence to admit paths that do not exist."""
+    _installed_package_root(tmp_path, monkeypatch)
+    with pytest.raises(PolicyDenied) as exc:
+        _gate(tmp_path).validate_intent(
+            "orchestration",
+            _dispatch_intent("hlfixture_aiter/ops/no_such_file.py"),
+        )
+    assert exc.value.rule == "source_file_outside_trusted_scope"
+
+
+def test_relative_traversal_out_of_an_installed_root_is_denied(tmp_path, monkeypatch):
+    """Resolving against installed roots must not become an escape hatch either."""
+    _installed_package_root(tmp_path, monkeypatch)
+    with pytest.raises(PolicyDenied) as exc:
+        _gate(tmp_path).validate_intent(
+            "orchestration",
+            _dispatch_intent("hlfixture_aiter/../../../../etc/passwd"),
+        )
+    assert exc.value.rule == "source_file_outside_trusted_scope"

--- a/src/hyperloom/inference_optimizer/tests/test_setup_cli.py
+++ b/src/hyperloom/inference_optimizer/tests/test_setup_cli.py
@@ -1486,7 +1486,8 @@ def test_hotfix_torch_lib_sync_refreshes_a_snapshot_after_a_torch_upgrade(tmp_pa
         tmp_path,
         body=(
             f"{_SYNC_BODY}\n"
-            # Stand in for `pip install -U torch`: fresh vendor bytes in place.
+            # Stand in for `pip install -U torch`: remove our symlinks, lay down fresh vendor bytes.
+            f'rm -f "{torch_lib}/libamdhip64.so" "{torch_lib}/libroctracer64.so"\n'
             f'printf vendor-hip-v2 > "{torch_lib}/libamdhip64.so"\n'
             f'printf vendor-tracer-v2 > "{torch_lib}/libroctracer64.so"\n'
             f"{_SYNC_BODY}"

--- a/src/hyperloom/inference_optimizer/tests/test_setup_cli.py
+++ b/src/hyperloom/inference_optimizer/tests/test_setup_cli.py
@@ -1346,6 +1346,37 @@ def _fake_rocm_lib(tmp_path: Path) -> Path:
     return rocm_lib
 
 
+_SONAME_MARKER = ".hotfix_soname_links"
+_FAKE_SONAMES = {
+    "libamdhip64": "libamdhip64.so.7",
+    "libroctracer64": "libroctracer64.so.4",
+}
+
+
+def _fake_elf_tools(tmp_path: Path, sonames: dict[str, str] = _FAKE_SONAMES) -> Path:
+    """A readelf/ldconfig stub so the fake libraries report a DT_SONAME.
+
+    Real hosts read the soname off an ELF header; the fixtures here are plain
+    files, so without this the soname half of the hotfix is silently skipped.
+    """
+    bin_dir = tmp_path / "fake-elf-tools"
+    bin_dir.mkdir(exist_ok=True)
+    cases = "\n".join(
+        f'  *{stem}*) printf "  0x0e (SONAME)  Library soname: [{soname}]\\n" ;;' for stem, soname in sonames.items()
+    )
+    readelf = bin_dir / "readelf"
+    readelf.write_text(
+        "\n".join(["#!/usr/bin/env bash", 'case "${!#}" in', cases, "esac", "exit 0"]) + "\n",
+        encoding="utf-8",
+    )
+    readelf.chmod(0o755)
+    # The real one needs root to rewrite /etc/ld.so.cache.
+    ldconfig = bin_dir / "ldconfig"
+    ldconfig.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    ldconfig.chmod(0o755)
+    return bin_dir
+
+
 def _drive_torch_lib_sync(
     tmp_path: Path,
     *,
@@ -1556,6 +1587,103 @@ def test_refresh_preserves_vendor_when_torch_still_carries_hotfix(tmp_path: Path
     assert not (backup / "libroctracer64.so").read_bytes().startswith(b"hotfix")
 
 
+def test_torch_lib_sync_links_versioned_soname_aliases(tmp_path: Path):
+    """torch resolves the versioned soname first, so copying the bytes under the
+    unversioned name alone left the profiler on the vendor library."""
+    bin_dir = _fake_elf_tools(tmp_path)
+    res, _rocm_lib, torch_lib = _drive_torch_lib_sync(
+        tmp_path,
+        body=_SYNC_BODY,
+        torch_hip=b"stock-hip-bytes",
+        torch_tracer=b"stock-tracer-bytes",
+        extra_lines=(f'export PATH="{bin_dir}:$PATH"',),
+    )
+
+    assert res.returncode == 0, res.stderr
+    assert os.readlink(torch_lib / "libamdhip64.so.7") == "libamdhip64.so"
+    assert os.readlink(torch_lib / "libroctracer64.so.4") == "libroctracer64.so"
+    assert (torch_lib / "libamdhip64.so").read_bytes() == b"hotfix-hip-bytes"
+    marker = torch_lib / _BACKUP_DIRNAME / _SONAME_MARKER
+    assert marker.read_text(encoding="utf-8").split() == [
+        "libamdhip64.so.7",
+        "libroctracer64.so.4",
+    ]
+
+
+def test_torch_lib_sync_relinks_a_soname_alias_that_went_missing(tmp_path: Path):
+    """Matching bytes are not enough to call the sync done: a pip reinstall can
+    drop the alias and leave the versioned lookup back on the vendor library."""
+    bin_dir = _fake_elf_tools(tmp_path)
+    alias = tmp_path / "torch" / "lib" / "libamdhip64.so.7"
+    res, _rocm_lib, torch_lib = _drive_torch_lib_sync(
+        tmp_path,
+        body=f'{_SYNC_BODY}\nrm -f "{alias}"\n{_SYNC_BODY}',
+        torch_hip=b"stock-hip-bytes",
+        torch_tracer=b"stock-tracer-bytes",
+        extra_lines=(f'export PATH="{bin_dir}:$PATH"',),
+    )
+
+    assert res.returncode == 0, res.stderr
+    assert "already in sync" not in res.stdout
+    assert os.readlink(torch_lib / "libamdhip64.so.7") == "libamdhip64.so"
+
+
+def test_torch_lib_sync_skips_a_second_run_once_aliases_exist(tmp_path: Path):
+    """Bytes and aliases both in place must be a no-op, not another swap."""
+    bin_dir = _fake_elf_tools(tmp_path)
+    res, _rocm_lib, _torch_lib = _drive_torch_lib_sync(
+        tmp_path,
+        body=f"{_SYNC_BODY}\n{_SYNC_BODY}",
+        torch_hip=b"stock-hip-bytes",
+        torch_tracer=b"stock-tracer-bytes",
+        extra_lines=(f'export PATH="{bin_dir}:$PATH"',),
+    )
+
+    assert res.returncode == 0, res.stderr
+    assert "already in sync" in res.stdout
+
+
+def test_runtime_failure_restores_a_real_vendor_soname_file(tmp_path: Path):
+    """A torch that ships a real file under the versioned name must get it back
+    byte for byte, not the symlink the sync put there."""
+    bin_dir = _fake_elf_tools(tmp_path)
+    vendor_alias = tmp_path / "torch" / "lib" / "libamdhip64.so.7"
+    res, _rocm_lib, torch_lib = _drive_torch_lib_sync(
+        tmp_path,
+        body=_SYNC_BODY_SOFT,
+        torch_hip=b"vendor-hip-bytes",
+        torch_tracer=b"vendor-tracer-bytes",
+        runtime_ok=False,
+        extra_lines=(
+            f'export PATH="{bin_dir}:$PATH"',
+            f'printf vendor-hip-7 > "{vendor_alias}"',
+        ),
+    )
+
+    assert "vendor libraries restored" in res.stderr
+    assert not vendor_alias.is_symlink()
+    assert vendor_alias.read_bytes() == b"vendor-hip-7"
+    assert (torch_lib / "libamdhip64.so").read_bytes() == b"vendor-hip-bytes"
+    assert not (torch_lib / _BACKUP_DIRNAME / _SONAME_MARKER).exists()
+
+
+def test_verify_hotfix_only_fails_when_no_hotfix_is_installed(tmp_path: Path):
+    """--verify-hotfix is a standalone check, so it has to report a bad state
+    instead of exiting clean on a host that never applied the hotfix."""
+    bin_dir = _fake_elf_tools(tmp_path)
+    res, _rocm_lib, _torch_lib = _drive_torch_lib_sync(
+        tmp_path,
+        body="verify_rocm_profiler_hotfix_only || echo VERIFY_REPORTED_FAILURE",
+        torch_hip=b"stock-hip-bytes",
+        torch_tracer=b"stock-tracer-bytes",
+        extra_lines=(f'export PATH="{bin_dir}:$PATH"',),
+    )
+
+    assert res.returncode == 0, res.stderr
+    assert "VERIFY_REPORTED_FAILURE" in res.stdout
+    assert "no -hotfix libraries" in res.stderr
+
+
 def test_sync_warns_when_framework_imports_but_torch_lib_is_missing(tmp_path: Path):
     install_script = Path(setup.__file__).resolve().parent / "assets" / "install_baremetal.sh"
     lib = _sourceable_installer(install_script, tmp_path)
@@ -1653,8 +1781,9 @@ def test_hotfix_phase_survives_a_failed_torch_lib_sync(tmp_path: Path):
                 f'resolve_python() {{ printf "%s" "{py}"; }}',
                 # Stand in for the /opt/rocm half, which needs a real download.
                 "rocm_profiler_hotfix_compatible() { return 0; }",
-                "rocm_profiler_hotfix_applied() { return 0; }",
-                "verify_rocm_profiler_hotfix() { return 0; }",
+                "rocm_profiler_hotfix_ranked_applied() { return 0; }",
+                "verify_rocm_profiler_hotfix_links() { return 0; }",
+                "verify_rocm_profiler_hotfix_loaded() { return 0; }",
                 f'download_rocm_profiler_hotfix_libs() {{ printf "%s" "{extract}"; }}',
                 "apply_rocm_profiler_hotfix",
                 "echo REACHED_NEXT_PHASE",
@@ -1852,10 +1981,11 @@ def test_hotfix_logs_partial_apply_when_torch_sync_fails(tmp_path: Path):
                 f'ROCM_PROFILER_HOTFIX_TARGET_LIB_DIR="{rocm_lib}"',
                 f'resolve_python() {{ printf "%s" "{py}"; }}',
                 "rocm_profiler_hotfix_compatible() { return 0; }",
-                "rocm_profiler_hotfix_applied() { return 1; }",
-                "verify_rocm_profiler_hotfix() { return 0; }",
-                "backup_rocm_profiler_hotfix_targets() { :; }",
-                "install_rocm_profiler_hotfix_libs() { return 0; }",
+                "rocm_profiler_hotfix_ranked_applied() { return 1; }",
+                "verify_rocm_profiler_hotfix_links() { return 0; }",
+                "verify_rocm_profiler_hotfix_loaded() { return 0; }",
+                "backup_rocm_profiler_hotfix_links() { :; }",
+                "install_rocm_profiler_hotfix_ranked() { return 0; }",
                 f'download_rocm_profiler_hotfix_libs() {{ printf "%s" "{extract}"; }}',
                 "apply_rocm_profiler_hotfix",
             ]

--- a/src/hyperloom/orchestrator/framework/paths.py
+++ b/src/hyperloom/orchestrator/framework/paths.py
@@ -824,12 +824,20 @@ def source_file_candidates(value: str) -> tuple[str, ...]:
     session's framework tree rather than the process CWD, or every citation is
     denied. Each candidate is still bounded by :func:`resolved_within`.
 
+    A pip-installed framework names no checkout, so
+    :func:`resolve_session_framework_root` is empty and that join never fires --
+    while the frame's file does sit under an allowlist root. Those roots are
+    tried too, but only where the join names a file that exists: a root is a
+    permission set, not evidence that the frame belongs to it, and admitting
+    every root would turn one unresolvable frame into a path in each of them.
+
     Args:
         value (str): The raw field value.
 
     Returns:
         tuple[str, ...]: ``value`` first, then the de-annotated form, then that
-            form resolved against the tree this session is optimizing.
+            form resolved against the tree this session is optimizing, then
+            against each allowlist root that holds the named file.
     """
     raw = str(value).strip()
     out: list[str] = [raw]
@@ -840,6 +848,16 @@ def source_file_candidates(value: str) -> tuple[str, ...]:
         root = resolve_session_framework_root()
         if root:
             out.append(str(Path(root) / bare))
+        for allow_root in resolve_source_file_allowlist():
+            joined = Path(allow_root) / bare
+            try:
+                exists = joined.is_file()
+            except OSError:
+                continue
+            if exists:
+                candidate = str(joined)
+                if candidate not in out:
+                    out.append(candidate)
     return tuple(out)
 
 

--- a/src/hyperloom/orchestrator/loop/coordinator_helpers.py
+++ b/src/hyperloom/orchestrator/loop/coordinator_helpers.py
@@ -20,6 +20,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from hyperloom.common.env_safety import filter_untrusted_env_mapping, is_allowed_variant_env_key
+
 from ..specialists.patch_safety import (
     ADVISE_VERDICT,
     advisory_only_reason_codes,
@@ -1110,6 +1112,30 @@ def _split_env_and_flags(env_str: str) -> tuple[dict[str, str], str]:
     return envs, " ".join(flag_tokens).strip()
 
 
+def _accepted_config_as_variant(cfg: Any) -> tuple[str, dict[str, str]]:
+    """Normalize a GEAK ``accepted_config`` into the ``(args, envs)`` a variant runs.
+
+    ``accepted_config.env`` is a benchmark-harness snapshot, so it carries the
+    shell/loader keys ``GridVariant`` drops before it fingerprints. Anything that
+    fingerprints or dispatches that config has to see the same mapping the
+    executor will, or the identity it derives describes a config nothing runs.
+
+    Args:
+        cfg: The ``accepted_config`` blob (``flags`` / ``env``); non-dict is empty.
+
+    Returns:
+        ``(flags, envs)`` with harness-only flags folded into ``flags`` and
+        untrusted env names dropped.
+    """
+    cfg = cfg if isinstance(cfg, dict) else {}
+    flags = str(cfg.get("flags") or "").strip()
+    envs, extra_flags = _split_env_and_flags(str(cfg.get("env") or ""))
+    if extra_flags:
+        flags = (flags + " " + extra_flags).strip()
+    envs, _dropped = filter_untrusted_env_mapping(envs, allow_predicate=is_allowed_variant_env_key)
+    return flags, envs
+
+
 def _geak_revalidation_decision(
     *,
     measured: Any,
@@ -1222,21 +1248,20 @@ def _geak_result_has_material(
         return True
     if str(result.get("final_patch") or "").strip():
         return True
-    accepted_cfg = result.get("accepted_config") or {}
-    accepted_flags = str(accepted_cfg.get("flags") or "").strip()
-    parsed_envs, extra_flags = _split_env_and_flags(str(accepted_cfg.get("env") or ""))
-    if extra_flags:
-        accepted_flags = (accepted_flags + " " + extra_flags).strip()
+    accepted_flags, parsed_envs = _accepted_config_as_variant(result.get("accepted_config"))
     # A missing / all-empty accepted_config carries no config optimization; a
     # bare fingerprint mismatch against a non-empty current_best is NOT material
     # (promoting it would wipe the existing config to empty).
     if not accepted_flags and not parsed_envs:
         return False
-    got_fp = canonical_fingerprint(accepted_flags, parsed_envs)
-    prev_fp = canonical_fingerprint(
-        str(prev_best_flags or ""),
+    # Both sides go through the same guard: a resume can hand current_best the
+    # raw accepted_config, and an untrusted key on one side only reads as a diff.
+    prev_envs, _dropped = filter_untrusted_env_mapping(
         dict(prev_best_envs or {}),
+        allow_predicate=is_allowed_variant_env_key,
     )
+    got_fp = canonical_fingerprint(accepted_flags, parsed_envs)
+    prev_fp = canonical_fingerprint(str(prev_best_flags or ""), prev_envs)
     return got_fp != prev_fp
 
 

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Mapping
 from hyperloom.common.coerce import to_float, to_str_list
-from hyperloom.common.env_safety import filter_untrusted_env_mapping, is_allowed_variant_env_key
 from hyperloom.common.io import append_jsonl
 from hyperloom.inference_optimizer.breakdown.agent_ownership import (
     patch_owner_phase,
@@ -38,6 +37,7 @@ from hyperloom.inference_optimizer.protocol.intent import Intent
 from ..bus.message_bus import Message
 from .coordinator_helpers import (
     _MIN_KERNEL_ENGAGED_GAIN_PCT,
+    _accepted_config_as_variant,
     _baseline_params_fingerprint,
     _dedupe_extra_server_args,
     _merge_cumulative_extra_server_args,
@@ -52,7 +52,6 @@ from .coordinator_helpers import (
     _geak_sweep_measured_tput,
     _normalize_geak_overlay_dir,
     _scrape_resolved_launch_flags,
-    _split_env_and_flags,
 )
 from ..policy.gate import (
     PolicyDenied,
@@ -5125,13 +5124,7 @@ class WritebackCollaborator:
         if ps_admissible and (ps_cfg.get("flags") or ps_cfg.get("env") or ps_overlay):
             from ..actions.executors._canonical_fingerprint import canonical_fingerprint
 
-            ps_flags = str(ps_cfg.get("flags") or "").strip()
-            ps_envs, _ps_extra_flags = _split_env_and_flags(str(ps_cfg.get("env") or ""))
-            if _ps_extra_flags:
-                ps_flags = (ps_flags + " " + _ps_extra_flags).strip()
-            # GridVariant drops shell/loader keys before it fingerprints, so drop
-            # them here as well or the pinned hash never matches what ran.
-            ps_envs, _ = filter_untrusted_env_mapping(ps_envs, allow_predicate=is_allowed_variant_env_key)
+            ps_flags, ps_envs = _accepted_config_as_variant(ps_cfg)
             # An overlay that cannot load installs nothing: the server launches
             # as plain baseline and any delta measured against it belongs to the
             # flags alone. Resolve that BEFORE dispatch so the task never carries

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Mapping
 from hyperloom.common.coerce import to_float, to_str_list
+from hyperloom.common.env_safety import filter_untrusted_env_mapping, is_allowed_variant_env_key
 from hyperloom.common.io import append_jsonl
 from hyperloom.inference_optimizer.breakdown.agent_ownership import (
     patch_owner_phase,
@@ -5128,6 +5129,9 @@ class WritebackCollaborator:
             ps_envs, _ps_extra_flags = _split_env_and_flags(str(ps_cfg.get("env") or ""))
             if _ps_extra_flags:
                 ps_flags = (ps_flags + " " + _ps_extra_flags).strip()
+            # GridVariant drops shell/loader keys before it fingerprints, so drop
+            # them here as well or the pinned hash never matches what ran.
+            ps_envs, _ = filter_untrusted_env_mapping(ps_envs, allow_predicate=is_allowed_variant_env_key)
             # An overlay that cannot load installs nothing: the server launches
             # as plain baseline and any delta measured against it belongs to the
             # flags alone. Resolve that BEFORE dispatch so the task never carries


### PR DESCRIPTION
## Problem

**1. The loader was never asked which library it actually picks.** `verify_rocm_profiler_hotfix` loaded the library by absolute path (`ctypes.CDLL("/opt/rocm/lib/libamdhip64.so")` ) and compared symlink basenames. Both succeed whether or not the dynamic linker would resolve the same file at runtime, so a host could report a healthy hotfix and still profile on the vendor library.

**2. The `/opt/rocm` install hardcoded the soname and could overwrite the vendor library.** It installed the asset under its own file name and then pointed hand-written `libamdhip64.so.7` / `libroctracer64.so.4` symlinks at it. If the asset and the vendor library carry the same version string, `install -m 0644` replaces the vendor file in place, and the backup is the only remaining copy. The `.so.7` / `.so.4` names are also assumptions rather than the sonames the libraries actually declare.

**3. `torch/lib` only received the unversioned name.** torch resolves the versioned `DT_SONAME` (`libamdhip64.so.7`) before the unversioned `libamdhip64.so`, so copying hotfix bytes to `libamdhip64.so` alone leaves the versioned lookup on whatever torch shipped.

There was also no way to re-check hotfix state on a host that already ran setup, short of re-running the whole installer.

## Fix

All changes are in `install_baremetal.sh`.

**Install ranked above the vendor library instead of over it.** `_soname_of` reads the real `DT_SONAME` (readelf, objdump fallback) rather than assuming `.so.7` / `.so.4`. `_hotfix_installed_name` takes the highest-versioned non-hotfix file in the target directory — the vendor library — and appends `-hotfix`, so ldconfig's version ordering ranks the hotfix above it and the vendor file is never written. Every symlink is derived from the declared soname.

**Verify what the loader resolves, not what the paths say.** `verify_rocm_profiler_hotfix_links` loads each library *by soname*, then reads `/proc/self/maps` and sha256-compares the mapped file against the hotfix asset. `verify_rocm_profiler_hotfix_loaded` repeats that check inside each framework interpreter after touching torch, which is the environment that actually profiles.

**Cover the versioned name in `torch/lib` too.** After the byte sync, `link_torch_soname_aliases` symlinks the versioned soname to the unversioned hotfix file. `torch/lib` sits outside every ldconfig search path, so an alias there survives a ROCm package update. A real file already occupying that name was shipped by torch and is copied into the backup before being shadowed; created aliases are recorded in `.profiler_hotfix_backup/.hotfix_soname_links` so restore knows exactly what to undo.

**Keep re-runs and rollback honest.** The sync is a no-op only when the bytes *and* the aliases match, so a pip reinstall that drops an alias is repaired rather than reported as already in sync. A failed runtime probe restores the vendor bytes and the aliases; a failed `/opt/rocm` install removes the `-hotfix` files and puts the saved links back.

**`--verify-hotfix`.** A standalone path (`verify_rocm_profiler_hotfix_only`) that checks the `/opt/rocm` ranked links, the `torch/lib` byte sync and aliases, and the framework-mapped libraries, then exits non-zero without running the rest of setup.

## Bug caught by the new tests

`restore_torch_soname_aliases` used `cp -a` onto a destination that is the alias symlink we installed, and cp writes *through* a symlink to its target. Restoring therefore left the alias in place and overwrote the unversioned file, permanently losing the real versioned file torch had shipped. The destination is now removed before the copy.

## Files

- `src/hyperloom/inference_optimizer/assets/install_baremetal.sh`
- `src/hyperloom/inference_optimizer/tests/test_setup_cli.py`

## Test plan

- [x] `pytest src/hyperloom/inference_optimizer/tests/test_setup_cli.py` — 77 passed
- [x] Repointed the hotfix-phase stubs at the ranked install helpers; the two failing tests were stubbing names this PR renamed, which let the real ranked path run against fixtures that have no ELF header
- [x] Added a `readelf`/`ldconfig` stub so the fixtures declare a soname — without it `_soname_of` failed silently and the entire soname half of the hotfix was untested
- [x] New coverage: alias creation and marker contents, relinking after an alias goes missing, idempotency with aliases in place, vendor restore on runtime failure, `--verify-hotfix` on a host with no hotfix
- [x] On-host validation on MI355X: `--verify-hotfix` passes after setup, and a `decode_only` trace still reports non-zero `num_gpu_events`
