### PR TITLE
Force vLLM V1 on profile so CUDA graph traces are captured

### DIFF
--- a/src/hyperloom/inference_optimizer/assets/configs/profile_vllm.yaml
+++ b/src/hyperloom/inference_optimizer/assets/configs/profile_vllm.yaml
@@ -30,6 +30,10 @@
 # today's safe behaviour: only delay_iterations / max_iterations +
 # ignore_frontend get injected.
 # Set HYPERLOOM_ENABLE_PATCH=0 to disable runtime patching entirely.
+#
+# vLLM V2 does not enable torch profiler during CUDA graph capture, so
+# materialize_config_with_envs forces VLLM_USE_V2_MODEL_RUNNER=0 on
+# profile/roofline only (baseline keeps vLLM's default runner).
 
 benchmark:
   framework: vllm

--- a/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -423,6 +423,7 @@ def _clear_workload_env(monkeypatch):
         "ROCR_VISIBLE_DEVICES",
         "FRAMEWORK",
         "INFERENCEX_PATH",
+        "VLLM_USE_V2_MODEL_RUNNER",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -994,6 +995,80 @@ def test_materialize_profile_vllm_injects_tracelens_flags_when_patched(
     assert "--profiler-config.detailed_trace_annotation True" in extra, extra
     # Per-framework dispatch: the SGLang patcher must NOT run for a vLLM YAML.
     assert counts == {"vllm": 1, "sglang": 0}, counts
+
+
+def test_materialize_profile_vllm_forces_v1_model_runner(
+    tmp_path,
+    monkeypatch,
+):
+    """vLLM V2 skips torch profiler during CUDA graph capture, so profile forces V1."""
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=True, sglang=False)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(src, tmp_path)
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    assert envs["VLLM_USE_V2_MODEL_RUNNER"] == "0", envs.get("VLLM_USE_V2_MODEL_RUNNER")
+
+
+def test_materialize_profile_vllm_force_v1_wins_over_extra_envs(
+    tmp_path,
+    monkeypatch,
+):
+    """Profile must keep V1 even if a candidate extra_envs pin requests V2."""
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=True, sglang=False)
+    src = _profile_yaml(tmp_path, "vllm", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(
+        src,
+        tmp_path,
+        extra_envs={"VLLM_USE_V2_MODEL_RUNNER": "1"},
+    )
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    assert envs["VLLM_USE_V2_MODEL_RUNNER"] == "0", envs.get("VLLM_USE_V2_MODEL_RUNNER")
+
+
+def test_materialize_baseline_vllm_does_not_force_v1_model_runner(
+    tmp_path,
+    monkeypatch,
+):
+    """Throughput baseline stays on vLLM's default runner selection."""
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    src = tmp_path / "baseline_vllm.yaml"
+    src.write_text(
+        yaml.safe_dump(
+            {
+                "benchmark": {
+                    "framework": "vllm",
+                    "model": "/m",
+                    "envs": {"CONC": 32, "ISL": 256, "OSL": 1024},
+                },
+            }
+        )
+    )
+    out = _materialize_config_with_envs(src, tmp_path)
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    assert "VLLM_USE_V2_MODEL_RUNNER" not in envs, envs.get("VLLM_USE_V2_MODEL_RUNNER")
+
+
+def test_materialize_profile_sglang_does_not_force_vllm_v1(
+    tmp_path,
+    monkeypatch,
+):
+    """The V1 pin is vLLM-only; SGLang profile must not inherit it."""
+    import yaml
+
+    _clear_workload_env(monkeypatch)
+    _mock_patchers(monkeypatch, vllm=False, sglang=True)
+    src = _profile_yaml(tmp_path, "sglang", {"CONC": 32, "ISL": 256, "OSL": 1024})
+    out = _materialize_config_with_envs(src, tmp_path)
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+    assert "VLLM_USE_V2_MODEL_RUNNER" not in envs, envs.get("VLLM_USE_V2_MODEL_RUNNER")
 
 
 def test_materialize_profile_vllm_omits_tracelens_flags_when_patch_fails(

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -94,6 +94,9 @@ _SGLANG_DISABLE_CUDA_GRAPH_FLAG = "--disable-cuda-graph"
 # was attempted and did not apply. Distinct from "never attempted": patching can
 # be disabled for an image that already ships the patch.
 _TRACELENS_PATCH_UNAVAILABLE = "tracelens_runtime_patch_unavailable"
+# vLLM V2 does not wrap CUDA graph capture with torch profiler, so graph
+# kernels never land in capture_traces/. Profile/roofline force the V1 runner.
+_VLLM_USE_V2_MODEL_RUNNER = "VLLM_USE_V2_MODEL_RUNNER"
 _AGENTX_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 
 # Quality-reference env names, in resolution order. Every scriptable workload
@@ -989,6 +992,7 @@ def materialize_config_with_envs(
     # a max_iterations that is above it (or non-positive, which vLLM reads as no limit)
     # instead of accepting the flag on its name alone.
     pending_vllm_profiler_cap: int = 0
+    pending_force_vllm_v1 = False
     if is_profile and not _is_scriptable_profile:
         try:
             r_val = float(envs.get("RANDOM_RANGE_RATIO", 1.0))
@@ -1131,6 +1135,7 @@ def materialize_config_with_envs(
             # (ATOM_PROFILE_OSL / ATOM_PROFILE_NUM_PROMPTS); defer to Magpie.
             profile_num_prompts = None
         elif "vllm" in fw:
+            pending_force_vllm_v1 = True
             existing_vllm_args = str(envs.get("EXTRA_VLLM_ARGS", ""))
             profiler_flags = [
                 ("delay_iterations", f"--profiler-config.delay_iterations {delay_iters}"),
@@ -1651,6 +1656,10 @@ def materialize_config_with_envs(
             # _finalize_framework_server_args already ran, so re-apply the sink-side
             # guard it ends with rather than shipping an unvalidated string.
             envs[framework_env] = validate_server_args_shell_safe(merged)
+    if pending_force_vllm_v1:
+        # Last word after extra_envs / unset_envs: V2 graph capture has no
+        # torch-profiler wrap, so profile must stay on V1.
+        envs[_VLLM_USE_V2_MODEL_RUNNER] = "0"
     # The rendered YAML is persisted, so credentials must not reach it.
     filtered_envs, dropped_credentials = filter_untrusted_env_mapping(
         envs,


### PR DESCRIPTION
## Problem

vLLM V2 does not enable torch profiler during CUDA graph capture. Profile/roofline therefore never writes `capture_traces/`, and kernel-level analysis is empty.

## Fix

On vLLM profile/roofline materialization, set `VLLM_USE_V2_MODEL_RUNNER=0` so graph capture uses V1, which records those traces. Baseline is unchanged.