### PR TITLE
Fix vLLM native TraceLens profiler sentinel name

### DIFF
--- a/src/hyperloom/inference_optimizer/assets/configs/profile_vllm.yaml
+++ b/src/hyperloom/inference_optimizer/assets/configs/profile_vllm.yaml
@@ -14,7 +14,7 @@
 #      vllm_*.sh when PROFILE=1.
 # These are required for TraceLens fusion / roofline analysis.
 #
-# Issue #194 §4: `capture_torch_profiler_dir` and `detailed_trace_annotation`
+# Issue #194 §4: `capture_torch_profiler` and `detailed_trace_annotation`
 # ship upstream from vLLM 0.26; below that they come from the TraceLens
 # patch set at
 # TraceLens-internal/examples/custom_workflows/inference_analysis/vllm_patches/.
@@ -22,9 +22,9 @@
 # Hyperloom's runtime patcher (HYPERLOOM_ENABLE_PATCH=1, default) tries
 # to apply the matching `config_vllm_v<version>.patch` against the
 # in-container vLLM install at the start of every profile. Capture
-# sidecars land under <torch_profiler_dir>/capture_traces, driven by the
-# `capture_torch_profiler_dir` path Magpie's TraceLens route supplies. If
-# patching succeeds, materialize_config_with_envs auto-appends
+# sidecars land under <torch_profiler_dir>/capture_traces when
+# `capture_torch_profiler` is enabled. If patching succeeds,
+# materialize_config_with_envs auto-appends capture_torch_profiler and
 # detailed_trace_annotation to EXTRA_VLLM_ARGS; if it fails (version
 # unsupported, fs read-only, already-patched fork, etc.) we fall back to
 # today's safe behaviour: only delay_iterations / max_iterations +

--- a/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -980,7 +980,7 @@ def test_materialize_profile_vllm_injects_tracelens_flags_when_patched(
     tmp_path,
     monkeypatch,
 ):
-    """Patcher True for vLLM ⇒ EXTRA_VLLM_ARGS gains detailed_trace_annotation on top of the default iteration count."""
+    """Patcher True for vLLM ⇒ EXTRA_VLLM_ARGS gains capture + annotation flags on top of iteration bounds."""
     import yaml
 
     _clear_workload_env(monkeypatch)
