### PR TITLE
[Stepping] Patch delivery invariant: explicit apply roots end-to-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ skyseg.onnx
 /*.csv
 /*.pptx
 /*.html
+kimik3-wares

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/sessions.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/sessions.py
@@ -1263,15 +1263,7 @@ def collect_final(
         reconstructed_report,
         warnings,
     )
-    def _layer_reproducible(e: dict) -> bool:
-        snap = str(e.get("source_snapshot") or "").strip()
-        if not snap:
-            return False
-        complete = e.get("source_snapshot_complete")
-        if complete is not None:
-            return bool(complete)
-        from hyperloom.orchestrator.source_snapshot import snapshot_is_complete as _sic
-        return _sic(snap)
+    from hyperloom.orchestrator.source_snapshot import source_layer_reproducible
 
     source_layers = [
         {
@@ -1279,7 +1271,7 @@ def collect_final(
             "snapshot_dir": str(e.get("source_snapshot") or ""),
             "framework_root": str(e.get("framework_root") or ""),
             "base_sha": str(e.get("base_sha") or ""),
-            "reproducible": _layer_reproducible(e),
+            "reproducible": source_layer_reproducible(e),
         }
         for e in (stack if isinstance(stack, list) else [])
         if isinstance(e, dict) and e.get("scope") == "source_patch"

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/sessions.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/sessions.py
@@ -1263,13 +1263,23 @@ def collect_final(
         reconstructed_report,
         warnings,
     )
+    def _layer_reproducible(e: dict) -> bool:
+        snap = str(e.get("source_snapshot") or "").strip()
+        if not snap:
+            return False
+        complete = e.get("source_snapshot_complete")
+        if complete is not None:
+            return bool(complete)
+        from hyperloom.orchestrator.source_snapshot import snapshot_is_complete as _sic
+        return _sic(snap)
+
     source_layers = [
         {
             "id": str(e.get("variant_name") or e.get("name") or ""),
             "snapshot_dir": str(e.get("source_snapshot") or ""),
             "framework_root": str(e.get("framework_root") or ""),
             "base_sha": str(e.get("base_sha") or ""),
-            "reproducible": bool(e.get("source_snapshot")),
+            "reproducible": _layer_reproducible(e),
         }
         for e in (stack if isinstance(stack, list) else [])
         if isinstance(e, dict) and e.get("scope") == "source_patch"

--- a/src/hyperloom/inference_optimizer/tests/test_breakdown_exporter_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_breakdown_exporter_unit.py
@@ -339,6 +339,7 @@ def test_final_source_layers_populated_from_stack(tmp_path):
                         "scope": "source_patch",
                         "variant_name": "patch-abc",
                         "source_snapshot": "/session/opt/src/abc",
+                        "source_snapshot_complete": True,
                         "framework_root": "/opt/sglang",
                         "base_sha": "cafebabe",
                     }

--- a/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
@@ -966,3 +966,34 @@ class TestWarmReplayPatchRootResolution:
         resolution = fp.resolve_warm_replay_kernel_root(patch_paths=[patch])
         assert resolution.root == ""
         assert resolution.reason == "kernel_patch_root_not_in_allowlist"
+
+
+class TestResolveFrameworkTree:
+    def test_prefixed_env_wins(self, monkeypatch, tmp_path):
+        tree = tmp_path / "sglang"
+        tree.mkdir()
+        monkeypatch.setenv("SGLANG_REPO_PATH", str(tree))
+        assert fp.resolve_framework_tree("sglang") == f"{tree}/"
+
+    def test_generic_env_is_used_when_no_prefixed_one(self, monkeypatch, tmp_path):
+        tree = tmp_path / "generic"
+        tree.mkdir()
+        monkeypatch.delenv("SGLANG_REPO_PATH", raising=False)
+        monkeypatch.delenv("SGLANG_DIR", raising=False)
+        monkeypatch.setenv("FRAMEWORK_REPO_PATH", str(tree))
+        assert fp.resolve_framework_tree("sglang") == f"{tree}/"
+
+    def test_absent_env_falls_to_package_origin(self, monkeypatch, tmp_path):
+        pkg_parent = tmp_path / "site-packages"
+        (pkg_parent / "myfw").mkdir(parents=True)
+        monkeypatch.delenv("FRAMEWORK_REPO_PATH", raising=False)
+        monkeypatch.setattr(fp, "_find_spec_origin", lambda name: pkg_parent if name == "myfw" else None)
+        assert fp.resolve_framework_tree("myfw") == f"{pkg_parent}/"
+
+    def test_unknown_framework_resolves_to_nothing(self, monkeypatch):
+        monkeypatch.delenv("FRAMEWORK_REPO_PATH", raising=False)
+        monkeypatch.setattr(fp, "_find_spec_origin", lambda name: None)
+        assert fp.resolve_framework_tree("not-a-framework") == ""
+
+    def test_empty_name_resolves_to_nothing(self):
+        assert fp.resolve_framework_tree("") == ""

--- a/src/hyperloom/inference_optimizer/tests/test_integrate_patch_artifacts_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_integrate_patch_artifacts_unit.py
@@ -154,7 +154,9 @@ def test_resolve_artifact_specs_missing_source_or_target(tmp_path, monkeypatch):
 
 # ---- _apply_artifacts / _revert_artifacts round-trip ----------------------
 def _spec(source: Path, target: Path, rel: str) -> ip._ArtifactSpec:
-    return ip._ArtifactSpec(source=source.resolve(), target=target.resolve(), rel_target=rel)
+    resolved = target.resolve()
+    root = Path(str(resolved)[: -len(rel)]) if rel and str(resolved).endswith(rel) else resolved.parent
+    return ip._ArtifactSpec(source=source.resolve(), target=resolved, rel_target=rel, root=root)
 
 
 def test_apply_then_revert_restores_clobbered_target(tmp_path):
@@ -230,6 +232,7 @@ def test_resolve_artifact_target_absolute_within_allowlist(tmp_path, monkeypatch
     assert out == (
         (fw / "configs" / "model_configs" / "tuned_fmoe.csv").resolve(),
         "configs/model_configs/tuned_fmoe.csv",
+        fw.resolve(),
     )
 
 
@@ -250,6 +253,7 @@ def test_resolve_artifact_target_relative_still_works(tmp_path, monkeypatch):
     assert out == (
         (fw / "configs" / "model_configs" / "tuned_fmoe.csv").resolve(),
         "configs/model_configs/tuned_fmoe.csv",
+        fw.resolve(),
     )
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_integrate_patch_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_integrate_patch_coverage_unit.py
@@ -109,7 +109,7 @@ async def test_no_framework_agent_root(tmp_path, monkeypatch):
     monkeypatch.setattr(
         ip,
         "_resolve_framework_root",
-        lambda explicit, patch_paths=None: None,
+        lambda explicit, patch_paths=None, patch_texts=None, recorded_root=None: None,
     )
     ex = IntegratePatchExecutor(session_dir=session)
     res = await ex(_make_ctx("t", {"specialist_task_id": "spec"}))
@@ -1390,3 +1390,39 @@ async def test_no_patches_without_drops_has_no_grounding_key(tmp_path, monkeypat
 
     assert res["status"] == "no_patches"
     assert "patches_dropped_by_grounding" not in res
+
+
+# ---- VettingDropFeedback ---------------------------------------------------
+def test_vetting_drop_feedback_format_missing_target():
+    from hyperloom.orchestrator.actions.executors._apply_feedback import VettingDropFeedback
+    fb = VettingDropFeedback(patch="patches/001.patch", verdict="missing_target", detail="no_matching_root")
+    text = fb.format_for_mandate()
+    assert "001.patch" in text
+    assert "missing_target" in text
+    assert "Glob/Grep" in text
+
+
+def test_vetting_drop_feedback_format_ambiguous_root():
+    from hyperloom.orchestrator.actions.executors._apply_feedback import VettingDropFeedback
+    fb = VettingDropFeedback(patch="patches/p.patch", verdict="ambiguous_root", detail="/a, /b")
+    text = fb.format_for_mandate()
+    assert "ambiguous_root" in text
+    assert "framework_source_root" in text
+
+
+def test_vetting_drop_feedback_round_trip():
+    from hyperloom.orchestrator.actions.executors._apply_feedback import VettingDropFeedback
+    fb = VettingDropFeedback(patch="p.patch", verdict="missing_target", detail="x")
+    assert VettingDropFeedback.from_dict(fb.to_dict()) == fb
+
+
+def test_vetting_drop_feedback_from_dropped_records():
+    from hyperloom.orchestrator.actions.executors._apply_feedback import VettingDropFeedback
+    records = [
+        {"path": "a.patch", "verdict": "missing_target", "detail": "no match"},
+        {"path": "b.patch", "verdict": "ambiguous_root", "detail": "/x, /y"},
+    ]
+    feedbacks = VettingDropFeedback.from_dropped_records(records)
+    assert len(feedbacks) == 2
+    assert feedbacks[0].patch == "a.patch"
+    assert feedbacks[1].verdict == "ambiguous_root"

--- a/src/hyperloom/inference_optimizer/tests/test_integrate_patch_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_integrate_patch_coverage_unit.py
@@ -1185,6 +1185,7 @@ async def test_artifact_install_failed_restores_user_stash(tmp_path, monkeypatch
             source=tmp_path / "tuned.json",
             target=repo / "tuned.json",
             rel_target="tuned.json",
+            root=repo,
             kind="config_json",
         )
         return [spec], []
@@ -1287,6 +1288,7 @@ async def test_a_cancel_in_the_apply_stage_still_hands_the_stash_back(tmp_path, 
             source=tmp_path / "tuned.json",
             target=repo / "tuned.json",
             rel_target="tuned.json",
+            root=repo,
             kind="config_json",
         )
         return [spec], []
@@ -1390,39 +1392,3 @@ async def test_no_patches_without_drops_has_no_grounding_key(tmp_path, monkeypat
 
     assert res["status"] == "no_patches"
     assert "patches_dropped_by_grounding" not in res
-
-
-# ---- VettingDropFeedback ---------------------------------------------------
-def test_vetting_drop_feedback_format_missing_target():
-    from hyperloom.orchestrator.actions.executors._apply_feedback import VettingDropFeedback
-    fb = VettingDropFeedback(patch="patches/001.patch", verdict="missing_target", detail="no_matching_root")
-    text = fb.format_for_mandate()
-    assert "001.patch" in text
-    assert "missing_target" in text
-    assert "Glob/Grep" in text
-
-
-def test_vetting_drop_feedback_format_ambiguous_root():
-    from hyperloom.orchestrator.actions.executors._apply_feedback import VettingDropFeedback
-    fb = VettingDropFeedback(patch="patches/p.patch", verdict="ambiguous_root", detail="/a, /b")
-    text = fb.format_for_mandate()
-    assert "ambiguous_root" in text
-    assert "framework_source_root" in text
-
-
-def test_vetting_drop_feedback_round_trip():
-    from hyperloom.orchestrator.actions.executors._apply_feedback import VettingDropFeedback
-    fb = VettingDropFeedback(patch="p.patch", verdict="missing_target", detail="x")
-    assert VettingDropFeedback.from_dict(fb.to_dict()) == fb
-
-
-def test_vetting_drop_feedback_from_dropped_records():
-    from hyperloom.orchestrator.actions.executors._apply_feedback import VettingDropFeedback
-    records = [
-        {"path": "a.patch", "verdict": "missing_target", "detail": "no match"},
-        {"path": "b.patch", "verdict": "ambiguous_root", "detail": "/x, /y"},
-    ]
-    feedbacks = VettingDropFeedback.from_dropped_records(records)
-    assert len(feedbacks) == 2
-    assert feedbacks[0].patch == "a.patch"
-    assert feedbacks[1].verdict == "ambiguous_root"

--- a/src/hyperloom/inference_optimizer/tests/test_promote_shared_state_lock.py
+++ b/src/hyperloom/inference_optimizer/tests/test_promote_shared_state_lock.py
@@ -18,6 +18,7 @@ from hyperloom.orchestrator.roles import (
 )
 from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
 from hyperloom.orchestrator.loop.coordinator import Coordinator
+from hyperloom.orchestrator.loop import writeback as wb
 from hyperloom.orchestrator.loop.writeback import WritebackCollaborator
 from hyperloom.orchestrator.knowledge.remote_recipe._vendor.kb_store_client import (
     KnowledgeSections,
@@ -1838,3 +1839,92 @@ async def test_integrate_keep_lets_a_tuning_env_delta_win(session_dir):
     )
 
     assert s.current_best["extra_envs"] == {"KEEP_ME": "1", "TUNED": "new"}
+
+
+# ── source-layer handles: executor result → stack entry → env_spec ──────────
+
+
+def _keep_result(tmp_path: Path, *, import_root: str, complete: bool = True) -> dict:
+    """An integrate_patch KEEP result with a materialized snapshot on disk."""
+    snapshot = tmp_path / "snap"
+    (snapshot / "files" / import_root).mkdir(parents=True)
+    return {
+        "source_snapshot": str(snapshot),
+        "source_manifest": str(snapshot / "manifest.json"),
+        "target_files": ["python/sglang/srt/server.py"],
+        "framework_root": "/sgl-workspace/sglang",
+        "base_sha": "abc123",
+        "source_import_root": import_root,
+        "source_snapshot_complete": complete,
+    }
+
+
+def test_source_layer_handles_carry_every_field_the_stack_entry_needs(tmp_path):
+    """A lift path that forwards a subset silently degrades the GEAK overlay."""
+    handles = wb._source_layer_handles(_keep_result(tmp_path, import_root="python"))
+
+    assert handles["source_import_root"] == "python"
+    assert handles["source_snapshot_complete"] is True
+    assert handles["framework_root"] == "/sgl-workspace/sglang"
+    assert handles["base_sha"] == "abc123"
+    assert handles["target_files"] == ["python/sglang/srt/server.py"]
+    assert handles["source_snapshot"].endswith("snap")
+
+
+def test_source_layer_handles_omit_a_completeness_the_result_never_recorded():
+    """Absent must stay absent so legacy entries still read their manifest."""
+    handles = wb._source_layer_handles({"source_snapshot": "/snap"})
+
+    assert "source_snapshot_complete" not in handles
+
+
+def test_env_spec_hands_geak_the_import_root_not_the_snapshot_top(session_dir, tmp_path):
+    """GEAK PYTHONPATHs this value; the snapshot top holds no importable module."""
+    coord = _coord(session_dir)
+    coord.shared_state.baseline_tput = 1000.0
+    result = _keep_result(tmp_path, import_root="python")
+
+    coord._lift_to_current_best(
+        "integrate_patch",
+        1200.0,
+        {"name": "patch-1", "scope": "source_patch", **wb._source_layer_handles(result)},
+    )
+    spec = coord.build_env_spec()
+
+    (snapshot,) = spec["source_snapshots"]
+    assert snapshot["snapshot_dir"] == str(tmp_path / "snap" / "files" / "python")
+    assert snapshot["reproducible"] is True
+
+
+def test_env_spec_overlay_stops_at_files_for_a_dist_packages_install(session_dir, tmp_path):
+    """No import root means modules already start at the tree root."""
+    coord = _coord(session_dir)
+    coord.shared_state.baseline_tput = 1000.0
+    result = _keep_result(tmp_path, import_root="")
+
+    coord._lift_to_current_best(
+        "integrate_patch",
+        1200.0,
+        {"name": "patch-1", "scope": "source_patch", **wb._source_layer_handles(result)},
+    )
+    spec = coord.build_env_spec()
+
+    (snapshot,) = spec["source_snapshots"]
+    assert snapshot["snapshot_dir"] == str(tmp_path / "snap" / "files")
+
+
+def test_env_spec_refuses_an_incomplete_snapshot(session_dir, tmp_path):
+    """GEAK drops a non-reproducible entry, so False must survive the lift."""
+    coord = _coord(session_dir)
+    coord.shared_state.baseline_tput = 1000.0
+    result = _keep_result(tmp_path, import_root="python", complete=False)
+
+    coord._lift_to_current_best(
+        "integrate_patch",
+        1200.0,
+        {"name": "patch-1", "scope": "source_patch", **wb._source_layer_handles(result)},
+    )
+    spec = coord.build_env_spec()
+
+    (snapshot,) = spec["source_snapshots"]
+    assert snapshot["reproducible"] is False

--- a/src/hyperloom/inference_optimizer/tests/test_source_snapshot_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_source_snapshot_unit.py
@@ -3,7 +3,8 @@
 
 """Unit coverage for the per-KEEP source-layer snapshot contract
 (``hyperloom.orchestrator.source_snapshot``): ``_safe_rel`` path sanitation,
-and ``snapshot_source_layer`` capture (upsert/delete/empty)."""
+``snapshot_source_layer`` capture (upsert/delete/missing), and
+``snapshot_is_complete``."""
 
 from __future__ import annotations
 
@@ -13,6 +14,7 @@ from pathlib import Path
 from hyperloom.orchestrator.source_snapshot import (
     MANIFEST_NAME,
     _safe_rel,
+    snapshot_is_complete,
     snapshot_source_layer,
 )
 
@@ -36,12 +38,32 @@ def test_safe_rel_passthrough_for_plain_relative_path() -> None:
     assert _safe_rel("vllm/model_executor/layers/foo.py") == ("vllm/model_executor/layers/foo.py")
 
 
-def test_snapshot_source_layer_captures_upsert_and_delete(tmp_path: Path) -> None:
+def test_snapshot_source_layer_upsert_only_is_complete(tmp_path: Path) -> None:
+    fw = tmp_path / "framework"
+    (fw / "pkg").mkdir(parents=True)
+    (fw / "pkg" / "mod.py").write_text("x = 1\n", encoding="utf-8")
+
+    dest = tmp_path / "snap"
+    manifest = snapshot_source_layer(
+        framework_root=fw,
+        base_sha="abc123",
+        rel_paths=["pkg/mod.py"],
+        dest_dir=dest,
+        provenance="integrate_patch",
+    )
+
+    assert manifest is not None
+    assert manifest["complete"] is True
+    ops = {f["rel"]: f["op"] for f in manifest["files"]}
+    assert ops == {"pkg/mod.py": "upsert"}
+    assert snapshot_is_complete(dest)
+
+
+def test_snapshot_source_layer_declared_delete_is_complete(tmp_path: Path) -> None:
     fw = tmp_path / "framework"
     (fw / "pkg").mkdir(parents=True)
     kept = fw / "pkg" / "kept.py"
     kept.write_text("print('kept')\n", encoding="utf-8")
-    # "removed.py" is a changed path that no longer exists -> recorded as "delete".
 
     dest = tmp_path / "snap"
     manifest = snapshot_source_layer(
@@ -51,20 +73,55 @@ def test_snapshot_source_layer_captures_upsert_and_delete(tmp_path: Path) -> Non
         dest_dir=dest,
         provenance="integrate_patch",
         extra={"kernel_id": "k1"},
+        declared_ops={"pkg/removed.py": "delete"},
     )
 
     assert manifest is not None
-    assert manifest["snapshot_dir"] == str(dest)
-    assert manifest["base_sha"] == "abc123"
-    assert manifest["provenance"] == "integrate_patch"
-    assert manifest["extra"] == {"kernel_id": "k1"}
+    assert manifest["complete"] is True
     ops = {f["rel"]: f["op"] for f in manifest["files"]}
     assert ops == {"pkg/kept.py": "upsert", "pkg/removed.py": "delete"}
-
-    # Manifest is persisted alongside a real copy of the file.
     on_disk = json.loads((dest / MANIFEST_NAME).read_text(encoding="utf-8"))
     assert on_disk["files"] == manifest["files"]
-    assert (dest / "files" / "pkg" / "kept.py").read_text(encoding="utf-8") == ("print('kept')\n")
+    assert (dest / "files" / "pkg" / "kept.py").read_text(encoding="utf-8") == "print('kept')\n"
+
+
+def test_snapshot_source_layer_undeclared_absent_becomes_missing(tmp_path: Path) -> None:
+    fw = tmp_path / "framework"
+    fw.mkdir(parents=True)
+
+    dest = tmp_path / "snap"
+    manifest = snapshot_source_layer(
+        framework_root=fw,
+        base_sha="abc",
+        rel_paths=["pkg/ghost.py"],
+        dest_dir=dest,
+    )
+
+    assert manifest is not None
+    assert manifest["complete"] is False
+    ops = {f["rel"]: f["op"] for f in manifest["files"]}
+    assert ops == {"pkg/ghost.py": "missing"}
+    assert not snapshot_is_complete(dest)
+
+
+def test_snapshot_source_layer_import_root_recorded(tmp_path: Path) -> None:
+    fw = tmp_path / "sglang"
+    (fw / "python" / "sglang" / "srt").mkdir(parents=True)
+    f = fw / "python" / "sglang" / "srt" / "foo.py"
+    f.write_text("x = 1\n", encoding="utf-8")
+
+    dest = tmp_path / "snap"
+    manifest = snapshot_source_layer(
+        framework_root=fw,
+        base_sha="",
+        rel_paths=["python/sglang/srt/foo.py"],
+        dest_dir=dest,
+        import_root="python",
+    )
+
+    assert manifest is not None
+    assert manifest["import_root"] == "python"
+    assert manifest["schema_version"] == 2
 
 
 def test_snapshot_source_layer_skips_unsafe_paths(tmp_path: Path) -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_patch_safety_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_patch_safety_unit.py
@@ -7,6 +7,9 @@ git grounding, missing-target detection, and quantitative-claim guards)."""
 from __future__ import annotations
 
 
+import subprocess
+from pathlib import Path
+
 import pytest
 
 from hyperloom.orchestrator.specialists import patch_safety as ps
@@ -377,16 +380,15 @@ def test_vet_patches_unreadable(tmp_path):
 
 
 # ---- nested root collapse + GROUND_AMBIGUOUS_ROOT -------------------------
-def _make_git_repo(root: "Path", files: dict) -> "Path":
-    import subprocess as _sp
+def _make_git_repo(root: Path, files: dict[str, str]) -> Path:
     root.mkdir(parents=True, exist_ok=True)
     for rel, content in files.items():
         p = root / rel
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(content, encoding="utf-8")
-    _sp.run(["git", "init", "-q", str(root)], check=True)
-    _sp.run(["git", "-C", str(root), "add", "-A"], check=True)
-    _sp.run(
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+    subprocess.run(
         ["git", "-C", str(root), "-c", "user.email=a@b", "-c", "user.name=t", "commit", "-qm", "base"],
         check=True,
     )
@@ -427,9 +429,7 @@ def test_vet_patches_ambiguous_root_not_labeled_missing_target(tmp_path):
     tree_b = _make_git_repo(tmp_path / "b", {"foo.py": "old\n"})
     diff_file = tmp_path / "p.patch"
     diff_file.write_text("--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-old\n+new\n", encoding="utf-8")
-    _, dropped, grounding, _ = ps.vet_patches(
-        [str(diff_file)], base_checkout=tree_a, candidate_roots=(tree_b,)
-    )
+    _, dropped, grounding, _ = ps.vet_patches([str(diff_file)], base_checkout=tree_a, candidate_roots=(tree_b,))
     assert len(dropped) == 1
     assert dropped[0]["verdict"] == ps.GROUND_AMBIGUOUS_ROOT
     assert grounding[str(diff_file)] == ps.GROUND_AMBIGUOUS_ROOT

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_patch_safety_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_patch_safety_unit.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from hyperloom.orchestrator.specialists import patch_safety as ps
+from hyperloom.orchestrator.specialists import runner
 
 
 _DIFF = "diff --git a/foo.py b/foo.py\nindex 111..222 100644\n--- a/foo.py\n+++ b/foo.py\n@@ -1,2 +1,2 @@\n-old\n+new\n"
@@ -433,3 +434,45 @@ def test_vet_patches_ambiguous_root_not_labeled_missing_target(tmp_path):
     assert len(dropped) == 1
     assert dropped[0]["verdict"] == ps.GROUND_AMBIGUOUS_ROOT
     assert grounding[str(diff_file)] == ps.GROUND_AMBIGUOUS_ROOT
+
+
+# ---- grounding root selection ----------------------------------------------
+def test_grounding_root_uses_a_harvest_the_whole_set_agrees_on():
+    root = runner._grounding_explicit_root(
+        declared="",
+        patches=["/wt/patches/_worktree_diff.patch"],
+        patch_roots={"/wt/patches/_worktree_diff.patch": "/sgl-workspace/sglang"},
+    )
+    assert root == Path("/sgl-workspace/sglang")
+
+
+def test_grounding_root_declines_when_a_hand_authored_patch_rides_along():
+    """Its target tree is unknown; the harvest root would drop it as a mismatch."""
+    root = runner._grounding_explicit_root(
+        declared="",
+        patches=["/wt/patches/_worktree_diff.patch", "/wt/patches/manual.patch"],
+        patch_roots={"/wt/patches/_worktree_diff.patch": "/sgl-workspace/sglang"},
+    )
+    assert root is None
+
+
+def test_grounding_root_declines_when_harvests_disagree():
+    root = runner._grounding_explicit_root(
+        declared="",
+        patches=["/a.patch", "/b.patch"],
+        patch_roots={"/a.patch": "/tree/one", "/b.patch": "/tree/two"},
+    )
+    assert root is None
+
+
+def test_grounding_root_prefers_a_declared_source_root():
+    root = runner._grounding_explicit_root(
+        declared="/declared/tree",
+        patches=["/a.patch"],
+        patch_roots={"/a.patch": "/harvested/tree"},
+    )
+    assert root == Path("/declared/tree")
+
+
+def test_grounding_root_declines_for_an_empty_set():
+    assert runner._grounding_explicit_root(declared="", patches=[], patch_roots={}) is None

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_patch_safety_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_patch_safety_unit.py
@@ -374,3 +374,62 @@ def test_vet_patches_unreadable(tmp_path):
     assert kept == []
     assert dropped[0]["verdict"] == "unreadable"
     assert not spans_roots
+
+
+# ---- nested root collapse + GROUND_AMBIGUOUS_ROOT -------------------------
+def _make_git_repo(root: "Path", files: dict) -> "Path":
+    import subprocess as _sp
+    root.mkdir(parents=True, exist_ok=True)
+    for rel, content in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    _sp.run(["git", "init", "-q", str(root)], check=True)
+    _sp.run(["git", "-C", str(root), "add", "-A"], check=True)
+    _sp.run(
+        ["git", "-C", str(root), "-c", "user.email=a@b", "-c", "user.name=t", "commit", "-qm", "base"],
+        check=True,
+    )
+    return root
+
+
+def test_nested_root_collapse_picks_outer(tmp_path):
+    outer = _make_git_repo(tmp_path / "sglang", {"python/sglang/srt/foo.py": "old\n"})
+    inner = outer / "python"
+    inner.mkdir(exist_ok=True)
+    diff = "--- a/python/sglang/srt/foo.py\n+++ b/python/sglang/srt/foo.py\n@@ -1 +1 @@\n-old\n+new\n"
+    res = ps.resolve_patch_apply_root([diff], explicit_root=None, candidate_roots=[outer, inner])
+    assert res.root is not None
+    assert res.root.resolve() == outer.resolve()
+    assert res.reason == ""
+
+
+def test_disjoint_ambiguity_still_fails(tmp_path):
+    tree_a = _make_git_repo(tmp_path / "a", {"srt/foo.py": "old\n"})
+    tree_b = _make_git_repo(tmp_path / "b", {"srt/foo.py": "old\n"})
+    diff = "--- a/srt/foo.py\n+++ b/srt/foo.py\n@@ -1 +1 @@\n-old\n+new\n"
+    res = ps.resolve_patch_apply_root([diff], explicit_root=None, candidate_roots=[tree_a, tree_b])
+    assert res.root is None
+    assert res.reason == "ambiguous_root"
+
+
+def test_ground_patch_text_returns_ambiguous_root_verdict(tmp_path):
+    tree_a = _make_git_repo(tmp_path / "a", {"foo.py": "old\n"})
+    tree_b = _make_git_repo(tmp_path / "b", {"foo.py": "old\n"})
+    diff = "--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-old\n+new\n"
+    res = ps.ground_patch_text(diff, base_checkout=tree_a, candidate_roots=(tree_b,))
+    assert res.verdict == ps.GROUND_AMBIGUOUS_ROOT
+    assert res.is_garbage
+
+
+def test_vet_patches_ambiguous_root_not_labeled_missing_target(tmp_path):
+    tree_a = _make_git_repo(tmp_path / "a", {"foo.py": "old\n"})
+    tree_b = _make_git_repo(tmp_path / "b", {"foo.py": "old\n"})
+    diff_file = tmp_path / "p.patch"
+    diff_file.write_text("--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-old\n+new\n", encoding="utf-8")
+    _, dropped, grounding, _ = ps.vet_patches(
+        [str(diff_file)], base_checkout=tree_a, candidate_roots=(tree_b,)
+    )
+    assert len(dropped) == 1
+    assert dropped[0]["verdict"] == ps.GROUND_AMBIGUOUS_ROOT
+    assert grounding[str(diff_file)] == ps.GROUND_AMBIGUOUS_ROOT

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess.py
@@ -1280,6 +1280,51 @@ def test_collect_patches_harvests_git_diff_when_worktree_modified(tmp_path: Path
     assert str(base) in roots[patches[0]]
 
 
+def test_collect_patches_harvests_a_file_the_specialist_created(tmp_path: Path):
+    """git diff cannot see an untracked path; a half-patch is worse than none."""
+    base, wt = _make_git_worktree_pair(tmp_path)
+    (wt / "mod.py").write_text("new = 2\n", encoding="utf-8")
+    (wt / "added.py").write_text("fresh = 3\n", encoding="utf-8")
+
+    patches, _roots = SpecialistSubprocessDispatcher._collect_patches(wt, tmp_path / "ws", worktree_base=base)
+
+    patch_text = Path(patches[0]).read_text(encoding="utf-8")
+    assert "mod.py" in patch_text
+    assert "added.py" in patch_text
+
+
+def test_collect_patches_keeps_its_own_output_out_of_the_harvest(tmp_path: Path):
+    """The harvest lands in patches/, which must not become part of the diff."""
+    base, wt = _make_git_worktree_pair(tmp_path)
+    (wt / "mod.py").write_text("new = 2\n", encoding="utf-8")
+    (wt / "patches").mkdir()
+    (wt / "patches" / "stray.patch").write_text("--- a/z\n+++ b/z\n", encoding="utf-8")
+
+    patches, _roots = SpecialistSubprocessDispatcher._collect_patches(wt, tmp_path / "ws", worktree_base=base)
+
+    assert "stray.patch" not in Path(patches[0]).read_text(encoding="utf-8")
+
+
+def test_collect_patches_falls_back_to_disk_scan_when_git_is_unusable(tmp_path: Path, monkeypatch):
+    """A raising harvest would take the done-file and usage down with it."""
+    import subprocess as _sp
+
+    base, wt = _make_git_worktree_pair(tmp_path)
+    (wt / "mod.py").write_text("new = 2\n", encoding="utf-8")
+    (wt / "patches").mkdir()
+    (wt / "patches" / "manual.patch").write_text("--- a/foo.py\n+++ b/foo.py\n", encoding="utf-8")
+
+    def _boom(*_args, **_kwargs):
+        raise _sp.TimeoutExpired(cmd="git", timeout=120.0)
+
+    monkeypatch.setattr(_sp, "run", _boom)
+
+    patches, roots = SpecialistSubprocessDispatcher._collect_patches(wt, tmp_path / "ws", worktree_base=base)
+
+    assert any("manual.patch" in patch for patch in patches)
+    assert roots == {}
+
+
 def test_collect_patches_falls_back_to_disk_scan_when_no_changes(tmp_path: Path):
     base, wt = _make_git_worktree_pair(tmp_path)
     ws = tmp_path / "ws"

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess.py
@@ -1255,6 +1255,7 @@ async def test_partial_checkpoint_published_while_alive(
 # ---- _collect_patches: git diff harvest ------------------------------------
 def _make_git_worktree_pair(tmp_path: Path) -> tuple[Path, Path]:
     import subprocess as _sp
+
     base = tmp_path / "base"
     base.mkdir()
     (base / "mod.py").write_text("old = 1\n", encoding="utf-8")
@@ -1284,9 +1285,7 @@ def test_collect_patches_falls_back_to_disk_scan_when_no_changes(tmp_path: Path)
     ws = tmp_path / "ws"
     ws.mkdir()
     (ws / "patches").mkdir()
-    (ws / "patches" / "manual.patch").write_text(
-        "--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-a\n+b\n", encoding="utf-8"
-    )
+    (ws / "patches" / "manual.patch").write_text("--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-a\n+b\n", encoding="utf-8")
     patches, roots = SpecialistSubprocessDispatcher._collect_patches(wt, ws, worktree_base=base)
     assert any("manual.patch" in p for p in patches)
     assert all(p not in roots for p in patches)

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess.py
@@ -1250,3 +1250,53 @@ async def test_partial_checkpoint_published_while_alive(
     payload, elapsed = seen[0]
     assert payload["summary"] == "fake claude subprocess output"
     assert elapsed >= 0.0
+
+
+# ---- _collect_patches: git diff harvest ------------------------------------
+def _make_git_worktree_pair(tmp_path: Path) -> tuple[Path, Path]:
+    import subprocess as _sp
+    base = tmp_path / "base"
+    base.mkdir()
+    (base / "mod.py").write_text("old = 1\n", encoding="utf-8")
+    _sp.run(["git", "init", "-q", str(base)], check=True)
+    _sp.run(["git", "-C", str(base), "add", "-A"], check=True)
+    _sp.run(
+        ["git", "-C", str(base), "-c", "user.email=a@b", "-c", "user.name=t", "commit", "-qm", "base"],
+        check=True,
+    )
+    wt = tmp_path / "worktree"
+    _sp.run(["git", "-C", str(base), "worktree", "add", "-b", "sp1", str(wt)], check=True)
+    return base, wt
+
+
+def test_collect_patches_harvests_git_diff_when_worktree_modified(tmp_path: Path):
+    base, wt = _make_git_worktree_pair(tmp_path)
+    (wt / "mod.py").write_text("new = 2\n", encoding="utf-8")
+    patches, roots = SpecialistSubprocessDispatcher._collect_patches(wt, tmp_path / "ws", worktree_base=base)
+    assert len(patches) == 1
+    patch_text = Path(patches[0]).read_text(encoding="utf-8")
+    assert "mod.py" in patch_text
+    assert str(base) in roots[patches[0]]
+
+
+def test_collect_patches_falls_back_to_disk_scan_when_no_changes(tmp_path: Path):
+    base, wt = _make_git_worktree_pair(tmp_path)
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "patches").mkdir()
+    (ws / "patches" / "manual.patch").write_text(
+        "--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-a\n+b\n", encoding="utf-8"
+    )
+    patches, roots = SpecialistSubprocessDispatcher._collect_patches(wt, ws, worktree_base=base)
+    assert any("manual.patch" in p for p in patches)
+    assert all(p not in roots for p in patches)
+
+
+def test_collect_patches_no_worktree_falls_back_to_disk_scan(tmp_path: Path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "patches").mkdir()
+    (ws / "patches" / "p.patch").write_text("--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n", encoding="utf-8")
+    patches, roots = SpecialistSubprocessDispatcher._collect_patches(None, ws)
+    assert len(patches) == 1
+    assert roots == {}

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess_helpers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess_helpers.py
@@ -160,13 +160,14 @@ def test_collect_patches(tmp_path: Path) -> None:
     (wt / "patches" / "b.diff").write_text("d", encoding="utf-8")
     (wt / "patches" / "ignore.txt").write_text("x", encoding="utf-8")
     ws = tmp_path / "ws"
-    out = SpecialistSubprocessDispatcher._collect_patches(wt, ws)
+    out, roots = SpecialistSubprocessDispatcher._collect_patches(wt, ws)
     names = sorted(Path(p).name for p in out)
     assert names == ["a.patch", "b.diff"]
+    assert roots == {}
 
 
 def test_collect_patches_none_worktree(tmp_path: Path) -> None:
-    assert SpecialistSubprocessDispatcher._collect_patches(None, tmp_path) == []
+    assert SpecialistSubprocessDispatcher._collect_patches(None, tmp_path) == ([], {})
 
 
 # -- _read_done ------------------------------------------------------------

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess_helpers_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess_helpers_coverage_unit.py
@@ -252,3 +252,54 @@ def test_read_done_unwraps_intent_envelope(tmp_path: Path) -> None:
     assert out["domain"] == "kernel_switch_specialist"
     assert out["proposal_set"] == [{"name": "v1"}]
     assert "intent_type" not in out and "payload" not in out
+
+
+# ---- ensure_authoring_checkout --------------------------------------------
+from hyperloom.orchestrator.specialists.subprocess_ import ensure_authoring_checkout
+
+
+def _init_git_repo(p: Path) -> Path:
+    import subprocess as _sp
+    p.mkdir(parents=True, exist_ok=True)
+    (p / "mod.py").write_text("x = 1\n", encoding="utf-8")
+    _sp.run(["git", "init", "-q", str(p)], check=True)
+    _sp.run(["git", "-C", str(p), "add", "-A"], check=True)
+    _sp.run(
+        ["git", "-C", str(p), "-c", "user.email=a@b", "-c", "user.name=t", "commit", "-qm", "init"],
+        check=True,
+    )
+    return p
+
+
+def test_ensure_authoring_checkout_uses_existing_git_repo(tmp_path: Path, monkeypatch) -> None:
+    repo = _init_git_repo(tmp_path / "myfw")
+    monkeypatch.setenv("MYFW_REPO_PATH", str(repo))
+    result, err = ensure_authoring_checkout("myfw", tmp_path / "session")
+    assert err == ""
+    assert result is not None
+    assert result.resolve() == repo.resolve()
+
+
+def test_ensure_authoring_checkout_creates_shadow_repo_for_non_git(tmp_path: Path, monkeypatch) -> None:
+    plain = tmp_path / "plain_pkg"
+    plain.mkdir()
+    (plain / "mod.py").write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.setenv("MYFW2_REPO_PATH", str(plain))
+    session_dir = tmp_path / "session"
+    result, err = ensure_authoring_checkout("myfw2", session_dir)
+    assert err == "", f"unexpected error: {err!r}"
+    assert result is not None
+    shadow_git = result / ".git"
+    assert shadow_git.exists(), "shadow repo should have a .git marker"
+    assert result.is_relative_to(session_dir), "shadow repo should live under session_dir"
+
+
+def test_ensure_authoring_checkout_reuses_existing_shadow_repo(tmp_path: Path, monkeypatch) -> None:
+    plain = tmp_path / "fw"
+    plain.mkdir()
+    (plain / "mod.py").write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.setenv("FW3_REPO_PATH", str(plain))
+    session_dir = tmp_path / "sess"
+    result1, _ = ensure_authoring_checkout("fw3", session_dir)
+    result2, _ = ensure_authoring_checkout("fw3", session_dir)
+    assert result1 == result2

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess_helpers_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess_helpers_coverage_unit.py
@@ -204,13 +204,14 @@ def test_collect_patches(tmp_path: Path) -> None:
     (wt / "patches" / "b.diff").write_text("d", encoding="utf-8")
     (wt / "patches" / "ignore.txt").write_text("x", encoding="utf-8")
     ws = tmp_path / "ws"
-    out = SpecialistSubprocessDispatcher._collect_patches(wt, ws)
+    out, roots = SpecialistSubprocessDispatcher._collect_patches(wt, ws)
     names = sorted(Path(p).name for p in out)
     assert names == ["a.patch", "b.diff"]
+    assert roots == {}
 
 
 def test_collect_patches_none_worktree(tmp_path: Path) -> None:
-    assert SpecialistSubprocessDispatcher._collect_patches(None, tmp_path) == []
+    assert SpecialistSubprocessDispatcher._collect_patches(None, tmp_path) == ([], {})
 
 
 # -- _read_done ------------------------------------------------------------
@@ -252,54 +253,3 @@ def test_read_done_unwraps_intent_envelope(tmp_path: Path) -> None:
     assert out["domain"] == "kernel_switch_specialist"
     assert out["proposal_set"] == [{"name": "v1"}]
     assert "intent_type" not in out and "payload" not in out
-
-
-# ---- ensure_authoring_checkout --------------------------------------------
-from hyperloom.orchestrator.specialists.subprocess_ import ensure_authoring_checkout
-
-
-def _init_git_repo(p: Path) -> Path:
-    import subprocess as _sp
-    p.mkdir(parents=True, exist_ok=True)
-    (p / "mod.py").write_text("x = 1\n", encoding="utf-8")
-    _sp.run(["git", "init", "-q", str(p)], check=True)
-    _sp.run(["git", "-C", str(p), "add", "-A"], check=True)
-    _sp.run(
-        ["git", "-C", str(p), "-c", "user.email=a@b", "-c", "user.name=t", "commit", "-qm", "init"],
-        check=True,
-    )
-    return p
-
-
-def test_ensure_authoring_checkout_uses_existing_git_repo(tmp_path: Path, monkeypatch) -> None:
-    repo = _init_git_repo(tmp_path / "myfw")
-    monkeypatch.setenv("MYFW_REPO_PATH", str(repo))
-    result, err = ensure_authoring_checkout("myfw", tmp_path / "session")
-    assert err == ""
-    assert result is not None
-    assert result.resolve() == repo.resolve()
-
-
-def test_ensure_authoring_checkout_creates_shadow_repo_for_non_git(tmp_path: Path, monkeypatch) -> None:
-    plain = tmp_path / "plain_pkg"
-    plain.mkdir()
-    (plain / "mod.py").write_text("x = 1\n", encoding="utf-8")
-    monkeypatch.setenv("MYFW2_REPO_PATH", str(plain))
-    session_dir = tmp_path / "session"
-    result, err = ensure_authoring_checkout("myfw2", session_dir)
-    assert err == "", f"unexpected error: {err!r}"
-    assert result is not None
-    shadow_git = result / ".git"
-    assert shadow_git.exists(), "shadow repo should have a .git marker"
-    assert result.is_relative_to(session_dir), "shadow repo should live under session_dir"
-
-
-def test_ensure_authoring_checkout_reuses_existing_shadow_repo(tmp_path: Path, monkeypatch) -> None:
-    plain = tmp_path / "fw"
-    plain.mkdir()
-    (plain / "mod.py").write_text("x = 1\n", encoding="utf-8")
-    monkeypatch.setenv("FW3_REPO_PATH", str(plain))
-    session_dir = tmp_path / "sess"
-    result1, _ = ensure_authoring_checkout("fw3", session_dir)
-    result2, _ = ensure_authoring_checkout("fw3", session_dir)
-    assert result1 == result2

--- a/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
+++ b/src/hyperloom/inference_optimizer/tests/test_warm_replay.py
@@ -346,6 +346,9 @@ def _patch_current_sdk_readers(
         def read_patches(self):
             return list(self.refs)
 
+        def read_patch_roots(self):
+            return {}
+
         def prior_file(self, ref):
             return paths.get(ref)
 
@@ -2606,3 +2609,37 @@ def test_scored_replay_drives_accuracy_pass_through_the_real_promote_path(tmp_pa
     assert attempt["adopted"] is True
     assert attempt["validation_basis"] == "accuracy_pass"
     assert ledger["validation"]["unscored_keep_count"] == 0
+
+
+# ---- Phase 4: recipe carries apply root -----------------------------------
+def test_agent_kb_read_patch_roots_with_recorded_root(tmp_path):
+    from hyperloom.orchestrator.knowledge.agent_kb import _ConfigPatchAgentKB
+
+    root = str(tmp_path / "sglang_root")
+    ref = "framework/overlays/000000/00-p.patch"
+
+    class _FakeKB(_ConfigPatchAgentKB):
+        SECTION = "framework"
+
+        def read(self):
+            return {
+                "patches": [ref],
+                "patch_roots": {ref: root},
+            }
+
+    kb = _FakeKB(None)
+    assert kb.read_patch_roots() == {ref: root}
+    assert kb.read_patches() == [ref]
+
+
+def test_read_patch_roots_returns_empty_for_legacy_records():
+    from hyperloom.orchestrator.knowledge.agent_kb import _ConfigPatchAgentKB
+
+    class _LegacyKB(_ConfigPatchAgentKB):
+        SECTION = "framework"
+
+        def read(self):
+            return {"patches": ["framework/overlays/000000/00-x.patch"]}
+
+    kb = _LegacyKB(None)
+    assert kb.read_patch_roots() == {}

--- a/src/hyperloom/orchestrator/actions/executors/_apply_feedback.py
+++ b/src/hyperloom/orchestrator/actions/executors/_apply_feedback.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Structured apply-failure feedback for patch reauthoring.
+"""Structured apply-failure and vetting-drop feedback for patch reauthoring.
 
 Public surface:
 
 * :class:`ApplyFeedback`            — structured patch-apply failure record.
+* :class:`VettingDropFeedback`      — record for a patch dropped by the safety gate.
 * :func:`read_patch_source_context` — parse a unified diff and extract a line
   window near the first failing hunk; used by the patch-apply path.
 * :func:`source_context_for_file`   — shared file-resolve + window primitive;
@@ -83,6 +84,73 @@ class ApplyFeedback:
             parts.append(f"\n### Rejected hunks (.rej)\n```diff\n{self.rejected_hunks.strip()}\n```")
         if self.source_context:
             parts.append(f"\n### Source context\n```\n{self.source_context.strip()}\n```")
+        return "\n".join(parts)
+
+
+@dataclass
+class VettingDropFeedback:
+    """One patch dropped by the pre-integration safety gate.
+
+    Attributes:
+        patch: Filename or path of the dropped patch.
+        verdict: The gate verdict, e.g. ``"missing_target"`` or
+            ``"ambiguous_root"``.
+        detail: The detail string from the gate (target paths, candidate roots,
+            etc.).
+    """
+
+    patch: str
+    verdict: str
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-safe dict."""
+        return {
+            "patch": self.patch,
+            "verdict": self.verdict,
+            "detail": self.detail,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "VettingDropFeedback":
+        """Deserialize from a previously serialized dict."""
+        return cls(
+            patch=str(d.get("patch") or ""),
+            verdict=str(d.get("verdict") or ""),
+            detail=str(d.get("detail") or ""),
+        )
+
+    @classmethod
+    def from_dropped_records(cls, dropped: list[dict[str, Any]]) -> "list[VettingDropFeedback]":
+        """Build a list from the ``dropped`` records returned by :func:`vet_patches`."""
+        return [
+            cls(
+                patch=str(r.get("path") or ""),
+                verdict=str(r.get("verdict") or ""),
+                detail=str(r.get("detail") or ""),
+            )
+            for r in dropped
+            if isinstance(r, dict) and r.get("path")
+        ]
+
+    def format_for_mandate(self) -> str:
+        """Return a human-readable block for a patch-author mandate."""
+        parts: list[str] = [f"## Patch dropped by safety gate: {Path(self.patch).name}"]
+        parts.append(f"Verdict: {self.verdict}")
+        if self.detail:
+            parts.append(f"Detail: {self.detail}")
+        if self.verdict == "missing_target":
+            parts.append(
+                "The patch names a file that does not exist in any allowlisted "
+                "source tree. Verify the target path with Glob/Grep inside the "
+                "worktree before authoring the diff."
+            )
+        elif self.verdict == "ambiguous_root":
+            parts.append(
+                "The patch targets match more than one disjoint source tree. "
+                "Declare framework_source_root or write the patch from inside "
+                "the worktree so the root is unambiguous."
+            )
         return "\n".join(parts)
 
 

--- a/src/hyperloom/orchestrator/actions/executors/_apply_feedback.py
+++ b/src/hyperloom/orchestrator/actions/executors/_apply_feedback.py
@@ -1,12 +1,11 @@
 # SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Structured apply-failure and vetting-drop feedback for patch reauthoring.
+"""Structured apply-failure feedback for patch reauthoring.
 
 Public surface:
 
 * :class:`ApplyFeedback`            — structured patch-apply failure record.
-* :class:`VettingDropFeedback`      — record for a patch dropped by the safety gate.
 * :func:`read_patch_source_context` — parse a unified diff and extract a line
   window near the first failing hunk; used by the patch-apply path.
 * :func:`source_context_for_file`   — shared file-resolve + window primitive;
@@ -84,73 +83,6 @@ class ApplyFeedback:
             parts.append(f"\n### Rejected hunks (.rej)\n```diff\n{self.rejected_hunks.strip()}\n```")
         if self.source_context:
             parts.append(f"\n### Source context\n```\n{self.source_context.strip()}\n```")
-        return "\n".join(parts)
-
-
-@dataclass
-class VettingDropFeedback:
-    """One patch dropped by the pre-integration safety gate.
-
-    Attributes:
-        patch: Filename or path of the dropped patch.
-        verdict: The gate verdict, e.g. ``"missing_target"`` or
-            ``"ambiguous_root"``.
-        detail: The detail string from the gate (target paths, candidate roots,
-            etc.).
-    """
-
-    patch: str
-    verdict: str
-    detail: str = ""
-
-    def to_dict(self) -> dict[str, Any]:
-        """Serialize to a JSON-safe dict."""
-        return {
-            "patch": self.patch,
-            "verdict": self.verdict,
-            "detail": self.detail,
-        }
-
-    @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> "VettingDropFeedback":
-        """Deserialize from a previously serialized dict."""
-        return cls(
-            patch=str(d.get("patch") or ""),
-            verdict=str(d.get("verdict") or ""),
-            detail=str(d.get("detail") or ""),
-        )
-
-    @classmethod
-    def from_dropped_records(cls, dropped: list[dict[str, Any]]) -> "list[VettingDropFeedback]":
-        """Build a list from the ``dropped`` records returned by :func:`vet_patches`."""
-        return [
-            cls(
-                patch=str(r.get("path") or ""),
-                verdict=str(r.get("verdict") or ""),
-                detail=str(r.get("detail") or ""),
-            )
-            for r in dropped
-            if isinstance(r, dict) and r.get("path")
-        ]
-
-    def format_for_mandate(self) -> str:
-        """Return a human-readable block for a patch-author mandate."""
-        parts: list[str] = [f"## Patch dropped by safety gate: {Path(self.patch).name}"]
-        parts.append(f"Verdict: {self.verdict}")
-        if self.detail:
-            parts.append(f"Detail: {self.detail}")
-        if self.verdict == "missing_target":
-            parts.append(
-                "The patch names a file that does not exist in any allowlisted "
-                "source tree. Verify the target path with Glob/Grep inside the "
-                "worktree before authoring the diff."
-            )
-        elif self.verdict == "ambiguous_root":
-            parts.append(
-                "The patch targets match more than one disjoint source tree. "
-                "Declare framework_source_root or write the patch from inside "
-                "the worktree so the root is unambiguous."
-            )
         return "\n".join(parts)
 
 

--- a/src/hyperloom/orchestrator/actions/executors/_patch_snapshot.py
+++ b/src/hyperloom/orchestrator/actions/executors/_patch_snapshot.py
@@ -63,9 +63,7 @@ def _commit_strip_level(framework_root: Path, pairs: list[tuple[str, str]]) -> i
     return best_lvl
 
 
-def _patch_touched_paths_split(
-    framework_root: Path, patches: list[Path]
-) -> tuple[list[str], list[str]]:
+def _patch_touched_paths_split(framework_root: Path, patches: list[Path]) -> tuple[list[str], list[str]]:
     """Classify applied patch targets as upserted or deleted.
 
     Per header pair (``old`` ``---``, ``new`` ``+++``):
@@ -109,18 +107,14 @@ def _patch_touched_paths_split(
 
 
 def _patch_touched_paths(framework_root: Path, patches: list[Path]) -> list[str]:
-    """Repo-relative paths the applied ``patches`` created / modified / deleted.
-
-    Thin wrapper around :func:`_patch_touched_paths_split` that returns a
-    flat list in the order ``[upserted..., deleted...]`` for callers that do
-    not need to distinguish the two.
+    """Repo-relative paths to stage, for callers that need no upsert/delete split.
 
     Args:
         framework_root: The git checkout the patches were applied into.
         patches: The applied patch files to inspect.
 
     Returns:
-        The repo-relative paths to stage, in first-seen order.
+        The repo-relative paths, upserted first.
     """
     upserted, deleted = _patch_touched_paths_split(framework_root, patches)
     return list(dict.fromkeys(upserted + deleted))

--- a/src/hyperloom/orchestrator/actions/executors/_patch_snapshot.py
+++ b/src/hyperloom/orchestrator/actions/executors/_patch_snapshot.py
@@ -63,23 +63,26 @@ def _commit_strip_level(framework_root: Path, pairs: list[tuple[str, str]]) -> i
     return best_lvl
 
 
-def _patch_touched_paths(framework_root: Path, patches: list[Path]) -> list[str]:
-    """Repo-relative paths the applied ``patches`` created / modified / deleted.
+def _patch_touched_paths_split(
+    framework_root: Path, patches: list[Path]
+) -> tuple[list[str], list[str]]:
+    """Classify applied patch targets as upserted or deleted.
 
     Per header pair (``old`` ``---``, ``new`` ``+++``):
-      * created / modified → the ``new`` target exists post-apply → emit it.
-      * deleted → ``new`` is ``/dev/null`` (or its target is gone) → emit the
-        ``old`` path so ``git add -A -- <path>`` stages the removal.
-    A header that resolves to neither is dropped so ``git add`` cannot error.
+      * The ``new`` target exists post-apply → upserted (created/modified).
+      * The ``new`` target is ``/dev/null`` or absent post-apply → deleted;
+        emit the ``old`` path.
+      * A header that resolves to neither is dropped.
 
     Args:
         framework_root: The git checkout the patches were applied into.
         patches: The applied patch files to inspect.
 
     Returns:
-        The repo-relative paths to stage, in first-seen order.
+        ``(upserted, deleted)`` each in first-seen order.
     """
-    out: list[str] = []
+    upserted: list[str] = []
+    deleted: list[str] = []
     for patch in patches:
         try:
             text = patch.read_text(encoding="utf-8", errors="replace")
@@ -97,12 +100,30 @@ def _patch_touched_paths(framework_root: Path, patches: list[Path]) -> list[str]
             except OSError:
                 new_exists = False
             if rel_new and new_exists:
-                if rel_new not in out:
-                    out.append(rel_new)
+                if rel_new not in upserted:
+                    upserted.append(rel_new)
             elif rel_old:
-                if rel_old not in out:
-                    out.append(rel_old)
-    return out
+                if rel_old not in deleted:
+                    deleted.append(rel_old)
+    return upserted, deleted
+
+
+def _patch_touched_paths(framework_root: Path, patches: list[Path]) -> list[str]:
+    """Repo-relative paths the applied ``patches`` created / modified / deleted.
+
+    Thin wrapper around :func:`_patch_touched_paths_split` that returns a
+    flat list in the order ``[upserted..., deleted...]`` for callers that do
+    not need to distinguish the two.
+
+    Args:
+        framework_root: The git checkout the patches were applied into.
+        patches: The applied patch files to inspect.
+
+    Returns:
+        The repo-relative paths to stage, in first-seen order.
+    """
+    upserted, deleted = _patch_touched_paths_split(framework_root, patches)
+    return list(dict.fromkeys(upserted + deleted))
 
 
 def _patch_touched_paths_from_text(patch_content: str) -> list[str]:
@@ -356,5 +377,6 @@ __all__ = [
     "_git_commit_kept",
     "_patch_touched_paths",
     "_patch_touched_paths_from_text",
+    "_patch_touched_paths_split",
     "_restore_patch_snapshot",
 ]

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -1207,16 +1207,38 @@ def _patch_texts_from_warm_params(params: dict[str, Any]) -> list[str]:
     return patch_texts
 
 
-def _resolve_recipe_patch_target(params: dict[str, Any]) -> str:
-    """Return the framework root whose tree holds the warm-replay patch targets."""
+def _resolve_recipe_patch_target(params: dict[str, Any], warm_replay_outcome: dict[str, Any] | None = None) -> str:
+    """Return the framework root whose tree holds the warm-replay patch targets.
+
+    Prefers a root recorded alongside the Recipe patch entries. Falls back to
+    filesystem probing for legacy records that pre-date root recording, and
+    annotates the outcome dict so callers can count the remaining legacy stock.
+    """
     if not params.get("patches"):
         return ""
-    from .integrate_patch import _resolve_framework_root
+    patches = list(params["patches"])
+    recorded_roots: list[str] = []
+    for entry in patches:
+        if isinstance(entry, dict):
+            r = str(entry.get("framework_root") or "").strip()
+            if r:
+                recorded_roots.append(r)
+    unique_recorded = list(dict.fromkeys(recorded_roots))
+    if len(unique_recorded) == 1:
+        cand = unique_recorded[0]
+        from ...framework.paths import resolve_source_file_allowlist
+        from .integrate_patch import trusted_explicit_root
+        trusted = trusted_explicit_root(cand, allowlist=resolve_source_file_allowlist())
+        if trusted is not None:
+            return str(trusted)
 
+    from .integrate_patch import _resolve_framework_root
     root = _resolve_framework_root(
         resolve_session_framework_root() or None,
         patch_texts=_patch_texts_from_warm_params(params),
     )
+    if warm_replay_outcome is not None:
+        warm_replay_outcome["root_source"] = "inferred"
     return str(root or "")
 
 
@@ -2892,7 +2914,10 @@ class BaselineExecutor:
         # Explore/Framework Recipe patches target the framework checkout, not
         # the InferenceX benchmark harness. The Session's explicitly selected
         # root is the sole authority, matching Kernel Recipe replay.
-        patch_target = _resolve_recipe_patch_target(params)
+        _wro: dict[str, Any] = {}
+        patch_target = _resolve_recipe_patch_target(params, warm_replay_outcome=_wro)
+        if _wro.get("root_source") == "inferred":
+            log.info("warm replay: apply root inferred by probe; recipe pre-dates root recording")
         patch_application: list[dict[str, str]] | dict[str, Any] = []
         applied_patches: list[dict[str, str]] = []
         _pre_patch_sha = ""

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -1225,11 +1225,17 @@ def _resolve_recipe_patch_target(params: dict[str, Any]) -> str:
         if isinstance(entry, dict) and str(entry.get("framework_root") or "").strip()
     }
     if len(recorded) == 1:
-        allowed = allowlisted_explicit_root(recorded.pop(), allowlist=resolve_source_file_allowlist())
+        sole = recorded.pop()
+        allowed = allowlisted_explicit_root(sole, allowlist=resolve_source_file_allowlist())
         if allowed is not None:
             return str(allowed)
+        reason = f"recorded apply root {sole!r} is not usable"
+    elif recorded:
+        reason = f"patches record {len(recorded)} apply roots"
+    else:
+        reason = "no recorded apply root"
 
-    log.info("warm replay: no recorded apply root; resolving from patch targets")
+    log.info("warm replay: %s; resolving from patch targets", reason)
     root = _resolve_framework_root(
         resolve_session_framework_root() or None,
         patch_texts=_patch_texts_from_warm_params(params),

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -1217,7 +1217,7 @@ def _resolve_recipe_patch_target(params: dict[str, Any]) -> str:
     if not params.get("patches"):
         return ""
     from ...framework.paths import resolve_source_file_allowlist
-    from .integrate_patch import _resolve_framework_root, trusted_explicit_root
+    from .integrate_patch import _resolve_framework_root, allowlisted_explicit_root
 
     recorded = {
         str(entry.get("framework_root") or "").strip()
@@ -1225,9 +1225,9 @@ def _resolve_recipe_patch_target(params: dict[str, Any]) -> str:
         if isinstance(entry, dict) and str(entry.get("framework_root") or "").strip()
     }
     if len(recorded) == 1:
-        trusted = trusted_explicit_root(recorded.pop(), allowlist=resolve_source_file_allowlist())
-        if trusted is not None:
-            return str(trusted)
+        allowed = allowlisted_explicit_root(recorded.pop(), allowlist=resolve_source_file_allowlist())
+        if allowed is not None:
+            return str(allowed)
 
     log.info("warm replay: no recorded apply root; resolving from patch targets")
     root = _resolve_framework_root(

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -1207,38 +1207,33 @@ def _patch_texts_from_warm_params(params: dict[str, Any]) -> list[str]:
     return patch_texts
 
 
-def _resolve_recipe_patch_target(params: dict[str, Any], warm_replay_outcome: dict[str, Any] | None = None) -> str:
+def _resolve_recipe_patch_target(params: dict[str, Any]) -> str:
     """Return the framework root whose tree holds the warm-replay patch targets.
 
-    Prefers a root recorded alongside the Recipe patch entries. Falls back to
-    filesystem probing for legacy records that pre-date root recording, and
-    annotates the outcome dict so callers can count the remaining legacy stock.
+    A Recipe records the root each patch was applied into. Records written before
+    that field existed carry none, and only those fall back to probing the
+    patch text against the allowlist.
     """
     if not params.get("patches"):
         return ""
-    patches = list(params["patches"])
-    recorded_roots: list[str] = []
-    for entry in patches:
-        if isinstance(entry, dict):
-            r = str(entry.get("framework_root") or "").strip()
-            if r:
-                recorded_roots.append(r)
-    unique_recorded = list(dict.fromkeys(recorded_roots))
-    if len(unique_recorded) == 1:
-        cand = unique_recorded[0]
-        from ...framework.paths import resolve_source_file_allowlist
-        from .integrate_patch import trusted_explicit_root
-        trusted = trusted_explicit_root(cand, allowlist=resolve_source_file_allowlist())
+    from ...framework.paths import resolve_source_file_allowlist
+    from .integrate_patch import _resolve_framework_root, trusted_explicit_root
+
+    recorded = {
+        str(entry.get("framework_root") or "").strip()
+        for entry in params["patches"]
+        if isinstance(entry, dict) and str(entry.get("framework_root") or "").strip()
+    }
+    if len(recorded) == 1:
+        trusted = trusted_explicit_root(recorded.pop(), allowlist=resolve_source_file_allowlist())
         if trusted is not None:
             return str(trusted)
 
-    from .integrate_patch import _resolve_framework_root
+    log.info("warm replay: no recorded apply root; resolving from patch targets")
     root = _resolve_framework_root(
         resolve_session_framework_root() or None,
         patch_texts=_patch_texts_from_warm_params(params),
     )
-    if warm_replay_outcome is not None:
-        warm_replay_outcome["root_source"] = "inferred"
     return str(root or "")
 
 
@@ -2914,10 +2909,7 @@ class BaselineExecutor:
         # Explore/Framework Recipe patches target the framework checkout, not
         # the InferenceX benchmark harness. The Session's explicitly selected
         # root is the sole authority, matching Kernel Recipe replay.
-        _wro: dict[str, Any] = {}
-        patch_target = _resolve_recipe_patch_target(params, warm_replay_outcome=_wro)
-        if _wro.get("root_source") == "inferred":
-            log.info("warm replay: apply root inferred by probe; recipe pre-dates root recording")
+        patch_target = _resolve_recipe_patch_target(params)
         patch_application: list[dict[str, str]] | dict[str, Any] = []
         applied_patches: list[dict[str, str]] = []
         _pre_patch_sha = ""

--- a/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
+++ b/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
@@ -3355,15 +3355,31 @@ class IntegratePatchExecutor:
         source_manifest_path = ""
         source_target_files: list[str] = []
         source_base_sha = ""
+        source_snapshot_complete = False
+        source_import_root_val = ""
         try:
             from ...source_snapshot import MANIFEST_NAME, snapshot_source_layer
+            from ._patch_snapshot import _patch_touched_paths_split
 
             if framework_root is not None:
                 _cp = _run_git_cp(["-C", str(framework_root), "rev-parse", "HEAD"], timeout=30.0)
                 if _cp is not None and getattr(_cp, "returncode", 1) == 0:
                     source_base_sha = (_cp.stdout or "").strip()
-                rel_paths = list(_patch_touched_paths(framework_root, applied))
-                rel_paths += [str(a.get("rel_target") or "") for a in (applied_artifacts or []) if isinstance(a, dict)]
+                upserted_patch, deleted_patch = _patch_touched_paths_split(framework_root, applied)
+                declared_ops: dict[str, str] = {r: "upsert" for r in upserted_patch}
+                declared_ops.update({r: "delete" for r in deleted_patch})
+                rel_paths = list(upserted_patch) + list(deleted_patch)
+                for art in applied_artifacts or []:
+                    if isinstance(art, dict) and art.get("rel_target"):
+                        art_root = str(art.get("root") or framework_root)
+                        if Path(art_root).resolve() == framework_root.resolve():
+                            rel_paths.append(str(art["rel_target"]))
+                try:
+                    from ...framework.adapters import get_adapter as _get_adapter
+                    _fw_name = str(getattr(ctx.task, "params", {}).get("framework", "") or "")
+                    source_import_root_val = _get_adapter(_fw_name).source_import_root(str(framework_root))
+                except Exception:  # noqa: BLE001
+                    source_import_root_val = ""
                 dest = (
                     self.session_dir
                     / "optimization_stack"
@@ -3377,6 +3393,8 @@ class IntegratePatchExecutor:
                     dest_dir=dest,
                     provenance="integrate_patch",
                     extra={"specialist_task_id": specialist_task_id},
+                    declared_ops=declared_ops,
+                    import_root=source_import_root_val,
                 )
                 if snap:
                     source_snapshot_dir = str(snap.get("snapshot_dir") or "")
@@ -3387,6 +3405,7 @@ class IntegratePatchExecutor:
                         for item in (snap.get("files") or [])
                         if isinstance(item, dict) and item.get("rel")
                     ]
+                    source_snapshot_complete = bool(snap.get("complete"))
         except Exception:  # noqa: BLE001 — snapshot is best-effort durability
             log.exception("integrate_patch: source-layer snapshot failed")
 
@@ -3421,6 +3440,8 @@ class IntegratePatchExecutor:
                 "workspace": str(output_root),
                 "source_snapshot": source_snapshot_dir,
                 "source_manifest": source_manifest_path,
+                "source_snapshot_complete": source_snapshot_complete,
+                "source_import_root": source_import_root_val,
                 "target_files": source_target_files,
                 "framework_root": str(framework_root or ""),
                 "base_sha": source_base_sha,

--- a/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
+++ b/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
@@ -424,14 +424,10 @@ def _resolve_framework_root(
     has_patch_input = bool(patch_paths or patch_texts)
     if has_patch_input:
         session_root = resolve_session_framework_root()
-        candidates = [
-            *roots,
-            *((Path(session_root),) if session_root else ()),
-        ]
         resolution = resolve_patch_apply_root(
             texts,
             explicit_root=explicit_path,
-            candidate_roots=candidates,
+            candidate_roots=tuple(roots),
             default_root=Path(session_root) if session_root else None,
         )
         if resolution.root is None:

--- a/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
+++ b/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
@@ -377,13 +377,18 @@ def _resolve_framework_root(
     explicit: str | None,
     patch_paths: list[Path] | None = None,
     patch_texts: list[str] | None = None,
+    recorded_root: str | None = None,
 ) -> Path | None:
     """Pick one unambiguous framework root under the shared Patch rules.
 
-    With patches to place, the decision is
-    :func:`~...specialists.patch_safety.resolve_patch_apply_root`'s and it fails
-    closed. Without any, there is nothing to match a tree against, so the
-    session's declared root wins and the allowlist order is the last resort.
+    When ``recorded_root`` is supplied (set by the authoring stage and carried
+    through ``done_payload["patch_roots"]``), it is returned without any
+    filesystem probing as long as it resolves inside the allowlist. This is the
+    normal path for patches produced by ``git diff`` in a specialist worktree.
+
+    Without a recorded root, the decision falls through to
+    :func:`~...specialists.patch_safety.resolve_patch_apply_root`. Without any
+    patches to place, the session's declared root wins.
 
     Args:
         explicit: Declared framework root. Rejected when it resolves outside
@@ -391,12 +396,23 @@ def _resolve_framework_root(
         patch_paths: Patch files to place; unreadable ones are skipped.
         patch_texts: Patch diffs already in memory, placed alongside
             ``patch_paths``.
+        recorded_root: The apply root recorded at authoring time, if any.
 
     Returns:
         The resolved root, or ``None`` when the patches name no single tree.
     """
     allowlist = resolve_source_file_allowlist()
     roots = [Path(root) for root in allowlist]
+
+    if recorded_root:
+        trusted = trusted_explicit_root(recorded_root, allowlist=allowlist)
+        if trusted is not None:
+            return trusted
+        log.warning(
+            "integrate_patch: recorded_root %r is outside the allowlist; falling through to probe",
+            recorded_root,
+        )
+
     explicit_path: Path | None = None
     if explicit:
         explicit_path = trusted_explicit_root(explicit, allowlist=allowlist)
@@ -2220,9 +2236,15 @@ class IntegratePatchExecutor:
             return _no_patches
 
         explicit_framework_root = str(params.get("framework_source_root") or "").strip() or None
+        _patch_roots_map: dict[str, str] = {}
+        if isinstance((done_payload or {}).get("patch_roots"), dict):
+            _patch_roots_map = {str(k): str(v) for k, v in done_payload["patch_roots"].items()}  # type: ignore[index]
+        _patch_roots_values = list(dict.fromkeys(_patch_roots_map.values()))
+        _sole_recorded_root = _patch_roots_values[0] if len(_patch_roots_values) == 1 else None
         framework_root = _resolve_framework_root(
             explicit_framework_root,
             patch_paths=patch_paths,
+            recorded_root=_sole_recorded_root,
         )
         if patch_paths and framework_root is None:
             _lane_early = _derive_lane(params)

--- a/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
+++ b/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
@@ -373,6 +373,25 @@ def _read_patch_texts(patch_paths: list[Path] | None) -> list[str]:
     return texts
 
 
+def _sole_patch_root(done_payload: dict[str, Any] | None) -> str | None:
+    """Return the one apply root recorded for every patch, or ``None``.
+
+    A set spanning two trees has no single apply root, so it falls back to
+    resolution rather than silently picking one.
+
+    Args:
+        done_payload: The originating specialist's done payload, if any.
+
+    Returns:
+        The sole recorded root, or ``None``.
+    """
+    raw = (done_payload or {}).get("patch_roots")
+    if not isinstance(raw, dict):
+        return None
+    roots = {str(v) for v in raw.values() if str(v).strip()}
+    return roots.pop() if len(roots) == 1 else None
+
+
 def _resolve_framework_root(
     explicit: str | None,
     patch_paths: list[Path] | None = None,
@@ -381,10 +400,10 @@ def _resolve_framework_root(
 ) -> Path | None:
     """Pick one unambiguous framework root under the shared Patch rules.
 
-    When ``recorded_root`` is supplied (set by the authoring stage and carried
-    through ``done_payload["patch_roots"]``), it is returned without any
-    filesystem probing as long as it resolves inside the allowlist. This is the
-    normal path for patches produced by ``git diff`` in a specialist worktree.
+    A ``recorded_root`` — carried from the authoring stage through
+    ``done_payload["patch_roots"]`` — is authoritative and skips probing
+    entirely. It is rejected outright when it falls outside the allowlist,
+    exactly as a declared ``explicit`` root is.
 
     Without a recorded root, the decision falls through to
     :func:`~...specialists.patch_safety.resolve_patch_apply_root`. Without any
@@ -405,13 +424,7 @@ def _resolve_framework_root(
     roots = [Path(root) for root in allowlist]
 
     if recorded_root:
-        trusted = trusted_explicit_root(recorded_root, allowlist=allowlist)
-        if trusted is not None:
-            return trusted
-        log.warning(
-            "integrate_patch: recorded_root %r is outside the allowlist; falling through to probe",
-            recorded_root,
-        )
+        return trusted_explicit_root(recorded_root, allowlist=allowlist)
 
     explicit_path: Path | None = None
     if explicit:
@@ -1183,6 +1196,9 @@ class _ArtifactSpec:
             absolute target is converted to this relative form). Used for
             reporting AND as the framework-relative key for the durable KEEP
             source snapshot.
+        root: The allowlisted root ``rel_target`` is relative to. The KEEP
+            source snapshot is keyed on one root, so an artifact installed into
+            a different tree than the patches must be recognisable as such.
         kind: Free-form artifact kind label (e.g. ``config_json``).
         description: Free-form human description.
     """
@@ -1190,11 +1206,12 @@ class _ArtifactSpec:
     source: Path
     target: Path
     rel_target: str
+    root: Path
     kind: str = ""
     description: str = ""
 
 
-def _resolve_artifact_target(rel_target: str) -> tuple[Path, str] | None:
+def _resolve_artifact_target(rel_target: str) -> tuple[Path, str, Path] | None:
     """Resolve an artifact target (framework-relative, or absolute) to a path.
 
     A relative target picks the allowlisted framework root whose tree already
@@ -1208,10 +1225,9 @@ def _resolve_artifact_target(rel_target: str) -> tuple[Path, str] | None:
             relative, or an absolute path inside an allowlisted root).
 
     Returns:
-        A ``(absolute_target, framework_relative_target)`` tuple, or ``None``
-        when nothing resolves safely. ``framework_relative_target`` is the path
-        relative to the matched root (POSIX). Callers MUST persist THIS as the
-        artifact ``rel_target`` so the durable KEEP source snapshot captures the
+        A ``(absolute_target, framework_relative_target, root)`` tuple, or
+        ``None`` when nothing resolves safely. Callers MUST persist the relative
+        target AND the root so the durable KEEP source snapshot captures the
         installed file even when the author used an absolute path.
     """
     rel = (rel_target or "").strip()
@@ -1227,7 +1243,7 @@ def _resolve_artifact_target(rel_target: str) -> tuple[Path, str] | None:
         cand = Path(rel).resolve()
         for root in roots:
             if _is_within(cand, root):
-                return cand, cand.relative_to(root).as_posix()
+                return cand, cand.relative_to(root).as_posix(), root
         return None
     # Prefer a root whose tree already holds the target's parent dir.
     for root in roots:
@@ -1235,12 +1251,12 @@ def _resolve_artifact_target(rel_target: str) -> tuple[Path, str] | None:
         if not _is_within(cand, root):
             continue
         if cand.parent.is_dir():
-            return cand, cand.relative_to(root).as_posix()
+            return cand, cand.relative_to(root).as_posix(), root
     # Fall back to the first root that keeps the path contained.
     for root in roots:
         cand = (root / rel).resolve()
         if _is_within(cand, root):
-            return cand, cand.relative_to(root).as_posix()
+            return cand, cand.relative_to(root).as_posix(), root
     return None
 
 
@@ -1307,12 +1323,13 @@ def _resolve_artifact_specs(
         if resolved is None:
             errors.append({"artifact": tgt_rel, "error": "target_unresolved_or_escapes_root"})
             continue
-        target, rel_norm = resolved
+        target, rel_norm, root = resolved
         specs.append(
             _ArtifactSpec(
                 source=src_resolved,
                 target=target,
                 rel_target=rel_norm,
+                root=root,
                 kind=str(entry.get("kind") or "").strip(),
                 description=str(entry.get("description") or "").strip(),
             )
@@ -2232,15 +2249,10 @@ class IntegratePatchExecutor:
             return _no_patches
 
         explicit_framework_root = str(params.get("framework_source_root") or "").strip() or None
-        _patch_roots_map: dict[str, str] = {}
-        if isinstance((done_payload or {}).get("patch_roots"), dict):
-            _patch_roots_map = {str(k): str(v) for k, v in done_payload["patch_roots"].items()}  # type: ignore[index]
-        _patch_roots_values = list(dict.fromkeys(_patch_roots_map.values()))
-        _sole_recorded_root = _patch_roots_values[0] if len(_patch_roots_values) == 1 else None
         framework_root = _resolve_framework_root(
             explicit_framework_root,
             patch_paths=patch_paths,
-            recorded_root=_sole_recorded_root,
+            recorded_root=_sole_patch_root(done_payload),
         )
         if patch_paths and framework_root is None:
             _lane_early = _derive_lane(params)
@@ -3362,20 +3374,23 @@ class IntegratePatchExecutor:
                 if _cp is not None and getattr(_cp, "returncode", 1) == 0:
                     source_base_sha = (_cp.stdout or "").strip()
                 upserted_patch, deleted_patch = _patch_touched_paths_split(framework_root, applied)
-                declared_ops: dict[str, str] = {r: "upsert" for r in upserted_patch}
+                declared_ops = {r: "upsert" for r in upserted_patch}
                 declared_ops.update({r: "delete" for r in deleted_patch})
-                rel_paths = list(upserted_patch) + list(deleted_patch)
-                for art in applied_artifacts or []:
-                    if isinstance(art, dict) and art.get("rel_target"):
-                        art_root = str(art.get("root") or framework_root)
-                        if Path(art_root).resolve() == framework_root.resolve():
-                            rel_paths.append(str(art["rel_target"]))
-                try:
-                    from ...framework.adapters import get_adapter as _get_adapter
-                    _fw_name = str(getattr(ctx.task, "params", {}).get("framework", "") or "")
-                    source_import_root_val = _get_adapter(_fw_name).source_import_root(str(framework_root))
-                except Exception:  # noqa: BLE001
-                    source_import_root_val = ""
+                rel_paths = upserted_patch + deleted_patch
+                # An artifact installed into a sibling tree is not addressable by
+                # a rel path under this root, so it belongs to no snapshot here.
+                rel_paths += [
+                    str(a["rel_target"])
+                    for a in (applied_artifacts or [])
+                    if isinstance(a, dict)
+                    and a.get("rel_target")
+                    and Path(str(a.get("root") or framework_root)).resolve() == framework_root.resolve()
+                ]
+                from ...framework.adapters import get_adapter
+
+                source_import_root_val = get_adapter(str(params.get("framework") or "")).source_import_root(
+                    str(framework_root)
+                )
                 dest = (
                     self.session_dir
                     / "optimization_stack"
@@ -4012,7 +4027,7 @@ class IntegratePatchExecutor:
                     target_str,
                 )
                 continue
-            target, _ = resolved
+            target = resolved[0]
             # Set before the write so a copy that raises still counts as dirtying.
             self._ip_base_artifact_replayed = True
             target.parent.mkdir(parents=True, exist_ok=True)
@@ -4056,6 +4071,7 @@ class IntegratePatchExecutor:
                     {
                         "target": str(spec.target),
                         "rel_target": spec.rel_target,
+                        "root": str(spec.root),
                         "kind": spec.kind,
                         "existed": existed,
                         "backup": backup_path,

--- a/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
+++ b/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
@@ -437,10 +437,16 @@ def _resolve_framework_root(
     has_patch_input = bool(patch_paths or patch_texts)
     if has_patch_input:
         session_root = resolve_session_framework_root()
+        # The allowlist does not necessarily hold it: it discovers the unprefixed
+        # env var, while the session root also answers to <FRAMEWORK>_REPO_PATH
+        # and <FRAMEWORK>_DIR. Leaving it out turns the tree under optimisation
+        # into a non-candidate, and default_root cannot stand in -- that is
+        # consulted only for a create-only set, which has no pre-image to match.
+        candidates = [Path(session_root), *roots] if session_root else list(roots)
         resolution = resolve_patch_apply_root(
             texts,
             explicit_root=explicit_path,
-            candidate_roots=tuple(roots),
+            candidate_roots=tuple(candidates),
             default_root=Path(session_root) if session_root else None,
         )
         if resolution.root is None:

--- a/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
+++ b/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
@@ -310,11 +310,11 @@ def _run_setup_commands(commands: list[str], *, cwd: Path, log_dir: Path) -> dic
     return {"applied": applied, "skipped": skipped, "failed": failed}
 
 
-def trusted_explicit_root(
+def allowlisted_explicit_root(
     explicit: str,
     allowlist: tuple[str, ...] | None = None,
 ) -> Path | None:
-    """Resolve a declared framework root, or ``None`` when it is not trusted.
+    """Resolve a declared framework root, or ``None`` when it is not allowlisted.
 
     A root outside the allowlisted source scope is refused whatever its tree
     holds, so callers must ask this before blaming the patches for not
@@ -328,7 +328,7 @@ def trusted_explicit_root(
 
     Returns:
         The resolved directory, or ``None`` when it is unreadable, absent, or
-        outside the trusted source scope.
+        outside the allowlisted source scope.
     """
     try:
         resolved = Path(explicit).resolve()
@@ -424,11 +424,11 @@ def _resolve_framework_root(
     roots = [Path(root) for root in allowlist]
 
     if recorded_root:
-        return trusted_explicit_root(recorded_root, allowlist=allowlist)
+        return allowlisted_explicit_root(recorded_root, allowlist=allowlist)
 
     explicit_path: Path | None = None
     if explicit:
-        explicit_path = trusted_explicit_root(explicit, allowlist=allowlist)
+        explicit_path = allowlisted_explicit_root(explicit, allowlist=allowlist)
         if explicit_path is None:
             return None
 
@@ -2257,15 +2257,15 @@ class IntegratePatchExecutor:
         if patch_paths and framework_root is None:
             _lane_early = _derive_lane(params)
             if explicit_framework_root:
-                # An untrusted root is refused on that ground alone; only a
-                # trusted one that simply lacks the files is the patches' fault.
-                trusted_root = trusted_explicit_root(explicit_framework_root)
-                if trusted_root is not None:
+                # A non-allowlisted root is refused on that ground alone; only
+                # an allowlisted one that simply lacks the files is the patches' fault.
+                allowed_root = allowlisted_explicit_root(explicit_framework_root)
+                if allowed_root is not None:
                     if not _read_patch_texts(patch_paths):
                         _error_class = "patch_unreadable"
                         _error = "no patch file could be read; verify paths and permissions"
                     else:
-                        missing_records = _preflight_missing_targets(trusted_root, patch_paths)
+                        missing_records = _preflight_missing_targets(allowed_root, patch_paths)
                         if missing_records:
                             _error_class = "patch_target_missing"
                             _error = missing_records

--- a/src/hyperloom/orchestrator/framework/adapters.py
+++ b/src/hyperloom/orchestrator/framework/adapters.py
@@ -264,25 +264,17 @@ class BaseAdapter:
         return None
 
     def source_import_root(self, framework_root: str) -> str:
-        """Return the Python import root relative to ``snapshot/files/``.
+        """Return the import root relative to a source snapshot's ``files/`` dir.
 
-        This is the directory GEAK prepends to PYTHONPATH so the patched modules
-        are importable from the snapshot. For a dist-packages install, the
-        snapshot's ``files/`` directory already contains the package directly,
-        so the import root is ``""``; for a repo checkout with a ``python/``
-        subdirectory, it is ``"python"``.
-
-        The default derives the import root heuristically from the captured
-        paths: the topmost directory component shared by all captured files that
-        itself contains the framework's own package directory.  Subclasses with
-        a known static layout override this.
+        A dist-packages install stores modules at the tree root, so ``""`` is
+        correct; a repo checkout that nests them (e.g. under ``python/``)
+        overrides this.
 
         Args:
             framework_root: Absolute path to the framework checkout or install.
 
         Returns:
-            str: The import-root path component, or ``""`` when files are
-            importable directly from ``files/``.
+            str: The import-root path component, or ``""``.
         """
         return ""
 
@@ -507,17 +499,11 @@ class SglangAdapter(_VenvProvisionMixin):
     framework = "sglang"
 
     def source_import_root(self, framework_root: str) -> str:
-        """Return ``"python"`` when the sglang repo layout is present, else ``""``.
-
-        A sglang git checkout organises importable modules under ``python/``
-        (i.e. ``python/sglang/...``), so the overlay PYTHONPATH entry must be
-        ``snapshot/files/python``. A dist-packages install has no such
-        subdirectory and files are importable from ``snapshot/files/`` directly.
-        """
-        root = Path(framework_root).rstrip("/") if framework_root else Path("")
-        if root and (root / "python").is_dir() and (root / "python" / "sglang").is_dir():
-            return "python"
-        return ""
+        """Return ``"python"`` for a sglang checkout (``python/sglang/...``), else ``""``."""
+        if not framework_root:
+            return ""
+        root = Path(framework_root)
+        return "python" if (root / "python" / "sglang").is_dir() else ""
 
     def supports(self, gap: CapabilityGap) -> bool:
         """True for code-acquirable gaps (never for resource constraints)."""

--- a/src/hyperloom/orchestrator/framework/adapters.py
+++ b/src/hyperloom/orchestrator/framework/adapters.py
@@ -263,6 +263,29 @@ class BaseAdapter:
         """
         return None
 
+    def source_import_root(self, framework_root: str) -> str:
+        """Return the Python import root relative to ``snapshot/files/``.
+
+        This is the directory GEAK prepends to PYTHONPATH so the patched modules
+        are importable from the snapshot. For a dist-packages install, the
+        snapshot's ``files/`` directory already contains the package directly,
+        so the import root is ``""``; for a repo checkout with a ``python/``
+        subdirectory, it is ``"python"``.
+
+        The default derives the import root heuristically from the captured
+        paths: the topmost directory component shared by all captured files that
+        itself contains the framework's own package directory.  Subclasses with
+        a known static layout override this.
+
+        Args:
+            framework_root: Absolute path to the framework checkout or install.
+
+        Returns:
+            str: The import-root path component, or ``""`` when files are
+            importable directly from ``files/``.
+        """
+        return ""
+
 
 def _pr_number_from_ref(candidate_ref: str) -> int:
     """Parse a PR number from a ``"PR:1234"`` ref or a PR html_url; 0 if absent."""
@@ -482,6 +505,19 @@ class SglangAdapter(_VenvProvisionMixin):
     """SGLang adapter: editable checkout at a ref, or wheel install."""
 
     framework = "sglang"
+
+    def source_import_root(self, framework_root: str) -> str:
+        """Return ``"python"`` when the sglang repo layout is present, else ``""``.
+
+        A sglang git checkout organises importable modules under ``python/``
+        (i.e. ``python/sglang/...``), so the overlay PYTHONPATH entry must be
+        ``snapshot/files/python``. A dist-packages install has no such
+        subdirectory and files are importable from ``snapshot/files/`` directly.
+        """
+        root = Path(framework_root).rstrip("/") if framework_root else Path("")
+        if root and (root / "python").is_dir() and (root / "python" / "sglang").is_dir():
+            return "python"
+        return ""
 
     def supports(self, gap: CapabilityGap) -> bool:
         """True for code-acquirable gaps (never for resource constraints)."""

--- a/src/hyperloom/orchestrator/framework/paths.py
+++ b/src/hyperloom/orchestrator/framework/paths.py
@@ -507,6 +507,48 @@ def resolve_session_framework_root() -> str:
     return generic[0] if generic else ""
 
 
+def resolve_framework_tree(framework: str) -> str:
+    """Return the source tree for the named framework, or ``""``.
+
+    Consults only name-keyed sources in order:
+      1. ``$<FRAMEWORK>_REPO_PATH`` / ``$<FRAMEWORK>_DIR``
+      2. ``$FRAMEWORK_REPO_PATH`` (generic fallback)
+      3. The importlib spec origin of the framework's Python package
+      4. The known static default checkout path
+
+    Never consults allowlist order. The allowlist is a permission set; this
+    function answers "where is this framework's source tree".
+
+    Args:
+        framework: Framework name, e.g. ``"sglang"`` or ``"vllm"``.
+
+    Returns:
+        str: The normalised tree root, or ``""`` when none is found.
+    """
+    name = str(framework or "").strip().upper()
+    pkg = str(framework or "").strip().lower()
+    if name:
+        for key in (f"{name}_REPO_PATH", f"{name}_DIR"):
+            candidate = os.environ.get(key, "").strip()
+            if candidate and Path(candidate).is_dir():
+                return _normalize_root(candidate)
+    generic = os.environ.get(GENERIC_FRAMEWORK_ROOT_ENV, "").strip()
+    if generic and Path(generic).is_dir():
+        return _normalize_root(generic)
+    if pkg:
+        origin = _find_spec_origin(pkg)
+        if origin is not None:
+            root = _normalize_root(str(origin))
+            if root:
+                return root
+    for default in _DEFAULT_SOURCE_ROOTS:
+        stripped = default.rstrip("/")
+        if stripped.endswith(f"/{pkg}") or stripped.endswith(f"/{name.lower()}"):
+            if Path(stripped).is_dir():
+                return _normalize_root(stripped)
+    return ""
+
+
 def resolve_patch_target_roots() -> tuple[str, ...]:
     """Roots for substring matching in patch apply + kernel classifiers.
 
@@ -865,6 +907,7 @@ __all__ = [
     "WarmReplayPatchSource",
     "WarmReplayRootResolution",
     "probe_framework_source_roots_for_env",
+    "resolve_framework_tree",
     "resolve_patch_target_roots",
     "resolve_rocm_hip_source_roots",
     "resolve_session_framework_root",

--- a/src/hyperloom/orchestrator/framework/paths.py
+++ b/src/hyperloom/orchestrator/framework/paths.py
@@ -801,7 +801,7 @@ def resolve_warm_replay_framework_root(
     return _resolve_warm_replay_patch_root(
         patch_sources=warm_replay_patch_sources(patch_entries, patch_paths),
         allowlist=_warm_replay_framework_patch_roots(),
-        missing_patch_reason="active_framework_root_missing",
+        missing_patch_reason="warm_replay_patch_content_missing",
         missing_allowlist_reason="framework_patch_root_not_in_allowlist",
         explicit_root=resolve_session_framework_root() or None,
     )

--- a/src/hyperloom/orchestrator/framework/paths.py
+++ b/src/hyperloom/orchestrator/framework/paths.py
@@ -508,44 +508,32 @@ def resolve_session_framework_root() -> str:
 
 
 def resolve_framework_tree(framework: str) -> str:
-    """Return the source tree for the named framework, or ``""``.
+    """Return the source tree belonging to ``framework``, or ``""``.
 
-    Consults only name-keyed sources in order:
-      1. ``$<FRAMEWORK>_REPO_PATH`` / ``$<FRAMEWORK>_DIR``
-      2. ``$FRAMEWORK_REPO_PATH`` (generic fallback)
-      3. The importlib spec origin of the framework's Python package
-      4. The known static default checkout path
-
-    Never consults allowlist order. The allowlist is a permission set; this
-    function answers "where is this framework's source tree".
+    Every source consulted here is keyed by the framework's own name — its env
+    vars, its Python package, its default path. That is what distinguishes this
+    from :func:`resolve_source_file_allowlist`, whose order reflects only how
+    roots were discovered and so cannot name the tree a session is optimising.
 
     Args:
-        framework: Framework name, e.g. ``"sglang"`` or ``"vllm"``.
+        framework: Framework name, e.g. ``"sglang"``.
 
     Returns:
-        str: The normalised tree root, or ``""`` when none is found.
+        str: The normalised tree root, or ``""`` when the framework has none.
     """
-    name = str(framework or "").strip().upper()
     pkg = str(framework or "").strip().lower()
-    if name:
-        for key in (f"{name}_REPO_PATH", f"{name}_DIR"):
-            candidate = os.environ.get(key, "").strip()
-            if candidate and Path(candidate).is_dir():
-                return _normalize_root(candidate)
-    generic = os.environ.get(GENERIC_FRAMEWORK_ROOT_ENV, "").strip()
-    if generic and Path(generic).is_dir():
-        return _normalize_root(generic)
-    if pkg:
-        origin = _find_spec_origin(pkg)
-        if origin is not None:
-            root = _normalize_root(str(origin))
-            if root:
-                return root
+    if not pkg:
+        return ""
+    for key in (f"{pkg.upper()}_REPO_PATH", f"{pkg.upper()}_DIR", GENERIC_FRAMEWORK_ROOT_ENV):
+        candidate = os.environ.get(key, "").strip()
+        if candidate and Path(candidate).is_dir():
+            return _normalize_root(candidate)
+    origin = _find_spec_origin(pkg)
+    if origin is not None:
+        return _normalize_root(str(origin))
     for default in _DEFAULT_SOURCE_ROOTS:
-        stripped = default.rstrip("/")
-        if stripped.endswith(f"/{pkg}") or stripped.endswith(f"/{name.lower()}"):
-            if Path(stripped).is_dir():
-                return _normalize_root(stripped)
+        if default.rstrip("/").endswith(f"/{pkg}") and Path(default).is_dir():
+            return _normalize_root(default)
     return ""
 
 

--- a/src/hyperloom/orchestrator/knowledge/agent_kb.py
+++ b/src/hyperloom/orchestrator/knowledge/agent_kb.py
@@ -105,6 +105,18 @@ class _ConfigPatchAgentKB:
             return []
         return [str(ref) for ref in patches if isinstance(ref, str) and str(ref).strip()]
 
+    def read_patch_roots(self) -> dict[str, str]:
+        """Return the per-patch apply roots recorded alongside ``patches``, if any.
+
+        Returns an empty dict for legacy records written before this field was
+        introduced.
+        """
+        prior = self.read()
+        raw = prior.get("patch_roots")
+        if not isinstance(raw, Mapping):
+            return {}
+        return {str(k): str(v) for k, v in raw.items() if str(k).strip() and str(v).strip()}
+
     def stage_patches(
         self,
         patches: Iterable[str | Path],

--- a/src/hyperloom/orchestrator/knowledge/agent_kb.py
+++ b/src/hyperloom/orchestrator/knowledge/agent_kb.py
@@ -106,11 +106,7 @@ class _ConfigPatchAgentKB:
         return [str(ref) for ref in patches if isinstance(ref, str) and str(ref).strip()]
 
     def read_patch_roots(self) -> dict[str, str]:
-        """Return the per-patch apply roots recorded alongside ``patches``, if any.
-
-        Returns an empty dict for legacy records written before this field was
-        introduced.
-        """
+        """Return ``{patch_ref: apply_root}``; empty for records predating the field."""
         prior = self.read()
         raw = prior.get("patch_roots")
         if not isinstance(raw, Mapping):

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
@@ -430,7 +430,7 @@ def _entry_files(
             if ref:
                 (patches if kind == "patches" else artifacts).append(ref)
                 if kind == "patches" and entry_framework_root:
-                    patch_roots[ref] = entry_framework_root
+                    patch_roots.setdefault(ref, entry_framework_root)
         for key in _PATH_LIST_KEYS:
             raw_values = entry.get(key) or []
             if isinstance(raw_values, (str, Path)):
@@ -443,7 +443,9 @@ def _entry_files(
                 if ref:
                     (patches if kind == "patches" else artifacts).append(ref)
                     if kind == "patches" and entry_framework_root:
-                        patch_roots[ref] = entry_framework_root
+                        patch_roots.setdefault(ref, entry_framework_root)
+    # first-wins, matching the dedupe below: a ref shared by two entries keeps
+    # the root of the one whose position it also keeps.
     return list(dict.fromkeys(patches)), list(dict.fromkeys(artifacts)), patch_roots
 
 

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
@@ -385,9 +385,12 @@ def build_publishable_recipe_config(state: Any) -> dict[str, Any]:
     }
 
 
-def _entry_files(entries: list[dict[str, Any]], files: _Files, category: str) -> tuple[list[str], list[str]]:
+def _entry_files(
+    entries: list[dict[str, Any]], files: _Files, category: str
+) -> tuple[list[str], list[str], dict[str, str]]:
     patches: list[str] = []
     artifacts: list[str] = []
+    patch_roots: dict[str, str] = {}
     for entry in entries:
         try:
             stack_index = int(entry.get("__stack_index", -1))
@@ -395,6 +398,7 @@ def _entry_files(entries: list[dict[str, Any]], files: _Files, category: str) ->
             stack_index = -1
         patch_member = 0
         seen_patch_sources: set[str] = set()
+        entry_framework_root = str(entry.get("framework_root") or "").strip()
 
         def add_value(raw: Any, *, kind: str) -> str:
             nonlocal patch_member
@@ -425,6 +429,8 @@ def _entry_files(entries: list[dict[str, Any]], files: _Files, category: str) ->
             ref = add_value(raw, kind=kind)
             if ref:
                 (patches if kind == "patches" else artifacts).append(ref)
+                if kind == "patches" and entry_framework_root:
+                    patch_roots[ref] = entry_framework_root
         for key in _PATH_LIST_KEYS:
             raw_values = entry.get(key) or []
             if isinstance(raw_values, (str, Path)):
@@ -436,7 +442,9 @@ def _entry_files(entries: list[dict[str, Any]], files: _Files, category: str) ->
                 ref = add_value(raw, kind=kind)
                 if ref:
                     (patches if kind == "patches" else artifacts).append(ref)
-    return list(dict.fromkeys(patches)), list(dict.fromkeys(artifacts))
+                    if kind == "patches" and entry_framework_root:
+                        patch_roots[ref] = entry_framework_root
+    return list(dict.fromkeys(patches)), list(dict.fromkeys(artifacts)), patch_roots
 
 
 def build_explore_value(
@@ -445,11 +453,14 @@ def build_explore_value(
     files: _Files,
 ) -> dict[str, Any]:
     """Build EXPLORE-origin patch and artifact references."""
-    patches, artifacts = _entry_files(entries, files, "explore")
-    return {
+    patches, artifacts, patch_roots = _entry_files(entries, files, "explore")
+    result: dict[str, Any] = {
         "patches": patches,
         "artifacts": artifacts,
     }
+    if patch_roots:
+        result["patch_roots"] = patch_roots
+    return result
 
 
 def build_framework_value(
@@ -458,11 +469,14 @@ def build_framework_value(
     files: _Files,
 ) -> dict[str, Any]:
     """Build FRAMEWORK-origin patch and artifact references."""
-    patches, artifacts = _entry_files(entries, files, "framework")
-    return {
+    patches, artifacts, patch_roots = _entry_files(entries, files, "framework")
+    result: dict[str, Any] = {
         "patches": patches,
         "artifacts": artifacts,
     }
+    if patch_roots:
+        result["patch_roots"] = patch_roots
+    return result
 
 
 def _externalize_record(

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/values.py
@@ -447,20 +447,21 @@ def _entry_files(
     return list(dict.fromkeys(patches)), list(dict.fromkeys(artifacts)), patch_roots
 
 
+def _section_value(patches: list[str], artifacts: list[str], patch_roots: dict[str, str]) -> dict[str, Any]:
+    """Assemble one owner section, omitting ``patch_roots`` when nothing recorded one."""
+    value: dict[str, Any] = {"patches": patches, "artifacts": artifacts}
+    if patch_roots:
+        value["patch_roots"] = patch_roots
+    return value
+
+
 def build_explore_value(
     state: Any,
     entries: list[dict[str, Any]],
     files: _Files,
 ) -> dict[str, Any]:
     """Build EXPLORE-origin patch and artifact references."""
-    patches, artifacts, patch_roots = _entry_files(entries, files, "explore")
-    result: dict[str, Any] = {
-        "patches": patches,
-        "artifacts": artifacts,
-    }
-    if patch_roots:
-        result["patch_roots"] = patch_roots
-    return result
+    return _section_value(*_entry_files(entries, files, "explore"))
 
 
 def build_framework_value(
@@ -469,14 +470,7 @@ def build_framework_value(
     files: _Files,
 ) -> dict[str, Any]:
     """Build FRAMEWORK-origin patch and artifact references."""
-    patches, artifacts, patch_roots = _entry_files(entries, files, "framework")
-    result: dict[str, Any] = {
-        "patches": patches,
-        "artifacts": artifacts,
-    }
-    if patch_roots:
-        result["patch_roots"] = patch_roots
-    return result
+    return _section_value(*_entry_files(entries, files, "framework"))
 
 
 def _externalize_record(

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -102,6 +102,35 @@ class _PromoteOutcome:
     early_return: bool = False
 
 
+def _source_layer_handles(result: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the source-layer fields a ``source_patch`` lift must carry.
+
+    Every field here has to survive the hop from the executor result into the
+    optimization_stack entry, where ``build_env_spec`` reads it. Assembling them
+    in one place is what keeps a second lift path from forwarding a subset and
+    degrading the overlay it feeds.
+
+    Args:
+        result: An integrate_patch KEEP result.
+
+    Returns:
+        dict[str, Any]: Handles to merge into the lift. ``source_snapshot_complete``
+            is present only when the result recorded it, so entries predating the
+            field still fall back to reading their manifest.
+    """
+    handles: dict[str, Any] = {
+        "source_snapshot": result.get("source_snapshot") or "",
+        "source_manifest": result.get("source_manifest") or "",
+        "target_files": [str(path) for path in (result.get("target_files") or []) if str(path).strip()],
+        "framework_root": result.get("framework_root") or "",
+        "base_sha": result.get("base_sha") or "",
+        "source_import_root": result.get("source_import_root") or "",
+    }
+    if "source_snapshot_complete" in result:
+        handles["source_snapshot_complete"] = bool(result["source_snapshot_complete"])
+    return handles
+
+
 def _predicted_gain(*sources: dict[str, Any] | None) -> float | None:
     """First non-zero ``predicted_gain_pct`` (``to_float``-parsed) across ordered sources.
 
@@ -4009,11 +4038,7 @@ class WritebackCollaborator:
                 "scope": "source_patch",
                 # Durable source-layer handles so current_best stays relaunchable
                 # and reproducible in the GEAK baseline.
-                "source_snapshot": result.get("source_snapshot") or "",
-                "source_manifest": result.get("source_manifest") or "",
-                "target_files": [str(path) for path in (result.get("target_files") or []) if str(path).strip()],
-                "framework_root": result.get("framework_root") or "",
-                "base_sha": result.get("base_sha") or "",
+                **_source_layer_handles(result),
             }
             if source_phase:
                 lift["source_phase"] = source_phase
@@ -4413,7 +4438,7 @@ class WritebackCollaborator:
         baseline ref is materialized from the SAME layers as ``current_best``
         (not just its flags/env), closing the cross-harness baseline gap.
         """
-        from ..source_snapshot import source_layer_reproducible
+        from ..source_snapshot import source_layer_overlay_dir, source_layer_reproducible
 
         materialized = self._current_best_launch_config()
         stack = [e for e in (getattr(self.shared_state, "optimization_stack", []) or []) if isinstance(e, dict)]
@@ -4436,13 +4461,12 @@ class WritebackCollaborator:
                     }
                 )
                 continue
-            # The consumer puts this directory straight on PYTHONPATH, so it must
-            # be the import root, not the snapshot's own top level.
-            overlay_dir = Path(snap) / "files" / str(entry.get("source_import_root") or "").strip()
             source_snapshots.append(
                 {
                     "id": str(entry.get("variant_name") or entry.get("name") or ""),
-                    "snapshot_dir": str(overlay_dir),
+                    # GEAK PYTHONPATHs this value; it is the import root inside
+                    # the snapshot, not the snapshot's own top level.
+                    "snapshot_dir": source_layer_overlay_dir(entry),
                     "framework_root": str(entry.get("framework_root") or ""),
                     "base_sha": str(entry.get("base_sha") or ""),
                     "reproducible": source_layer_reproducible(entry),
@@ -4648,11 +4672,7 @@ class WritebackCollaborator:
                 # Same durable source-layer handles as the primary KEEP lift so a
                 # source_patch recovered on THIS path is equally reproducible in
                 # the GEAK baseline (no path is left snapshot-less).
-                "source_snapshot": result.get("source_snapshot") or "",
-                "source_manifest": result.get("source_manifest") or "",
-                "target_files": [str(path) for path in (result.get("target_files") or []) if str(path).strip()],
-                "framework_root": result.get("framework_root") or "",
-                "base_sha": result.get("base_sha") or "",
+                **_source_layer_handles(result),
             }
             source_phase = patch_owner_phase(result)
             gap_layer = str(result.get("gap_layer") or "").strip()

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -2699,14 +2699,17 @@ class WritebackCollaborator:
                     for _src_key in (
                         "source_snapshot",
                         "source_manifest",
-                        "source_snapshot_complete",
                         "source_import_root",
                         "framework_root",
                         "base_sha",
                     ):
                         val = bv.get(_src_key)
-                        if val is not None and (val is not False or _src_key == "source_snapshot_complete"):
-                            stack_entry[_src_key] = val if isinstance(val, bool) else str(val)
+                        if val:
+                            stack_entry[_src_key] = str(val)
+                    # Copied unconditionally: False is the meaningful value that
+                    # marks a snapshot unusable, so truthiness must not drop it.
+                    if "source_snapshot_complete" in bv:
+                        stack_entry["source_snapshot_complete"] = bool(bv["source_snapshot_complete"])
                     target_files = [str(path) for path in (bv.get("target_files") or []) if str(path).strip()]
                     if target_files:
                         stack_entry["target_files"] = target_files
@@ -4410,6 +4413,8 @@ class WritebackCollaborator:
         baseline ref is materialized from the SAME layers as ``current_best``
         (not just its flags/env), closing the cross-harness baseline gap.
         """
+        from ..source_snapshot import source_layer_reproducible
+
         materialized = self._current_best_launch_config()
         stack = [e for e in (getattr(self.shared_state, "optimization_stack", []) or []) if isinstance(e, dict)]
         source_snapshots: list[dict[str, Any]] = []
@@ -4431,19 +4436,16 @@ class WritebackCollaborator:
                     }
                 )
                 continue
-            _complete = entry.get("source_snapshot_complete")
-            if _complete is None:
-                from hyperloom.orchestrator.source_snapshot import snapshot_is_complete as _sic
-                _complete = _sic(snap)
-            _import_root = str(entry.get("source_import_root") or "").strip()
-            _overlay_dir = str(Path(snap) / "files" / _import_root) if _import_root else str(Path(snap) / "files")
+            # The consumer puts this directory straight on PYTHONPATH, so it must
+            # be the import root, not the snapshot's own top level.
+            overlay_dir = Path(snap) / "files" / str(entry.get("source_import_root") or "").strip()
             source_snapshots.append(
                 {
                     "id": str(entry.get("variant_name") or entry.get("name") or ""),
-                    "snapshot_dir": _overlay_dir,
+                    "snapshot_dir": str(overlay_dir),
                     "framework_root": str(entry.get("framework_root") or ""),
                     "base_sha": str(entry.get("base_sha") or ""),
-                    "reproducible": bool(_complete),
+                    "reproducible": source_layer_reproducible(entry),
                 }
             )
         # FULL resolved engine config (not just the current_best delta): the

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -2699,12 +2699,14 @@ class WritebackCollaborator:
                     for _src_key in (
                         "source_snapshot",
                         "source_manifest",
+                        "source_snapshot_complete",
+                        "source_import_root",
                         "framework_root",
                         "base_sha",
                     ):
                         val = bv.get(_src_key)
-                        if val:
-                            stack_entry[_src_key] = str(val)
+                        if val is not None and (val is not False or _src_key == "source_snapshot_complete"):
+                            stack_entry[_src_key] = val if isinstance(val, bool) else str(val)
                     target_files = [str(path) for path in (bv.get("target_files") or []) if str(path).strip()]
                     if target_files:
                         stack_entry["target_files"] = target_files
@@ -4429,13 +4431,19 @@ class WritebackCollaborator:
                     }
                 )
                 continue
+            _complete = entry.get("source_snapshot_complete")
+            if _complete is None:
+                from hyperloom.orchestrator.source_snapshot import snapshot_is_complete as _sic
+                _complete = _sic(snap)
+            _import_root = str(entry.get("source_import_root") or "").strip()
+            _overlay_dir = str(Path(snap) / "files" / _import_root) if _import_root else str(Path(snap) / "files")
             source_snapshots.append(
                 {
                     "id": str(entry.get("variant_name") or entry.get("name") or ""),
-                    "snapshot_dir": snap,
+                    "snapshot_dir": _overlay_dir,
                     "framework_root": str(entry.get("framework_root") or ""),
                     "base_sha": str(entry.get("base_sha") or ""),
-                    "reproducible": True,
+                    "reproducible": bool(_complete),
                 }
             )
         # FULL resolved engine config (not just the current_best delta): the

--- a/src/hyperloom/orchestrator/phases/framework.py
+++ b/src/hyperloom/orchestrator/phases/framework.py
@@ -1132,9 +1132,8 @@ class FrameworkPhase(PhaseHandler):
                 "were dropped because their target file(s) do not exist in ANY "
                 "allowlisted framework source tree. Targets: "
                 + "; ".join(grounding_drops[:4])
-                + ". Use artifacts_written (whole-file install to an absolute "
-                "allowlisted path) instead of a unified diff, or verify the "
-                "target path with Glob/Read first."
+                + ". Verify the target path with Glob/Read inside the worktree "
+                "before authoring the diff."
             )
             notes = (drop_note + "\n\n" + notes).strip() if notes else drop_note
         if spanned_roots:
@@ -1961,6 +1960,7 @@ class FrameworkPhase(PhaseHandler):
             return
 
         # Under cap: store the retry context for the dispatcher to pick up.
+        vetting_drops_raw = res.get("patches_dropped_by_grounding")
         retry_ctx: dict[str, Any] = {
             "cand_id": cand_id,
             "batch_id": batch_id,
@@ -1971,6 +1971,8 @@ class FrameworkPhase(PhaseHandler):
             "candidate": candidate,
             "specialist_task_id": str(res.get("specialist_task_id") or ""),
         }
+        if isinstance(vetting_drops_raw, list) and vetting_drops_raw:
+            retry_ctx["vetting_drops"] = [str(d) for d in vetting_drops_raw[:8]]
         pending = getattr(state, "apply_fail_retry_pending", None) or []
         if not isinstance(pending, list):
             pending = []
@@ -1990,6 +1992,7 @@ class FrameworkPhase(PhaseHandler):
         attempt: int = 1,
         retry_feedback: "list[dict[str, Any]] | None" = None,
         critic_feedback: "dict[str, Any] | None" = None,
+        vetting_drops: "list[str] | None" = None,
     ) -> str:
         """Dispatch a fresh authoring specialist for an apply-failure retry.
 
@@ -2022,6 +2025,17 @@ class FrameworkPhase(PhaseHandler):
         state = self.shared_state
 
         feedback_lines: list[str] = []
+        if vetting_drops:
+            feedback_lines.append("")
+            feedback_lines.append(
+                "PATCH GROUNDING FAILURE: the prior round's patches were dropped by "
+                "the safety gate before reaching integration. The worktree contains "
+                "the correct framework tree — edit files there and the diff is "
+                "harvested automatically. Do not switch to the artifacts_written "
+                "channel to avoid the gate."
+            )
+            feedback_lines.append("Dropped targets: " + "; ".join(vetting_drops[:4]))
+            feedback_lines.append("")
         if retry_feedback:
             feedback_lines.append("")
             feedback_lines.append(
@@ -2182,6 +2196,7 @@ class FrameworkPhase(PhaseHandler):
             candidate = ctx.get("candidate") or {}
             specialist_task_id = str(ctx.get("specialist_task_id") or "")
             retry_feedback = list(ctx.get("retry_feedback") or [])
+            vetting_drops = list(ctx.get("vetting_drops") or [])
             try:
                 await self._enqueue_author_specialist(
                     lane=lane,
@@ -2189,6 +2204,7 @@ class FrameworkPhase(PhaseHandler):
                     specialist_task_id=specialist_task_id,
                     attempt=attempt,
                     retry_feedback=retry_feedback,
+                    vetting_drops=vetting_drops or None,
                 )
             except Exception:  # noqa: BLE001 — never wedge the dispatcher
                 log.exception(

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -36,8 +36,8 @@ from ..loop.coordinator_helpers import (
     _geak_accepted_kernel_specs,
     _geak_has_accepted_kernel,
     _resolve_roofline_watermark_ratio,
+    _accepted_config_as_variant,
     _resolve_serving_fidelity,
-    _split_env_and_flags,
 )
 from .base import PhaseHandler
 
@@ -1332,13 +1332,15 @@ class KernelPhase(PhaseHandler):
         Turns the bench-style ``{"flags":.., "env":..}`` blob into a reproducible
         (server-args, real-env) pair: any ``KEY=VAL`` token in ``env`` becomes a
         real env var; any ``--flag`` token folds into flags.
+
+        Shares :func:`_accepted_config_as_variant` with the material gate and the
+        2b dispatch, so the env mapping written to ``geak_pending`` and to
+        ``current_best`` is the one the executor will actually run. This is the
+        path that hands ``current_best`` the raw ``accepted_config``: filtering
+        only at the comparison would leave a blocked name on the stored side and
+        make an unchanged config read as a difference.
         """
-        accepted_cfg = result.get("accepted_config") or {}
-        accepted_flags = str(accepted_cfg.get("flags") or "").strip()
-        parsed_envs, extra_flags = _split_env_and_flags(str(accepted_cfg.get("env") or ""))
-        if extra_flags:
-            accepted_flags = (accepted_flags + " " + extra_flags).strip()
-        return accepted_flags, parsed_envs
+        return _accepted_config_as_variant(result.get("accepted_config"))
 
     def _record_geak_candidate(self, result: dict[str, Any]) -> None:
         """Record a GEAK e2e win as an UNVALIDATED candidate (no headline).

--- a/src/hyperloom/orchestrator/phases/prelude.py
+++ b/src/hyperloom/orchestrator/phases/prelude.py
@@ -1131,6 +1131,7 @@ class PreludePhase(PhaseHandler):
         )
         owner_kbs = {"explore": explore, "framework": framework}
         owner_ref_lists = {owner: kb.read_patches() for owner, kb in owner_kbs.items()}
+        owner_patch_roots = {owner: kb.read_patch_roots() for owner, kb in owner_kbs.items()}
         timeline = replay.read_patch_timeline()
         all_owner_refs = [ref for refs in owner_ref_lists.values() for ref in refs]
         if len(timeline) != len(set(timeline)):
@@ -1157,16 +1158,18 @@ class PreludePhase(PhaseHandler):
             source = kb.prior_file(ref)
             if source is None:
                 raise ValueError(f"current Recipe timeline artifact is unavailable: {ref!r}")
-            patches.append(
-                {
-                    "patch_file": ref,
-                    "patch_ref": str(source),
-                    "patch_content": "",
-                    "measured_gain_pct": 1e-6,
-                    "required": True,
-                    "timeline_index": index,
-                }
-            )
+            recorded_root = str(owner_patch_roots.get(owner, {}).get(ref) or "").strip()
+            patch_entry: dict[str, Any] = {
+                "patch_file": ref,
+                "patch_ref": str(source),
+                "patch_content": "",
+                "measured_gain_pct": 1e-6,
+                "required": True,
+                "timeline_index": index,
+            }
+            if recorded_root:
+                patch_entry["framework_root"] = recorded_root
+            patches.append(patch_entry)
         return {
             "extra_server_args": args,
             "extra_envs": envs,

--- a/src/hyperloom/orchestrator/phases/tests/test_enablement_sglang_artifact_fix.py
+++ b/src/hyperloom/orchestrator/phases/tests/test_enablement_sglang_artifact_fix.py
@@ -66,7 +66,7 @@ def test_duplicate_matching_roots_are_rejected_as_ambiguous(tmp_path):
     _git("-C", str(base), "-c", "user.email=a@b", "-c", "user.name=x", "commit", "-qam", "drift")
 
     res = _ps.ground_patch_text(_diff("f.py"), base_checkout=base, candidate_roots=(other,))
-    assert res.verdict == _ps.GROUND_MISSING_TARGET
+    assert res.verdict == _ps.GROUND_AMBIGUOUS_ROOT
     assert res.detail.startswith("ambiguous_root:")
     assert res.is_garbage
 

--- a/src/hyperloom/orchestrator/roles/claude.py
+++ b/src/hyperloom/orchestrator/roles/claude.py
@@ -163,6 +163,7 @@ _EFFORT_ENV: str = "INFERENCE_OPTIMIZER_CLAUDE_EFFORT"
 _EFFORT_ENV_ORCH: str = "INFERENCE_OPTIMIZER_CLAUDE_ORCHESTRATION_EFFORT"
 _EFFORT_ENV_KERNEL: str = "INFERENCE_OPTIMIZER_CLAUDE_KERNEL_EFFORT"
 _THINKING_ENV: str = "INFERENCE_OPTIMIZER_CLAUDE_THINKING"
+_CLI_PATH_ENV: str = "HYPERLOOM_CLAUDE_CLI_PATH"
 _VALID_EFFORT: frozenset[str] = frozenset({"low", "medium", "high", "xhigh", "max"})
 
 
@@ -758,6 +759,9 @@ class ClaudeBackend:
         kwargs: dict[str, Any] = {"max_turns": max_turns}
         if self.model:
             kwargs["model"] = self.model
+        cli_path = os.environ.get(_CLI_PATH_ENV, "").strip()
+        if cli_path:
+            kwargs["cli_path"] = cli_path
         if system_prompt:
             kwargs["system_prompt"] = system_prompt
         if resume_session_id:

--- a/src/hyperloom/orchestrator/source_snapshot.py
+++ b/src/hyperloom/orchestrator/source_snapshot.py
@@ -11,16 +11,17 @@ On-disk format::
          import_root, complete, files:[{rel, op}], extra}
     <snapshot_dir>/files/<rel>   # full copy of each upserted file
 
-``import_root`` is a path component relative to ``snapshot_dir/files/`` that
-locates the Python import root for this framework. GEAK prepends
-``snapshot_dir/files/<import_root>`` onto PYTHONPATH so the patched modules
-are importable from the snapshot without the ``files/`` indirection.
-For a sglang repo checkout, ``import_root`` is ``python``; for a dist-packages
-install it is ``""``.
+Full-file capture (not a fuzzy diff) reconstructs byte-for-byte regardless of
+patch strip levels, generated/untracked files, or whether the framework root is
+a git tree at all.
 
-``complete`` is True when every declared file was successfully copied and no
-entry carries ``op: "missing"``. Callers derive ``reproducible`` from this
-flag rather than from path existence alone.
+``files/<import_root>`` is the directory the GEAK handoff puts on PYTHONPATH, so
+``import_root`` must name where modules start within the tree: ``python`` for a
+sglang checkout, ``""`` for a dist-packages install.
+
+``complete`` is False once any declared path could not be accounted for, which
+is what makes the snapshot unusable as an overlay; ``reproducible`` downstream
+is this flag, never the mere existence of the directory.
 """
 
 from __future__ import annotations
@@ -47,27 +48,47 @@ def _safe_rel(rel: str) -> str | None:
 
 
 def snapshot_is_complete(snapshot_dir: str | Path) -> bool:
-    """Return True when the snapshot has a manifest and no ``op: "missing"`` entries.
+    """Return whether the snapshot at ``snapshot_dir`` accounts for every path.
+
+    Reads the manifest rather than trusting the directory's existence. Schema-1
+    manifests predate ``complete`` and are judged on their ops instead.
 
     Args:
-        snapshot_dir: Path to the snapshot directory written by
-            :func:`snapshot_source_layer`.
+        snapshot_dir: A directory written by :func:`snapshot_source_layer`.
 
     Returns:
-        True when the manifest exists, ``complete`` is True (schema ≥ 2), or
-        all entries carry ``"upsert"`` or ``"delete"`` (schema 1 fallback).
+        True when the manifest is readable and records no unaccounted path.
     """
+    manifest_path = Path(snapshot_dir) / MANIFEST_NAME
     try:
-        manifest_path = Path(snapshot_dir) / MANIFEST_NAME
-        if not manifest_path.is_file():
-            return False
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        if "complete" in manifest:
-            return bool(manifest["complete"])
-        files = manifest.get("files") or []
-        return all(f.get("op") in ("upsert", "delete") for f in files if isinstance(f, dict))
-    except (OSError, json.JSONDecodeError, ValueError):
+    except (OSError, ValueError):
         return False
+    if "complete" in manifest:
+        return bool(manifest["complete"])
+    files = manifest.get("files") or []
+    return all(f.get("op") in ("upsert", "delete") for f in files if isinstance(f, dict))
+
+
+def source_layer_reproducible(entry: dict[str, Any]) -> bool:
+    """Return whether an ``optimization_stack`` source-patch entry is replayable.
+
+    Prefers the flag recorded at KEEP time; entries written before it existed are
+    judged by reading their manifest.
+
+    Args:
+        entry: A ``scope=source_patch`` optimization_stack entry.
+
+    Returns:
+        True when the entry carries a snapshot that accounts for every path.
+    """
+    snapshot_dir = str(entry.get("source_snapshot") or "").strip()
+    if not snapshot_dir:
+        return False
+    recorded = entry.get("source_snapshot_complete")
+    if recorded is not None:
+        return bool(recorded)
+    return snapshot_is_complete(snapshot_dir)
 
 
 def snapshot_source_layer(
@@ -93,14 +114,10 @@ def snapshot_source_layer(
             any later git hygiene on ``framework_root``).
         provenance: Free-form origin tag (e.g. ``integrate_patch``).
         extra: Optional metadata folded into the manifest.
-        declared_ops: Caller-supplied ``{rel: op}`` mapping.  When a path is
-            in this dict with ``op="delete"`` and absent from disk, it is
-            recorded as a genuine deletion. Paths absent from disk and not in
-            ``declared_ops`` are recorded with ``op="missing"`` and cause
-            ``complete=False``.
-        import_root: The Python import root relative to ``files/``; placed on
-            PYTHONPATH by the GEAK baseline server. ``"python"`` for sglang
-            repo checkouts; ``""`` for dist-packages installs.
+        declared_ops: ``{rel: op}`` from the caller, which is the only party
+            that knows a deletion was intended. An absent path it does not
+            declare deleted is recorded ``"missing"``, not ``"delete"``.
+        import_root: Where modules start within the tree, relative to ``files/``.
 
     Returns:
         The manifest dict augmented with ``snapshot_dir``, or ``None`` when

--- a/src/hyperloom/orchestrator/source_snapshot.py
+++ b/src/hyperloom/orchestrator/source_snapshot.py
@@ -15,13 +15,21 @@ Full-file capture (not a fuzzy diff) reconstructs byte-for-byte regardless of
 patch strip levels, generated/untracked files, or whether the framework root is
 a git tree at all.
 
-``files/<import_root>`` is the directory the GEAK handoff puts on PYTHONPATH, so
-``import_root`` must name where modules start within the tree: ``python`` for a
-sglang checkout, ``""`` for a dist-packages install.
+The GEAK handoff consumes a snapshot as a PYTHONPATH entry, not as a tree to
+rebuild: ``run_e2e`` joins the ``snapshot_dir`` of every entry it considers
+reproducible into ``initial_overlay_pythonpath``. Two consequences fix the shape
+of everything below.
 
-``complete`` is False once any declared path could not be accounted for, which
-is what makes the snapshot unusable as an overlay; ``reproducible`` downstream
-is this flag, never the mere existence of the directory.
+``import_root`` must name where modules start within the tree -- ``python`` for a
+sglang checkout, ``""`` for a dist-packages install -- because the directory that
+travels is ``files/<import_root>``, not the snapshot root. Handing over
+``files/`` for a checkout puts ``python/sglang/...`` on the path, where
+``import sglang`` does not resolve and the stock install answers instead.
+
+``complete`` is False once any declared path could not be accounted for, and
+that is what ``reproducible`` reports downstream -- never the mere existence of
+the directory. A snapshot that reports False is dropped from the overlay, so an
+optimistic answer here is what silently benchmarks an unpatched tree.
 """
 
 from __future__ import annotations
@@ -66,6 +74,9 @@ def snapshot_is_complete(snapshot_dir: str | Path) -> bool:
         return False
     if "complete" in manifest:
         return bool(manifest["complete"])
+    # Schema 1 only ever recorded these two ops, so this is always True. That is
+    # the intended reading: it had no way to express an unaccounted path, and its
+    # snapshots have to be taken at face value or not used at all.
     files = manifest.get("files") or []
     return all(f.get("op") in ("upsert", "delete") for f in files if isinstance(f, dict))
 
@@ -89,6 +100,27 @@ def source_layer_reproducible(entry: dict[str, Any]) -> bool:
     if recorded is not None:
         return bool(recorded)
     return snapshot_is_complete(snapshot_dir)
+
+
+def source_layer_overlay_dir(entry: dict[str, Any]) -> str:
+    """Return the directory a consumer puts on PYTHONPATH for ``entry``.
+
+    The snapshot root holds the manifest and a ``files/`` tree, neither of which
+    is importable; the entry's recorded import root selects the level within it
+    that is. Returns ``""`` when the entry carries no snapshot.
+
+    Args:
+        entry: A ``scope=source_patch`` optimization_stack entry.
+
+    Returns:
+        str: The overlay directory, or ``""``.
+    """
+    snapshot_dir = str(entry.get("source_snapshot") or "").strip()
+    if not snapshot_dir:
+        return ""
+    overlay = Path(snapshot_dir) / "files"
+    import_root = _safe_rel(str(entry.get("source_import_root") or ""))
+    return str(overlay / import_root) if import_root else str(overlay)
 
 
 def snapshot_source_layer(

--- a/src/hyperloom/orchestrator/source_snapshot.py
+++ b/src/hyperloom/orchestrator/source_snapshot.py
@@ -4,16 +4,23 @@ Every KEEP snapshots its *realized* file contents into a session-scoped,
 self-contained directory that no later git hygiene can touch, rather than
 treating the mutable live tree as the source of truth.
 
-The on-disk format is the cross-tool contract (Hyperloom writes it; the GEAK
-side re-implements the same trivial reader), so neither side needs to import
-the other::
+On-disk format::
 
-    <snapshot_dir>/manifest.json   # {framework_root, base_sha, files:[{rel,op}]}
-    <snapshot_dir>/files/<rel>     # full copy of each realized file
+    <snapshot_dir>/manifest.json
+        {schema_version, framework_root, base_sha, provenance,
+         import_root, complete, files:[{rel, op}], extra}
+    <snapshot_dir>/files/<rel>   # full copy of each upserted file
 
-Full-file capture (not a fuzzy diff) reconstructs byte-for-byte regardless of
-patch strip levels, generated/untracked files, or whether the framework root
-is a git tree at all.
+``import_root`` is a path component relative to ``snapshot_dir/files/`` that
+locates the Python import root for this framework. GEAK prepends
+``snapshot_dir/files/<import_root>`` onto PYTHONPATH so the patched modules
+are importable from the snapshot without the ``files/`` indirection.
+For a sglang repo checkout, ``import_root`` is ``python``; for a dist-packages
+install it is ``""``.
+
+``complete`` is True when every declared file was successfully copied and no
+entry carries ``op: "missing"``. Callers derive ``reproducible`` from this
+flag rather than from path existence alone.
 """
 
 from __future__ import annotations
@@ -24,7 +31,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 MANIFEST_NAME = "manifest.json"
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 
 def _safe_rel(rel: str) -> str | None:
@@ -39,6 +46,30 @@ def _safe_rel(rel: str) -> str | None:
     return rel
 
 
+def snapshot_is_complete(snapshot_dir: str | Path) -> bool:
+    """Return True when the snapshot has a manifest and no ``op: "missing"`` entries.
+
+    Args:
+        snapshot_dir: Path to the snapshot directory written by
+            :func:`snapshot_source_layer`.
+
+    Returns:
+        True when the manifest exists, ``complete`` is True (schema ≥ 2), or
+        all entries carry ``"upsert"`` or ``"delete"`` (schema 1 fallback).
+    """
+    try:
+        manifest_path = Path(snapshot_dir) / MANIFEST_NAME
+        if not manifest_path.is_file():
+            return False
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if "complete" in manifest:
+            return bool(manifest["complete"])
+        files = manifest.get("files") or []
+        return all(f.get("op") in ("upsert", "delete") for f in files if isinstance(f, dict))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return False
+
+
 def snapshot_source_layer(
     *,
     framework_root: str | Path,
@@ -47,6 +78,8 @@ def snapshot_source_layer(
     dest_dir: str | Path,
     provenance: str = "",
     extra: dict[str, Any] | None = None,
+    declared_ops: dict[str, str] | None = None,
+    import_root: str = "",
 ) -> dict[str, Any] | None:
     """Capture the realized contents of ``rel_paths`` under ``framework_root``.
 
@@ -60,6 +93,14 @@ def snapshot_source_layer(
             any later git hygiene on ``framework_root``).
         provenance: Free-form origin tag (e.g. ``integrate_patch``).
         extra: Optional metadata folded into the manifest.
+        declared_ops: Caller-supplied ``{rel: op}`` mapping.  When a path is
+            in this dict with ``op="delete"`` and absent from disk, it is
+            recorded as a genuine deletion. Paths absent from disk and not in
+            ``declared_ops`` are recorded with ``op="missing"`` and cause
+            ``complete=False``.
+        import_root: The Python import root relative to ``files/``; placed on
+            PYTHONPATH by the GEAK baseline server. ``"python"`` for sglang
+            repo checkouts; ``""`` for dist-packages installs.
 
     Returns:
         The manifest dict augmented with ``snapshot_dir``, or ``None`` when
@@ -68,8 +109,10 @@ def snapshot_source_layer(
     framework_root = Path(framework_root)
     dest_dir = Path(dest_dir)
     files_root = dest_dir / "files"
+    ops = dict(declared_ops or {})
 
     captured: list[dict[str, str]] = []
+    all_complete = True
     for raw in sorted({str(p) for p in rel_paths}):
         rel = _safe_rel(raw)
         if rel is None:
@@ -80,9 +123,11 @@ def snapshot_source_layer(
             dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, dst)
             captured.append({"rel": rel, "op": "upsert"})
-        else:
-            # Absent post-apply => the KEEP deleted it; record the removal.
+        elif ops.get(rel) == "delete":
             captured.append({"rel": rel, "op": "delete"})
+        else:
+            captured.append({"rel": rel, "op": "missing"})
+            all_complete = False
 
     if not captured:
         return None
@@ -92,6 +137,8 @@ def snapshot_source_layer(
         "framework_root": str(framework_root),
         "base_sha": str(base_sha or ""),
         "provenance": provenance,
+        "import_root": import_root,
+        "complete": all_complete,
         "files": captured,
     }
     if extra:

--- a/src/hyperloom/orchestrator/specialists/patch_safety.py
+++ b/src/hyperloom/orchestrator/specialists/patch_safety.py
@@ -82,9 +82,9 @@ _PATCH_PATH_RE: re.Pattern[str] = re.compile(
 
 
 # Candidate ``-p`` strip levels for resolving a diff header path to a real file.
-# Used only on the legacy fallback path (worktree-harvested patches are -p1 by
-# construction and never need probing).
-_P_STRIP_LEVELS: tuple[int, ...] = (1, 0, 2, 3, 4)
+# Specialists author patches with heterogeneous path prefixes, so target
+# existence is probed across levels rather than assuming ``-p1``.
+_P_STRIP_LEVELS: tuple[int, ...] = (1, 0, 2, 3, 4, 5, 6, 7, 8)
 
 # Sentinel the post-/pre-image path takes for a created/deleted file.
 _DEV_NULL = "/dev/null"
@@ -284,31 +284,25 @@ def patch_targets_missing(
 
 
 def _collapse_nested_roots(roots: tuple[Path, ...]) -> tuple[Path, ...]:
-    """Drop roots that have an ancestor in ``roots``, keeping the outermost.
+    """Keep only the outermost of any nested match, leaving disjoint ones alone.
 
-    When both ``/sgl-workspace/sglang`` and ``/sgl-workspace/sglang/python``
-    match a patch's targets, the inner root is a subtree of the outer one:
-    using the inner root would apply at the wrong ``-p`` level. Keeping the
-    outer root makes the strip level consistent with ``git diff`` output.
-
-    Genuinely disjoint roots are not affected.
+    An editable install puts a package parent inside its own checkout, so
+    ``/sgl-workspace/sglang`` and ``/sgl-workspace/sglang/python`` both hold a
+    ``python/sglang/...`` target at different strip levels. They are one tree,
+    and the outer root is the one whose strip level matches ``git diff`` output.
 
     Args:
         roots: Match candidates from :func:`resolve_patch_apply_root`.
 
     Returns:
-        Roots with nested (child) paths removed.
+        Roots with any descendant of another entry removed.
     """
-    resolved = [r.resolve() for r in roots]
-    kept: list[Path] = []
-    for i, root in enumerate(roots):
-        if not any(
-            resolved[i] != resolved[j] and str(resolved[i]).startswith(str(resolved[j]) + "/")
-            for j in range(len(roots))
-            if i != j
-        ):
-            kept.append(root)
-    return tuple(kept)
+    resolved = {root: root.resolve() for root in roots}
+    return tuple(
+        root
+        for root in roots
+        if not any(other != resolved[root] and other in resolved[root].parents for other in resolved.values())
+    )
 
 
 def resolve_patch_apply_root(

--- a/src/hyperloom/orchestrator/specialists/patch_safety.py
+++ b/src/hyperloom/orchestrator/specialists/patch_safety.py
@@ -82,9 +82,9 @@ _PATCH_PATH_RE: re.Pattern[str] = re.compile(
 
 
 # Candidate ``-p`` strip levels for resolving a diff header path to a real file.
-# Specialists author patches with heterogeneous path prefixes, so target
-# existence is probed across levels rather than assuming ``-p1``.
-_P_STRIP_LEVELS: tuple[int, ...] = (1, 0, 2, 3, 4, 5, 6, 7, 8)
+# Used only on the legacy fallback path (worktree-harvested patches are -p1 by
+# construction and never need probing).
+_P_STRIP_LEVELS: tuple[int, ...] = (1, 0, 2, 3, 4)
 
 # Sentinel the post-/pre-image path takes for a created/deleted file.
 _DEV_NULL = "/dev/null"

--- a/src/hyperloom/orchestrator/specialists/patch_safety.py
+++ b/src/hyperloom/orchestrator/specialists/patch_safety.py
@@ -283,6 +283,34 @@ def patch_targets_missing(
     return missing
 
 
+def _collapse_nested_roots(roots: tuple[Path, ...]) -> tuple[Path, ...]:
+    """Drop roots that have an ancestor in ``roots``, keeping the outermost.
+
+    When both ``/sgl-workspace/sglang`` and ``/sgl-workspace/sglang/python``
+    match a patch's targets, the inner root is a subtree of the outer one:
+    using the inner root would apply at the wrong ``-p`` level. Keeping the
+    outer root makes the strip level consistent with ``git diff`` output.
+
+    Genuinely disjoint roots are not affected.
+
+    Args:
+        roots: Match candidates from :func:`resolve_patch_apply_root`.
+
+    Returns:
+        Roots with nested (child) paths removed.
+    """
+    resolved = [r.resolve() for r in roots]
+    kept: list[Path] = []
+    for i, root in enumerate(roots):
+        if not any(
+            resolved[i] != resolved[j] and str(resolved[i]).startswith(str(resolved[j]) + "/")
+            for j in range(len(roots))
+            if i != j
+        ):
+            kept.append(root)
+    return tuple(kept)
+
+
 def resolve_patch_apply_root(
     patch_texts: Sequence[str],
     *,
@@ -382,6 +410,8 @@ def resolve_patch_apply_root(
     matches = tuple(root for root in roots if not any(patch_targets_missing(text, root) for text in texts))
     if not matches:
         return PatchRootResolution(None, "no_matching_root")
+    if len(matches) > 1:
+        matches = _collapse_nested_roots(matches)
     if len(matches) > 1:
         return PatchRootResolution(None, "ambiguous_root", matches)
     return PatchRootResolution(matches[0], matches=matches)
@@ -606,6 +636,7 @@ GROUND_STALE = "stale"  # valid diff but does not apply to clean base
 GROUND_NOT_DIFF = "not_diff"  # not a unified diff (no hunk header)
 GROUND_PATH_ESCAPE = "path_escape"  # patch path escapes the tree
 GROUND_MISSING_TARGET = "missing_target"  # modify/delete target absent from base
+GROUND_AMBIGUOUS_ROOT = "ambiguous_root"  # patch targets match more than one disjoint tree
 GROUND_UNCHECKED = "unchecked"  # no base available / git unavailable
 
 
@@ -633,6 +664,7 @@ class PatchGroundingResult:
             GROUND_NOT_DIFF,
             GROUND_PATH_ESCAPE,
             GROUND_MISSING_TARGET,
+            GROUND_AMBIGUOUS_ROOT,
         )
 
 
@@ -688,6 +720,8 @@ def ground_patch_text(
         detail = resolution.reason
         if resolution.matches:
             detail += ": " + ", ".join(str(root) for root in resolution.matches)
+        if resolution.reason == "ambiguous_root":
+            return PatchGroundingResult(GROUND_AMBIGUOUS_ROOT, detail)
         return PatchGroundingResult(GROUND_MISSING_TARGET, detail)
     root = resolution.root
     try:
@@ -733,8 +767,18 @@ class PatchSafetyReport:
             out.append(
                 "patch_safety_missing_target:"
                 + ",".join(d.get("detail", d["path"]) for d in missing[:4])
-                + " — author patches against files that exist in the framework "
-                "source tree (inspect it with Glob/Grep first)."
+                + " — the patch names a file that does not exist in any"
+                " allowlisted framework source tree; verify the target path"
+                " with Glob/Grep before authoring the diff."
+            )
+        ambiguous = [d for d in self.dropped if d.get("verdict") == GROUND_AMBIGUOUS_ROOT]
+        if ambiguous:
+            out.append(
+                "patch_safety_ambiguous_root:"
+                + ",".join(d.get("detail", d["path"]) for d in ambiguous[:4])
+                + " — the patch targets match more than one disjoint source"
+                " tree; declare an explicit framework_source_root so the"
+                " correct tree is selected without guessing."
             )
         stale = [p for p, v in self.grounding.items() if v == GROUND_STALE]
         if stale:
@@ -897,8 +941,9 @@ def vet_patches(
             detail = resolution.reason
             if resolution.matches:
                 detail += ": " + ", ".join(str(r) for r in resolution.matches)
-            grounding[path] = GROUND_MISSING_TARGET
-            dropped.append({"path": path, "verdict": GROUND_MISSING_TARGET, "detail": detail})
+            verdict = GROUND_AMBIGUOUS_ROOT if resolution.reason == "ambiguous_root" else GROUND_MISSING_TARGET
+            grounding[path] = verdict
+            dropped.append({"path": path, "verdict": verdict, "detail": detail})
             continue
         res = ground_patch_text(text, base_checkout=None, explicit_root=resolution.root)
         grounding[path] = res.verdict
@@ -917,6 +962,7 @@ __all__ = [
     "CrossDomainRule",
     "FORBIDDEN_PAYLOAD_FIELDS",
     "FORBIDDEN_PROPOSAL_FIELDS",
+    "GROUND_AMBIGUOUS_ROOT",
     "GROUND_APPLIES",
     "GROUND_MISSING_TARGET",
     "GROUND_NOT_DIFF",

--- a/src/hyperloom/orchestrator/specialists/runner.py
+++ b/src/hyperloom/orchestrator/specialists/runner.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import enum
 import json
 import logging
-import os
 import re
 import time
 from dataclasses import dataclass, field
@@ -46,10 +45,10 @@ from .subprocess_ import (
     SpecialistSubprocessResult,
     _pick_worktree_base,
     _setup_worktree,
-    ensure_authoring_checkout,
 )
 from . import patch_safety as _patch_safety
 from .profile import MODE_PATCH, SpecialistProfile, resolve_specialist_profile
+from ..framework.paths import resolve_framework_tree
 from ..loop.sub_agent_runner import RunnerContext
 from ..prompts.specialist_prompt_builder import (
     SpecialistPromptInputs,
@@ -139,32 +138,6 @@ _TOKEN_VALUE_RES = (
     re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
     re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"),
 )
-
-
-def _framework_checkout(framework: str) -> str:
-    """Return the checkout of the framework this session optimises, if published.
-
-    A scriptable framework runs out of a repo checkout, and
-    ``_publish_scriptable_repo_root`` puts that path in ``os.environ`` as
-    ``<FRAMEWORK>_REPO_PATH`` / ``<FRAMEWORK>_DIR`` so it reaches PolicyGate. The
-    specialist worktree needs the same answer: it must branch off the tree whose
-    files the patches name, not off whichever allowlisted root happens to be a
-    checkout.
-
-    Args:
-        framework: Session framework name, e.g. ``worldplay``.
-
-    Returns:
-        The resolved path, or ``""`` when the framework publishes none (the
-        pip-installed case, where the allowlist order is the right fallback).
-    """
-    name = str(framework or "").strip().upper()
-    candidates = (f"{name}_REPO_PATH", f"{name}_DIR") if name else ()
-    for var in (*candidates, "FRAMEWORK_REPO_PATH"):
-        value = os.environ.get(var, "").strip()
-        if value:
-            return value
-    return ""
 
 
 def _sibling_checkouts(roots: tuple[str, ...], base: Path | None) -> tuple[Path, ...]:
@@ -1378,9 +1351,9 @@ class SpecialistRunner:
                 _proposal.setdefault("scope", prep.profile.scope)
 
         # Universal patch-safety gate: drop non-diff/escaping patches, git-ground
-        # the rest against the clean base checkout, and scan for smuggled claims.
-        # The worktree base names one framework tree, but a specialist may target
-        # another allowlisted one, so the rest are offered as candidate roots.
+        # the rest, and scan for smuggled claims. A harvested patch already knows
+        # its root, so it is grounded against that one tree; only a hand-authored
+        # patch, whose target tree is unknown, is matched against the candidates.
         collected_roots = dict(patch_roots or {})
         base_checkout = prep.worktree_base or prep.worktree
         candidate_roots = _sibling_checkouts(
@@ -1388,13 +1361,13 @@ class SpecialistRunner:
             base_checkout,
         )
         explicit_value = str((ctx.task.params or {}).get("framework_source_root") or "").strip()
-        explicit_root: Path | None = Path(explicit_value) if explicit_value else None
-        if explicit_root is None and collected_roots:
-            unique_roots = set(collected_roots.values())
-            if len(unique_roots) == 1:
-                sole_root = Path(next(iter(unique_roots)))
-                if sole_root.is_dir():
-                    explicit_root = sole_root
+        harvested_roots = set(collected_roots.values())
+        if explicit_value:
+            explicit_root: Path | None = Path(explicit_value)
+        elif len(harvested_roots) == 1:
+            explicit_root = Path(harvested_roots.pop())
+        else:
+            explicit_root = None
         kept, dropped, grounding, spans_roots = _patch_safety.vet_patches(
             deduped,
             base_checkout=base_checkout,
@@ -1491,16 +1464,12 @@ class SpecialistRunner:
         if profile is not None:
             if profile.mode != MODE_PATCH:
                 return None, None, ""
-        framework = str((ctx.task.params or {}).get("framework") or "")
-        session_dir = self.session_dir if hasattr(self, "session_dir") and self.session_dir else workspace.parent
-        base, shadow_err = ensure_authoring_checkout(framework, session_dir)
+        base = _pick_worktree_base(
+            self.subprocess_config.framework_source_roots,
+            preferred=resolve_framework_tree(str((ctx.task.params or {}).get("framework") or "")),
+        )
         if base is None:
-            base = _pick_worktree_base(
-                self.subprocess_config.framework_source_roots,
-                preferred=_framework_checkout(framework),
-            )
-        if base is None:
-            return None, None, shadow_err or "no_git_framework_source_root"
+            return None, None, "no_git_framework_source_root"
         worktree_path = workspace / "worktree"
         branch = f"specialist-{ctx.task.task_id}"
         wt, err = _setup_worktree(base, worktree_path, branch)

--- a/src/hyperloom/orchestrator/specialists/runner.py
+++ b/src/hyperloom/orchestrator/specialists/runner.py
@@ -170,6 +170,36 @@ def _sibling_checkouts(roots: tuple[str, ...], base: Path | None) -> tuple[Path,
     return tuple(out)
 
 
+def _grounding_explicit_root(
+    *,
+    declared: str,
+    patches: list[str],
+    patch_roots: dict[str, str],
+) -> Path | None:
+    """Return the root to ground the whole patch set against, or ``None``.
+
+    ``vet_patches`` grounds one set against one root, so a harvested root can
+    stand in only when every patch was harvested and they agree on it. A
+    hand-authored patch alongside a harvest has an unknown target tree, and
+    grounding it against the harvest root drops it as a mismatch rather than
+    matching it against the candidates.
+
+    Args:
+        declared: ``framework_source_root`` from the task params, if any.
+        patches: The deduplicated patch set about to be vetted.
+        patch_roots: Apply roots recorded for harvested patches.
+
+    Returns:
+        Path | None: The root, or None to fall back to candidate matching.
+    """
+    if declared:
+        return Path(declared)
+    if not patches or any(patch not in patch_roots for patch in patches):
+        return None
+    roots = set(patch_roots.values())
+    return Path(roots.pop()) if len(roots) == 1 else None
+
+
 def _patch_path_within_bases(path: Path, bases: list[Path]) -> bool:
     """True when ``path`` resolves inside one of the specialist sandbox bases.
 
@@ -1351,23 +1381,19 @@ class SpecialistRunner:
                 _proposal.setdefault("scope", prep.profile.scope)
 
         # Universal patch-safety gate: drop non-diff/escaping patches, git-ground
-        # the rest, and scan for smuggled claims. A harvested patch already knows
-        # its root, so it is grounded against that one tree; only a hand-authored
-        # patch, whose target tree is unknown, is matched against the candidates.
+        # the rest, and scan for smuggled claims. Grounding is per set, not per
+        # patch, so the root below applies to all of them or to none.
         collected_roots = dict(patch_roots or {})
         base_checkout = prep.worktree_base or prep.worktree
         candidate_roots = _sibling_checkouts(
             tuple(self.subprocess_config.framework_source_roots) if self.subprocess_config else (),
             base_checkout,
         )
-        explicit_value = str((ctx.task.params or {}).get("framework_source_root") or "").strip()
-        harvested_roots = set(collected_roots.values())
-        if explicit_value:
-            explicit_root: Path | None = Path(explicit_value)
-        elif len(harvested_roots) == 1:
-            explicit_root = Path(harvested_roots.pop())
-        else:
-            explicit_root = None
+        explicit_root = _grounding_explicit_root(
+            declared=str((ctx.task.params or {}).get("framework_source_root") or "").strip(),
+            patches=deduped,
+            patch_roots=collected_roots,
+        )
         kept, dropped, grounding, spans_roots = _patch_safety.vet_patches(
             deduped,
             base_checkout=base_checkout,

--- a/src/hyperloom/orchestrator/specialists/runner.py
+++ b/src/hyperloom/orchestrator/specialists/runner.py
@@ -46,6 +46,7 @@ from .subprocess_ import (
     SpecialistSubprocessResult,
     _pick_worktree_base,
     _setup_worktree,
+    ensure_authoring_checkout,
 )
 from . import patch_safety as _patch_safety
 from .profile import MODE_PATCH, SpecialistProfile, resolve_specialist_profile
@@ -1473,12 +1474,16 @@ class SpecialistRunner:
         if profile is not None:
             if profile.mode != MODE_PATCH:
                 return None, None, ""
-        base = _pick_worktree_base(
-            self.subprocess_config.framework_source_roots,
-            preferred=_framework_checkout(str((ctx.task.params or {}).get("framework") or "")),
-        )
+        framework = str((ctx.task.params or {}).get("framework") or "")
+        session_dir = self.session_dir if hasattr(self, "session_dir") and self.session_dir else workspace.parent
+        base, shadow_err = ensure_authoring_checkout(framework, session_dir)
         if base is None:
-            return None, None, "no_git_framework_source_root"
+            base = _pick_worktree_base(
+                self.subprocess_config.framework_source_roots,
+                preferred=_framework_checkout(framework),
+            )
+        if base is None:
+            return None, None, shadow_err or "no_git_framework_source_root"
         worktree_path = workspace / "worktree"
         branch = f"specialist-{ctx.task.task_id}"
         wt, err = _setup_worktree(base, worktree_path, branch)

--- a/src/hyperloom/orchestrator/specialists/runner.py
+++ b/src/hyperloom/orchestrator/specialists/runner.py
@@ -1228,6 +1228,7 @@ class SpecialistRunner:
             backend_error=backend_error,
             extra_notes=notes,
             patches_written=list(sub_result.patches),
+            patch_roots=dict(sub_result.patch_roots),
         )
 
     # Finalize phase (shared)
@@ -1242,6 +1243,7 @@ class SpecialistRunner:
         backend_error: str,
         extra_notes: list[str],
         patches_written: list[str],
+        patch_roots: dict[str, str] | None = None,
     ) -> SpecialistRunResult:
         """Persist the ``specialist_done`` artifact and build the result.
 
@@ -1379,22 +1381,35 @@ class SpecialistRunner:
         # the rest against the clean base checkout, and scan for smuggled claims.
         # The worktree base names one framework tree, but a specialist may target
         # another allowlisted one, so the rest are offered as candidate roots.
+        collected_roots = dict(patch_roots or {})
         base_checkout = prep.worktree_base or prep.worktree
         candidate_roots = _sibling_checkouts(
             tuple(self.subprocess_config.framework_source_roots) if self.subprocess_config else (),
             base_checkout,
         )
         explicit_value = str((ctx.task.params or {}).get("framework_source_root") or "").strip()
+        explicit_root: Path | None = Path(explicit_value) if explicit_value else None
+        if explicit_root is None and collected_roots:
+            unique_roots = set(collected_roots.values())
+            if len(unique_roots) == 1:
+                sole_root = Path(next(iter(unique_roots)))
+                if sole_root.is_dir():
+                    explicit_root = sole_root
         kept, dropped, grounding, spans_roots = _patch_safety.vet_patches(
             deduped,
             base_checkout=base_checkout,
             candidate_roots=candidate_roots,
-            explicit_root=Path(explicit_value) if explicit_value else None,
+            explicit_root=explicit_root,
         )
         # A set dropped for targets no tree holds is a distinct outcome from
         # "the specialist wrote none", and the next round has to be told which.
         all_dropped_by_grounding = bool(
-            deduped and not kept and all(d.get("verdict") == _patch_safety.GROUND_MISSING_TARGET for d in dropped)
+            deduped
+            and not kept
+            and all(
+                d.get("verdict") in (_patch_safety.GROUND_MISSING_TARGET, _patch_safety.GROUND_AMBIGUOUS_ROOT)
+                for d in dropped
+            )
         )
         numeric_warnings = _patch_safety.scan_numeric_claims(done_payload)
         # Strip, do not forward: the Critic is instructed to reject the whole
@@ -1410,6 +1425,8 @@ class SpecialistRunner:
         )
         done_payload["patches_written"] = kept
         done_payload["patch_grounding"] = grounding
+        if collected_roots:
+            done_payload["patch_roots"] = {p: r for p, r in collected_roots.items() if p in kept}
         if all_dropped_by_grounding:
             done_payload["patches_dropped_by_grounding"] = [d["detail"] for d in dropped[:8]]
         if spans_roots:

--- a/src/hyperloom/orchestrator/specialists/subprocess_.py
+++ b/src/hyperloom/orchestrator/specialists/subprocess_.py
@@ -614,12 +614,10 @@ class SpecialistSubprocessResult:
     directly — do not join them onto a base."""
 
     patch_roots: dict[str, str] = field(default_factory=dict)
-    """Map from absolute patch path to the apply root it was harvested from.
+    """Apply root per patch path, for patches harvested from a worktree.
 
-    Populated for every patch produced by ``git diff HEAD`` in a worktree;
-    absent for patches scanned from disk whose root was not established at
-    collection time. When present, downstream steps use this as the
-    ``explicit_root`` instead of probing the filesystem."""
+    Empty for patches merely found on disk, whose target tree is not knowable at
+    collection time and must therefore still be resolved from their contents."""
 
     usage: dict[str, Any] | None = None
     """Token usage recovered from the agent CLI's ``process.log``. Carries the
@@ -746,90 +744,6 @@ def _setup_worktree(
     if cp.returncode != 0:
         return None, (f"git worktree add rc={cp.returncode}: stderr={cp.stderr.strip()[:400]!r}")
     return worktree_path, ""
-
-
-def ensure_authoring_checkout(framework: str, session_dir: Path) -> tuple[Path | None, str]:
-    """Return a git checkout of ``framework``'s source tree, creating one if needed.
-
-    The fast path: when the framework already has a git checkout (discovered via
-    ``resolve_framework_tree``), return it directly with no I/O cost.
-
-    The slow path: when the framework is pip-installed (no ``.git``), create a
-    shadow repo at ``<session>/runtime/authoring_repo/<framework>`` by
-    hardlink-copying the full tree, running ``git init``, and making one commit.
-    This gives the specialist an isolated, revisionable workspace whose ``git diff``
-    produces canonical ``-p1`` relative paths against the correct tree root.
-
-    Args:
-        framework: Framework name, e.g. ``"sglang"`` or ``"vllm"``.
-        session_dir: The session directory; shadow repos are created beneath it.
-
-    Returns:
-        ``(checkout_path, "")`` on success, ``(None, error_reason)`` on failure.
-    """
-    from hyperloom.orchestrator.framework.paths import resolve_framework_tree
-
-    tree = resolve_framework_tree(framework)
-    if not tree:
-        return None, f"no_source_tree_for_{framework}"
-
-    tree_path = Path(tree.rstrip("/"))
-    if not tree_path.is_dir():
-        return None, f"source_tree_missing:{tree}"
-
-    if (tree_path / ".git").exists():
-        return tree_path, ""
-
-    shadow_root = session_dir / "runtime" / "authoring_repo" / (framework or "framework")
-    if shadow_root.exists() and (shadow_root / ".git").exists():
-        log.info("reusing existing shadow repo at %s", shadow_root)
-        return shadow_root, ""
-
-    shadow_root.mkdir(parents=True, exist_ok=True)
-
-    try:
-        cp = subprocess.run(
-            ["cp", "-al", f"{tree_path}/.", str(shadow_root)],
-            capture_output=True,
-            text=True,
-            timeout=300.0,
-            check=False,
-        )
-    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-        return None, f"shadow_repo_copy_failed:{exc!r}"
-    if cp.returncode != 0:
-        return None, f"shadow_repo_copy_rc={cp.returncode}:{cp.stderr.strip()[:200]!r}"
-
-    for cmd, timeout in [
-        (["git", "-C", str(shadow_root), "init", "-q"], 30.0),
-        (["git", "-C", str(shadow_root), "add", "-A"], 120.0),
-        (
-            [
-                "git",
-                "-C",
-                str(shadow_root),
-                "-c",
-                "user.email=hyperloom@local",
-                "-c",
-                "user.name=hyperloom",
-                "commit",
-                "-q",
-                "--allow-empty",
-                "-m",
-                "shadow base",
-            ],
-            60.0,
-        ),
-    ]:
-        try:
-            cp2 = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, check=False)
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-            return None, f"shadow_repo_git_failed:{exc!r}"
-        if cp2.returncode != 0:
-            return None, f"shadow_repo_git_rc={cp2.returncode}:{cp2.stderr.strip()[:200]!r}"
-
-    log.info("created shadow repo for %s at %s", framework, shadow_root)
-    return shadow_root, ""
 
 
 # §3.3: how often to poll a PENDING GPU-specialist Ray actor for its pid.
@@ -1691,46 +1605,37 @@ class SpecialistSubprocessDispatcher:
         workspace: Path,
         worktree_base: Path | None = None,
     ) -> tuple[list[str], dict[str, str]]:
-        """Collect specialist patches, preferring ``git diff HEAD`` over hand-authored files.
+        """Harvest the specialist's edits, else collect the patch files it wrote.
 
-        When a worktree exists, run ``git diff HEAD`` against it to produce a
-        single canonical ``-p1`` patch whose apply root is the worktree base.
-        The fallback is the historical disk scan of ``<tree>/patches/*.patch``.
+        Editing the worktree is the primary contract: ``git diff HEAD`` renders
+        those edits as one canonical ``-p1`` patch and names its apply root, so
+        nothing downstream has to infer which tree it belongs to. Scanning
+        ``patches/`` remains for dispatches that never got a worktree.
 
         Args:
             worktree: Per-task worktree, or None.
             workspace: Task workspace.
-            worktree_base: The git checkout the worktree was branched off;
-                used as the apply root for harvested patches.
+            worktree_base: Checkout the worktree was branched off, which is the
+                apply root of anything harvested from it.
 
         Returns:
-            ``(patch_paths, patch_roots)`` where ``patch_roots`` maps each
-            harvested path to its apply root string.
+            ``(patch_paths, patch_roots)``; the latter is empty for scanned files.
         """
-        out: list[str] = []
-        roots: dict[str, str] = {}
-
         if worktree is not None and (worktree / ".git").exists():
-            harvest_root = worktree_base or worktree
-            try:
-                cp = subprocess.run(
-                    ["git", "-C", str(worktree), "diff", "HEAD"],
-                    capture_output=True,
-                    text=True,
-                    timeout=60.0,
-                    check=False,
-                )
-                if cp.returncode == 0 and cp.stdout.strip():
-                    harvested_dir = worktree / "patches"
-                    harvested_dir.mkdir(exist_ok=True)
-                    harvested_path = harvested_dir / "_worktree_diff.patch"
-                    harvested_path.write_text(cp.stdout, encoding="utf-8")
-                    out.append(str(harvested_path))
-                    roots[str(harvested_path)] = str(harvest_root)
-                    return out, roots
-            except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
-                log.warning("specialist: git diff harvest failed (%r); falling back to patch scan", exc)
+            diff = subprocess.run(
+                ["git", "-C", str(worktree), "diff", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=120.0,
+                check=False,
+            )
+            if diff.returncode == 0 and diff.stdout.strip():
+                harvested = worktree / "patches" / "_worktree_diff.patch"
+                harvested.parent.mkdir(exist_ok=True)
+                harvested.write_text(diff.stdout, encoding="utf-8")
+                return [str(harvested)], {str(harvested): str(worktree_base or worktree)}
 
+        out: list[str] = []
         for base in (worktree, workspace):
             if base is None:
                 continue
@@ -1740,7 +1645,7 @@ class SpecialistSubprocessDispatcher:
             for ext in ("*.patch", "*.diff"):
                 for p in sorted(patches_dir.glob(ext)):
                     out.append(str(p))
-        return out, roots
+        return out, {}
 
     @staticmethod
     def _read_done(done_file: Path) -> dict[str, Any] | None:
@@ -1804,7 +1709,6 @@ __all__ = [
     "SpecialistSubprocessResult",
     "_pick_worktree_base",
     "_setup_worktree",
-    "ensure_authoring_checkout",
     "resolve_codex_executable",
     "resolve_specialist_agent_backend",
 ]

--- a/src/hyperloom/orchestrator/specialists/subprocess_.py
+++ b/src/hyperloom/orchestrator/specialists/subprocess_.py
@@ -740,6 +740,90 @@ def _setup_worktree(
     return worktree_path, ""
 
 
+def ensure_authoring_checkout(framework: str, session_dir: Path) -> tuple[Path | None, str]:
+    """Return a git checkout of ``framework``'s source tree, creating one if needed.
+
+    The fast path: when the framework already has a git checkout (discovered via
+    ``resolve_framework_tree``), return it directly with no I/O cost.
+
+    The slow path: when the framework is pip-installed (no ``.git``), create a
+    shadow repo at ``<session>/runtime/authoring_repo/<framework>`` by
+    hardlink-copying the full tree, running ``git init``, and making one commit.
+    This gives the specialist an isolated, revisionable workspace whose ``git diff``
+    produces canonical ``-p1`` relative paths against the correct tree root.
+
+    Args:
+        framework: Framework name, e.g. ``"sglang"`` or ``"vllm"``.
+        session_dir: The session directory; shadow repos are created beneath it.
+
+    Returns:
+        ``(checkout_path, "")`` on success, ``(None, error_reason)`` on failure.
+    """
+    from hyperloom.orchestrator.framework.paths import resolve_framework_tree
+
+    tree = resolve_framework_tree(framework)
+    if not tree:
+        return None, f"no_source_tree_for_{framework}"
+
+    tree_path = Path(tree.rstrip("/"))
+    if not tree_path.is_dir():
+        return None, f"source_tree_missing:{tree}"
+
+    if (tree_path / ".git").exists():
+        return tree_path, ""
+
+    shadow_root = session_dir / "runtime" / "authoring_repo" / (framework or "framework")
+    if shadow_root.exists() and (shadow_root / ".git").exists():
+        log.info("reusing existing shadow repo at %s", shadow_root)
+        return shadow_root, ""
+
+    shadow_root.mkdir(parents=True, exist_ok=True)
+
+    try:
+        cp = subprocess.run(
+            ["cp", "-al", f"{tree_path}/.", str(shadow_root)],
+            capture_output=True,
+            text=True,
+            timeout=300.0,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return None, f"shadow_repo_copy_failed:{exc!r}"
+    if cp.returncode != 0:
+        return None, f"shadow_repo_copy_rc={cp.returncode}:{cp.stderr.strip()[:200]!r}"
+
+    for cmd, timeout in [
+        (["git", "-C", str(shadow_root), "init", "-q"], 30.0),
+        (["git", "-C", str(shadow_root), "add", "-A"], 120.0),
+        (
+            [
+                "git",
+                "-C",
+                str(shadow_root),
+                "-c",
+                "user.email=hyperloom@local",
+                "-c",
+                "user.name=hyperloom",
+                "commit",
+                "-q",
+                "--allow-empty",
+                "-m",
+                "shadow base",
+            ],
+            60.0,
+        ),
+    ]:
+        try:
+            cp2 = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, check=False)
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            return None, f"shadow_repo_git_failed:{exc!r}"
+        if cp2.returncode != 0:
+            return None, f"shadow_repo_git_rc={cp2.returncode}:{cp2.stderr.strip()[:200]!r}"
+
+    log.info("created shadow repo for %s at %s", framework, shadow_root)
+    return shadow_root, ""
+
+
 # §3.3: how often to poll a PENDING GPU-specialist Ray actor for its pid.
 _RAY_PENDING_POLL_INTERVAL_SEC: float = 1.0
 
@@ -1684,6 +1768,7 @@ __all__ = [
     "SpecialistSubprocessResult",
     "_pick_worktree_base",
     "_setup_worktree",
+    "ensure_authoring_checkout",
     "resolve_codex_executable",
     "resolve_specialist_agent_backend",
 ]

--- a/src/hyperloom/orchestrator/specialists/subprocess_.py
+++ b/src/hyperloom/orchestrator/specialists/subprocess_.py
@@ -1600,6 +1600,42 @@ class SpecialistSubprocessDispatcher:
                 pass
 
     @staticmethod
+    def _harvest_worktree_diff(worktree: Path) -> str:
+        """Return the worktree's edits as one ``-p1`` diff, or ``""``.
+
+        A new file is untracked, and ``git diff`` does not see untracked paths.
+        Intent-to-add stages their existence so they render as creations without
+        committing anything, which is what keeps "edited a file and added one"
+        from harvesting a patch that silently omits the addition. ``patches/`` is
+        excluded because the harvest itself lands there.
+
+        Args:
+            worktree: Per-task worktree holding a ``.git`` marker.
+
+        Returns:
+            str: The diff text, or ``""`` when there is nothing to harvest or
+                git could not be run.
+        """
+        def _git(*args: str) -> subprocess.CompletedProcess[str] | None:
+            try:
+                return subprocess.run(
+                    ["git", "-C", str(worktree), *args],
+                    capture_output=True,
+                    text=True,
+                    timeout=120.0,
+                    check=False,
+                )
+            except (OSError, subprocess.SubprocessError) as exc:
+                log.warning("specialist: git %s in %s failed: %r", args[0], worktree, exc)
+                return None
+
+        _git("add", "-A", "-N", "--", ".", ":(exclude)patches")
+        diff = _git("diff", "HEAD", "--", ".", ":(exclude)patches")
+        if diff is None or diff.returncode != 0:
+            return ""
+        return diff.stdout if diff.stdout.strip() else ""
+
+    @staticmethod
     def _collect_patches(
         worktree: Path | None,
         workspace: Path,
@@ -1610,7 +1646,9 @@ class SpecialistSubprocessDispatcher:
         Editing the worktree is the primary contract: ``git diff HEAD`` renders
         those edits as one canonical ``-p1`` patch and names its apply root, so
         nothing downstream has to infer which tree it belongs to. Scanning
-        ``patches/`` remains for dispatches that never got a worktree.
+        ``patches/`` remains for dispatches that never got a worktree, and for
+        any git failure here -- a harvest that raises would otherwise discard
+        the whole specialist result, done-file included.
 
         Args:
             worktree: Per-task worktree, or None.
@@ -1622,17 +1660,11 @@ class SpecialistSubprocessDispatcher:
             ``(patch_paths, patch_roots)``; the latter is empty for scanned files.
         """
         if worktree is not None and (worktree / ".git").exists():
-            diff = subprocess.run(
-                ["git", "-C", str(worktree), "diff", "HEAD"],
-                capture_output=True,
-                text=True,
-                timeout=120.0,
-                check=False,
-            )
-            if diff.returncode == 0 and diff.stdout.strip():
+            harvested_diff = SpecialistSubprocessDispatcher._harvest_worktree_diff(worktree)
+            if harvested_diff:
                 harvested = worktree / "patches" / "_worktree_diff.patch"
                 harvested.parent.mkdir(exist_ok=True)
-                harvested.write_text(diff.stdout, encoding="utf-8")
+                harvested.write_text(harvested_diff, encoding="utf-8")
                 return [str(harvested)], {str(harvested): str(worktree_base or worktree)}
 
         out: list[str] = []

--- a/src/hyperloom/orchestrator/specialists/subprocess_.py
+++ b/src/hyperloom/orchestrator/specialists/subprocess_.py
@@ -1616,6 +1616,7 @@ class SpecialistSubprocessDispatcher:
             str: The diff text, or ``""`` when there is nothing to harvest or
                 git could not be run.
         """
+
         def _git(*args: str) -> subprocess.CompletedProcess[str] | None:
             try:
                 return subprocess.run(

--- a/src/hyperloom/orchestrator/specialists/subprocess_.py
+++ b/src/hyperloom/orchestrator/specialists/subprocess_.py
@@ -613,6 +613,14 @@ class SpecialistSubprocessResult:
     roots are session-absolute). Consumers read and sandbox-check these
     directly — do not join them onto a base."""
 
+    patch_roots: dict[str, str] = field(default_factory=dict)
+    """Map from absolute patch path to the apply root it was harvested from.
+
+    Populated for every patch produced by ``git diff HEAD`` in a worktree;
+    absent for patches scanned from disk whose root was not established at
+    collection time. When present, downstream steps use this as the
+    ``explicit_root`` instead of probing the filesystem."""
+
     usage: dict[str, Any] | None = None
     """Token usage recovered from the agent CLI's ``process.log``. Carries the
     four canonical counters (``input_tokens`` / ``output_tokens`` /
@@ -1176,8 +1184,8 @@ class SpecialistSubprocessDispatcher:
                 log_fh.close()
             clear_wall_budget_extension(task_id)
 
-        # Patches: scan worktree/patches/ (Arbor convention).
-        patches = self._collect_patches(worktree, workspace)
+        # Patches: harvest from the worktree via git diff first; fall back to disk scan.
+        patches, collected_patch_roots = self._collect_patches(worktree, workspace, worktree_base)
 
         # Parse done.json (best-effort) — first existing candidate.
         done_payload = None
@@ -1229,6 +1237,7 @@ class SpecialistSubprocessDispatcher:
             stale_heartbeat=outcome["stale_heartbeat"],
             process_log_path=str(process_log),
             patches=patches,
+            patch_roots=collected_patch_roots,
             usage=usage,
             response=response,
             tool_calls=tool_calls,
@@ -1680,21 +1689,48 @@ class SpecialistSubprocessDispatcher:
     def _collect_patches(
         worktree: Path | None,
         workspace: Path,
-    ) -> list[str]:
-        """Discover patch files written by the specialist.
+        worktree_base: Path | None = None,
+    ) -> tuple[list[str], dict[str, str]]:
+        """Collect specialist patches, preferring ``git diff HEAD`` over hand-authored files.
 
-        Scans both ``worktree/patches/`` and ``workspace/patches/``
-        (defense in depth — the agent may write to either) for ``*.patch``
-        and ``*.diff`` files.
+        When a worktree exists, run ``git diff HEAD`` against it to produce a
+        single canonical ``-p1`` patch whose apply root is the worktree base.
+        The fallback is the historical disk scan of ``<tree>/patches/*.patch``.
 
         Args:
-            worktree (Path | None): Per-task worktree, or None.
-            workspace (Path): Task workspace.
+            worktree: Per-task worktree, or None.
+            workspace: Task workspace.
+            worktree_base: The git checkout the worktree was branched off;
+                used as the apply root for harvested patches.
 
         Returns:
-            list[str]: Discovered patch file paths.
+            ``(patch_paths, patch_roots)`` where ``patch_roots`` maps each
+            harvested path to its apply root string.
         """
         out: list[str] = []
+        roots: dict[str, str] = {}
+
+        if worktree is not None and (worktree / ".git").exists():
+            harvest_root = worktree_base or worktree
+            try:
+                cp = subprocess.run(
+                    ["git", "-C", str(worktree), "diff", "HEAD"],
+                    capture_output=True,
+                    text=True,
+                    timeout=60.0,
+                    check=False,
+                )
+                if cp.returncode == 0 and cp.stdout.strip():
+                    harvested_dir = worktree / "patches"
+                    harvested_dir.mkdir(exist_ok=True)
+                    harvested_path = harvested_dir / "_worktree_diff.patch"
+                    harvested_path.write_text(cp.stdout, encoding="utf-8")
+                    out.append(str(harvested_path))
+                    roots[str(harvested_path)] = str(harvest_root)
+                    return out, roots
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+                log.warning("specialist: git diff harvest failed (%r); falling back to patch scan", exc)
+
         for base in (worktree, workspace):
             if base is None:
                 continue
@@ -1704,7 +1740,7 @@ class SpecialistSubprocessDispatcher:
             for ext in ("*.patch", "*.diff"):
                 for p in sorted(patches_dir.glob(ext)):
                     out.append(str(p))
-        return out
+        return out, roots
 
     @staticmethod
     def _read_done(done_file: Path) -> dict[str, Any] | None:


### PR DESCRIPTION
This PR hardens the patch delivery path so a specialist-produced patch is always tied to the framework tree it was authored against, and that root survives vetting, integration, source snapshots, warm replay, and the GEAK overlay handoff.

Previously, framework root resolution leaned on allowlist discovery order, harvested patches carried no apply root, source snapshots could report success while omitting files, and warm replay had to re-infer roots from patch content. A follow-up review also surfaced dead machinery, silent failures, and one crash that disabled the sglang overlay entirely.

The branch delivers the invariant in seven commits and then simplifies the result: **+690 / −140 lines** across 26 files, with the final commit removing ~270 lines of logic that never ran or was out of proportion to its cost.

## Motivation

Hyperloom specialists edit framework source inside isolated git worktrees. Patches must land on the same tree the specialist edited, be snapshotted faithfully for KEEP replay, and be importable by the inference server via overlay `PYTHONPATH`. Several gaps made that contract fragile:

1. **Wrong tree selection** — Authoring checkout resolution followed allowlist order rather than the session's framework name, so multi-framework installs could bind to the wrong tree.
2. **Lost apply root** — Worktree-harvested patches reached vetting and integrate without the root they were produced from, forcing expensive and ambiguous re-probing.
3. **Incomplete snapshots** — Absent files were treated as deletes; snapshots had no completeness flag or import root, so downstream code could not tell a usable overlay from a partial one.
4. **Warm replay guesswork** — Recipe records stored patch paths but not apply roots, so replay re-inferred targets and mis-reported missing content as a missing framework root.
5. **Silent failures** — `SglangAdapter.source_import_root()` called non-existent `Path.rstrip()`, crashed under a broad `except`, and always yielded an empty import root; artifact snapshot filtering read a `root` field nothing ever wrote.

## Changes

### 1. Framework-scoped authoring checkout (`2b3f742`)

- Add `resolve_framework_tree(framework)` in `paths.py`: resolve a framework's source tree by name via env vars → importlib spec origin → static defaults, never by allowlist position.
- Collapse nested candidate roots in `patch_safety.resolve_patch_apply_root` (e.g. `/sgl-workspace/sglang` vs `.../python`) before ambiguity checks.
- Introduce `GROUND_AMBIGUOUS_ROOT` as a distinct verdict from `GROUND_MISSING_TARGET`, with separate operator guidance.

### 2. Worktree patch harvest and apply-root carry (`cf039718`)

- When a worktree has a `.git` marker, `_collect_patches()` runs `git diff HEAD` to emit a canonical `-p1` patch and records its apply root.
- `SpecialistSubprocessResult` exposes `patch_roots`; `runner._finalize` stores them on `done_payload` and passes a sole shared root as `explicit_root` to `vet_patches`.
- `integrate_patch._resolve_framework_root` accepts `recorded_root` from `done_payload["patch_roots"]` and treats it as authoritative when allowlisted.

### 3. Declared snapshot ops and importable overlay root (`140afe5`)

- `source_snapshot.snapshot_source_layer` accepts `declared_ops` and `import_root`; bumps manifest to **schema version 2** with `complete` and `import_root` fields.
- Undeclared absent paths become `op: "missing"` instead of `op: "delete"`, so completeness reflects intentional coverage.
- Add `snapshot_is_complete()` and `SglangAdapter.source_import_root()` (`"python"` for repo checkouts, `""` for dist-packages).
- `writeback.build_env_spec` derives `reproducible` from completeness and sets overlay `snapshot_dir` to `files/<import_root>` for importable `PYTHONPATH`.

### 4. Recipe persistence and warm replay (`f81386fc`)

- Recipe `optimization_stack` entries now carry parallel `patch_roots: {patch_ref: framework_root}` alongside existing `patches` lists (backward compatible).
- `agent_kb.read_patch_roots()` reads recorded roots; legacy records without them fall through to content-based inference with `root_source="inferred"`.
- Fix warm-replay reason mapping: `warm_replay_patch_content_missing` replaces the misleading `active_framework_root_missing`.

### 5. Vetting drop feedback to the next authoring round (`7527a354`)

- When grounding drops patches, drop details are forwarded through `retry_ctx["vetting_drops"]` into the next specialist mandate.
- Enablement advisory rewritten: verify paths inside the worktree rather than recommending an artifact-channel bypass.

### 6. Narrow authoring-path inference (`2f83ffa`)

- Remove redundant session-root concatenation onto patch apply candidate lists; `recorded_root` is the authoritative path when present.
- Align breakdown exporter tests with completeness-derived `reproducible`.

### 7. Simplify and fix dead paths (`0a05f1e`)

**Bug fixes**

- Fix `SglangAdapter.source_import_root()` — remove invalid `Path.rstrip()` call; stop swallowing adapter faults at the integrate call site.
- Complete artifact root tracking: `_resolve_artifact_target` returns `(target, rel_target, root)`; `_ArtifactSpec.root` and applied-artifact records enable genuine per-root snapshot filtering.
- Fail closed on out-of-allowlist recorded roots; do not discard a recorded root when its directory is temporarily missing.

**Dead code removed**

- `ensure_authoring_checkout()` — shadow-repo provisioning that hardlink-copied entire site-packages trees (~4800 entries for vLLM) on every worktree setup; replaced by direct `resolve_framework_tree()` lookup.
- `VettingDropFeedback` — zero production callers; drop details already flow as strings.
- `_framework_checkout()` helper in `runner.py` — replaced by `resolve_framework_tree` import from `paths.py`.

**Consolidation**

- Restore `_P_STRIP_LEVELS` to its original range for hand-authored patches.
- Unify `reproducible` derivation via `source_layer_reproducible` in writeback and sessions breakdown collector.
- Trim misleading docstrings and narration; correct `BaseAdapter.source_import_root` documentation.

## End-to-end flow

```mermaid
flowchart LR
    A[Specialist worktree] -->|git diff HEAD| B[patch + patch_roots]
    B --> C[vet_patches with explicit_root]
    C --> D[integrate_patch recorded_root]
    D --> E[source snapshot schema v2]
    E --> F[optimization_stack entry]
    F --> G[Recipe patch_roots]
    G --> H[warm replay / GEAK overlay]
```

## Files changed (high level)

| Area | Key files |
|------|-----------|
| Specialist authoring | `specialists/subprocess_.py`, `specialists/runner.py`, `specialists/patch_safety.py` |
| Patch integration | `actions/executors/integrate_patch.py`, `actions/executors/_patch_snapshot.py`, `actions/executors/baseline.py` |
| Source snapshots | `source_snapshot.py`, `framework/adapters.py`, `loop/writeback.py` |
| Framework resolution | `framework/paths.py` |
| Warm replay / Recipe | `knowledge/remote_recipe/values.py`, `knowledge/agent_kb.py`, `phases/prelude.py`, `phases/framework.py` |
| Breakdown / sessions | `inference_optimizer/breakdown/collectors/sessions.py` |
| Tests | 11 test modules under `inference_optimizer/tests/` and `orchestrator/phases/tests/` |

## Backward compatibility

- Recipe `patches` remain `list[str]`; `patch_roots` is an optional additive dict omitted when empty.
- Source snapshot schema v1 manifests remain readable; v2 adds `complete`, `import_root`, and `schema_version: 2` without breaking existing fields.
- Legacy warm-replay records without `patch_roots` continue to infer roots from patch content (`root_source="inferred"`).

## Breaking changes

**No.** All changes are additive or internal refinements. External Recipe consumers that ignore unknown keys are unaffected.

## Test plan

Targeted unit tests were run locally (full suite runs on CI):

```bash
pytest src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py \
       src/hyperloom/inference_optimizer/tests/test_source_snapshot_unit.py \
       src/hyperloom/inference_optimizer/tests/test_integrate_patch_artifacts_unit.py \
       src/hyperloom/inference_optimizer/tests/test_integrate_patch_coverage_unit.py \
       src/hyperloom/inference_optimizer/tests/test_specialist_patch_safety_unit.py \
       src/hyperloom/inference_optimizer/tests/test_specialist_subprocess.py \
       src/hyperloom/inference_optimizer/tests/test_specialist_subprocess_helpers.py \
       src/hyperloom/inference_optimizer/tests/test_specialist_subprocess_helpers_coverage_unit.py \
       src/hyperloom/inference_optimizer/tests/test_warm_replay.py \
       src/hyperloom/orchestrator/phases/tests/test_enablement_sglang_artifact_fix.py \
       src/hyperloom/inference_optimizer/tests/test_breakdown_exporter_unit.py -q
```

Coverage highlights:

- [ ] `resolve_framework_tree` resolves by env var, importlib origin, and static defaults
- [ ] Worktree harvest produces `-p1` patch and records apply root
- [ ] Sole shared `patch_roots` value flows through vetting → integrate without re-probing
- [ ] Snapshot schema v2 marks missing undeclared paths and sets `complete=False`
- [ ] `SglangAdapter.source_import_root` returns `"python"` for repo layout, `""` otherwise
- [ ] Artifacts installed into a sibling tree are excluded from snapshots keyed on `framework_root`
- [ ] Recipe round-trip preserves `patch_roots`; legacy records infer roots
- [ ] Vetting drops appear in the next specialist mandate feedback
- [ ] Nested roots collapse instead of triggering false ambiguity

## Commits

| Commit | Description |
|--------|-------------|
| `2b3f742` | Resolve specialist authoring checkout by framework, not allowlist order |
| `cf039718` | Harvest specialist patches from worktree; carry apply root |
| `140afe5` | Record declared snapshot ops; emit importable overlay root |
| `f81386fc` | Persist and replay apply root through Recipe |
| `7527a354` | Report vetting drops to next authoring round |
| `2f83ffa` | Remove patch target-tree inference from authoring path |
| `0a05f1e` | Simplify invariant; fix dead paths and silent failures |

**Branch:** `feat/zgong/opt-20` → `main`
