### PR TITLE
test: pin resolve_runtime_dtype branch priority (PRPUNDIT-11)

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling_perfmodel_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling_perfmodel_units.py
@@ -438,6 +438,7 @@ def test_select_peak_and_bound_ignores_a_projection_it_could_not_compute(mem, cm
     peak, _kind = rc.select_peak_and_bound(mem, cmp)
     assert peak == max(mem, cmp)
 
+
 def test_resolve_runtime_dtype_priority_and_ignores_workload_precision(tmp_path):
     """Recognized --quantization wins; unrecognized quant falls through; precision tags do not."""
     meta_fp32 = _dense_meta(weight_dtype_bytes=4.0)

--- a/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling_perfmodel_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling_perfmodel_units.py
@@ -437,3 +437,51 @@ def test_select_peak_and_bound_ignores_a_projection_it_could_not_compute(mem, cm
     """A zero is 'unknown', not 'infinitely slow'; it must not win the min."""
     peak, _kind = rc.select_peak_and_bound(mem, cmp)
     assert peak == max(mem, cmp)
+
+def test_resolve_runtime_dtype_priority_and_ignores_workload_precision(tmp_path):
+    """Recognized --quantization wins; unrecognized quant falls through; precision tags do not."""
+    meta_fp32 = _dense_meta(weight_dtype_bytes=4.0)
+    meta_fp8 = _dense_meta(weight_dtype_bytes=1.0)
+
+    (tmp_path / "quant").mkdir()
+    (tmp_path / "prequant").mkdir()
+    (tmp_path / "dtype").mkdir()
+    (tmp_path / "fallback").mkdir()
+
+    quant_state = _state(
+        tmp_path / "quant",
+        _serving_benchmark(tmp_path / "m", EXTRA_SGLANG_ARGS="--quantization fp8 --dtype bfloat16"),
+        precision="fp4",
+    )
+    quant = rc.resolve_runtime_dtype(quant_state, meta_fp32)
+    assert quant.source == "server_args_quantization"
+    assert quant.quantization == "fp8"
+    assert quant.weight_dtype_bytes == 1.0
+    assert quant.activation_dtype_bytes == 2.0
+
+    prequant_state = _state(
+        tmp_path / "prequant",
+        _serving_benchmark(tmp_path / "m", EXTRA_SGLANG_ARGS="--quantization not-a-method"),
+        precision="fp8",
+    )
+    prequant = rc.resolve_runtime_dtype(prequant_state, meta_fp8)
+    assert prequant.source == "quantization_config"
+    assert prequant.weight_dtype_bytes == 1.0
+
+    dtype_state = _state(
+        tmp_path / "dtype",
+        _serving_benchmark(tmp_path / "m", EXTRA_SGLANG_ARGS="--dtype float32"),
+        precision="fp8",
+    )
+    dtype = rc.resolve_runtime_dtype(dtype_state, meta_fp32)
+    assert dtype.source == "server_args_dtype"
+    assert dtype.quantization == "none"
+    assert dtype.weight_dtype_bytes == 4.0
+    assert dtype.activation_dtype_bytes == 4.0
+
+    fallback_state = _state(tmp_path / "fallback", _serving_benchmark(tmp_path / "m"), precision="fp8")
+    fallback = rc.resolve_runtime_dtype(fallback_state, meta_fp32)
+    assert fallback.source == "config_torch_dtype"
+    assert fallback.quantization == "none"
+    assert fallback.weight_dtype_bytes == 2.0
+    assert fallback.activation_dtype_bytes == 2.0


### PR DESCRIPTION
## Summary
- Covers the four provenance branches (`server_args_quantization`, `quantization_config`, `server_args_dtype`, `config_torch_dtype`) and asserts workload `precision` does not drive weight dtype.

Closes test gap **PRPUNDIT-11**.

## Test plan
- [x] `PYTHONPATH=src pytest src/hyperloom/inference_optimizer/tests/test_roofline_ceiling_perfmodel_units.py::test_resolve_runtime_dtype_priority_and_ignores_workload_precision`