### PR TITLE
Ask before stopping prior Hyperloom workload after error-driven restart

### DIFF
--- a/examples/hyperloom-custom-advanced/SKILL.md
+++ b/examples/hyperloom-custom-advanced/SKILL.md
@@ -35,31 +35,56 @@ In docker mode:
   framework must come from the image. Do **not** use `--skip-base-check`.
 - Do not run `python -m hyperloom.inference_optimizer.cli optimize` on the host.
 
-### Stale container after credential retry
+### Credential retry cleanup (required)
 
-A wrong LLM API key or auth failure often means fixing `.env` and starting a
-**replacement** long-running container. The first container may still be running
-and holding GPU memory.
+**Trigger (MUST):** whenever an LLM credential fails (401/403, invalid key,
+preflight auth error) and the user supplies a corrected key — **regardless of
+whether you reuse the existing Docker container or start a new one.** Agents
+often continue inside the same long-running container instead of `docker run`
+again; leftover optimizer or serving processes are the usual cause of misleading
+0% validated gain (#1314).
 
-Before `docker run` for the replacement, on the **docker host** (not inside a
+**Before** any replacement step (`docker run`, `docker exec`, `install.sh`, or
+a new/resumed `optimize`), probe the environment that will launch the workload
+(the current shell, or the target container via `docker exec`):
+
+```bash
+export USER_DATA_PATH="${USER_DATA_PATH:-$(grep '^USER_DATA_PATH=' .env | cut -d= -f2-)}"
+export RUN_DIR="${USER_DATA_PATH}/optimizer_runs"
+
+# Prior session handle (if any)
+test -f "$RUN_DIR/last_launch.env" && . "$RUN_DIR/last_launch.env"
+echo "prior_session=${SESSION_DIR:-none} prior_pid_file=${PID_FILE:-none}"
+
+# Leftover Hyperloom optimizer
+pgrep -af 'hyperloom\.inference_optimizer\.cli.*optimize' || true
+
+# Leftover serving stacks (IR-1 foreign processes)
+pgrep -af 'sglang\.launch_server|vllm\.entrypoints|Magpie' || true
+```
+
+In **docker mode**, also probe on the **docker host** (not only inside the
 container):
 
 ```bash
 docker ps --format '{{.Names}}' | grep -E '^hyperloom' || true
 ```
 
-When any names are printed, ask the user in plain language whether to stop
-those unused containers — for example: *"An earlier Hyperloom Docker container
-(`hyperloom-local`) is still running. Stop it before we start the new one?"*
-Wait for an explicit yes or no.
+**If anything is found** (prior `SESSION_DIR`, optimizer PID, `sglang`/`vllm`/
+Magpie process, or an extra `hyperloom*` container), stop and ask the user in
+plain language — for example: *"The previous run may still be active (optimizer
+PID …, session …). Stop it before we continue with the corrected API key?"*
+Wait for explicit yes/no.
 
-- **Yes:** stop each listed name with `docker stop <name>`. When reusing
-  `${HYPERLOOM_CONTAINER_NAME:-hyperloom-local}`, stopping the old instance is
-  required before `docker run --name ...` can succeed.
-- **No:** continue, but warn that GPU contention from the leftover container
-  can depress benchmarks and produce a misleading 0% validated gain.
+- **Yes:** stop in this order: serving processes from the old run, then the
+  optimizer (`kill` the PID from `PID_FILE` or the `pgrep` match), then stale
+  `hyperloom*` containers on the docker host (`docker stop <name>`). Only after
+  cleanup, continue with `--resume-from "$SESSION_DIR"` or a fresh launch as
+  appropriate.
+- **No:** continue, but warn that GPU contention or a stale baseline anchor
+  can depress benchmarks and show 0% validated gain.
 
-Never stop a container without the user's explicit approval.
+Never kill processes or stop containers without the user's explicit approval.
 
 Suggested Docker images:
 

--- a/examples/hyperloom-custom-advanced/SKILL.md
+++ b/examples/hyperloom-custom-advanced/SKILL.md
@@ -35,6 +35,32 @@ In docker mode:
   framework must come from the image. Do **not** use `--skip-base-check`.
 - Do not run `python -m hyperloom.inference_optimizer.cli optimize` on the host.
 
+### Stale container after credential retry
+
+A wrong LLM API key or auth failure often means fixing `.env` and starting a
+**replacement** long-running container. The first container may still be running
+and holding GPU memory.
+
+Before `docker run` for the replacement, on the **docker host** (not inside a
+container):
+
+```bash
+docker ps --format '{{.Names}}' | grep -E '^hyperloom' || true
+```
+
+When any names are printed, ask the user in plain language whether to stop
+those unused containers — for example: *"An earlier Hyperloom Docker container
+(`hyperloom-local`) is still running. Stop it before we start the new one?"*
+Wait for an explicit yes or no.
+
+- **Yes:** stop each listed name with `docker stop <name>`. When reusing
+  `${HYPERLOOM_CONTAINER_NAME:-hyperloom-local}`, stopping the old instance is
+  required before `docker run --name ...` can succeed.
+- **No:** continue, but warn that GPU contention from the leftover container
+  can depress benchmarks and produce a misleading 0% validated gain.
+
+Never stop a container without the user's explicit approval.
+
 Suggested Docker images:
 
 - `vllm`: `docker.io/vllm/vllm-openai-rocm:v0.27.1`

--- a/examples/hyperloom-custom-advanced/SKILL.md
+++ b/examples/hyperloom-custom-advanced/SKILL.md
@@ -35,14 +35,21 @@ In docker mode:
   framework must come from the image. Do **not** use `--skip-base-check`.
 - Do not run `python -m hyperloom.inference_optimizer.cli optimize` on the host.
 
-### Credential retry cleanup (required)
+### Prior workload cleanup (required)
 
-**Trigger (MUST):** whenever an LLM credential fails (401/403, invalid key,
-preflight auth error) and the user supplies a corrected key — **regardless of
-whether you reuse the existing Docker container or start a new one.** Agents
-often continue inside the same long-running container instead of `docker run`
-again; leftover optimizer or serving processes are the usual cause of misleading
-0% validated gain (#1314).
+**Trigger (MUST):** whenever a demo run fails, is abandoned, or you are about to
+start a **replacement** workload after any error — not only LLM credential
+failures (401/403, invalid key, gateway/auth misconfiguration). This also
+covers optimizer crash, install/preflight failure, the user asking to
+retry/restart, or any recovery where you would run `docker run`, `install.sh`,
+or a new/fresh `optimize`. It applies **regardless of whether you reuse the
+existing Docker container or start a new one.** Leftover optimizer or serving
+processes are the usual cause of misleading 0% validated gain (#1314).
+
+**Exception:** `--resume-from "$SESSION_DIR"` against the **same** session
+immediately after a clean crash (no credential change, user explicitly wants
+resume) may skip this gate — but if the probe below finds live or ambiguous
+leftover workload, run it anyway and ask the user.
 
 **Before** any replacement step (`docker run`, `docker exec`, `install.sh`, or
 a new/resumed `optimize`), probe the environment that will launch the workload
@@ -73,8 +80,7 @@ docker ps --format '{{.Names}}' | grep -E '^hyperloom' || true
 **If anything is found** (prior `SESSION_DIR`, optimizer PID, `sglang`/`vllm`/
 Magpie process, or an extra `hyperloom*` container), stop and ask the user in
 plain language — for example: *"The previous run may still be active (optimizer
-PID …, session …). Stop it before we continue with the corrected API key?"*
-Wait for explicit yes/no.
+PID …, session …). Stop it before we continue?"* Wait for explicit yes/no.
 
 - **Yes:** stop in this order: serving processes from the old run, then the
   optimizer (`kill` the PID from `PID_FILE` or the `pgrep` match), then stale

--- a/examples/hyperloom-custom-advanced/SKILL.md
+++ b/examples/hyperloom-custom-advanced/SKILL.md
@@ -37,60 +37,10 @@ In docker mode:
 
 ### Prior workload cleanup (required)
 
-**Trigger (MUST):** whenever a demo run fails, is abandoned, or you are about to
-start a **replacement** workload after any error — not only LLM credential
-failures (401/403, invalid key, gateway/auth misconfiguration). This also
-covers optimizer crash, install/preflight failure, the user asking to
-retry/restart, or any recovery where you would run `docker run`, `install.sh`,
-or a new/fresh `optimize`. It applies **regardless of whether you reuse the
-existing Docker container or start a new one.** Leftover optimizer or serving
-processes are the usual cause of misleading 0% validated gain (#1314).
-
-**Exception:** `--resume-from "$SESSION_DIR"` against the **same** session
-immediately after a clean crash (no credential change, user explicitly wants
-resume) may skip this gate — but if the probe below finds live or ambiguous
-leftover workload, run it anyway and ask the user.
-
-**Before** any replacement step (`docker run`, `docker exec`, `install.sh`, or
-a new/resumed `optimize`), probe the environment that will launch the workload
-(the current shell, or the target container via `docker exec`):
-
-```bash
-export USER_DATA_PATH="${USER_DATA_PATH:-$(grep '^USER_DATA_PATH=' .env | cut -d= -f2-)}"
-export RUN_DIR="${USER_DATA_PATH}/optimizer_runs"
-
-# Prior session handle (if any)
-test -f "$RUN_DIR/last_launch.env" && . "$RUN_DIR/last_launch.env"
-echo "prior_session=${SESSION_DIR:-none} prior_pid_file=${PID_FILE:-none}"
-
-# Leftover Hyperloom optimizer
-pgrep -af 'hyperloom\.inference_optimizer\.cli.*optimize' || true
-
-# Leftover serving stacks (IR-1 foreign processes)
-pgrep -af 'sglang\.launch_server|vllm\.entrypoints|Magpie' || true
-```
-
-In **docker mode**, also probe on the **docker host** (not only inside the
-container):
-
-```bash
-docker ps --format '{{.Names}}' | grep -E '^hyperloom' || true
-```
-
-**If anything is found** (prior `SESSION_DIR`, optimizer PID, `sglang`/`vllm`/
-Magpie process, or an extra `hyperloom*` container), stop and ask the user in
-plain language — for example: *"The previous run may still be active (optimizer
-PID …, session …). Stop it before we continue?"* Wait for explicit yes/no.
-
-- **Yes:** stop in this order: serving processes from the old run, then the
-  optimizer (`kill` the PID from `PID_FILE` or the `pgrep` match), then stale
-  `hyperloom*` containers on the docker host (`docker stop <name>`). Only after
-  cleanup, continue with `--resume-from "$SESSION_DIR"` or a fresh launch as
-  appropriate.
-- **No:** continue, but warn that GPU contention or a stale baseline anchor
-  can depress benchmarks and show 0% validated gain.
-
-Never kill processes or stop containers without the user's explicit approval.
+Before any replacement launch after a failed or abandoned demo run (`docker run`,
+`install.sh`, or a new/fresh `optimize`), follow **IR-1 — Prior workload cleanup
+gate** in `@${HYPERLOOM_SKILL_PATH}`. Run all probes on the **docker host**; never
+skip the user-approval step (#1314).
 
 Suggested Docker images:
 

--- a/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
+++ b/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
@@ -25,14 +25,21 @@ In docker mode:
   the container environment.
 - Do not run `python -m hyperloom.inference_optimizer.cli optimize` on the host.
 
-### Credential retry cleanup (required)
+### Prior workload cleanup (required)
 
-**Trigger (MUST):** whenever an LLM credential fails (401/403, invalid key,
-preflight auth error) and the user supplies a corrected key — **regardless of
-whether you reuse the existing Docker container or start a new one.** Agents
-often continue inside the same long-running container instead of `docker run`
-again; leftover optimizer or serving processes are the usual cause of misleading
-0% validated gain (#1314).
+**Trigger (MUST):** whenever a demo run fails, is abandoned, or you are about to
+start a **replacement** workload after any error — not only LLM credential
+failures (401/403, invalid key, gateway/auth misconfiguration). This also
+covers optimizer crash, install/preflight failure, the user asking to
+retry/restart, or any recovery where you would run `docker run`, `install.sh`,
+or a new/fresh `optimize`. It applies **regardless of whether you reuse the
+existing Docker container or start a new one.** Leftover optimizer or serving
+processes are the usual cause of misleading 0% validated gain (#1314).
+
+**Exception:** `--resume-from "$SESSION_DIR"` against the **same** session
+immediately after a clean crash (no credential change, user explicitly wants
+resume) may skip this gate — but if the probe below finds live or ambiguous
+leftover workload, run it anyway and ask the user.
 
 **Before** any replacement step (`docker run`, `docker exec`, `install.sh`, or
 a new/resumed `optimize`), probe the environment that will launch the workload
@@ -63,8 +70,7 @@ docker ps --format '{{.Names}}' | grep -E '^hyperloom' || true
 **If anything is found** (prior `SESSION_DIR`, optimizer PID, `sglang`/`vllm`/
 Magpie process, or an extra `hyperloom*` container), stop and ask the user in
 plain language — for example: *"The previous run may still be active (optimizer
-PID …, session …). Stop it before we continue with the corrected API key?"*
-Wait for explicit yes/no.
+PID …, session …). Stop it before we continue?"* Wait for explicit yes/no.
 
 - **Yes:** stop in this order: serving processes from the old run, then the
   optimizer (`kill` the PID from `PID_FILE` or the `pgrep` match), then stale

--- a/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
+++ b/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
@@ -25,31 +25,56 @@ In docker mode:
   the container environment.
 - Do not run `python -m hyperloom.inference_optimizer.cli optimize` on the host.
 
-### Stale container after credential retry
+### Credential retry cleanup (required)
 
-A wrong LLM API key or auth failure often means fixing `.env` and starting a
-**replacement** long-running container. The first container may still be running
-and holding GPU memory.
+**Trigger (MUST):** whenever an LLM credential fails (401/403, invalid key,
+preflight auth error) and the user supplies a corrected key — **regardless of
+whether you reuse the existing Docker container or start a new one.** Agents
+often continue inside the same long-running container instead of `docker run`
+again; leftover optimizer or serving processes are the usual cause of misleading
+0% validated gain (#1314).
 
-Before `docker run` for the replacement, on the **docker host** (not inside a
+**Before** any replacement step (`docker run`, `docker exec`, `install.sh`, or
+a new/resumed `optimize`), probe the environment that will launch the workload
+(the current shell, or the target container via `docker exec`):
+
+```bash
+export USER_DATA_PATH="${USER_DATA_PATH:-$(grep '^USER_DATA_PATH=' .env | cut -d= -f2-)}"
+export RUN_DIR="${USER_DATA_PATH}/optimizer_runs"
+
+# Prior session handle (if any)
+test -f "$RUN_DIR/last_launch.env" && . "$RUN_DIR/last_launch.env"
+echo "prior_session=${SESSION_DIR:-none} prior_pid_file=${PID_FILE:-none}"
+
+# Leftover Hyperloom optimizer
+pgrep -af 'hyperloom\.inference_optimizer\.cli.*optimize' || true
+
+# Leftover serving stacks (IR-1 foreign processes)
+pgrep -af 'sglang\.launch_server|vllm\.entrypoints|Magpie' || true
+```
+
+In **docker mode**, also probe on the **docker host** (not only inside the
 container):
 
 ```bash
 docker ps --format '{{.Names}}' | grep -E '^hyperloom' || true
 ```
 
-When any names are printed, ask the user in plain language whether to stop
-those unused containers — for example: *"An earlier Hyperloom Docker container
-(`hyperloom-local`) is still running. Stop it before we start the new one?"*
-Wait for an explicit yes or no.
+**If anything is found** (prior `SESSION_DIR`, optimizer PID, `sglang`/`vllm`/
+Magpie process, or an extra `hyperloom*` container), stop and ask the user in
+plain language — for example: *"The previous run may still be active (optimizer
+PID …, session …). Stop it before we continue with the corrected API key?"*
+Wait for explicit yes/no.
 
-- **Yes:** stop each listed name with `docker stop <name>`. When reusing
-  `${HYPERLOOM_CONTAINER_NAME:-hyperloom-local}`, stopping the old instance is
-  required before `docker run --name ...` can succeed.
-- **No:** continue, but warn that GPU contention from the leftover container
-  can depress benchmarks and produce a misleading 0% validated gain.
+- **Yes:** stop in this order: serving processes from the old run, then the
+  optimizer (`kill` the PID from `PID_FILE` or the `pgrep` match), then stale
+  `hyperloom*` containers on the docker host (`docker stop <name>`). Only after
+  cleanup, continue with `--resume-from "$SESSION_DIR"` or a fresh launch as
+  appropriate.
+- **No:** continue, but warn that GPU contention or a stale baseline anchor
+  can depress benchmarks and show 0% validated gain.
 
-Never stop a container without the user's explicit approval.
+Never kill processes or stop containers without the user's explicit approval.
 
 Suggested Docker images:
 

--- a/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
+++ b/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
@@ -25,6 +25,32 @@ In docker mode:
   the container environment.
 - Do not run `python -m hyperloom.inference_optimizer.cli optimize` on the host.
 
+### Stale container after credential retry
+
+A wrong LLM API key or auth failure often means fixing `.env` and starting a
+**replacement** long-running container. The first container may still be running
+and holding GPU memory.
+
+Before `docker run` for the replacement, on the **docker host** (not inside a
+container):
+
+```bash
+docker ps --format '{{.Names}}' | grep -E '^hyperloom' || true
+```
+
+When any names are printed, ask the user in plain language whether to stop
+those unused containers — for example: *"An earlier Hyperloom Docker container
+(`hyperloom-local`) is still running. Stop it before we start the new one?"*
+Wait for an explicit yes or no.
+
+- **Yes:** stop each listed name with `docker stop <name>`. When reusing
+  `${HYPERLOOM_CONTAINER_NAME:-hyperloom-local}`, stopping the old instance is
+  required before `docker run --name ...` can succeed.
+- **No:** continue, but warn that GPU contention from the leftover container
+  can depress benchmarks and produce a misleading 0% validated gain.
+
+Never stop a container without the user's explicit approval.
+
 Suggested Docker images:
 
 - `vllm`: `docker.io/vllm/vllm-openai-rocm:v0.27.1`

--- a/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
+++ b/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
@@ -27,60 +27,10 @@ In docker mode:
 
 ### Prior workload cleanup (required)
 
-**Trigger (MUST):** whenever a demo run fails, is abandoned, or you are about to
-start a **replacement** workload after any error — not only LLM credential
-failures (401/403, invalid key, gateway/auth misconfiguration). This also
-covers optimizer crash, install/preflight failure, the user asking to
-retry/restart, or any recovery where you would run `docker run`, `install.sh`,
-or a new/fresh `optimize`. It applies **regardless of whether you reuse the
-existing Docker container or start a new one.** Leftover optimizer or serving
-processes are the usual cause of misleading 0% validated gain (#1314).
-
-**Exception:** `--resume-from "$SESSION_DIR"` against the **same** session
-immediately after a clean crash (no credential change, user explicitly wants
-resume) may skip this gate — but if the probe below finds live or ambiguous
-leftover workload, run it anyway and ask the user.
-
-**Before** any replacement step (`docker run`, `docker exec`, `install.sh`, or
-a new/resumed `optimize`), probe the environment that will launch the workload
-(the current shell, or the target container via `docker exec`):
-
-```bash
-export USER_DATA_PATH="${USER_DATA_PATH:-$(grep '^USER_DATA_PATH=' .env | cut -d= -f2-)}"
-export RUN_DIR="${USER_DATA_PATH}/optimizer_runs"
-
-# Prior session handle (if any)
-test -f "$RUN_DIR/last_launch.env" && . "$RUN_DIR/last_launch.env"
-echo "prior_session=${SESSION_DIR:-none} prior_pid_file=${PID_FILE:-none}"
-
-# Leftover Hyperloom optimizer
-pgrep -af 'hyperloom\.inference_optimizer\.cli.*optimize' || true
-
-# Leftover serving stacks (IR-1 foreign processes)
-pgrep -af 'sglang\.launch_server|vllm\.entrypoints|Magpie' || true
-```
-
-In **docker mode**, also probe on the **docker host** (not only inside the
-container):
-
-```bash
-docker ps --format '{{.Names}}' | grep -E '^hyperloom' || true
-```
-
-**If anything is found** (prior `SESSION_DIR`, optimizer PID, `sglang`/`vllm`/
-Magpie process, or an extra `hyperloom*` container), stop and ask the user in
-plain language — for example: *"The previous run may still be active (optimizer
-PID …, session …). Stop it before we continue?"* Wait for explicit yes/no.
-
-- **Yes:** stop in this order: serving processes from the old run, then the
-  optimizer (`kill` the PID from `PID_FILE` or the `pgrep` match), then stale
-  `hyperloom*` containers on the docker host (`docker stop <name>`). Only after
-  cleanup, continue with `--resume-from "$SESSION_DIR"` or a fresh launch as
-  appropriate.
-- **No:** continue, but warn that GPU contention or a stale baseline anchor
-  can depress benchmarks and show 0% validated gain.
-
-Never kill processes or stop containers without the user's explicit approval.
+Before any replacement launch after a failed or abandoned demo run (`docker run`,
+`install.sh`, or a new/fresh `optimize`), follow **IR-1 — Prior workload cleanup
+gate** in `@${HYPERLOOM_SKILL_PATH}`. Run all probes on the **docker host**; never
+skip the user-approval step (#1314).
 
 Suggested Docker images:
 

--- a/examples/hyperloom-qwen3-8b-3h/SKILL.md
+++ b/examples/hyperloom-qwen3-8b-3h/SKILL.md
@@ -25,14 +25,21 @@ In docker mode:
   the container environment.
 - Do not run `python -m hyperloom.inference_optimizer.cli optimize` on the host.
 
-### Credential retry cleanup (required)
+### Prior workload cleanup (required)
 
-**Trigger (MUST):** whenever an LLM credential fails (401/403, invalid key,
-preflight auth error) and the user supplies a corrected key — **regardless of
-whether you reuse the existing Docker container or start a new one.** Agents
-often continue inside the same long-running container instead of `docker run`
-again; leftover optimizer or serving processes are the usual cause of misleading
-0% validated gain (#1314).
+**Trigger (MUST):** whenever a demo run fails, is abandoned, or you are about to
+start a **replacement** workload after any error — not only LLM credential
+failures (401/403, invalid key, gateway/auth misconfiguration). This also
+covers optimizer crash, install/preflight failure, the user asking to
+retry/restart, or any recovery where you would run `docker run`, `install.sh`,
+or a new/fresh `optimize`. It applies **regardless of whether you reuse the
+existing Docker container or start a new one.** Leftover optimizer or serving
+processes are the usual cause of misleading 0% validated gain (#1314).
+
+**Exception:** `--resume-from "$SESSION_DIR"` against the **same** session
+immediately after a clean crash (no credential change, user explicitly wants
+resume) may skip this gate — but if the probe below finds live or ambiguous
+leftover workload, run it anyway and ask the user.
 
 **Before** any replacement step (`docker run`, `docker exec`, `install.sh`, or
 a new/resumed `optimize`), probe the environment that will launch the workload
@@ -63,8 +70,7 @@ docker ps --format '{{.Names}}' | grep -E '^hyperloom' || true
 **If anything is found** (prior `SESSION_DIR`, optimizer PID, `sglang`/`vllm`/
 Magpie process, or an extra `hyperloom*` container), stop and ask the user in
 plain language — for example: *"The previous run may still be active (optimizer
-PID …, session …). Stop it before we continue with the corrected API key?"*
-Wait for explicit yes/no.
+PID …, session …). Stop it before we continue?"* Wait for explicit yes/no.
 
 - **Yes:** stop in this order: serving processes from the old run, then the
   optimizer (`kill` the PID from `PID_FILE` or the `pgrep` match), then stale

--- a/examples/hyperloom-qwen3-8b-3h/SKILL.md
+++ b/examples/hyperloom-qwen3-8b-3h/SKILL.md
@@ -25,31 +25,56 @@ In docker mode:
   the container environment.
 - Do not run `python -m hyperloom.inference_optimizer.cli optimize` on the host.
 
-### Stale container after credential retry
+### Credential retry cleanup (required)
 
-A wrong LLM API key or auth failure often means fixing `.env` and starting a
-**replacement** long-running container. The first container may still be running
-and holding GPU memory.
+**Trigger (MUST):** whenever an LLM credential fails (401/403, invalid key,
+preflight auth error) and the user supplies a corrected key — **regardless of
+whether you reuse the existing Docker container or start a new one.** Agents
+often continue inside the same long-running container instead of `docker run`
+again; leftover optimizer or serving processes are the usual cause of misleading
+0% validated gain (#1314).
 
-Before `docker run` for the replacement, on the **docker host** (not inside a
+**Before** any replacement step (`docker run`, `docker exec`, `install.sh`, or
+a new/resumed `optimize`), probe the environment that will launch the workload
+(the current shell, or the target container via `docker exec`):
+
+```bash
+export USER_DATA_PATH="${USER_DATA_PATH:-$(grep '^USER_DATA_PATH=' .env | cut -d= -f2-)}"
+export RUN_DIR="${USER_DATA_PATH}/optimizer_runs"
+
+# Prior session handle (if any)
+test -f "$RUN_DIR/last_launch.env" && . "$RUN_DIR/last_launch.env"
+echo "prior_session=${SESSION_DIR:-none} prior_pid_file=${PID_FILE:-none}"
+
+# Leftover Hyperloom optimizer
+pgrep -af 'hyperloom\.inference_optimizer\.cli.*optimize' || true
+
+# Leftover serving stacks (IR-1 foreign processes)
+pgrep -af 'sglang\.launch_server|vllm\.entrypoints|Magpie' || true
+```
+
+In **docker mode**, also probe on the **docker host** (not only inside the
 container):
 
 ```bash
 docker ps --format '{{.Names}}' | grep -E '^hyperloom' || true
 ```
 
-When any names are printed, ask the user in plain language whether to stop
-those unused containers — for example: *"An earlier Hyperloom Docker container
-(`hyperloom-local`) is still running. Stop it before we start the new one?"*
-Wait for an explicit yes or no.
+**If anything is found** (prior `SESSION_DIR`, optimizer PID, `sglang`/`vllm`/
+Magpie process, or an extra `hyperloom*` container), stop and ask the user in
+plain language — for example: *"The previous run may still be active (optimizer
+PID …, session …). Stop it before we continue with the corrected API key?"*
+Wait for explicit yes/no.
 
-- **Yes:** stop each listed name with `docker stop <name>`. When reusing
-  `${HYPERLOOM_CONTAINER_NAME:-hyperloom-local}`, stopping the old instance is
-  required before `docker run --name ...` can succeed.
-- **No:** continue, but warn that GPU contention from the leftover container
-  can depress benchmarks and produce a misleading 0% validated gain.
+- **Yes:** stop in this order: serving processes from the old run, then the
+  optimizer (`kill` the PID from `PID_FILE` or the `pgrep` match), then stale
+  `hyperloom*` containers on the docker host (`docker stop <name>`). Only after
+  cleanup, continue with `--resume-from "$SESSION_DIR"` or a fresh launch as
+  appropriate.
+- **No:** continue, but warn that GPU contention or a stale baseline anchor
+  can depress benchmarks and show 0% validated gain.
 
-Never stop a container without the user's explicit approval.
+Never kill processes or stop containers without the user's explicit approval.
 
 Suggested Docker images:
 

--- a/examples/hyperloom-qwen3-8b-3h/SKILL.md
+++ b/examples/hyperloom-qwen3-8b-3h/SKILL.md
@@ -25,6 +25,32 @@ In docker mode:
   the container environment.
 - Do not run `python -m hyperloom.inference_optimizer.cli optimize` on the host.
 
+### Stale container after credential retry
+
+A wrong LLM API key or auth failure often means fixing `.env` and starting a
+**replacement** long-running container. The first container may still be running
+and holding GPU memory.
+
+Before `docker run` for the replacement, on the **docker host** (not inside a
+container):
+
+```bash
+docker ps --format '{{.Names}}' | grep -E '^hyperloom' || true
+```
+
+When any names are printed, ask the user in plain language whether to stop
+those unused containers — for example: *"An earlier Hyperloom Docker container
+(`hyperloom-local`) is still running. Stop it before we start the new one?"*
+Wait for an explicit yes or no.
+
+- **Yes:** stop each listed name with `docker stop <name>`. When reusing
+  `${HYPERLOOM_CONTAINER_NAME:-hyperloom-local}`, stopping the old instance is
+  required before `docker run --name ...` can succeed.
+- **No:** continue, but warn that GPU contention from the leftover container
+  can depress benchmarks and produce a misleading 0% validated gain.
+
+Never stop a container without the user's explicit approval.
+
 Suggested Docker images:
 
 - `vllm`: `docker.io/vllm/vllm-openai-rocm:v0.27.1`

--- a/examples/hyperloom-qwen3-8b-3h/SKILL.md
+++ b/examples/hyperloom-qwen3-8b-3h/SKILL.md
@@ -27,60 +27,10 @@ In docker mode:
 
 ### Prior workload cleanup (required)
 
-**Trigger (MUST):** whenever a demo run fails, is abandoned, or you are about to
-start a **replacement** workload after any error — not only LLM credential
-failures (401/403, invalid key, gateway/auth misconfiguration). This also
-covers optimizer crash, install/preflight failure, the user asking to
-retry/restart, or any recovery where you would run `docker run`, `install.sh`,
-or a new/fresh `optimize`. It applies **regardless of whether you reuse the
-existing Docker container or start a new one.** Leftover optimizer or serving
-processes are the usual cause of misleading 0% validated gain (#1314).
-
-**Exception:** `--resume-from "$SESSION_DIR"` against the **same** session
-immediately after a clean crash (no credential change, user explicitly wants
-resume) may skip this gate — but if the probe below finds live or ambiguous
-leftover workload, run it anyway and ask the user.
-
-**Before** any replacement step (`docker run`, `docker exec`, `install.sh`, or
-a new/resumed `optimize`), probe the environment that will launch the workload
-(the current shell, or the target container via `docker exec`):
-
-```bash
-export USER_DATA_PATH="${USER_DATA_PATH:-$(grep '^USER_DATA_PATH=' .env | cut -d= -f2-)}"
-export RUN_DIR="${USER_DATA_PATH}/optimizer_runs"
-
-# Prior session handle (if any)
-test -f "$RUN_DIR/last_launch.env" && . "$RUN_DIR/last_launch.env"
-echo "prior_session=${SESSION_DIR:-none} prior_pid_file=${PID_FILE:-none}"
-
-# Leftover Hyperloom optimizer
-pgrep -af 'hyperloom\.inference_optimizer\.cli.*optimize' || true
-
-# Leftover serving stacks (IR-1 foreign processes)
-pgrep -af 'sglang\.launch_server|vllm\.entrypoints|Magpie' || true
-```
-
-In **docker mode**, also probe on the **docker host** (not only inside the
-container):
-
-```bash
-docker ps --format '{{.Names}}' | grep -E '^hyperloom' || true
-```
-
-**If anything is found** (prior `SESSION_DIR`, optimizer PID, `sglang`/`vllm`/
-Magpie process, or an extra `hyperloom*` container), stop and ask the user in
-plain language — for example: *"The previous run may still be active (optimizer
-PID …, session …). Stop it before we continue?"* Wait for explicit yes/no.
-
-- **Yes:** stop in this order: serving processes from the old run, then the
-  optimizer (`kill` the PID from `PID_FILE` or the `pgrep` match), then stale
-  `hyperloom*` containers on the docker host (`docker stop <name>`). Only after
-  cleanup, continue with `--resume-from "$SESSION_DIR"` or a fresh launch as
-  appropriate.
-- **No:** continue, but warn that GPU contention or a stale baseline anchor
-  can depress benchmarks and show 0% validated gain.
-
-Never kill processes or stop containers without the user's explicit approval.
+Before any replacement launch after a failed or abandoned demo run (`docker run`,
+`install.sh`, or a new/fresh `optimize`), follow **IR-1 — Prior workload cleanup
+gate** in `@${HYPERLOOM_SKILL_PATH}`. Run all probes on the **docker host**; never
+skip the user-approval step (#1314).
 
 Suggested Docker images:
 

--- a/src/hyperloom/inference_optimizer/SKILL.md
+++ b/src/hyperloom/inference_optimizer/SKILL.md
@@ -162,6 +162,91 @@ pollution after the fact.
 > stale servers before every restart. IR-1 above is the *outer* gate that
 > fires before the optimizer process exists.
 
+#### Prior workload cleanup gate (error recovery)
+
+**Trigger (MUST):** whenever a run fails, is abandoned, or you are about to
+start a **replacement** workload after any error — credential failures,
+optimizer crash, install/preflight failure, user retry/restart, or any recovery
+where you would run `docker run`, `install.sh`, or a new/fresh `optimize`.
+Applies in bare-metal and docker mode, **whether reusing the existing container
+or starting a new one.** Leftover optimizer/serving processes or occupied VRAM
+are the usual cause of misleading 0% validated gain (#1314).
+
+**Exception:** `--resume-from "$SESSION_DIR"` against the **same** session
+immediately after a clean crash (no credential change, user explicitly wants
+resume) may skip — but if the probe finds live or ambiguous leftover workload,
+run it anyway and ask the user.
+
+**Probe on the docker host** (bare-metal: current host). **Never** rely on
+`docker exec` for process or VRAM checks — container PID namespaces hide
+processes in *other* containers; the host namespace is the superset (#1314).
+
+```bash
+export REPO_ROOT="${REPO_ROOT:-$(pwd -P)}"
+# .env fills gaps only — same pattern as the launch block below.
+_dotenv_prev="$(export -p | grep -v -e '=""$' -e "=''\$")"
+if [ -f "$REPO_ROOT/.env" ]; then set -a; . "$REPO_ROOT/.env"; set +a; fi
+eval "$_dotenv_prev"
+unset _dotenv_prev
+export USER_DATA_PATH="${USER_DATA_PATH:-/workspace/hyperloom}"
+export RUN_DIR="${USER_DATA_PATH}/optimizer_runs"
+
+# Prior launch handles from canonical artifacts (no last_launch.env — never written)
+LATEST_PID_FILE="$(ls -t "$RUN_DIR"/run_*.pid 2>/dev/null | head -1 || true)"
+LATEST_LAUNCH_INFO="$(ls -t "$RUN_DIR"/launch_*.json 2>/dev/null | head -1 || true)"
+PRIOR_SESSION=""
+if [ -n "$LATEST_LAUNCH_INFO" ] && command -v jq >/dev/null 2>&1; then
+  PRIOR_SESSION="$(jq -r '.session_dir // empty' "$LATEST_LAUNCH_INFO" 2>/dev/null)"
+fi
+echo "prior_pid_file=${LATEST_PID_FILE:-none}"
+echo "prior_launch_info=${LATEST_LAUNCH_INFO:-none}"
+echo "prior_session=${PRIOR_SESSION:-none}"
+
+# Foreign processes — host-level pgrep (patterns match preflight_optimizer.py)
+pgrep -af 'hyperloom\.inference_optimizer\.cli.*optimize' || true
+pgrep -af 'sglang\.launch_server|vllm\.entrypoints|Magpie' || true
+
+# VRAM — each card must be < 1% of capacity (IR-1); catches unrelated occupiers too
+python3 - <<'PY' 2>/dev/null || true
+from hyperloom.common import rocm_smi
+
+snaps = rocm_smi.gpu_vram_usage()
+if snaps is None:
+    print("gpu_vram=unreadable")
+else:
+    for i, snap in enumerate(snaps):
+        pct = (snap.used_mib / snap.total_mib) if snap.total_mib else 1.0
+        busy = pct > 0.01
+        print(
+            f"gpu{i}_vram_used={snap.used_mib:.1f}/{snap.total_mib:.1f} MiB "
+            f"({pct:.2%}) {'BUSY' if busy else 'idle'}"
+        )
+PY
+
+# Other running containers — exclude the one we will reuse (name is user-set)
+CURRENT_CONTAINER="${HYPERLOOM_CONTAINER_NAME:-hyperloom-local}"
+docker ps --format '{{.Names}}' 2>/dev/null | grep -v "^${CURRENT_CONTAINER}$" || true
+```
+
+**If anything is found** (non-empty `prior_session`, a live PID in
+`prior_pid_file`, foreign process, any GPU line marked `BUSY` or
+`gpu_vram=unreadable`, or any extra running container), stop and ask the user
+explicitly — e.g. *"The previous run may still be active (session …, PID …,
+GPU VRAM …). Stop it before we continue?"* Wait for yes/no.
+
+- **Yes:** stop in this order: serving PIDs from pgrep, then the optimizer
+  (`kill "$(cat "$LATEST_PID_FILE")"` when the PID file is live, else the pgrep
+  match), then other containers (`docker stop <name>`). Only then continue with
+  `--resume-from "$PRIOR_SESSION"` or a fresh launch as appropriate.
+- **No:** do **not** treat results as clean. Continue only if the user insists;
+  **MUST** add this caveat verbatim to the final report / session summary:
+
+  > **Contaminated baseline warning (#1314):** Prior GPU workload was not
+  > stopped per user choice. Validated gain and benchmark numbers may be
+  > unreliable.
+
+Never kill processes or stop containers without explicit user approval.
+
 ### IR-2 — install.sh MUST succeed before every launch
 
 Run `bash "$REPO_ROOT/src/hyperloom/inference_optimizer/assets/install.sh"` and

--- a/src/hyperloom/inference_optimizer/SKILL.md
+++ b/src/hyperloom/inference_optimizer/SKILL.md
@@ -195,10 +195,20 @@ export RUN_DIR="${USER_DATA_PATH}/optimizer_runs"
 LATEST_PID_FILE="$(ls -t "$RUN_DIR"/run_*.pid 2>/dev/null | head -1 || true)"
 LATEST_LAUNCH_INFO="$(ls -t "$RUN_DIR"/launch_*.json 2>/dev/null | head -1 || true)"
 PRIOR_SESSION=""
-if [ -n "$LATEST_LAUNCH_INFO" ] && command -v jq >/dev/null 2>&1; then
-  PRIOR_SESSION="$(jq -r '.session_dir // empty' "$LATEST_LAUNCH_INFO" 2>/dev/null)"
+if [ -n "$LATEST_LAUNCH_INFO" ]; then
+  PRIOR_SESSION="$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(d.get("session_dir") or "")' "$LATEST_LAUNCH_INFO" 2>/dev/null || true)"
+fi
+PRIOR_PID=""
+PRIOR_PID_LIVE=false
+if [ -n "$LATEST_PID_FILE" ] && [ -f "$LATEST_PID_FILE" ]; then
+  PRIOR_PID="$(tr -d '[:space:]' < "$LATEST_PID_FILE" 2>/dev/null || true)"
+  if [ -n "$PRIOR_PID" ] && kill -0 "$PRIOR_PID" 2>/dev/null; then
+    PRIOR_PID_LIVE=true
+  fi
 fi
 echo "prior_pid_file=${LATEST_PID_FILE:-none}"
+echo "prior_pid=${PRIOR_PID:-none}"
+echo "prior_pid_live=${PRIOR_PID_LIVE}"
 echo "prior_launch_info=${LATEST_LAUNCH_INFO:-none}"
 echo "prior_session=${PRIOR_SESSION:-none}"
 
@@ -206,38 +216,94 @@ echo "prior_session=${PRIOR_SESSION:-none}"
 pgrep -af 'hyperloom\.inference_optimizer\.cli.*optimize' || true
 pgrep -af 'sglang\.launch_server|vllm\.entrypoints|Magpie' || true
 
-# VRAM — each card must be < 1% of capacity (IR-1); catches unrelated occupiers too
-python3 - <<'PY' 2>/dev/null || true
-from hyperloom.common import rocm_smi
+# VRAM — stdlib-only rocm-smi parse (must run on docker host; no hyperloom import)
+python3 - <<'PY'
+import json, shutil, subprocess
 
-snaps = rocm_smi.gpu_vram_usage()
-if snaps is None:
+def unreadable():
     print("gpu_vram=unreadable")
-else:
-    for i, snap in enumerate(snaps):
-        pct = (snap.used_mib / snap.total_mib) if snap.total_mib else 1.0
-        busy = pct > 0.01
-        print(
-            f"gpu{i}_vram_used={snap.used_mib:.1f}/{snap.total_mib:.1f} MiB "
-            f"({pct:.2%}) {'BUSY' if busy else 'idle'}"
-        )
+
+if not shutil.which("rocm-smi"):
+    unreadable()
+    raise SystemExit(0)
+try:
+    proc = subprocess.run(
+        ["rocm-smi", "--showmeminfo", "vram", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+except (OSError, subprocess.SubprocessError):
+    unreadable()
+    raise SystemExit(0)
+if proc.returncode != 0:
+    unreadable()
+    raise SystemExit(0)
+try:
+    data = json.loads(proc.stdout)
+except (json.JSONDecodeError, ValueError):
+    unreadable()
+    raise SystemExit(0)
+if not isinstance(data, dict):
+    unreadable()
+    raise SystemExit(0)
+
+rows: list[tuple[float, float]] = []
+for fields in data.values():
+    if not isinstance(fields, dict):
+        continue
+    raw: dict[str, float] = {}
+    for key, val in fields.items():
+        kl = key.lower()
+        if "vram" not in kl:
+            continue
+        if "used" in kl:
+            raw["used"] = float(val)
+        elif "total" in kl:
+            raw["total"] = float(val)
+    if not raw:
+        continue
+    try:
+        used_mib = raw["used"] / 1024**2
+        total_mib = raw["total"] / 1024**2
+    except (KeyError, TypeError, ValueError):
+        unreadable()
+        raise SystemExit(0)
+    if total_mib <= 0.0:
+        unreadable()
+        raise SystemExit(0)
+    rows.append((used_mib, total_mib))
+
+if not rows:
+    unreadable()
+    raise SystemExit(0)
+
+for i, (used_mib, total_mib) in enumerate(rows):
+    pct = used_mib / total_mib
+    busy = pct > 0.01
+    print(
+        f"gpu{i}_vram_used={used_mib:.1f}/{total_mib:.1f} MiB "
+        f"({pct:.2%}) {'BUSY' if busy else 'idle'}"
+    )
 PY
 
-# Other running containers — exclude the one we will reuse (name is user-set)
+# Other hyperloom-named containers — exclude the one we will reuse
 CURRENT_CONTAINER="${HYPERLOOM_CONTAINER_NAME:-hyperloom-local}"
-docker ps --format '{{.Names}}' 2>/dev/null | grep -v "^${CURRENT_CONTAINER}$" || true
+docker ps --filter "name=hyperloom" --format '{{.Names}}' 2>/dev/null \
+  | grep -v "^${CURRENT_CONTAINER}$" || true
 ```
 
-**If anything is found** (non-empty `prior_session`, a live PID in
-`prior_pid_file`, foreign process, any GPU line marked `BUSY` or
-`gpu_vram=unreadable`, or any extra running container), stop and ask the user
-explicitly — e.g. *"The previous run may still be active (session …, PID …,
-GPU VRAM …). Stop it before we continue?"* Wait for yes/no.
+**If anything is found** (`prior_pid_live=true`, foreign process from pgrep,
+any GPU line marked `BUSY` or `gpu_vram=unreadable`, or another
+hyperloom-named running container), stop and ask the user explicitly — e.g.
+*"The previous run may still be active (session …, PID …, GPU VRAM …). Stop
+it before we continue?"* Wait for yes/no.
 
 - **Yes:** stop in this order: serving PIDs from pgrep, then the optimizer
-  (`kill "$(cat "$LATEST_PID_FILE")"` when the PID file is live, else the pgrep
-  match), then other containers (`docker stop <name>`). Only then continue with
-  `--resume-from "$PRIOR_SESSION"` or a fresh launch as appropriate.
+  (`kill "$PRIOR_PID"` when `prior_pid_live=true`, else the pgrep match), then
+  **only** other hyperloom-named containers from the filtered list above
+  (`docker stop <name>`). Only then continue with `--resume-from "$PRIOR_SESSION"`
+  or a fresh launch as appropriate.
 - **No:** do **not** treat results as clean. Continue only if the user insists;
   **MUST** add this caveat verbatim to the final report / session summary:
 


### PR DESCRIPTION
## Problem

In docker-mode demo runs, any failed or abandoned attempt (credential errors, optimizer crash, preflight failure, user-requested retry, etc.) can leave a prior session still active. The agent may reuse the same long-running container instead of starting a new one, while leftover optimize or serving workloads in another container's host PID namespace keep GPU memory and depress benchmarks. That can show as 0% validated gain even though the retry session otherwise completes (see #1314).

## Fix

Add **IR-1 — Prior workload cleanup gate** to the canonical optimizer skill (`src/hyperloom/inference_optimizer/SKILL.md`). Before any replacement launch (`docker run`, `install.sh`, or a new/fresh `optimize`), the agent must probe on the **docker host** (not via `docker exec`):

- Latest prior handles from `$RUN_DIR/run_*.pid` (with `kill -0` liveness) and `$RUN_DIR/launch_*.json` (`session_dir` via stdlib `python3 -c`)
- Host-level optimizer/serving PIDs (`pgrep`, same patterns as `preflight_optimizer.py`)
- Per-GPU VRAM via stdlib `rocm-smi --showmeminfo vram --json` parsing (< 1% threshold; always emits `BUSY`/`idle` or `gpu_vram=unreadable`)
- Other running Docker containers matching `name=hyperloom`, excluding the container about to be reused

If anything is found, ask the user explicitly before kill/stop. If the user declines cleanup, require a **Contaminated baseline warning (#1314)** in the final report. The three example demo skills point to this canonical section instead of duplicating the gate.