### PR TITLE
Bump SGLang ROCm images to v0.5.18 (20260825)

### DIFF
--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -142,9 +142,9 @@ uses a private registry mirror, set the registry prefix accordingly.
 
    * - Image
      - GPU
-   * - ``lmsysorg/sglang-rocm:v0.5.17-rocm724-mi30x-20260821``
+   * - ``lmsysorg/sglang-rocm:v0.5.18-rocm724-mi30x-20260825``
      - MI300X / MI325X
-   * - ``lmsysorg/sglang-rocm:v0.5.17-rocm724-mi35x-20260821``
+   * - ``lmsysorg/sglang-rocm:v0.5.18-rocm724-mi35x-20260825``
      - MI355X
    * - ``vllm/vllm-openai-rocm:v0.27.1``
      - MI300X / MI325X / MI355X
@@ -180,8 +180,8 @@ Hyperloom does not install ROCm or torch itself.
      - ROCm build matching the host ROCm
      - Preinstalled by the operator; not managed by Hyperloom.
    * - SGLang
-     - v0.5.17 (rocm724)
-     - Installed in ``shared`` mode (reuses the host torch). Uses the ROCm 7.2.4 AMD wheel index (``SGLANG_ROCM_EXTRA=rocm724``), so the SGLang ROCm layer is 7.2.4. Note: ``SGLANG_REF`` (v0.5.17) only pins the version on the source-install branch (non-3.10 Python); on Python 3.10 the AMD wheel index installs ``amd-sglang`` unpinned, which might resolve to a different patch release.
+     - v0.5.18 (rocm724)
+     - Installed in ``shared`` mode (reuses the host torch). Uses the ROCm 7.2.4 AMD wheel index (``SGLANG_ROCM_EXTRA=rocm724``), so the SGLang ROCm layer is 7.2.4. Note: ``SGLANG_REF`` (v0.5.18) only pins the version on the source-install branch (non-3.10 Python); on Python 3.10 the AMD wheel index installs ``amd-sglang`` unpinned, which might resolve to a different patch release.
    * - vLLM
      - v0.27.1 (rocm723), isolated venv
      - Installs ``vllm==0.27.1+rocm723`` from the wheels.vllm.ai pip index. vLLM's ROCm wheel pins its own torch, so it installs into a dedicated venv (``--framework-env isolated``, the default for vLLM) and never touches the host torch.
@@ -190,7 +190,7 @@ Bare-metal ROCm patch levels differ per framework, and each one matches its
 container image. The vLLM stack installs the ``rocm723`` variant (ROCm
 7.2.3), matching ``vllm/vllm-openai-rocm:v0.27.1``; the SGLang stack
 installs from the ROCm 7.2.4 AMD wheel index, matching the two
-``lmsysorg/sglang-rocm:v0.5.17-rocm724-*`` images. ``docker`` mode is still
+``lmsysorg/sglang-rocm:v0.5.18-rocm724-*`` images. ``docker`` mode is still
 the preferred route for a pre-validated stack, since the images also pin the
 surrounding torch, Triton, and AITER builds.
 

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -394,8 +394,8 @@ framework, so nothing needs to be installed inside the container beyond
 Hyperloom's runtime deps. The following images are recommended:
 
 - `vllm`: `docker.io/vllm/vllm-openai-rocm:v0.27.1`
-- `sglang` MI300X: `docker.io/lmsysorg/sglang-rocm:v0.5.17-rocm724-mi30x-20260821`
-- `sglang` MI355X: `docker.io/lmsysorg/sglang-rocm:v0.5.17-rocm724-mi35x-20260821`
+- `sglang` MI300X: `docker.io/lmsysorg/sglang-rocm:v0.5.18-rocm724-mi30x-20260825`
+- `sglang` MI355X: `docker.io/lmsysorg/sglang-rocm:v0.5.18-rocm724-mi35x-20260825`
 
 Start a long-running container from the repo root, mounting it at the same path
 so `.env`, logs, and session artifacts stay valid:

--- a/docs/reference/session-breakdown.md
+++ b/docs/reference/session-breakdown.md
@@ -743,12 +743,12 @@ The following example shows a complete `session_breakdown.json` for a finished G
     "pid": 12345,
     "session_dir": "/workspace/hyperloom/GLM-5-FP8/20260517T113000Z",
     "tick_count": 89,
