### PR TITLE
Trim the profiler-start transient before steady-state splitting

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -2126,8 +2126,13 @@ def test_127_splitter_cli_uses_positional_trace_path_and_find_steady_state(
 
 # Splitter must receive --R (from --split-r or $RANDOM_RANGE_RATIO) so mixed-window
 # selection uses the analytic PD ratio instead of an empirical heuristic.
-def _drive_main_capturing_subprocess(tmp_path, extra_argv, env_overrides=None):
-    """Helper: stage a TraceLens-ish tree, stub subprocess.run, drive tla.main() once, return captured argvs."""
+def _drive_main_capturing_subprocess(tmp_path, extra_argv, env_overrides=None, trace_factory=None):
+    """Helper: stage a TraceLens-ish tree, stub subprocess.run, drive tla.main() once, return captured argvs.
+
+    ``trace_factory`` builds the input trace from the staging directory when the
+    default single-kernel stub is not enough (for example a step-annotated trace
+    the pretrimmer can act on); it returns the path it wrote.
+    """
     import gzip
     import json as _json
     import os as _os
@@ -2141,16 +2146,19 @@ def _drive_main_capturing_subprocess(tmp_path, extra_argv, env_overrides=None):
     workspace.mkdir()
     capture = tmp_path / "capture_traces"
     capture.mkdir()
-    trace = tmp_path / "trace.json.gz"
-    with gzip.open(trace, "wt") as f:
-        _json.dump(
-            {
-                "traceEvents": [
-                    {"cat": "kernel", "name": "void some_real_kernel<...>", "dur": 5.0},
-                ]
-            },
-            f,
-        )
+    if trace_factory is not None:
+        trace = trace_factory(tmp_path)
+    else:
+        trace = tmp_path / "trace.json.gz"
+        with gzip.open(trace, "wt") as f:
+            _json.dump(
+                {
+                    "traceEvents": [
+                        {"cat": "kernel", "name": "void some_real_kernel<...>", "dur": 5.0},
+                    ]
+                },
+                f,
+            )
 
     captured: list[list[str]] = []
 
@@ -5443,12 +5451,29 @@ def test_graph_coverage_from_raw_trace_never_raises():
 # --- pretrim_startup_transient (#profiler-start transient) -------------------
 
 
-def _write_trace(path: Path, step_durs, *, step_us_gap=0.0, host_lead_us=30_000.0, extra_events=None):
+def _write_trace(
+    path: Path,
+    step_durs,
+    *,
+    step_us_gap=0.0,
+    host_lead_us=30_000.0,
+    phases=None,
+    unique_names=True,
+    omit_host_steps=(),
+    extra_events=None,
+):
     """Build a minimal torch-profiler trace with GPU step annotations.
 
     ``step_durs`` are microsecond durations laid end to end; each becomes one
-    ``step[DECODE bs=64]`` gpu_user_annotation plus a kernel inside it, so the
-    trimmer has both something to measure and something to drop.
+    ``step[<phase> ...]`` gpu_user_annotation, its host-side twin, and a kernel
+    inside it, so the trimmer has both something to measure and something to
+    drop. ``phases`` supplies a per-step phase token (default ``DECODE`` for
+    every step).
+
+    ``unique_names=False`` omits the per-step ``g_sk`` field, reproducing the
+    framework builds whose step annotations repeat verbatim; the two timelines
+    then cannot be paired by name. ``omit_host_steps`` drops the host-side
+    annotation for the given step indices.
     """
     # torch stamps metadata with the profiler-open ts, i.e. always before any
     # cut point -- reproduce that, it is what made a naive ts filter drop it.
@@ -5458,14 +5483,17 @@ def _write_trace(path: Path, step_durs, *, step_us_gap=0.0, host_lead_us=30_000.
     ]
     ts = 1_000_000.0
     for i, dur in enumerate(step_durs):
-        name = f"step[DECODE bs=64 g_sk={i}]"
+        phase = (phases or ["DECODE"] * len(step_durs))[i]
+        name = f"step[{phase} bs=64 g_sk={i}]" if unique_names else f"step[{phase} bs=64]"
         # The host runs a step ahead: step N's launches are issued while step
-        # N-1 still owns the GPU. Reproduce that offset -- it is what makes a
+        # N-1 still owns the GPU, so the lead is bounded by the *previous*
+        # step's duration. Reproduce that offset -- it is what makes a
         # single-timestamp cut unable to separate the two.
-        host_ts = ts - min(host_lead_us, dur) if i else ts - 1.0
-        events.append(
-            {"ph": "X", "cat": "user_annotation", "name": name, "pid": 1, "tid": 1, "ts": host_ts, "dur": 3.0}
-        )
+        host_ts = ts - min(host_lead_us, step_durs[i - 1]) if i else ts - 1.0
+        if i not in omit_host_steps:
+            events.append(
+                {"ph": "X", "cat": "user_annotation", "name": name, "pid": 1, "tid": 1, "ts": host_ts, "dur": 3.0}
+            )
         events.append(
             {"ph": "X", "cat": "cpu_op", "name": f"launch_{i}", "pid": 1, "tid": 1, "ts": host_ts + 0.1, "dur": 1.0}
         )
@@ -5530,7 +5558,7 @@ def test_pretrim_noop_on_clean_trace(tmp_path):
     trimmed, report = tla.pretrim_startup_transient(src, dst)
 
     assert trimmed is False
-    assert report["reason"] == "clean"
+    assert report["reason"] == "no_leading_outlier"
     assert not dst.exists()
 
 
@@ -5543,7 +5571,7 @@ def test_pretrim_keeps_midstream_outlier(tmp_path):
     trimmed, report = tla.pretrim_startup_transient(src, dst)
 
     assert trimmed is False
-    assert report["reason"] == "clean"
+    assert report["reason"] == "no_leading_outlier"
 
 
 def test_pretrim_refuses_when_too_many_leading_outliers(tmp_path):
@@ -5627,7 +5655,9 @@ def test_pretrim_keeps_host_side_of_first_surviving_step(tmp_path):
 
     trimmed, report = tla.pretrim_startup_transient(src, dst)
     assert trimmed is True
-    assert report["cpu_cut_ts"] < report["gpu_cut_ts"]  # two cuts, host earlier
+    # Two cuts, host earlier -- and by the full lead, not a value clamped down
+    # to the kept step's own duration.
+    assert report["gpu_cut_ts"] - report["cpu_cut_ts"] == pytest.approx(839_000.0)
 
     ev = tla.open_json(dst)["traceEvents"]
     kept_host = {e["name"] for e in ev if e.get("cat") == "user_annotation"}
@@ -5670,3 +5700,212 @@ def test_pretrim_leaves_enough_steps_for_the_splitter(tmp_path):
 
     assert report["remaining_steps"] == 127
     assert report["remaining_steps"] >= 32  # the default --split-num-steps
+
+
+def test_pretrim_pairs_timelines_by_position_not_by_name(tmp_path):
+    """Repeated step names must still cut both timelines at the right place.
+
+    Framework builds that omit the cumulative-sequence-length fields emit the
+    same ``step[DECODE bs=64]`` for every step. Pairing the timelines by name
+    resolves the surviving step to the *first* occurrence, which puts the host
+    cut at the head of the capture and leaves the dropped step's entire host
+    side in the trimmed trace.
+    """
+    src = _write_trace(
+        tmp_path / "r.trace.json.gz",
+        [15_781_320.0] + [32_944.0] * 40,
+        host_lead_us=839_000.0,
+        unique_names=False,
+    )
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+
+    trimmed, report = tla.pretrim_startup_transient(src, dst)
+    assert trimmed is True
+    assert report["gpu_cut_ts"] - report["cpu_cut_ts"] == pytest.approx(839_000.0)
+
+    ev = tla.open_json(dst)["traceEvents"]
+    # One host annotation per surviving device step, and no more: the dropped
+    # step's host side went with its device side.
+    assert len(tla._step_annotation_spans(ev)) == 40
+    assert sum(1 for e in ev if e.get("cat") == "user_annotation") == 40
+    # launch_0 is the dropped step's host op; it must not survive on the
+    # strength of a name it shares with every other step.
+    launches = {e["name"] for e in ev if e.get("cat") == "cpu_op"}
+    assert "launch_0" not in launches
+    assert "launch_1" in launches
+
+
+def test_pretrim_refuses_when_host_step_annotations_are_missing(tmp_path):
+    """Without a host annotation per device step the timelines cannot be paired.
+
+    Falling back to a single cut is the outcome the split-cut design exists to
+    avoid, so the trim is refused and the reason recorded instead.
+    """
+    src = _write_trace(
+        tmp_path / "r.trace.json.gz",
+        [15_781_320.0] + [32_944.0] * 20,
+        omit_host_steps=(1, 2),
+    )
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+
+    trimmed, report = tla.pretrim_startup_transient(src, dst)
+
+    assert trimmed is False
+    assert report["reason"] == "host_steps_missing"
+    assert report["steps"] == 21
+    assert report["host_steps"] == 19
+    assert not dst.exists()
+
+
+def test_pretrim_keeps_leading_prefill_steps(tmp_path):
+    """Prefill steps are not transients just because decode dominates the trace.
+
+    A mixed capture's EXTEND steps run one to two orders of magnitude longer
+    than its DECODE steps. Measured against a whole-trace median they all read
+    as outliers, and the leading ones -- the window
+    ``--steady-state-mode=prefilldecode`` exists to analyse -- get trimmed away.
+    """
+    durs = [1_200_000.0, 880_000.0, 1_530_000.0] + [32_944.0] * 30
+    phases = ["EXTEND"] * 3 + ["DECODE"] * 30
+    src = _write_trace(tmp_path / "r.trace.json.gz", durs, phases=phases)
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+
+    trimmed, report = tla.pretrim_startup_transient(src, dst)
+
+    assert trimmed is False
+    assert report["reason"] == "no_leading_outlier"
+    # Each phase gets its own baseline rather than one median for the trace.
+    assert set(report["phase_medians_ms"]) == {"EXTEND", "DECODE"}
+    assert report["first_step_phase"] == "EXTEND"
+    assert report["first_step_ratio"] < tla._PRETRIM_OUTLIER_FACTOR
+    assert not dst.exists()
+
+
+def test_pretrim_drops_a_prefill_transient_against_its_own_phase(tmp_path):
+    """The guard still fires when the transient lands on a prefill step.
+
+    Per-phase baselines must not amount to exempting prefill: a barrier that
+    opens on an EXTEND step is as fatal to the window as one on a DECODE step.
+    """
+    durs = [15_781_320.0, 1_200_000.0, 1_150_000.0, 1_180_000.0] + [32_944.0] * 30
+    phases = ["EXTEND"] * 4 + ["DECODE"] * 30
+    src = _write_trace(tmp_path / "r.trace.json.gz", durs, phases=phases)
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+
+    trimmed, report = tla.pretrim_startup_transient(src, dst)
+
+    assert trimmed is True
+    assert report["dropped_steps"] == 1
+    assert report["dropped_phase"] == "EXTEND"
+    # Measured against EXTEND's 1.2 s median (13x) rather than decode's 33 ms,
+    # which would have made it 479x and swept the healthy prefill steps with it.
+    assert report["outlier_ratio"] == pytest.approx(15_781_320.0 / 1_200_000.0, rel=1e-3)
+    assert report["phase_medians_ms"]["EXTEND"] == pytest.approx(1_200.0)
+    assert report["remaining_steps"] == 33
+
+
+def test_pretrim_leaves_a_phase_without_a_baseline_alone(tmp_path):
+    """A leading step whose phase is too rare to have a median is not dropped.
+
+    With no population of its own to compare against there is no evidence the
+    step is abnormal, so it stays and the window keeps it.
+    """
+    durs = [9_000_000.0] + [32_944.0] * 30
+    phases = ["EXTEND"] + ["DECODE"] * 30
+    src = _write_trace(tmp_path / "r.trace.json.gz", durs, phases=phases)
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+
+    trimmed, report = tla.pretrim_startup_transient(src, dst)
+
+    assert trimmed is False
+    assert report["reason"] == "no_leading_outlier"
+    assert "EXTEND" not in report["phase_medians_ms"]
+    assert report["first_step_ratio"] is None
+
+
+def test_pretrim_reports_the_worst_ratio_across_dropped_steps(tmp_path):
+    """``outlier_ratio`` covers the whole dropped run, not just its first step."""
+    durs = [500_000.0, 5_000_000.0] + [32_944.0] * 20
+    src = _write_trace(tmp_path / "r.trace.json.gz", durs)
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+
+    trimmed, report = tla.pretrim_startup_transient(src, dst)
+
+    assert trimmed is True
+    assert report["dropped_steps"] == 2
+    assert report["outlier_ratio"] == pytest.approx(5_000_000.0 / 32_944.0, rel=1e-3)
+
+
+def test_pretrim_write_failure_is_reported_as_a_failure(tmp_path, monkeypatch):
+    """A failed write must not be reported with the ``trimmed`` reason.
+
+    The caller keys its log line and the pretrim artifact off ``reason``; a
+    report that still says ``trimmed`` after the write failed makes a full-disk
+    run look like a successful trim that simply was not applied.
+    """
+    src = _write_trace(tmp_path / "r.trace.json.gz", [15_781_320.0] + [32_944.0] * 40)
+    dst = tmp_path / "out" / "r.pretrimmed.trace.json.gz"
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("No space left on device")
+
+    # Fails after the output file is opened, so a partial one is on disk.
+    monkeypatch.setattr(tla.json, "dump", _boom)
+    trimmed, report = tla.pretrim_startup_transient(src, dst)
+
+    assert trimmed is False
+    assert report["reason"] == "write_failed"
+    assert "No space left on device" in report["error"]
+    # The step accounting is kept for diagnosis, but no partial file is left
+    # behind for a later step to mistake for a usable trace.
+    assert report["dropped_steps"] == 1
+    assert not dst.exists()
+
+
+def test_pretrim_redirects_only_the_splitter_input(tmp_path):
+    """The splitter reads the trimmed copy; nothing else is repointed at it.
+
+    ``analysis_trace_path`` is what capture-folder discovery and the split
+    warnings resolve against, so reassigning it to the derived file under
+    ``trace_split/`` moves both onto a directory that holds neither the capture
+    nor its graph-capture sidecar.
+    """
+    captured, trace = _drive_main_capturing_subprocess(
+        tmp_path,
+        [],
+        trace_factory=lambda root: _write_trace(root / "trace.trace.json.gz", [15_781_320.0] + [32_944.0] * 40),
+    )
+
+    splitter_cmd = _find_splitter_cmd(captured)
+    assert splitter_cmd is not None, f"splitter never invoked; cmds={captured}"
+    positional = splitter_cmd[3]
+    assert positional.endswith(".pretrimmed.trace.json.gz"), splitter_cmd
+    assert str(trace) not in splitter_cmd, splitter_cmd
+
+    # The trim ran, and the raw capture is still on disk and unmodified.
+    pretrim_files = list((tmp_path / "ws").rglob("pretrim.json"))
+    assert len(pretrim_files) == 1, pretrim_files
+    pretrim = json.loads(pretrim_files[0].read_text())
+    assert pretrim["applied"] is True
+    assert pretrim["source"] == str(trace)
+    assert len(tla._step_annotation_spans(tla.open_json(trace)["traceEvents"])) == 41
+
+
+def test_capture_folder_is_not_discoverable_from_the_split_directory(tmp_path):
+    """Why the splitter's input has to stay separate from the analysed path.
+
+    Discovery searches the trace file's own directory and its parent. A trimmed
+    copy lives in ``tracelens/trace_split/``, whose neighbourhood is the run's
+    output tree -- the capture's sidecar is not in it.
+    """
+    capture_dir = tmp_path / "torch_trace"
+    (capture_dir / "graph_capture_profile").mkdir(parents=True)
+    raw = capture_dir / "r.trace.json.gz"
+    raw.write_bytes(b"")
+    split_dir = tmp_path / "tracelens" / "trace_split"
+    split_dir.mkdir(parents=True)
+    trimmed = split_dir / "r.pretrimmed.trace.json.gz"
+    trimmed.write_bytes(b"")
+
+    assert tlr.discover_capture_folder(raw, [raw]) == capture_dir / "graph_capture_profile"
+    assert tlr.discover_capture_folder(raw, [trimmed]) is None

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -5438,3 +5438,235 @@ def test_graph_coverage_from_raw_trace_never_raises():
     # Missing/unreadable trace must degrade to {} (fall back to the plain gate).
     assert tla._graph_coverage_from_raw_trace(None) == {}
     assert tla._graph_coverage_from_raw_trace("/no/such/trace.json") == {}
+
+
+# --- pretrim_startup_transient (#profiler-start transient) -------------------
+
+
+def _write_trace(path: Path, step_durs, *, step_us_gap=0.0, host_lead_us=30_000.0, extra_events=None):
+    """Build a minimal torch-profiler trace with GPU step annotations.
+
+    ``step_durs`` are microsecond durations laid end to end; each becomes one
+    ``step[DECODE bs=64]`` gpu_user_annotation plus a kernel inside it, so the
+    trimmer has both something to measure and something to drop.
+    """
+    # torch stamps metadata with the profiler-open ts, i.e. always before any
+    # cut point -- reproduce that, it is what made a naive ts filter drop it.
+    events = [
+        {"ph": "M", "name": "process_name", "ts": 999_999.0, "pid": 1, "args": {"name": "python"}},
+        {"ph": "M", "name": "thread_name", "ts": 999_999.0, "pid": 1, "tid": 7, "args": {"name": "t"}},
+    ]
+    ts = 1_000_000.0
+    for i, dur in enumerate(step_durs):
+        name = f"step[DECODE bs=64 g_sk={i}]"
+        # The host runs a step ahead: step N's launches are issued while step
+        # N-1 still owns the GPU. Reproduce that offset -- it is what makes a
+        # single-timestamp cut unable to separate the two.
+        host_ts = ts - min(host_lead_us, dur) if i else ts - 1.0
+        events.append(
+            {"ph": "X", "cat": "user_annotation", "name": name, "pid": 1, "tid": 1, "ts": host_ts, "dur": 3.0}
+        )
+        events.append(
+            {"ph": "X", "cat": "cpu_op", "name": f"launch_{i}", "pid": 1, "tid": 1, "ts": host_ts + 0.1, "dur": 1.0}
+        )
+        events.append(
+            {
+                "ph": "X",
+                "cat": "gpu_user_annotation",
+                "name": name,
+                "pid": 5,
+                "tid": 7,
+                "ts": ts,
+                "dur": dur,
+            }
+        )
+        events.append(
+            {
+                "ph": "X",
+                "cat": "kernel",
+                "name": f"some_kernel_{i}",
+                "pid": 5,
+                "tid": 7,
+                "ts": ts + 1.0,
+                "dur": max(1.0, dur / 2),
+            }
+        )
+        ts += dur + step_us_gap
+    events.extend(extra_events or [])
+    payload = {"schemaVersion": 1, "baseTimeNanoseconds": 12345, "traceEvents": events}
+    with gzip.open(path, "wt", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+    return path
+
+
+def test_pretrim_drops_leading_barrier_step(tmp_path):
+    """A 479x leading step is cut; the steady tail and metadata survive."""
+    src = _write_trace(tmp_path / "r.trace.json.gz", [15_781_320.0] + [32_944.0] * 127)
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+
+    trimmed, report = tla.pretrim_startup_transient(src, dst)
+
+    assert trimmed is True
+    assert report["reason"] == "trimmed"
+    assert report["dropped_steps"] == 1
+    assert report["remaining_steps"] == 127
+    assert report["outlier_ratio"] > 400
+
+    out = tla.open_json(dst)
+    spans = tla._step_annotation_spans(out["traceEvents"])
+    assert len(spans) == 127
+    assert max(dur for _, dur, _ in spans) < 40_000.0  # the barrier step is gone
+    # ph:"M" metadata has no ts and must be preserved, else the chunk loses its
+    # process/thread names and TraceLens can't attribute anything.
+    assert sum(1 for ev in out["traceEvents"] if ev.get("ph") == "M") == 2
+    assert out["baseTimeNanoseconds"] == 12345
+
+
+def test_pretrim_noop_on_clean_trace(tmp_path):
+    """Uniform steps are left alone and no output file is written."""
+    src = _write_trace(tmp_path / "r.trace.json.gz", [32_900.0, 33_100.0] * 32)
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+
+    trimmed, report = tla.pretrim_startup_transient(src, dst)
+
+    assert trimmed is False
+    assert report["reason"] == "clean"
+    assert not dst.exists()
+
+
+def test_pretrim_keeps_midstream_outlier(tmp_path):
+    """Only a *leading* run is cut; a slow step in the middle is real behaviour."""
+    durs = [32_944.0] * 10 + [5_000_000.0] + [32_944.0] * 10
+    src = _write_trace(tmp_path / "r.trace.json.gz", durs)
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+
+    trimmed, report = tla.pretrim_startup_transient(src, dst)
+
+    assert trimmed is False
+    assert report["reason"] == "clean"
+
+
+def test_pretrim_refuses_when_too_many_leading_outliers(tmp_path):
+    """A run that never reaches steady state is surfaced, not trimmed away."""
+    durs = [5_000_000.0] * 6 + [32_944.0] * 20
+    src = _write_trace(tmp_path / "r.trace.json.gz", durs)
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+
+    trimmed, report = tla.pretrim_startup_transient(src, dst)
+
+    assert trimmed is False
+    assert report["reason"] == "too_many_leading_outliers"
+    assert report["leading_outliers"] == 6
+    assert not dst.exists()
+
+
+def test_pretrim_skips_short_traces(tmp_path):
+    """Below the step floor the median is not worth trusting."""
+    src = _write_trace(tmp_path / "r.trace.json.gz", [9_000_000.0] + [32_944.0] * 3)
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+
+    trimmed, report = tla.pretrim_startup_transient(src, dst)
+
+    assert trimmed is False
+    assert report["reason"] == "too_few_steps"
+
+
+def test_pretrim_degrades_on_unreadable_trace(tmp_path):
+    """An unreadable trace must fall through to the raw path, not raise."""
+    bad = tmp_path / "bad.trace.json.gz"
+    bad.write_bytes(b"not a gzip")
+
+    trimmed, report = tla.pretrim_startup_transient(bad, tmp_path / "out.trace.json.gz")
+
+    assert trimmed is False
+    assert report["reason"] == "unreadable_trace"
+
+
+def test_pretrim_ignores_traces_without_step_annotations(tmp_path):
+    """No step annotations -> nothing to measure against."""
+    payload = {"traceEvents": [{"ph": "X", "cat": "kernel", "name": "k", "ts": 1.0, "dur": 5.0} for _ in range(50)]}
+    src = tmp_path / "r.trace.json.gz"
+    with gzip.open(src, "wt", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+
+    trimmed, report = tla.pretrim_startup_transient(src, tmp_path / "out.trace.json.gz")
+
+    assert trimmed is False
+    assert report["reason"] == "too_few_steps"
+    assert report["steps"] == 0
+
+
+def test_pretrim_threshold_is_the_module_default(tmp_path):
+    """A step under the default multiple is left alone; over it is cut."""
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+    # ~6x the median -- real jitter can reach this, so it must survive.
+    under = _write_trace(tmp_path / "under.trace.json.gz", [200_000.0] + [32_944.0] * 20)
+    assert tla.pretrim_startup_transient(under, dst)[0] is False
+    # ~15x -- past the default, and nowhere near the 479x the real barrier hits.
+    over = _write_trace(tmp_path / "over.trace.json.gz", [500_000.0] + [32_944.0] * 20)
+    trimmed, report = tla.pretrim_startup_transient(over, dst)
+    assert trimmed is True
+    assert report["dropped_steps"] == 1
+    assert report["outlier_factor"] == tla._PRETRIM_OUTLIER_FACTOR
+
+
+def test_pretrim_keeps_host_side_of_first_surviving_step(tmp_path):
+    """The kept step's host ops survive even though they start inside the
+    dropped step's device span.
+
+    Host launches run a step ahead of the device, so a single-timestamp cut on
+    the device boundary would strip them -- and with them the shape-carrying
+    frames TraceLens attributes MoE kernels through.
+    """
+    src = _write_trace(
+        tmp_path / "r.trace.json.gz",
+        [15_781_320.0] + [32_944.0] * 40,
+        host_lead_us=839_000.0,
+    )
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+
+    trimmed, report = tla.pretrim_startup_transient(src, dst)
+    assert trimmed is True
+    assert report["cpu_cut_ts"] < report["gpu_cut_ts"]  # two cuts, host earlier
+
+    ev = tla.open_json(dst)["traceEvents"]
+    kept_host = {e["name"] for e in ev if e.get("cat") == "user_annotation"}
+    kept_dev = {n for _, _, n in tla._step_annotation_spans(ev)}
+    # Same set on both timelines: no step is half-present.
+    assert kept_host == kept_dev
+    assert "step[DECODE bs=64 g_sk=0]" not in kept_host  # dropped step, both sides
+    assert "step[DECODE bs=64 g_sk=1]" in kept_host  # kept step, host side survived
+    assert len(kept_host) == 40
+
+
+def test_pretrim_drops_dropped_step_device_work_after_the_host_cut(tmp_path):
+    """Kernels belonging to the dropped step do not leak past the host cut.
+
+    The dropped step's device span extends beyond the kept step's host start, so
+    a host-boundary cut alone would leave its trailing kernels behind as orphans.
+    """
+    src = _write_trace(
+        tmp_path / "r.trace.json.gz",
+        [15_781_320.0] + [32_944.0] * 40,
+        host_lead_us=839_000.0,
+    )
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+    tla.pretrim_startup_transient(src, dst)
+
+    ev = tla.open_json(dst)["traceEvents"]
+    kernels = {e["name"] for e in ev if e.get("cat") == "kernel"}
+    assert "some_kernel_0" not in kernels
+    assert "some_kernel_1" in kernels
+    assert len(kernels) == 40
+
+
+def test_pretrim_leaves_enough_steps_for_the_splitter(tmp_path):
+    """Step count downstream is set by --num-steps, and the trim keeps well
+    clear of it: the splitter still gets its full window, only shifted."""
+    src = _write_trace(tmp_path / "r.trace.json.gz", [15_781_320.0] + [32_944.0] * 127)
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+
+    _, report = tla.pretrim_startup_transient(src, dst)
+
+    assert report["remaining_steps"] == 127
+    assert report["remaining_steps"] >= 32  # the default --split-num-steps

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -5460,6 +5460,7 @@ def _write_trace(
     phases=None,
     unique_names=True,
     omit_host_steps=(),
+    omit_device_steps=(),
     extra_events=None,
 ):
     """Build a minimal torch-profiler trace with GPU step annotations.
@@ -5472,8 +5473,10 @@ def _write_trace(
 
     ``unique_names=False`` omits the per-step ``g_sk`` field, reproducing the
     framework builds whose step annotations repeat verbatim; the two timelines
-    then cannot be paired by name. ``omit_host_steps`` drops the host-side
-    annotation for the given step indices.
+    then cannot be paired by name. ``omit_host_steps`` and ``omit_device_steps``
+    drop one side's annotation for the given step indices, which is how real
+    captures arrive: most measured rank traces carry every host ``step[...]``
+    against only a handful of device ones.
     """
     # torch stamps metadata with the profiler-open ts, i.e. always before any
     # cut point -- reproduce that, it is what made a naive ts filter drop it.
@@ -5497,17 +5500,18 @@ def _write_trace(
         events.append(
             {"ph": "X", "cat": "cpu_op", "name": f"launch_{i}", "pid": 1, "tid": 1, "ts": host_ts + 0.1, "dur": 1.0}
         )
-        events.append(
-            {
-                "ph": "X",
-                "cat": "gpu_user_annotation",
-                "name": name,
-                "pid": 5,
-                "tid": 7,
-                "ts": ts,
-                "dur": dur,
-            }
-        )
+        if i not in omit_device_steps:
+            events.append(
+                {
+                    "ph": "X",
+                    "cat": "gpu_user_annotation",
+                    "name": name,
+                    "pid": 5,
+                    "tid": 7,
+                    "ts": ts,
+                    "dur": dur,
+                }
+            )
         events.append(
             {
                 "ph": "X",
@@ -5735,14 +5739,14 @@ def test_pretrim_pairs_timelines_by_position_not_by_name(tmp_path):
     assert "launch_1" in launches
 
 
-def test_pretrim_refuses_when_host_step_annotations_are_missing(tmp_path):
-    """Without a host annotation per device step the timelines cannot be paired.
+def test_pretrim_refuses_when_the_timelines_hold_different_step_counts(tmp_path):
+    """Unequal step counts make positional pairing meaningless, either way round.
 
     Falling back to a single cut is the outcome the split-cut design exists to
-    avoid, so the trim is refused and the reason recorded instead.
+    avoid, so the trim is refused and the counts recorded instead.
     """
     src = _write_trace(
-        tmp_path / "r.trace.json.gz",
+        tmp_path / "fewer_host.trace.json.gz",
         [15_781_320.0] + [32_944.0] * 20,
         omit_host_steps=(1, 2),
     )
@@ -5751,9 +5755,33 @@ def test_pretrim_refuses_when_host_step_annotations_are_missing(tmp_path):
     trimmed, report = tla.pretrim_startup_transient(src, dst)
 
     assert trimmed is False
-    assert report["reason"] == "host_steps_missing"
-    assert report["steps"] == 21
-    assert report["host_steps"] == 19
+    assert report["reason"] == "timeline_step_count_mismatch"
+    assert (report["steps"], report["host_steps"]) == (21, 19)
+    assert not dst.exists()
+
+
+def test_pretrim_refuses_when_device_step_annotations_are_missing(tmp_path):
+    """More host steps than device steps is the shape real captures arrive in.
+
+    Measured rank traces carry every host ``step[...]`` against a fraction of
+    the device ones, and the gaps are not at the tail. Indexing the host list by
+    the device position then resolves to some earlier step, putting the host cut
+    before the transient and leaving its host side in the window -- and a guard
+    that only rejects *too few* host entries lets it through, because there are
+    more of them, not fewer.
+    """
+    src = _write_trace(
+        tmp_path / "fewer_device.trace.json.gz",
+        [15_781_320.0] + [32_944.0] * 20,
+        omit_device_steps=(5, 9, 13),
+    )
+    dst = tmp_path / "r.pretrimmed.trace.json.gz"
+
+    trimmed, report = tla.pretrim_startup_transient(src, dst)
+
+    assert trimmed is False
+    assert report["reason"] == "timeline_step_count_mismatch"
+    assert (report["steps"], report["host_steps"]) == (18, 21)
     assert not dst.exists()
 
 

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -978,6 +978,251 @@ def count_gpu_kernel_events(trace_file: Path, max_events: int = 1_000_000) -> in
     return count
 
 
+#: How many times the median step a leading step must exceed before it counts as
+#: a profiler-start transient rather than real work. Observed transients run
+#: two-to-three orders of magnitude over the median (479x on the reference
+#: capture) while healthy decode steps hold inside 2% of it, so anything in this
+#: range separates them with a wide margin either way.
+_PRETRIM_OUTLIER_FACTOR = 10.0
+
+#: Fewest step annotations a trace must carry before the median is worth
+#: trusting. Below this a single slow step skews the median enough that the
+#: comparison stops meaning anything, so the trim is skipped rather than guessed.
+_PRETRIM_MIN_STEPS = 8
+
+#: Ceiling on how many leading steps may be dropped. A transient is one step in
+#: every capture examined; needing more than a handful means the run never
+#: reached steady state, which the splitter and the health gates should see
+#: rather than have quietly trimmed away.
+_PRETRIM_MAX_DROPPED_STEPS = 4
+
+
+#: Categories that live on the device timeline. Everything else in a torch
+#: trace -- ``cpu_op``, ``python_function``, ``user_annotation``,
+#: ``cuda_runtime`` -- is host-side.
+_GPU_TIMELINE_CATS = frozenset({"kernel", "gpu_memcpy", "gpu_memset", "gpu_user_annotation"})
+
+
+def _step_annotation_spans(events: list[Any]) -> list[tuple[float, float, str]]:
+    """``(ts, dur, name)`` for every GPU-side step annotation, ordered by start.
+
+    Args:
+        events (list[Any]): ``traceEvents`` from a torch-profiler trace.
+
+    Returns:
+        list[tuple[float, float, str]]: One entry per ``step[...]`` annotation on
+            the GPU timeline. Empty when the trace carries no step annotations.
+    """
+    spans: list[tuple[float, float, str]] = []
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        if ev.get("cat") != "gpu_user_annotation":
+            continue
+        name = ev.get("name")
+        if not isinstance(name, str) or not name.startswith("step["):
+            continue
+        ts = ev.get("ts")
+        dur = ev.get("dur")
+        if isinstance(ts, (int, float)) and isinstance(dur, (int, float)):
+            spans.append((float(ts), float(dur), name))
+    spans.sort()
+    return spans
+
+
+def _host_step_starts(events: list[Any]) -> dict[str, float]:
+    """Earliest host-side start for each ``step[...]`` annotation, keyed by name.
+
+    The host runs ahead of the device -- a step's launches are issued while the
+    previous step is still executing -- so a step's host span begins before its
+    device span. Step names embed the cumulative sequence length, so they pair
+    the two timelines exactly.
+
+    Args:
+        events (list[Any]): ``traceEvents`` from a torch-profiler trace.
+
+    Returns:
+        dict[str, float]: Step annotation name to its host-timeline start.
+    """
+    starts: dict[str, float] = {}
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        if ev.get("cat") != "user_annotation":
+            continue
+        name = ev.get("name")
+        ts = ev.get("ts")
+        if not isinstance(name, str) or not name.startswith("step["):
+            continue
+        if not isinstance(ts, (int, float)):
+            continue
+        prev = starts.get(name)
+        if prev is None or ts < prev:
+            starts[name] = float(ts)
+    return starts
+
+
+def pretrim_startup_transient(
+    src: Path,
+    dst: Path,
+    *,
+    outlier_factor: float = _PRETRIM_OUTLIER_FACTOR,
+    min_steps: int = _PRETRIM_MIN_STEPS,
+    max_dropped_steps: int = _PRETRIM_MAX_DROPPED_STEPS,
+) -> tuple[bool, dict[str, Any]]:
+    """Drop the profiler-start transient from the head of a torch trace.
+
+    ``torch.profiler.start()`` is a local, unfenced call whose cost varies by
+    seconds across ranks, and SGLang does not barrier after it. The ranks whose
+    profiler comes up first therefore reach the first collective of the step and
+    spin there until the slowest peer arrives. A spin-waiting collective is
+    charged as GPU-busy time, so that wait lands in the trace as one enormous
+    kernel at the head of the window: on the reference capture a single
+    ``cross_device_reduce_2stage`` held 15747 ms of a 16805 ms window, leaving
+    Compute% at 5.75% and tripping the low-compute gate that suppresses the
+    entire hot-kernel candidate list.
+
+    The collective is self-healing -- releasing it re-synchronises every rank --
+    so the contamination is confined to the first step and everything after it is
+    already steady (32.94 ms +/- 0.3 across the following 127 steps on the same
+    capture). Cutting the leading outlier steps therefore recovers an honest
+    window without touching instrumentation, and keeps ``shape_discovery`` and
+    the ``with_stack`` frames its shapes ride on fully intact.
+
+    Detection is on step duration, not on any kernel name, so the same guard
+    catches other head-of-window transients (first-replay JIT, KV-pool growth)
+    without knowing what they are. Only a *leading* run of outliers is cut: a
+    slow step in the middle is real behaviour the splitter and the health gates
+    should still see.
+
+    The cut is applied per timeline rather than as one timestamp, because the
+    host runs a step ahead of the device and the two spans interleave across the
+    boundary. See the comment at the cut for what each single-point alternative
+    loses.
+
+    Step count is unaffected downstream: the splitter is invoked with
+    ``--num-steps`` and caps its window there, so it still hands TraceLens
+    exactly that many steps -- only which ones changes. The caller refuses the
+    trim outright when fewer than ``--num-steps`` would remain.
+
+    Args:
+        src (Path): Raw per-rank trace, JSON or ``.gz``.
+        dst (Path): Where the trimmed trace is written. Untouched when no trim
+            is performed.
+        outlier_factor (float): Multiple of the median step duration above
+            which a leading step is treated as a transient.
+        min_steps (int): Fewest step annotations required before trimming.
+        max_dropped_steps (int): Refuse to trim when more than this many leading
+            steps look like transients.
+
+    Returns:
+        tuple[bool, dict[str, Any]]: ``(trimmed, report)``. ``report`` always
+            carries a ``reason``; when ``trimmed`` is True it also carries the
+            step counts and durations for the run log and status file.
+    """
+    factor = outlier_factor
+    try:
+        payload = open_json(src)
+    except Exception as exc:  # noqa: BLE001 - unreadable trace is the splitter's problem, not ours
+        return False, {"reason": "unreadable_trace", "error": str(exc)[:200]}
+    if not isinstance(payload, dict):
+        return False, {"reason": "unexpected_payload"}
+    events = payload.get("traceEvents")
+    if not isinstance(events, list):
+        return False, {"reason": "no_trace_events"}
+
+    spans = _step_annotation_spans(events)
+    if len(spans) < min_steps:
+        return False, {"reason": "too_few_steps", "steps": len(spans), "min_steps": min_steps}
+
+    durations = sorted(dur for _, dur, _ in spans)
+    median_us = durations[len(durations) // 2]
+    if median_us <= 0:
+        return False, {"reason": "degenerate_median", "steps": len(spans)}
+
+    dropped = 0
+    while dropped < len(spans) and spans[dropped][1] > factor * median_us:
+        dropped += 1
+    if dropped == 0:
+        return False, {
+            "reason": "clean",
+            "steps": len(spans),
+            "median_step_ms": round(median_us / 1000.0, 3),
+            "first_step_ratio": round(spans[0][1] / median_us, 2),
+        }
+    if dropped > max_dropped_steps:
+        # Not a start-up blip. Leave it visible so the health gates can act.
+        return False, {
+            "reason": "too_many_leading_outliers",
+            "steps": len(spans),
+            "leading_outliers": dropped,
+            "max_dropped_steps": max_dropped_steps,
+            "median_step_ms": round(median_us / 1000.0, 3),
+        }
+
+    remaining = len(spans) - dropped
+    # One cut per timeline, not one for the trace. The host runs a step ahead of
+    # the device, so the first kept step's launches are issued *while the dropped
+    # step is still executing on the GPU* -- on the reference capture the kept
+    # step's host span starts 839 ms inside the dropped step's 15.78 s device
+    # span. A single timestamp therefore cannot both drop the transient whole and
+    # keep the first surviving step whole: cutting on the device boundary strips
+    # that step's host ops, taking the `kernel_shape_profiler` frames its shape
+    # attribution rides on with them, and cutting on the host boundary leaves the
+    # dropped step's post-barrier kernels behind as orphans.
+    gpu_cut = spans[dropped][0]
+    host_starts = _host_step_starts(events)
+    cpu_cut = min(host_starts.get(spans[dropped][2], gpu_cut), gpu_cut)
+
+    def _survives(ev: Any) -> bool:
+        if not isinstance(ev, dict):
+            return True
+        # ph:"M" is metadata (process_name / process_labels / thread_name /
+        # sort indices), not timeline work. torch stamps it with the
+        # profiler-open ts, which is always before either cut, so a plain ts
+        # filter would strip every one of them and leave the chunk with
+        # unnamed processes and threads for TraceLens to attribute against.
+        if ev.get("ph") == "M":
+            return True
+        ts = ev.get("ts")
+        if not isinstance(ts, (int, float)):
+            return True
+        ph = ev.get("ph")
+        if ph == "s":  # flow start: sits on the host timeline
+            return ts >= cpu_cut
+        if ph == "f":  # flow finish: sits on the device timeline
+            return ts >= gpu_cut
+        return ts >= (gpu_cut if ev.get("cat") in _GPU_TIMELINE_CATS else cpu_cut)
+
+    kept = [ev for ev in events if _survives(ev)]
+
+    report = {
+        "reason": "trimmed",
+        "dropped_steps": dropped,
+        "dropped_ms": round(sum(dur for _, dur, _ in spans[:dropped]) / 1000.0, 3),
+        "median_step_ms": round(median_us / 1000.0, 3),
+        "outlier_ratio": round(spans[0][1] / median_us, 2),
+        "outlier_factor": factor,
+        "remaining_steps": remaining,
+        "events_before": len(events),
+        "events_after": len(kept),
+        "gpu_cut_ts": gpu_cut,
+        "cpu_cut_ts": cpu_cut,
+        "source": str(src),
+        "output": str(dst),
+    }
+
+    payload["traceEvents"] = kept
+    try:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        opener = gzip.open if dst.suffix == ".gz" else open
+        with opener(dst, "wt", encoding="utf-8") as fh:
+            json.dump(payload, fh)
+    except Exception as exc:  # noqa: BLE001 - fall back to the raw trace rather than fail the run
+        return False, {"reason": "write_failed", "error": str(exc)[:200], **report}
+    return True, report
+
+
 #: Directory name the splitter writes its per-phase output into. Everything
 #: below it is derived from a raw capture, never a capture itself.
 _SPLIT_DIR_NAME = "trace_split"
@@ -7593,6 +7838,51 @@ def main() -> int:
                 )
                 split_dir = tracelens_dir / "trace_split"
                 split_dir.mkdir(parents=True, exist_ok=True)
+                # Cut the profiler-start transient before the splitter sees the
+                # trace. --find-steady-state selects on load composition, not on
+                # timing, so it will happily hand back a window whose first step
+                # is a multi-second rank-arrival barrier -- and every downstream
+                # percentage is then computed against that inflated denominator.
+                # Trimming here keeps the splitter and TraceLens untouched.
+                trimmed_trace = split_dir / (analysis_trace_path.name.replace(".trace.json", ".pretrimmed.trace.json"))
+                min_remaining = max(8, int(args.split_num_steps or 32))
+                did_trim, pretrim_report = pretrim_startup_transient(
+                    analysis_trace_path,
+                    trimmed_trace,
+                )
+                pretrim_summary = dict(pretrim_report)
+                pretrim_summary["applied"] = False
+                if did_trim and pretrim_report["remaining_steps"] < min_remaining:
+                    # Trimming would leave the splitter fewer steps than it
+                    # was asked for. A silently short window reads as a clean
+                    # measurement; the untrimmed one at least shows the damage.
+                    append_log(
+                        log_path,
+                        f"pretrim: only {pretrim_report['remaining_steps']} step(s) would "
+                        f"remain < --split-num-steps {min_remaining}; keeping untrimmed trace",
+                    )
+                    pretrim_summary["reason"] = "insufficient_remaining_steps"
+                    pretrim_summary["min_remaining_steps"] = min_remaining
+                elif did_trim:
+                    append_log(
+                        log_path,
+                        f"pretrim: dropped {pretrim_report['dropped_steps']} leading step(s), "
+                        f"{pretrim_report['dropped_ms']:.1f} ms, "
+                        f"{pretrim_report['outlier_ratio']:.0f}x median "
+                        f"{pretrim_report['median_step_ms']:.1f} ms; "
+                        f"{pretrim_report['remaining_steps']} step(s) remain",
+                    )
+                    pretrim_summary["applied"] = True
+                    analysis_trace_path = trimmed_trace
+                    artifacts["tracelens_pretrimmed_trace"] = str(trimmed_trace)
+                elif pretrim_report.get("reason") != "clean":
+                    append_log(log_path, f"pretrim: not applied ({pretrim_report.get('reason')})")
+                # Persist as an artifact, not just a log line: the status
+                # file is rewritten by every later step, so a diagnostic
+                # parked there is gone by the time anyone reads the report.
+                pretrim_path = tracelens_dir / "pretrim.json"
+                atomic_write_json(pretrim_path, pretrim_summary)
+                artifacts["tracelens_pretrim"] = str(pretrim_path)
                 # --find-steady-state writes the three *_steady_state_* chunks; --R feeds PD-ratio selection.
                 split_cmd = [
                     sys.executable,

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -11,6 +11,7 @@ capture directories, and has a dry-run path that works without TraceLens install
 import argparse
 import ast
 import asyncio
+import contextlib
 import csv
 import functools
 import gzip
@@ -523,6 +524,53 @@ def _build_trace_split_warning(
     }
 
 
+def _build_pretrim_no_steady_state_warning(
+    *,
+    trace_input: Path,
+    steps: int,
+    leading_outliers: int,
+    max_dropped_steps: int,
+    outlier_factor: float,
+) -> dict[str, Any]:
+    """Build the ``pretrim_no_steady_state`` trace-health warning.
+
+    Emitted when so many leading steps exceed their phase median that the
+    capture cannot be said to have reached steady state. One such step is the
+    profiler-start transient and gets trimmed; a run of them is a workload still
+    warming up, which trimming cannot fix and which every percentage derived
+    from the window has to be read against.
+
+    Args:
+        trace_input (Path): The capture the pretrimmer inspected.
+        steps (int): Total step annotations in the capture.
+        leading_outliers (int): Leading steps found over the outlier threshold.
+        max_dropped_steps (int): The ceiling that was exceeded.
+        outlier_factor (float): Multiple of the phase median used as threshold.
+
+    Returns:
+        dict[str, Any]: A structured warning entry with code
+            ``pretrim_no_steady_state`` and the supporting counts/message.
+    """
+    return {
+        "code": "pretrim_no_steady_state",
+        "severity": "warning",
+        "trace_input": str(trace_input),
+        "steps": steps,
+        "leading_outliers": leading_outliers,
+        "max_dropped_steps": max_dropped_steps,
+        "outlier_factor": outlier_factor,
+        "message": (
+            f"{leading_outliers} of {steps} leading steps run more than "
+            f"{outlier_factor:g}x their phase median, past the "
+            f"{max_dropped_steps} a profiler-start transient accounts for, so "
+            "the capture never reached steady state and the head of the window "
+            "was left in place. Compute%/Comm% and every kernel's gpu_pct below "
+            "are computed over a window that includes the warm-up. Re-profile "
+            "with more warm-up steps before acting on them."
+        ),
+    }
+
+
 def _check_selected_chunk_has_gpu_events(
     *,
     split_dir: Path,
@@ -978,17 +1026,24 @@ def count_gpu_kernel_events(trace_file: Path, max_events: int = 1_000_000) -> in
     return count
 
 
-#: How many times the median step a leading step must exceed before it counts as
-#: a profiler-start transient rather than real work. Observed transients run
-#: two-to-three orders of magnitude over the median (479x on the reference
-#: capture) while healthy decode steps hold inside 2% of it, so anything in this
-#: range separates them with a wide margin either way.
+#: How many times the median step *of its own phase* a leading step must exceed
+#: before it counts as a profiler-start transient rather than real work. Observed
+#: transients run two-to-three orders of magnitude over the median (479x on the
+#: reference capture) while healthy decode steps hold inside 2% of it, so
+#: anything in this range separates them with a wide margin either way.
 _PRETRIM_OUTLIER_FACTOR = 10.0
 
 #: Fewest step annotations a trace must carry before the median is worth
 #: trusting. Below this a single slow step skews the median enough that the
 #: comparison stops meaning anything, so the trim is skipped rather than guessed.
 _PRETRIM_MIN_STEPS = 8
+
+#: Fewest steps of the *same phase* before that phase's median is used as a
+#: baseline. Prefill and decode differ by one to two orders of magnitude, so a
+#: phase has to recur often enough for its own median to mean something; a
+#: leading step whose phase is rarer than this is left alone rather than measured
+#: against a population it does not belong to.
+_PRETRIM_MIN_PHASE_STEPS = 3
 
 #: Ceiling on how many leading steps may be dropped. A transient is one step in
 #: every capture examined; needing more than a handful means the run never
@@ -1030,21 +1085,30 @@ def _step_annotation_spans(events: list[Any]) -> list[tuple[float, float, str]]:
     return spans
 
 
-def _host_step_starts(events: list[Any]) -> dict[str, float]:
-    """Earliest host-side start for each ``step[...]`` annotation, keyed by name.
+def _host_step_starts(events: list[Any]) -> list[float]:
+    """Host-timeline start of every ``step[...]`` annotation, ordered by start.
 
     The host runs ahead of the device -- a step's launches are issued while the
     previous step is still executing -- so a step's host span begins before its
-    device span. Step names embed the cumulative sequence length, so they pair
-    the two timelines exactly.
+    device span, and the two have to be paired to cut them at the right places.
+
+    Returned positionally rather than keyed by annotation name, because the
+    names are the framework's and are not unique: a build that omits the
+    cumulative-sequence-length fields repeats ``step[DECODE bs=36]`` for every
+    step at that batch size, and keying on it silently pairs the surviving step
+    with the *first* step of the capture. Both timelines carry one annotation per
+    step in execution order, so the Nth host entry is the Nth device step
+    whatever the names say. Indexing from the front also tolerates the host's
+    trailing extras: a capture can stop with launches already issued for a step
+    whose device span never landed.
 
     Args:
         events (list[Any]): ``traceEvents`` from a torch-profiler trace.
 
     Returns:
-        dict[str, float]: Step annotation name to its host-timeline start.
+        list[float]: Host-timeline start timestamps, ascending.
     """
-    starts: dict[str, float] = {}
+    starts: list[float] = []
     for ev in events:
         if not isinstance(ev, dict):
             continue
@@ -1056,10 +1120,62 @@ def _host_step_starts(events: list[Any]) -> dict[str, float]:
             continue
         if not isinstance(ts, (int, float)):
             continue
-        prev = starts.get(name)
-        if prev is None or ts < prev:
-            starts[name] = float(ts)
+        starts.append(float(ts))
+    starts.sort()
     return starts
+
+
+def _step_phase(name: str) -> str:
+    """The phase token of a ``step[...]`` annotation name.
+
+    ``step[DECODE bs=64 g_sk=580480]`` gives ``DECODE`` and
+    ``step[EXTEND bs=1 toks=16384]`` gives ``EXTEND``.
+
+    Args:
+        name (str): A ``step[...]`` annotation name.
+
+    Returns:
+        str: The leading token inside the brackets, or ``""`` when the name
+            carries none.
+    """
+    return name[len("step[") :].split(" ", 1)[0].rstrip("]")
+
+
+def _phase_step_medians(
+    spans: list[tuple[float, float, str]],
+    min_phase_steps: int = _PRETRIM_MIN_PHASE_STEPS,
+) -> dict[str, float]:
+    """Median step duration per phase, for phases that recur often enough.
+
+    A single median over the whole trace is not a usable baseline for a mixed
+    capture: decode dominates the population at tens of milliseconds while a
+    prefill step runs for the better part of a second, so every prefill step
+    reads as an outlier against it and the leading ones -- exactly the window
+    ``--steady-state-mode=prefilldecode`` exists to analyse -- would be trimmed
+    as start-up noise. Grouping by phase keeps each step measured against work
+    of its own kind.
+
+    Args:
+        spans (list[tuple[float, float, str]]): ``(ts, dur, name)`` per step.
+        min_phase_steps (int): Samples a phase needs before its median is used.
+
+    Returns:
+        dict[str, float]: Phase to median step duration in microseconds. Phases
+            below the sample floor, and phases whose median is not positive, are
+            omitted -- callers treat a missing phase as "no baseline".
+    """
+    by_phase: dict[str, list[float]] = {}
+    for _, dur, name in spans:
+        by_phase.setdefault(_step_phase(name), []).append(dur)
+    medians: dict[str, float] = {}
+    for phase, durs in by_phase.items():
+        if len(durs) < min_phase_steps:
+            continue
+        durs.sort()
+        median = durs[len(durs) // 2]
+        if median > 0:
+            medians[phase] = median
+    return medians
 
 
 def pretrim_startup_transient(
@@ -1068,6 +1184,7 @@ def pretrim_startup_transient(
     *,
     outlier_factor: float = _PRETRIM_OUTLIER_FACTOR,
     min_steps: int = _PRETRIM_MIN_STEPS,
+    min_phase_steps: int = _PRETRIM_MIN_PHASE_STEPS,
     max_dropped_steps: int = _PRETRIM_MAX_DROPPED_STEPS,
 ) -> tuple[bool, dict[str, Any]]:
     """Drop the profiler-start transient from the head of a torch trace.
@@ -1091,14 +1208,19 @@ def pretrim_startup_transient(
 
     Detection is on step duration, not on any kernel name, so the same guard
     catches other head-of-window transients (first-replay JIT, KV-pool growth)
-    without knowing what they are. Only a *leading* run of outliers is cut: a
-    slow step in the middle is real behaviour the splitter and the health gates
-    should still see.
+    without knowing what they are. Durations are compared against the median of
+    the step's *own phase*: a mixed capture's prefill steps run one to two orders
+    of magnitude longer than its decode steps, and against a whole-trace median
+    the leading prefill steps -- the window
+    ``--steady-state-mode=prefilldecode`` exists to analyse -- would all read as
+    start-up noise. Only a *leading* run of outliers is cut: a slow step in the
+    middle is real behaviour the splitter and the health gates should still see.
 
     The cut is applied per timeline rather than as one timestamp, because the
     host runs a step ahead of the device and the two spans interleave across the
     boundary. See the comment at the cut for what each single-point alternative
-    loses.
+    loses. The two timelines are paired by position, never by annotation name;
+    ``_host_step_starts`` has the reasoning.
 
     Step count is unaffected downstream: the splitter is invoked with
     ``--num-steps`` and caps its window there, so it still hands TraceLens
@@ -1109,16 +1231,18 @@ def pretrim_startup_transient(
         src (Path): Raw per-rank trace, JSON or ``.gz``.
         dst (Path): Where the trimmed trace is written. Untouched when no trim
             is performed.
-        outlier_factor (float): Multiple of the median step duration above
-            which a leading step is treated as a transient.
+        outlier_factor (float): Multiple of the phase median above which a
+            leading step is treated as a transient.
         min_steps (int): Fewest step annotations required before trimming.
+        min_phase_steps (int): Samples a phase needs before its median is
+            trusted as a baseline.
         max_dropped_steps (int): Refuse to trim when more than this many leading
             steps look like transients.
 
     Returns:
         tuple[bool, dict[str, Any]]: ``(trimmed, report)``. ``report`` always
             carries a ``reason``; when ``trimmed`` is True it also carries the
-            step counts and durations for the run log and status file.
+            step counts and durations for the run log and the pretrim artifact.
     """
     factor = outlier_factor
     try:
@@ -1135,20 +1259,36 @@ def pretrim_startup_transient(
     if len(spans) < min_steps:
         return False, {"reason": "too_few_steps", "steps": len(spans), "min_steps": min_steps}
 
-    durations = sorted(dur for _, dur, _ in spans)
-    median_us = durations[len(durations) // 2]
-    if median_us <= 0:
-        return False, {"reason": "degenerate_median", "steps": len(spans)}
+    medians = _phase_step_medians(spans, min_phase_steps)
+    if not medians:
+        # No phase recurs often enough to be a baseline; there is nothing to
+        # call a step abnormal against.
+        return False, {
+            "reason": "no_phase_baseline",
+            "steps": len(spans),
+            "min_phase_steps": min_phase_steps,
+        }
+    phase_medians_ms = {phase: round(med / 1000.0, 3) for phase, med in sorted(medians.items())}
 
     dropped = 0
-    while dropped < len(spans) and spans[dropped][1] > factor * median_us:
+    ratios: list[float] = []
+    while dropped < len(spans):
+        _, dur, name = spans[dropped]
+        # A step whose phase has no baseline stops the run rather than being
+        # dropped on a comparison that does not hold.
+        median_us = medians.get(_step_phase(name))
+        if median_us is None or dur <= factor * median_us:
+            break
+        ratios.append(dur / median_us)
         dropped += 1
     if dropped == 0:
+        first_median_us = medians.get(_step_phase(spans[0][2]))
         return False, {
-            "reason": "clean",
+            "reason": "no_leading_outlier",
             "steps": len(spans),
-            "median_step_ms": round(median_us / 1000.0, 3),
-            "first_step_ratio": round(spans[0][1] / median_us, 2),
+            "phase_medians_ms": phase_medians_ms,
+            "first_step_phase": _step_phase(spans[0][2]),
+            "first_step_ratio": (round(spans[0][1] / first_median_us, 2) if first_median_us else None),
         }
     if dropped > max_dropped_steps:
         # Not a start-up blip. Leave it visible so the health gates can act.
@@ -1157,7 +1297,8 @@ def pretrim_startup_transient(
             "steps": len(spans),
             "leading_outliers": dropped,
             "max_dropped_steps": max_dropped_steps,
-            "median_step_ms": round(median_us / 1000.0, 3),
+            "outlier_factor": factor,
+            "phase_medians_ms": phase_medians_ms,
         }
 
     remaining = len(spans) - dropped
@@ -1172,7 +1313,28 @@ def pretrim_startup_transient(
     # dropped step's post-barrier kernels behind as orphans.
     gpu_cut = spans[dropped][0]
     host_starts = _host_step_starts(events)
-    cpu_cut = min(host_starts.get(spans[dropped][2], gpu_cut), gpu_cut)
+    if len(host_starts) < len(spans):
+        # Without one host annotation per device step the two timelines cannot be
+        # paired positionally, and pairing by name is not an alternative (see
+        # `_host_step_starts`). Refuse rather than fall back to a single cut,
+        # which is the outcome this split exists to avoid.
+        return False, {
+            "reason": "host_steps_missing",
+            "steps": len(spans),
+            "host_steps": len(host_starts),
+        }
+    cpu_cut = host_starts[dropped]
+    if cpu_cut > gpu_cut:
+        # The host issues a step's launches before the device runs it, so a host
+        # start later than the paired device start means the two lists are not
+        # aligned and the cut points cannot be trusted.
+        return False, {
+            "reason": "timeline_pairing_unreliable",
+            "steps": len(spans),
+            "host_steps": len(host_starts),
+            "gpu_cut_ts": gpu_cut,
+            "cpu_cut_ts": cpu_cut,
+        }
 
     def _survives(ev: Any) -> bool:
         if not isinstance(ev, dict):
@@ -1187,6 +1349,11 @@ def pretrim_startup_transient(
         ts = ev.get("ts")
         if not isinstance(ts, (int, float)):
             return True
+        # Trace-level spans and markers (cat:"Trace", the ph:"i" iteration-start
+        # instant) are deliberately *not* given the ph:"M" treatment: unlike
+        # metadata their ts/dur describe the untrimmed window, so carrying them
+        # over unchanged would have the artifact state a start and a duration
+        # the events no longer support. They fall through the ts filter below.
         ph = ev.get("ph")
         if ph == "s":  # flow start: sits on the host timeline
             return ts >= cpu_cut
@@ -1196,14 +1363,20 @@ def pretrim_startup_transient(
 
     kept = [ev for ev in events if _survives(ev)]
 
+    dropped_phase = _step_phase(spans[0][2])
     report = {
         "reason": "trimmed",
         "dropped_steps": dropped,
         "dropped_ms": round(sum(dur for _, dur, _ in spans[:dropped]) / 1000.0, 3),
-        "median_step_ms": round(median_us / 1000.0, 3),
-        "outlier_ratio": round(spans[0][1] / median_us, 2),
+        "dropped_phase": dropped_phase,
+        "median_step_ms": phase_medians_ms[dropped_phase],
+        "phase_medians_ms": phase_medians_ms,
+        # The worst of the dropped steps, not the first: with more than one
+        # dropped the first is not necessarily the transient.
+        "outlier_ratio": round(max(ratios), 2),
         "outlier_factor": factor,
         "remaining_steps": remaining,
+        "host_steps": len(host_starts),
         "events_before": len(events),
         "events_after": len(kept),
         "gpu_cut_ts": gpu_cut,
@@ -1219,7 +1392,14 @@ def pretrim_startup_transient(
         with opener(dst, "wt", encoding="utf-8") as fh:
             json.dump(payload, fh)
     except Exception as exc:  # noqa: BLE001 - fall back to the raw trace rather than fail the run
-        return False, {"reason": "write_failed", "error": str(exc)[:200], **report}
+        # Drop the partial write. The caller keeps the untrimmed trace, and a
+        # truncated file left in the split directory is only something for a
+        # later step to mistake for a usable one. ``reason`` goes last so the
+        # failure is what the caller reads, not the "trimmed" this report was
+        # built with.
+        with contextlib.suppress(OSError):
+            dst.unlink(missing_ok=True)
+        return False, {**report, "reason": "write_failed", "error": str(exc)[:200]}
     return True, report
 
 
@@ -7845,38 +8025,63 @@ def main() -> int:
                 # percentage is then computed against that inflated denominator.
                 # Trimming here keeps the splitter and TraceLens untouched.
                 trimmed_trace = split_dir / (analysis_trace_path.name.replace(".trace.json", ".pretrimmed.trace.json"))
-                min_remaining = max(8, int(args.split_num_steps or 32))
+                split_num_steps = max(8, int(args.split_num_steps or 32))
                 did_trim, pretrim_report = pretrim_startup_transient(
                     analysis_trace_path,
                     trimmed_trace,
                 )
                 pretrim_summary = dict(pretrim_report)
                 pretrim_summary["applied"] = False
-                if did_trim and pretrim_report["remaining_steps"] < min_remaining:
+                # Only the splitter's input moves to the trimmed copy.
+                # analysis_trace_path stays on the real capture: capture-folder
+                # discovery resolves the graph-capture sidecar from the trace
+                # file's own directory, and the split warnings name it as the
+                # capture the operator profiled. Both would point into
+                # trace_split/ if this were reassigned.
+                split_input_path = analysis_trace_path
+                if did_trim and pretrim_report["remaining_steps"] < split_num_steps:
                     # Trimming would leave the splitter fewer steps than it
                     # was asked for. A silently short window reads as a clean
                     # measurement; the untrimmed one at least shows the damage.
                     append_log(
                         log_path,
                         f"pretrim: only {pretrim_report['remaining_steps']} step(s) would "
-                        f"remain < --split-num-steps {min_remaining}; keeping untrimmed trace",
+                        f"remain < --split-num-steps {split_num_steps}; keeping untrimmed trace",
                     )
                     pretrim_summary["reason"] = "insufficient_remaining_steps"
-                    pretrim_summary["min_remaining_steps"] = min_remaining
+                    pretrim_summary["min_remaining_steps"] = split_num_steps
+                    # The rejected copy is nearly the size of the capture; it is
+                    # not the input to anything now, so do not leave it behind.
+                    with contextlib.suppress(OSError):
+                        trimmed_trace.unlink(missing_ok=True)
                 elif did_trim:
                     append_log(
                         log_path,
-                        f"pretrim: dropped {pretrim_report['dropped_steps']} leading step(s), "
+                        f"pretrim: dropped {pretrim_report['dropped_steps']} leading "
+                        f"{pretrim_report['dropped_phase']} step(s), "
                         f"{pretrim_report['dropped_ms']:.1f} ms, "
-                        f"{pretrim_report['outlier_ratio']:.0f}x median "
+                        f"{pretrim_report['outlier_ratio']:.0f}x phase median "
                         f"{pretrim_report['median_step_ms']:.1f} ms; "
                         f"{pretrim_report['remaining_steps']} step(s) remain",
                     )
                     pretrim_summary["applied"] = True
-                    analysis_trace_path = trimmed_trace
+                    split_input_path = trimmed_trace
                     artifacts["tracelens_pretrimmed_trace"] = str(trimmed_trace)
-                elif pretrim_report.get("reason") != "clean":
+                elif pretrim_report.get("reason") != "no_leading_outlier":
                     append_log(log_path, f"pretrim: not applied ({pretrim_report.get('reason')})")
+                if pretrim_report.get("reason") == "too_many_leading_outliers":
+                    # A run of leading outliers is not a transient to trim but a
+                    # workload that never settled. Route it to the health
+                    # warnings so it reaches the report, not just the run log.
+                    trace_health_warnings.append(
+                        _build_pretrim_no_steady_state_warning(
+                            trace_input=analysis_trace_path,
+                            steps=int(pretrim_report["steps"]),
+                            leading_outliers=int(pretrim_report["leading_outliers"]),
+                            max_dropped_steps=int(pretrim_report["max_dropped_steps"]),
+                            outlier_factor=float(pretrim_report["outlier_factor"]),
+                        )
+                    )
                 # Persist as an artifact, not just a log line: the status
                 # file is rewritten by every later step, so a diagnostic
                 # parked there is gone by the time anyone reads the report.
@@ -7888,12 +8093,12 @@ def main() -> int:
                     sys.executable,
                     "-m",
                     "TraceLens.TraceUtils.split_inference_trace_annotation",
-                    str(analysis_trace_path),
+                    str(split_input_path),
                     "-o",
                     str(split_dir),
                     "--find-steady-state",
                     "--num-steps",
-                    str(max(8, int(args.split_num_steps or 32))),
+                    str(split_num_steps),
                 ]
                 conc = args.split_conc or os.environ.get("CONC", "").strip()
                 if str(conc).strip():

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -1096,11 +1096,18 @@ def _host_step_starts(events: list[Any]) -> list[float]:
     names are the framework's and are not unique: a build that omits the
     cumulative-sequence-length fields repeats ``step[DECODE bs=36]`` for every
     step at that batch size, and keying on it silently pairs the surviving step
-    with the *first* step of the capture. Both timelines carry one annotation per
-    step in execution order, so the Nth host entry is the Nth device step
-    whatever the names say. Indexing from the front also tolerates the host's
-    trailing extras: a capture can stop with launches already issued for a step
-    whose device span never landed.
+    with the *first* step of the capture.
+
+    Positional pairing needs the two timelines to hold one annotation per step,
+    and that is a property of the capture rather than something this can assume.
+    Across 32 measured per-rank captures only 5 held it; the other 27 carried
+    128 host ``step[...]`` annotations against a single device one, with the
+    step's own *children* (``scheduler.run_batch``, ``copy_result_to_cpu``)
+    projected onto the device 127 times each. Whatever produces that, the
+    missing entries are not a tail: the Nth host start is then some earlier
+    step's, and both the count check and the ordering check downstream would
+    pass while the host cut lands too early. The caller therefore requires the
+    counts to match exactly and refuses the trim otherwise.
 
     Args:
         events (list[Any]): ``traceEvents`` from a torch-profiler trace.
@@ -1313,13 +1320,16 @@ def pretrim_startup_transient(
     # dropped step's post-barrier kernels behind as orphans.
     gpu_cut = spans[dropped][0]
     host_starts = _host_step_starts(events)
-    if len(host_starts) < len(spans):
-        # Without one host annotation per device step the two timelines cannot be
-        # paired positionally, and pairing by name is not an alternative (see
-        # `_host_step_starts`). Refuse rather than fall back to a single cut,
-        # which is the outcome this split exists to avoid.
+    if len(host_starts) != len(spans):
+        # Exact equality, not "enough host entries": a capture that carries more
+        # host annotations than device ones is missing them from the middle, not
+        # the tail (see `_host_step_starts`), so the Nth host start belongs to
+        # some earlier step and the host cut silently lands too early. Pairing by
+        # name is not an alternative either. Refuse rather than approximate --
+        # the caller keeps the untrimmed trace, which is the state this whole
+        # step was added to improve on but never worse than it.
         return False, {
-            "reason": "host_steps_missing",
+            "reason": "timeline_step_count_mismatch",
             "steps": len(spans),
             "host_steps": len(host_starts),
         }


### PR DESCRIPTION
## Problem

`torch.profiler.start()` is a local, unfenced call whose cost varies by seconds across ranks, and SGLang does not barrier after it. Ranks whose profiler comes up first reach the first collective of the step and spin there until the slowest peer arrives. A spin-waiting collective is charged as GPU-busy time, so that wait lands in the trace as one enormous kernel at the head of the window.

On the `Qwen3.8-2.4T-A95B-Quark-MXFP4` reference capture (session `20260825T085359Z-74dc572c`), a single `cross_device_reduce_2stage` held **15747 ms of a 16805 ms window**.

### It is profiler-start skew, not communication

Measured per rank across both captures in that session:

| | run1 | run2 |
|---|---:|---:|
| profiler-open spread across 8 ranks | 30.88 s | 24.57 s |
| spinning ranks | 5/8 | 6/8 |
| all spinning ranks retire within | 0.8 us | 0.6 us |
| `spin_r` vs `(last_open - open_r)` residual | < 1 ms | < 1 ms |

Every spinning rank goes from profiler-open to entering the barrier in 4.08–5.71 ms (the six kernels ahead of the embedding all-reduce). The earliest rank was ready and waited; the others were still inside `start()`.

The window is not structurally special either — all 128 steps are `step[DECODE bs=64]` with `g_sqsk` incrementing by 64, so step 0 is an ordinary mid-stream decode step that happens to be the first one after the profiler opened.

Control: `Kimi-K3` on the same host, same image, launched 90 s apart, same `TP`/`CONC`/`ISL`/`OSL`/`start_step`/`num_steps`/`with_stack` — profiler-open spread **0.98 ms**, longest kernel 0.5 ms. It runs with `shape_discovery: false` and no `kernel_shape_profiler`.

### Consequences, which ran the length of the session

- Compute% read **5.75%**, tripping the 10% low-compute gate, which suppressed the entire hot-kernel candidate list at PRELUDE (`hot_kernels: []`, `source resolution: 0/0`). TraceLens had in fact already ranked the three BF16 `aiter::gemm_a16w16` decode shapes as **P1** with `aiter/tuned_gemm.py` resolved — the same three a specialist rediscovered by hand five hours later for the session's only validated gain (+2.58%).
- Every kernel's share of the window was deflated **15.9x** (4.2x on the second capture), so `gpu_pct` understated every dispatch candidate.
- The before/after Compute%/Comm% deltas in the final report (`+17.9` / `-18.0`) tracked the size of the barrier rather than any optimization. Across the 15 valid rank pairings the reportable delta ranges `+0.0` … `+20.5` pt.

## Fix

The collective is self-healing — releasing it re-synchronises every rank — so contamination is confined to the first step. The following 127 steps measure **32.94 ms ± 0.3**:

```
step 0        : 15781.320 ms      <- 479x the median
steps 1..31   : mean 32.944  min 32.649  max 33.153
steps 32..127 : mean 32.990  min 32.627  max 33.230
```

`pretrim_startup_transient()` cuts the leading outlier steps before the trace reaches `split_inference_trace_annotation`. TraceLens and the splitter are untouched.

**Instrumentation is untouched.** `shape_discovery` and the `with_stack` frames its shapes ride on are kept — `pseudo_op::moe_flydsl_stage1/2` carry their `perf_params` via `kernel_shape_profiler.py(364): impl`, a `python_function` frame, so disabling either would cost the MoE perf models (35% of compute).

### The cut is per timeline, not a single timestamp

The host runs a step ahead of the device, so the first kept step's launches are issued *while the dropped step still owns the GPU*:

```
dropped step 0, device : [4687499639913, 4687515421233]   15.78 s
kept    step 1, host   :         [4687514582330, 4687514585612]   <- 839 ms INSIDE the above
kept    step 1, device :                        [4687515421306, 4687515454269]
```

No single boundary separates them:

| cut at | drops step 0 whole | keeps step 1 whole |
|---|---|---|
| device boundary | ✅ | ❌ strips step 1's host ops, and with them the `kernel_shape_profiler` frames its shape attribution rides on |
| host boundary | ❌ leaves step 0's post-barrier kernels as orphans | ✅ |
| **per timeline** | ✅ | ✅ |

Device-timeline categories (`kernel`, `gpu_memcpy`, `gpu_memset`, `gpu_user_annotation`) cut at the device boundary; everything else cuts at the host boundary; flow events follow the endpoint they sit on (`ph:"s"` host, `ph:"f"` device). Result on the reference trace: **127 device and 127 host step annotations with identical name sets** — no step half-present.

### Other design notes

- Detection is on **step duration vs median**, not on any kernel name, so the same guard catches other head-of-window transients (first-replay JIT, KV-pool growth).
- Only a **leading** run is cut. A slow step mid-window is real behaviour the splitter and health gates should still see.
- More than `_PRETRIM_MAX_DROPPED_STEPS` (4) leading outliers means the run never reached steady state — surfaced, not trimmed away.
- `ph:"M"` metadata is preserved regardless of timestamp. torch stamps it with the profiler-open time, always before the cut, so a plain `ts` filter strips all 68 records. TraceLens's own splitter drops these downstream anyway, but the pretrimmed trace is also a readable artifact and should not be the thing that loses them.
- `raw_trace_path` still points at the untrimmed capture, so whole-run graph-capture health is read from the full trace.
- Report goes to `tracelens/pretrim.json` and is registered as an artifact rather than parked in the status file, which every later step rewrites.
- **No new switches.** The outlier multiple is a module constant: healthy decode steps hold inside 2% of the median while the transient runs 479x over it, so there is no operating point between them worth exposing — and a trace whose measurement window is dominated by a synchronisation artifact is not one any caller should be electing to analyse.

### Downstream step count is unchanged

The splitter caps its window at `--num-steps`, so it still hands TraceLens exactly that many steps — only which ones changes:

```
[decode_only] Longest pure decode-only run: [0, 127) (127 steps). Selected [0, 32) (32 steps, capped at num_steps=32).
```

128 → 127 stays far above the 32 requested. Derived counts hold with it: `operation_count` for the MoE ops stays 92 layers × 32 steps = 2944, and `Percentage (%)` is against the compute total rather than the window. The trim is refused outright when fewer than `--num-steps` would remain.

## Validation on the reference trace

`runs/roofline/99e9c7e5.../torch_trace/1787655005.0139868-TP-3.trace.json.gz`

| | before | after |
|---|---:|---:|
| dropped | — | 1 step / 15781.3 ms @ 478x median 32.99 ms |
| device / host step annotations | 128 / 128 | 127 / 127, identical name sets |
| longest kernel | 15747.04 ms | **0.16 ms** |
| window `[0,32)` | 16804.8 ms | **1056.4 ms** |
| `ph:"M"` metadata | 68 | 68 |

Every event category retains 98.6–99.2%, i.e. one step's worth removed uniformly:

```
python_function     1054079 / 1064036   (99.1%)      cpu_op            80746 /  81920  (98.6%)
ac2g                 319381 /  321921   (99.2%)      cuda_runtime       5711 /   5761  (99.1%)
kernel               312545 /  315008   (99.2%)      user_annotation    1016 /   1024  (99.2%)
kernel_shape_profiler   3048 /    3072  (99.2%)      gpu_user_annotation 507 /    511  (99.2%)
```

Runtime 26.6 s on a 1.79M-event / 25 MB gz trace, against a 1413–2210 s TraceLens run.

Expected downstream: Compute% 5.75% → ~91.6%, Comm% 94.22% → ~8.4% (matching TraceLens's own steady-state estimate in the same report), and `priority_data.baseline_ms` 16804.84 → ~1054 so the GEMM impact score goes 0.55 → ~8.7.

## Tests

11 new tests in `test_tracelens_csv.py`. The fixture reproduces the host-leads-device offset, since that is what makes the single-timestamp cut wrong.

Barrier trimmed · clean trace no-op · mid-stream outlier preserved · too-many-leading-outliers refusal · short-trace skip · unreadable-trace degradation · no-step-annotations · default-threshold boundary · host side of first surviving step preserved · dropped step's device work does not leak past the host cut · enough steps left for the splitter.

`ruff check` / `ruff format --check` clean. Full file: 276 passed, 1 failed — `test_run_tracelens_skill_uses_hermetic_claude_env`, which fails identically on `main` (verified via `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)