### PR TITLE
Updating TraceLens SHA for SGLang 5.18 patches

### DIFF
--- a/src/hyperloom/agents/kernel/scripts/install.sh
+++ b/src/hyperloom/agents/kernel/scripts/install.sh
@@ -161,7 +161,7 @@ TRACELENS_REPO="https://github.com/AMD-AGI/TraceLens.git"
 # the matching release/hyperloom_integration_v1.0 branch of
 # AMD-AGI/TraceLens-internal, but Hyperloom keeps no pin/URL for it — the
 # operator supplies it via TRACELENS_INTERNAL_ROOT.
-TRACELENS_REF="171dd74721ca1ec45709e5805b68ae1f65e27811"
+TRACELENS_REF="14eb554fab0363d9d827727f642a5523f2a50fd7"
 # Operator override iff TRACELENS_ROOT points OUTSIDE the pod-local default.
 # The persistent kernel-agent env re-exports the resolved default path, so a
 # presence-only check (${VAR:+1}) would misclassify it as an override and skip

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -5997,7 +5997,7 @@ def run_command(
 # TRACELENS_REF). Overridable via env so a run can pin its own SHA.
 _TRACELENS_REPO_DEFAULT = "https://github.com/AMD-AGI/TraceLens.git"
 # Head of release/hyperloom_integration_v1.0.
-_TRACELENS_REF_DEFAULT = "171dd74721ca1ec45709e5805b68ae1f65e27811"
+_TRACELENS_REF_DEFAULT = "14eb554fab0363d9d827727f642a5523f2a50fd7"
 
 
 def _default_tracelens_root() -> Path:


### PR DESCRIPTION
- Description: what and why: Updating TraceLens SHA that includes SGLang 5.18 patches
- Linked issue(s): close/fix refs
- Tests: added/updated? commands run: Locally profiling tested on Qwen3 and DeepSeekR1
- Breaking changes: yes/no (details if yes)
