### PR TITLE
fix: fail-closed localization allowlist and serialize vLLM kv-transfer JSON

### DIFF
--- a/src/hyperloom/inference_optimizer/multi_node/scripts/launch_multinode.py
+++ b/src/hyperloom/inference_optimizer/multi_node/scripts/launch_multinode.py
@@ -44,6 +44,16 @@ _PD_PREFILL_PORT = 30000
 _PD_DECODE_PORT = 30001
 # Default collective port ($RAYJOB_DIST_INIT_PORT else 29500).
 _DEFAULT_DIST_INIT_PORT = 29500
+# vLLM PD connectors named in ``--pd-transfer-backend`` help. Unknown names
+# still serialize (so a future vLLM connector is not blocked) but warn.
+_VLLM_KV_CONNECTORS: frozenset[str] = frozenset(
+    (
+        "NixlConnector",
+        "P2pNcclConnector",
+        "MooncakeConnector",
+        "LMCacheConnectorV1",
+    )
+)
 
 
 def _pd_decode_dist_init_port(prefill_dist_init_port: int) -> int:
@@ -353,14 +363,18 @@ def _build_vllm_cmd(
         # vllm PD: kv-transfer-config JSON with connector + role + kv slot.
         kv_role = "kv_producer" if role == "prefill" else "kv_consumer"
         connector = pd_transfer_backend or "NixlConnector"
-        kv_cfg = (
-            "{"
-            f'"kv_connector":"{connector}",'
-            f'"kv_role":"{kv_role}",'
-            f'"kv_rank":{int(pd_kv_rank)},'
-            f'"kv_parallel_size":{int(pd_kv_parallel_size)},'
-            '"kv_buffer_device":"cuda"'
-            "}"
+        if connector not in _VLLM_KV_CONNECTORS:
+            _log(f"WARN unknown vLLM kv connector {connector!r}; known: {sorted(_VLLM_KV_CONNECTORS)}")
+        kv_cfg = json.dumps(
+            {
+                "kv_connector": connector,
+                "kv_role": kv_role,
+                "kv_rank": int(pd_kv_rank),
+                "kv_parallel_size": int(pd_kv_parallel_size),
+                "kv_buffer_device": "cuda",
+            },
+            separators=(",", ":"),
+            sort_keys=False,
         )
         cmd.extend(["--kv-transfer-config", kv_cfg])
     if extra_args:

--- a/src/hyperloom/inference_optimizer/tests/test_integrate_patch_localize.py
+++ b/src/hyperloom/inference_optimizer/tests/test_integrate_patch_localize.py
@@ -150,3 +150,24 @@ async def test_attempt_root_added_to_allowlist_only(_executor, monkeypatch, tmp_
     out = await _executor._stage_localize_source(ctx, {"localization_candidate": _pr_candidate()}, "t-1")
     assert out is None, out
     assert len(ctx._ip_localization_patches) == 1
+
+
+def test_empty_allowlist_fail_closed():
+    """No trusted write root: every non-empty path is out of bounds."""
+    outside = ip._localization_paths_outside_allowlist(
+        ["a/b.py", "/etc/passwd", "", "  "],
+        None,
+        [],
+    )
+    assert outside == ["a/b.py", "/etc/passwd"]
+
+
+def test_empty_allowlist_still_uses_framework_root(tmp_path):
+    """framework_root alone is a trusted root even when allow_roots is empty."""
+    outside = ip._localization_paths_outside_allowlist(
+        ["ok.py", "/etc/passwd"],
+        tmp_path,
+        [],
+    )
+    assert "ok.py" not in outside
+    assert "/etc/passwd" in outside

--- a/src/hyperloom/inference_optimizer/tests/test_multi_node_scripts.py
+++ b/src/hyperloom/inference_optimizer/tests/test_multi_node_scripts.py
@@ -728,6 +728,49 @@ def test_build_vllm_cmd_includes_ray_backend():
     assert "--enforce-eager" in cmd
 
 
+def _kv_transfer_config(cmd: list[str]) -> dict:
+    return json.loads(cmd[cmd.index("--kv-transfer-config") + 1])
+
+
+def test_build_vllm_cmd_kv_transfer_config_escapes_quotes():
+    lm = _load_script_module("lm_test_vllm_kv_quote", "launch_multinode.py")
+    connector = 'Nixl"Connector'
+    cmd = lm._build_vllm_cmd(
+        model="/m",
+        tp=8,
+        extra_args=[],
+        pd_role="prefill",
+        pd_transfer_backend=connector,
+        pd_kv_rank=0,
+        pd_kv_parallel_size=2,
+    )
+    cfg = _kv_transfer_config(cmd)
+    assert cfg["kv_connector"] == connector
+    assert cfg["kv_role"] == "kv_producer"
+    assert cfg["kv_rank"] == 0
+    assert cfg["kv_parallel_size"] == 2
+    assert cfg["kv_buffer_device"] == "cuda"
+    assert set(cfg) == {
+        "kv_connector",
+        "kv_role",
+        "kv_rank",
+        "kv_parallel_size",
+        "kv_buffer_device",
+    }
+
+
+def test_build_vllm_cmd_kv_transfer_config_defaults_and_roles():
+    lm = _load_script_module("lm_test_vllm_kv_roles", "launch_multinode.py")
+    prefill = lm._build_vllm_cmd(model="/m", tp=8, extra_args=[], pd_role="prefill")
+    decode = lm._build_vllm_cmd(model="/m", tp=8, extra_args=[], pd_role="decode")
+    pcfg = _kv_transfer_config(prefill)
+    dcfg = _kv_transfer_config(decode)
+    assert pcfg["kv_connector"] == "NixlConnector"
+    assert pcfg["kv_role"] == "kv_producer"
+    assert dcfg["kv_connector"] == "NixlConnector"
+    assert dcfg["kv_role"] == "kv_consumer"
+
+
 def test_subprocess_env_prepends_venv_bin(monkeypatch):
     lm = _load_script_module("lm_test_env", "launch_multinode.py")
     monkeypatch.setenv("PATH", "/usr/bin:/bin")

--- a/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
+++ b/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
@@ -550,12 +550,14 @@ def _localization_paths_outside_allowlist(
     A localization diff may only write under the source-file allowlist or the
     attempt-local root. Paths are resolved against ``framework_root`` when
     relative. Returns the offending paths (empty when all are in-bounds).
+    Fail closed: with no trusted write root, every non-empty touched path is
+    treated as out of bounds.
     """
     roots = [Path(r).resolve() for r in allow_roots if str(r).strip()]
     if framework_root is not None:
         roots.append(Path(framework_root).resolve())
     if not roots:
-        return []
+        return [str(rel or "").strip() for rel in touched_paths if str(rel or "").strip()]
     outside: list[str] = []
     for rel in touched_paths:
         rel_s = str(rel or "").strip()


### PR DESCRIPTION
## Description
Two independent fixes. No change to the session breakdown contract.
1. When localization had no trusted write root, `_localization_paths_outside_allowlist()` returned `[]`, which the caller reads as "no violations" and applies the diff. With no root, no path can be proven in-bounds, so every non-empty touched path is now reported as out of bounds. The caller already reverts on a non-empty list (`localization_outside_allowlist`). This is defensive: `resolve_source_file_allowlist()` / `_merge_roots()` only drop blanks and duplicates and never check that directories exist, so the five static default roots are always present, and the call site also appends `framework_root`. The production path does not reach the empty-root branch today.
2. The vLLM PD `--kv-transfer-config` JSON was built with an f-string, and `--pd-transfer-backend` is free text (no `choices=`). A connector name containing a quote produced illegal JSON that only failed when the remote `vllm serve` parsed it, and a value shaped like `NixlConnector","kv_buffer_size":"1000000000` produced *valid* JSON carrying an extra field with no error at all. The config is now built with `json.dumps()`. Unknown connector names log a warning and still pass through so a future vLLM connector is not blocked. The shell layer was already safe (`shlex.quote` per argv); this is the JSON layer.
## Linked issue(s)
None.
## Tests
- With no trusted root, every touched path is reported out of bounds; `framework_root` alone still admits paths inside that tree
- A connector name containing a quote round-trips through `json.loads` as a single escaped field; default prefill / decode roles unchanged
90 passed on the targeted tests. `ruff check` / `ruff format --check` on the changed files passed.
## Breaking changes
No. Localization with no trusted root now reverts instead of applying. The vLLM PD launch argv is unchanged for well-formed connector names; malformed names stay one escaped field instead of breaking or injecting JSON.