-    "image": "lmsysorg/sglang-rocm:v0.5.17-rocm724-mi30x-20260821"
+    "image": "lmsysorg/sglang-rocm:v0.5.18-rocm724-mi30x-20260825"
   },
 
   "workload": {
     "framework_name": "sglang",
-    "framework_version": "0.5.17",
+    "framework_version": "0.5.18",
     "model_name": "GLM-5-FP8",
     "model_path": "/models/GLM-5-FP8",
     "model_class": "moe_mla_nsa",

--- a/examples/hyperloom-custom-advanced/SKILL.md
+++ b/examples/hyperloom-custom-advanced/SKILL.md
@@ -38,8 +38,8 @@ In docker mode:
 Suggested Docker images:
 
 - `vllm`: `docker.io/vllm/vllm-openai-rocm:v0.27.1`
-- `sglang` MI300X: `docker.io/lmsysorg/sglang-rocm:v0.5.17-rocm724-mi30x-20260821`
-- `sglang` MI355X: `docker.io/lmsysorg/sglang-rocm:v0.5.17-rocm724-mi35x-20260821`
+- `sglang` MI300X: `docker.io/lmsysorg/sglang-rocm:v0.5.18-rocm724-mi30x-20260825`
+- `sglang` MI355X: `docker.io/lmsysorg/sglang-rocm:v0.5.18-rocm724-mi35x-20260825`
 
 In Docker mode, start a long-running container on `HYPERLOOM_DOCKER_TARGET_HOST`
 (or the current host when it is unset) before running setup or optimize:

--- a/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
+++ b/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
@@ -28,8 +28,8 @@ In docker mode:
 Suggested Docker images:
 
 - `vllm`: `docker.io/vllm/vllm-openai-rocm:v0.27.1`
-- `sglang` MI300X: `docker.io/lmsysorg/sglang-rocm:v0.5.17-rocm724-mi30x-20260821`
-- `sglang` MI355X: `docker.io/lmsysorg/sglang-rocm:v0.5.17-rocm724-mi35x-20260821`
+- `sglang` MI300X: `docker.io/lmsysorg/sglang-rocm:v0.5.18-rocm724-mi30x-20260825`
+- `sglang` MI355X: `docker.io/lmsysorg/sglang-rocm:v0.5.18-rocm724-mi35x-20260825`
 
 In Docker mode, start a long-running container on `HYPERLOOM_DOCKER_TARGET_HOST`
 (or the current host when it is unset) before running setup or optimize:

--- a/examples/hyperloom-qwen3-8b-3h/SKILL.md
+++ b/examples/hyperloom-qwen3-8b-3h/SKILL.md
@@ -28,8 +28,8 @@ In docker mode:
 Suggested Docker images:
 
 - `vllm`: `docker.io/vllm/vllm-openai-rocm:v0.27.1`
-- `sglang` MI300X: `docker.io/lmsysorg/sglang-rocm:v0.5.17-rocm724-mi30x-20260821`
-- `sglang` MI355X: `docker.io/lmsysorg/sglang-rocm:v0.5.17-rocm724-mi35x-20260821`
+- `sglang` MI300X: `docker.io/lmsysorg/sglang-rocm:v0.5.18-rocm724-mi30x-20260825`
+- `sglang` MI355X: `docker.io/lmsysorg/sglang-rocm:v0.5.18-rocm724-mi35x-20260825`
 
 In Docker mode, start a long-running container on `HYPERLOOM_DOCKER_TARGET_HOST`
 (or the current host when it is unset) before running setup or optimize:

--- a/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
+++ b/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
@@ -48,13 +48,13 @@ INSTALL_FRAMEWORK="none"
 _FRAMEWORK_ENV_WAS_SET="${FRAMEWORK_ENV+x}"
 FRAMEWORK_ENV="${FRAMEWORK_ENV:-shared}"
 SGLANG_REPO="${SGLANG_REPO:-https://github.com/sgl-project/sglang.git}"
-# Framework versions track docs/compatibility.rst (SGLang v0.5.17, ROCm 7.2.4).
+# Framework versions track docs/compatibility.rst (SGLang v0.5.18, ROCm 7.2.4).
 # vLLM installs 0.27.1+rocm723 from the wheels.vllm.ai pip index, matching the
 # vllm/vllm-openai-rocm:v0.27.1 Docker image. The rocm723 variant puts the
 # vLLM ROCm layer at 7.2.3, one patch level above the SGLang stack. AITER_REF
 # can pin ROCm/aiter to a released tag; when unset, the installer selects the
 # newest tag compatible with the already-installed ROCm torch/triton stack.
-SGLANG_REF="${SGLANG_REF:-v0.5.17}"
+SGLANG_REF="${SGLANG_REF:-v0.5.18}"
 _SGLANG_ROCM_PYPI_VERSION_WAS_SET="${SGLANG_ROCM_PYPI_VERSION+x}"
 _AITER_REF_WAS_SET="${AITER_REF+x}"
 SGLANG_ROCM_EXTRA="${SGLANG_ROCM_EXTRA:-rocm724}"
@@ -177,7 +177,7 @@ warn() { echo "[install-baremetal WARN] $*" >&2; }
 die() { echo "[install-baremetal ERROR] $*" >&2; exit 1; }
 
 IMAGE_HINT="Provision the ROCm framework base first (run inside an AMD ROCm \
-SGLang/vLLM image such as lmsysorg/sglang-rocm:v0.5.17-rocm724-mi30x|mi35x-* or \
+SGLang/vLLM image such as lmsysorg/sglang-rocm:v0.5.18-rocm724-mi30x|mi35x-* or \
 vllm/vllm-openai-rocm:v0.27.1, or install an equivalent ROCm torch + \
 framework stack), then re-run."
 

--- a/src/hyperloom/inference_optimizer/assets/quick-start/Dockerfile
+++ b/src/hyperloom/inference_optimizer/assets/quick-start/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM lmsysorg/sglang-rocm:v0.5.17-rocm724-mi30x-20260821
+FROM lmsysorg/sglang-rocm:v0.5.18-rocm724-mi30x-20260825
 
 
 #install AMD self-signed certificate

--- a/src/hyperloom/inference_optimizer/assets/slurm/models.tsv
+++ b/src/hyperloom/inference_optimizer/assets/slurm/models.tsv
@@ -1,6 +1,6 @@
 # key	repo_id	framework	gpu_type	image	tp	prec	isl	osl	conc	model_class	max_hours	target_gain
 # Example registry consumed by submit.sh. Replace repo_id / image / gpu_type
 # with your own published models and container images before running.
-deepseek_r1_sglang	deepseek-ai/DeepSeek-R1	sglang	MI300X	lmsysorg/sglang-rocm:v0.5.17-rocm724-mi30x-20260821	8	fp8	1024	1024	64	moe_mla	6	10
+deepseek_r1_sglang	deepseek-ai/DeepSeek-R1	sglang	MI300X	lmsysorg/sglang-rocm:v0.5.18-rocm724-mi30x-20260825	8	fp8	1024	1024	64	moe_mla	6	10
 deepseek_r1_vllm	deepseek-ai/DeepSeek-R1	vllm	MI300X	vllm/vllm-openai-rocm:v0.27.1	8	fp8	1024	1024	64	moe_mla	6	10
 gptoss_vllm	openai/gpt-oss-120b	vllm	MI300X	vllm/vllm-openai-rocm:v0.27.1	8	fp4	1024	1024	64	moe_swa	6	10


### PR DESCRIPTION
## Problem

Hyperloom still pins SGLang ROCm Docker images and bare-metal defaults to v0.5.17 (20260821), while the current deployment environment uses the published v0.5.18 (20260825) tags.

## Fix

Update all documented and default SGLang ROCm image references to:
- `lmsysorg/sglang-rocm:v0.5.18-rocm724-mi30x-20260825`
- `lmsysorg/sglang-rocm:v0.5.18-rocm724-mi35x-20260825`

Also bump bare-metal `SGLANG_REF` default to `v0.5.18` to keep docs, installer, examples, and slurm config in sync.