@@ -990,7 +990,7 @@ def test_materialize_profile_vllm_injects_tracelens_flags_when_patched(
     extra = yaml.safe_load(out.read_text())["benchmark"]["envs"]["EXTRA_VLLM_ARGS"]
     assert "--profiler-config.delay_iterations 6080" in extra, extra
     assert "--profiler-config.max_iterations 128" in extra, extra
-    assert "--profiler-config.detailed_trace_annotation True" in extra, extra
+    assert "--profiler-config.capture_torch_profiler True" in extra, extra
     assert "--profiler-config.detailed_trace_annotation True" in extra, extra
     # Per-framework dispatch: the SGLang patcher must NOT run for a vLLM YAML.
     assert counts == {"vllm": 1, "sglang": 0}, counts
@@ -1012,6 +1012,7 @@ def test_materialize_profile_vllm_omits_tracelens_flags_when_patch_fails(
     envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
     extra = envs["EXTRA_VLLM_ARGS"]
     assert "--profiler-config.delay_iterations 6080" in extra, extra
+    assert "capture_torch_profiler" not in extra, extra
     assert "detailed_trace_annotation" not in extra, extra
     assert envs["HYPERLOOM_TRACELENS_PATCH_STATUS"] == "unavailable"
     assert envs["HYPERLOOM_PROFILE_DEGRADED_REASON"] == "tracelens_runtime_patch_unavailable"

--- a/src/hyperloom/inference_optimizer/tests/test_server_patcher_vllm_native_gate.py
+++ b/src/hyperloom/inference_optimizer/tests/test_server_patcher_vllm_native_gate.py
@@ -52,6 +52,38 @@ def test_native_local_build_is_accepted_without_patching(tmp_path, monkeypatch):
     assert calls == []
 
 
+_V028_PROFILER_PY_SNIPPET = """
+    capture_torch_profiler: bool = False
+    \"\"\"If `True`, enables a torch profiler during CUDA graph capture on rank 0.
+    Traces are saved to a `capture_traces` subdirectory under `torch_profiler_dir`.
+    Requires `profiler` to be set to 'torch'.\"\"\"
+
+    detailed_trace_annotation: bool = False
+    \"\"\"If `True`, uses detailed annotations with roofline metrics (sk, sqsq,
+    sqsk) in profiler trace events. If `False`, uses simple annotations with
+    only context/generation request counts and token counts.
+    Disabled by default.\"\"\"
+"""
+
+
+def test_native_v028_profiler_py_is_accepted_without_patching(tmp_path, monkeypatch):
+    """Regression: upstream v0.28 uses ``capture_torch_profiler`` (bool), not ``_dir``."""
+    sentinel = tmp_path / "vllm" / "config" / "profiler.py"
+    sentinel.parent.mkdir(parents=True, exist_ok=True)
+    sentinel.write_text(_V028_PROFILER_PY_SNIPPET, encoding="utf-8")
+    monkeypatch.setattr(sp, "_discover_vllm_install", lambda: ("0.28.0", tmp_path))
+    calls = _forbid_patching(monkeypatch)
+    assert sp.ensure_vllm_patched_for_tracelens(tmp_path / "tracelens") is True
+    assert calls == []
+
+
+def test_legacy_capture_torch_profiler_dir_substring_does_not_satisfy_sentinel(tmp_path):
+    """``torch_profiler_dir`` alone must not be mistaken for graph-capture support."""
+    path = Path(tmp_path) / "profiler.py"
+    path.write_text("torch_profiler_dir: str = ''\n", encoding="utf-8")
+    assert sp._markers_present(path, sp._VLLM_PROFILER_SENTINELS) is False
+
+
 def test_native_version_missing_the_fields_fails_soft(tmp_path, monkeypatch):
     # A 0.26 build without the upstream fields would reject the flags, and the
     # patch set does not cover it, so the caller has to drop them.

--- a/src/hyperloom/orchestrator/actions/executors/_server_patcher.py
+++ b/src/hyperloom/orchestrator/actions/executors/_server_patcher.py
@@ -51,7 +51,7 @@ _VLLM_NATIVE_PROFILER_MIN_VERSION: tuple[int, ...] = (0, 26)
 
 # Required in ``vllm/config/profiler.py`` for the server to accept the flags.
 _VLLM_PROFILER_SENTINELS: tuple[str, ...] = (
-    "capture_torch_profiler_dir",
+    "capture_torch_profiler",
     "detailed_trace_annotation",
 )
 

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -1137,6 +1137,12 @@ def materialize_config_with_envs(
                 ("max_iterations", f"--profiler-config.max_iterations {max_iters}"),
             ]
             if tracelens_patch_ok:
+                profiler_flags.append(
+                    (
+                        "capture_torch_profiler",
+                        "--profiler-config.capture_torch_profiler True",
+                    )
+                )
                 profiler_flags.append(("detailed_trace_annotation", "--profiler-config.detailed_trace_annotation True"))
             # vLLM's AsyncLLM-side profiler tracks no iterations and captures the
             # whole start_profile..stop_profile range, so it has to stay off


### PR DESCRIPTION
## Problem

Hyperloom's vLLM >=0.26 native profiler gate looked for capture_torch_profiler_dir in profiler.py, but upstream vLLM exposes capture_torch_profiler (bool). Native detection always failed, TraceLens flags were not injected, and capture_traces/ was missing.

## Fix

Restore capture_torch_profiler as the sentinel and re-inject --profiler-config.capture_torch_profiler True when the patch gate passes. Add regression tests for v0.28 profiler.py layout.