### PR TITLE
Add merged Framework Agent SBD V6 timeline

### DIFF
--- a/src/hyperloom/inference_optimizer/breakdown/collectors/v6.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/v6.py
@@ -1502,6 +1502,30 @@ def _source_attempts(
     progress_rows: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     candidates = _candidate_index(state)
+    source_operations = [
+        operation
+        for operation in operations
+        if _operation_name(operation) in {"framework_agent", "integrate", "integrate_patch"}
+    ]
+    candidate_operation_counts: dict[str, int] = {}
+    source_operation_counts: dict[str, int] = {}
+    for operation in source_operations:
+        outputs = _mapping(operation.get("outputs"))
+        inputs = _mapping(operation.get("inputs"))
+        candidate_id = str(
+            _first(
+                _candidate_id(_first(outputs.get("candidate"), inputs.get("candidate"))),
+                outputs.get("framework_agent_candidate_id"),
+                inputs.get("framework_agent_candidate_id"),
+                _nested(operation, "metadata", "extras", "candidate_id"),
+            )
+            or ""
+        )
+        if candidate_id:
+            candidate_operation_counts[candidate_id] = candidate_operation_counts.get(candidate_id, 0) + 1
+        source_task_id = str(_first(outputs.get("specialist_task_id"), inputs.get("specialist_task_id")) or "")
+        if source_task_id:
+            source_operation_counts[source_task_id] = source_operation_counts.get(source_task_id, 0) + 1
     progress_by_integrate = {
         str(row.get("integrate_task_id") or ""): row for row in progress_rows if row.get("integrate_task_id")
     }
@@ -1513,26 +1537,25 @@ def _source_attempts(
     }
     used_progress: set[int] = set()
     attempts: list[dict[str, Any]] = []
-    for operation in operations:
-        if _operation_name(operation) not in {"framework_agent", "integrate", "integrate_patch"}:
-            continue
+    for operation in source_operations:
         outputs = _mapping(operation.get("outputs"))
+        inputs = _mapping(operation.get("inputs"))
         candidate_id = str(
             _first(
-                _candidate_id(outputs.get("candidate")),
+                _candidate_id(_first(outputs.get("candidate"), inputs.get("candidate"))),
                 outputs.get("framework_agent_candidate_id"),
+                inputs.get("framework_agent_candidate_id"),
                 _nested(operation, "metadata", "extras", "candidate_id"),
             )
             or ""
         )
         task_id = _operation_task_id(operation)
-        source_task_id = str(outputs.get("specialist_task_id") or "")
-        progress = (
-            progress_by_integrate.get(task_id)
-            or progress_by_candidate.get(candidate_id)
-            or progress_by_source.get(source_task_id)
-            or {}
-        )
+        source_task_id = str(_first(outputs.get("specialist_task_id"), inputs.get("specialist_task_id")) or "")
+        progress = progress_by_integrate.get(task_id) or {}
+        if not progress and source_operation_counts.get(source_task_id) == 1:
+            progress = progress_by_source.get(source_task_id) or {}
+        if not progress and candidate_operation_counts.get(candidate_id) == 1:
+            progress = progress_by_candidate.get(candidate_id) or {}
         if progress:
             used_progress.add(id(progress))
         attempts.append(_source_attempt(operation, progress, candidates))
@@ -1981,14 +2004,23 @@ def _framework_event(
         window_count,
         evidence,
     )
+    critic_reviews = _critic_review_rows(
+        session_dir,
+        warnings,
+        state,
+        recorded_operations,
+        window,
+        window_count,
+    )
     exit_details = _framework_exit(window, config_arm, source_arm)
     failure = _framework_failure(window)
     has_work = bool(
         config_arm["specialist_runs"]
         or config_arm["rounds"]
-        or any(run["candidates"] for run in source_arm["candidate_discovery_runs"])
+        or source_arm["candidate_discovery_runs"]
         or source_arm["authoring_runs"]
         or source_arm["attempts"]
+        or critic_reviews
     )
     if any(value is not None for value in failure.values()):
         status = "failed"
@@ -2007,14 +2039,7 @@ def _framework_event(
         "ext": {
             "macro_cycle": int(window["cycle"]),
             "policy": policy,
-            "critic_reviews": _critic_review_rows(
-                session_dir,
-                warnings,
-                state,
-                recorded_operations,
-                window,
-                window_count,
-            ),
+            "critic_reviews": critic_reviews,
             "config_arm": config_arm,
             "source_arm": source_arm,
             "exit": exit_details,

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/v6.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/v6.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import re
+from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+from hyperloom.common.jsonio import read_json, read_jsonl
 
 from ...session.sbd_v6 import SCHEMA_VERSION_V6, read_timeline_events
 
@@ -26,6 +30,22 @@ _MODEL_GATE_STOP_REASONS = frozenset(
         "unsupported_model_arch",
     }
 )
+_FRAMEWORK_PHASES = frozenset({"FRAMEWORK_AGENT", "EXPLORE"})
+_FRAMEWORK_EXIT_REASON_MAP = {
+    "explore_no_more_leverage": "optimize_no_more_leverage",
+    "plateau_explore": "optimize_no_more_leverage",
+    "explore_phase_budget_exhausted": "optimize_phase_budget_exhausted",
+    "explore_budget_cap": "optimize_budget_cap",
+    "explore_force_exit_low_budget": "optimize_force_exit_low_budget",
+}
+_AUTHORING_TASK_KINDS = frozenset(
+    {
+        "explore_apply_retry",
+        "framework_authoring",
+        "framework_local_explore",
+    }
+)
+_MACRO_CYCLE_RE = re.compile(r"(?:^|\s)macro_cycle\s*=\s*(-?\d+)(?=\s|$)")
 
 
 def _tool_versions(versions: Any) -> dict[str, str | None]:
@@ -140,6 +160,1869 @@ def collect_v6_metadata(
     }
 
 
+def _mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _dict_rows(value: Any) -> list[dict[str, Any]]:
+    return [row for row in value if isinstance(row, dict)] if isinstance(value, list) else []
+
+
+def _dict_value_rows(value: Any) -> list[dict[str, Any]]:
+    return [row for row in value.values() if isinstance(row, dict)] if isinstance(value, dict) else []
+
+
+def _first(*values: Any) -> Any:
+    for value in values:
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None or value == "" or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None or value == "" or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on", "passed", "succeeded"}:
+            return True
+        if normalized in {"0", "false", "no", "off", "failed"}:
+            return False
+    return None
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    return [str(item) for item in value if item not in (None, "")]
+
+
+def _nested(mapping: dict[str, Any], *path: str) -> Any:
+    value: Any = mapping
+    for key in path:
+        if not isinstance(value, dict):
+            return None
+        value = value.get(key)
+    return value
+
+
+def _row_cycle(row: dict[str, Any]) -> int | None:
+    for value in (
+        row.get("macro_cycle"),
+        row.get("cycle"),
+        _nested(row, "outputs", "macro_cycle"),
+        _nested(row, "outputs", "cycle"),
+        _nested(row, "inputs", "macro_cycle"),
+        _nested(row, "inputs", "cycle"),
+        _nested(row, "metadata", "extras", "macro_cycle"),
+        _nested(row, "metadata", "extras", "cycle"),
+    ):
+        parsed = _optional_int(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _row_timestamp(row: dict[str, Any]) -> str:
+    return str(
+        _first(
+            row.get("ts"),
+            row.get("ended_at"),
+            row.get("completed_at"),
+            row.get("started_at"),
+        )
+        or ""
+    )
+
+
+def _prompt_macro_cycle(value: Any) -> int | None:
+    match = _MACRO_CYCLE_RE.search(str(value or ""))
+    return _optional_int(match.group(1)) if match else None
+
+
+def _timestamp_number(value: Any) -> float | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+    except (TypeError, ValueError):
+        return None
+
+
+def _operation_name(operation: dict[str, Any]) -> str:
+    return str(operation.get("name") or operation.get("kind") or "").strip().lower()
+
+
+def _declared_source_phase(row: dict[str, Any]) -> str:
+    return (
+        str(
+            _first(
+                row.get("source_phase"),
+                _nested(row, "outputs", "source_phase"),
+                _nested(row, "inputs", "source_phase"),
+                _nested(row, "metadata", "extras", "source_phase"),
+            )
+            or ""
+        )
+        .strip()
+        .upper()
+    )
+
+
+def _source_phase(row: dict[str, Any]) -> str:
+    return _declared_source_phase(row) or str(row.get("phase") or "").strip().upper()
+
+
+def _specialist_payloads(row: dict[str, Any]) -> tuple[dict[str, Any], ...]:
+    return (
+        row,
+        _mapping(row.get("inputs")),
+        _mapping(row.get("outputs")),
+        _mapping(row.get("extensions")),
+    )
+
+
+def _is_framework_specialist(row: dict[str, Any], *, allow_legacy: bool) -> bool:
+    declared_phase = _declared_source_phase(row)
+    phase = declared_phase or str(row.get("phase") or "").strip().upper()
+    if not declared_phase and str(row.get("source") or "").strip().lower() == "specialist_recorder_hook":
+        phase = ""
+    if phase:
+        return phase in _FRAMEWORK_PHASES
+
+    agent = str(row.get("agent") or "").strip().lower()
+    if agent in {"framework_agent", "explore"}:
+        return True
+    if agent in {"enablement", "kernel", "kernel_agent", "prelude", "internal"}:
+        return False
+
+    payloads = _specialist_payloads(row)
+    if any(_optional_bool(payload.get("enablement")) is True for payload in payloads):
+        return False
+    if any(
+        _optional_bool(payload.get("framework_agent_authoring")) is True
+        or bool(payload.get("framework_agent_candidate_id"))
+        or bool(payload.get("framework_batch_id"))
+        or str(payload.get("task_kind") or "").strip().lower() in _AUTHORING_TASK_KINDS
+        for payload in payloads
+    ):
+        return True
+    return allow_legacy
+
+
+def _operation_task_id(operation: dict[str, Any]) -> str:
+    return str(
+        _first(
+            _nested(operation, "extensions", "task_id"),
+            _nested(operation, "outputs", "task_id"),
+            _nested(operation, "metadata", "extras", "task_id"),
+        )
+        or ""
+    )
+
+
+def _candidate_id(value: Any) -> str:
+    candidate = _mapping(value)
+    return str(
+        _first(
+            candidate.get("candidate_id"),
+            candidate.get("pr_url"),
+            candidate.get("url"),
+            candidate.get("ref"),
+            candidate.get("head_sha"),
+        )
+        or ""
+    )
+
+
+def _is_framework_operation(operation: dict[str, Any]) -> bool:
+    name = _operation_name(operation)
+    phase = _source_phase(operation)
+    agent = str(operation.get("agent") or "").strip().lower()
+    outputs = _mapping(operation.get("outputs"))
+    if name == "framework_agent":
+        return True
+    if name == "explore":
+        if phase:
+            return phase in _FRAMEWORK_PHASES
+        return agent in {"framework_agent", "explore"}
+    if name in {"integrate", "integrate_patch"}:
+        if outputs.get("enablement") or outputs.get("enablement_landing"):
+            return False
+        if phase:
+            return phase in _FRAMEWORK_PHASES
+        return bool(
+            agent in {"framework_agent", "explore"}
+            or outputs.get("framework_agent_authoring")
+            or outputs.get("framework_agent_candidate_id")
+        )
+    return name.startswith("specialist") and _is_framework_specialist(operation, allow_legacy=True)
+
+
+def _new_framework_window(cycle: int, start_time: str = "") -> dict[str, Any]:
+    return {
+        "cycle": cycle,
+        "start_time": start_time,
+        "end_time": "",
+        "rows": [],
+        "exit_row": {},
+    }
+
+
+def _framework_windows(
+    state: dict[str, Any],
+    recorded_operations: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    windows: list[dict[str, Any]] = []
+    active: dict[str, Any] | None = None
+    history = _dict_rows(state.get("phase_history"))
+    for row in history:
+        from_phase = str(row.get("from_phase") or "").strip().upper()
+        to_phase = str(row.get("to_phase") or "").strip().upper()
+        if not from_phase and not to_phase:
+            continue
+        cycle = _row_cycle(row)
+        if cycle is None:
+            cycle = int(state.get("macro_cycle") or 0)
+        from_framework = from_phase in _FRAMEWORK_PHASES
+        to_framework = to_phase in _FRAMEWORK_PHASES
+        if to_framework and not from_framework:
+            active = _new_framework_window(cycle, str(row.get("ts") or ""))
+            active["rows"].append(row)
+            windows.append(active)
+            continue
+        if from_framework and to_framework:
+            if active is None or int(active["cycle"]) != cycle:
+                active = _new_framework_window(cycle)
+                windows.append(active)
+            active["rows"].append(row)
+            continue
+        if from_framework and not to_framework:
+            if active is None or int(active["cycle"]) != cycle:
+                active = next(
+                    (
+                        window
+                        for window in reversed(windows)
+                        if int(window["cycle"]) == cycle and not window["end_time"]
+                    ),
+                    None,
+                )
+            if active is None:
+                active = _new_framework_window(cycle)
+                windows.append(active)
+            active["rows"].append(row)
+            active["end_time"] = str(row.get("ts") or "")
+            active["exit_row"] = row
+            active = None
+            continue
+    current_phase = str(state.get("phase") or "").strip().upper()
+    current_cycle = int(state.get("macro_cycle") or 0)
+    if current_phase in _FRAMEWORK_PHASES and not any(
+        int(window["cycle"]) == current_cycle and not window["end_time"] for window in windows
+    ):
+        windows.append(_new_framework_window(current_cycle, str(state.get("phase_started_ts") or "")))
+
+    evidence_rows: list[dict[str, Any]] = []
+    for operation in recorded_operations:
+        if not _is_framework_operation(operation):
+            continue
+        if _operation_name(operation).startswith("specialist") and not _is_framework_specialist(
+            operation,
+            allow_legacy=False,
+        ):
+            continue
+        evidence_rows.append(operation)
+    evidence_rows.extend(_dict_rows(state.get("framework_agent_batches")))
+    evidence_rows.extend(_dict_rows(state.get("framework_agent_phase_progress")))
+    evidence_rows.extend(
+        row for row in _dict_rows(state.get("specialist_rounds")) if _is_framework_specialist(row, allow_legacy=False)
+    )
+    evidence_rows.extend(_dict_rows(state.get("framework_config_exploration_results")))
+    explore_search = _mapping(state.get("explore_search"))
+    tested = explore_search.get("tested")
+    if isinstance(tested, dict):
+        evidence_rows.extend(row for row in tested.values() if isinstance(row, dict))
+    evidence_rows.extend(_dict_rows(explore_search.get("winners_history")))
+    known_cycles = {int(window["cycle"]) for window in windows}
+    for row in evidence_rows:
+        cycle = _row_cycle(row)
+        if cycle is None or cycle in known_cycles:
+            continue
+        windows.append(_new_framework_window(cycle))
+        known_cycles.add(cycle)
+
+    windows.sort(
+        key=lambda window: (
+            int(window["cycle"]),
+            _timestamp_number(window.get("start_time")) or float("inf"),
+        )
+    )
+    return windows
+
+
+def _row_in_window(row: dict[str, Any], window: dict[str, Any], window_count: int) -> bool:
+    cycle = _row_cycle(row)
+    if cycle is not None and cycle != int(window["cycle"]):
+        return False
+    row_ts = _timestamp_number(_row_timestamp(row))
+    start_ts = _timestamp_number(window.get("start_time"))
+    end_ts = _timestamp_number(window.get("end_time"))
+    if row_ts is not None and (start_ts is not None or end_ts is not None):
+        return (start_ts is None or row_ts >= start_ts) and (end_ts is None or row_ts <= end_ts)
+    return cycle is not None or window_count == 1
+
+
+def _window_operations(
+    recorded_operations: list[dict[str, Any]],
+    window: dict[str, Any],
+    window_count: int,
+) -> list[dict[str, Any]]:
+    return [
+        operation
+        for operation in recorded_operations
+        if _is_framework_operation(operation) and _row_in_window(operation, window, window_count)
+    ]
+
+
+def _window_state_rows(
+    state: dict[str, Any],
+    field: str,
+    window: dict[str, Any],
+    window_count: int,
+) -> list[dict[str, Any]]:
+    return [row for row in _dict_rows(state.get(field)) if _row_in_window(row, window, window_count)]
+
+
+def _window_evidence(window: dict[str, Any]) -> dict[str, Any]:
+    evidence: dict[str, Any] = {}
+    for row in _dict_rows(window.get("rows")):
+        evidence.update(_mapping(row.get("evidence")))
+    return evidence
+
+
+def _operation_value(operations: list[dict[str, Any]], *paths: tuple[str, ...]) -> Any:
+    for operation in reversed(operations):
+        for path in paths:
+            value = _nested(operation, *path)
+            if value is not None and value != "":
+                return value
+    return None
+
+
+def _framework_policy(
+    state: dict[str, Any],
+    operations: list[dict[str, Any]],
+    evidence: dict[str, Any],
+) -> dict[str, Any]:
+    overrides = _mapping(state.get("plateau_overrides"))
+    stack_rebench_enabled = _optional_bool(
+        _operation_value(
+            operations,
+            ("outputs", "stack_rebench_enabled"),
+            ("outputs", "enable_stack_rebench"),
+            ("inputs", "stack_rebench_enabled"),
+            ("inputs", "enable_stack_rebench"),
+        )
+    )
+    return {
+        "keep_threshold_pct": _optional_float(
+            _first(
+                _operation_value(
+                    operations,
+                    ("outputs", "keep_threshold_pct"),
+                    ("inputs", "keep_threshold_pct"),
+                    ("decisions", "evidence", "keep_threshold_pct"),
+                ),
+                evidence.get("keep_threshold_pct"),
+            )
+        ),
+        "stack_stable_threshold_pct": _optional_float(
+            _operation_value(
+                operations,
+                ("outputs", "stack_stable_threshold_pct"),
+                ("inputs", "stack_stable_threshold_pct"),
+            )
+        ),
+        "stack_rebench_enabled": stack_rebench_enabled,
+        "variant_timeout_sec": _optional_int(
+            _first(
+                _operation_value(
+                    operations,
+                    ("outputs", "variant_timeout_sec"),
+                    ("inputs", "variant_timeout_sec"),
+                ),
+                state.get("explore_variant_timeout_sec_override"),
+            )
+        ),
+        "overtime_kill_ratio": _optional_float(
+            _first(
+                _operation_value(
+                    operations,
+                    ("outputs", "explore_overtime_kill_ratio"),
+                    ("outputs", "overtime_kill_ratio"),
+                    ("inputs", "explore_overtime_kill_ratio"),
+                ),
+                state.get("explore_overtime_kill_ratio"),
+            )
+        ),
+        "force_exit_budget_pct": _optional_float(
+            _first(evidence.get("force_exit_budget_pct"), overrides.get("force_exit_budget_pct"))
+        ),
+        "config_arm": {
+            "keep_gain_threshold_pct": _optional_float(
+                _first(evidence.get("keep_gain_threshold_pct"), overrides.get("explore_keep_gain_pct"))
+            ),
+            "empty_streak_threshold": _optional_int(
+                _first(evidence.get("empty_streak_threshold"), overrides.get("explore_empty_streak"))
+            ),
+            "lookback": _optional_int(_first(evidence.get("lookback"), overrides.get("explore_lookback"))),
+        },
+        "source_arm": {
+            "no_keep_streak_threshold": _optional_int(
+                _first(evidence.get("source_threshold"), evidence.get("no_keep_streak_threshold"))
+            ),
+            "discovery_retry_limit": _optional_int(
+                _first(evidence.get("retry_limit"), evidence.get("discovery_retry_limit"))
+            ),
+            "authoring_enabled": _optional_bool(state.get("framework_agent_authoring_enabled")),
+        },
+    }
+
+
+def _specialist_rows(
+    state: dict[str, Any],
+    operations: list[dict[str, Any]],
+    window: dict[str, Any],
+    window_count: int,
+) -> list[dict[str, Any]]:
+    ordered: list[str] = []
+    by_key: dict[str, dict[str, Any]] = {}
+
+    def _upsert(row: dict[str, Any]) -> None:
+        key = str(_first(row.get("task_id"), row.get("round_id")) or "")
+        if not key:
+            key = f"row:{len(ordered)}"
+        if key not in by_key:
+            ordered.append(key)
+            by_key[key] = dict(row)
+            return
+        merged = dict(row)
+        merged.update(by_key[key])
+        by_key[key] = merged
+
+    for row in _window_state_rows(state, "specialist_rounds", window, window_count):
+        if not _is_framework_specialist(row, allow_legacy=True):
+            continue
+        _upsert(row)
+    for operation in operations:
+        if not _operation_name(operation).startswith("specialist"):
+            continue
+        row = dict(_mapping(operation.get("inputs")))
+        row.update(_mapping(operation.get("outputs")))
+        row.setdefault("task_id", _operation_task_id(operation))
+        row.setdefault("cycle", _row_cycle(operation))
+        row.setdefault("status", operation.get("status"))
+        row.setdefault("completed_at", operation.get("ended_at"))
+        row.setdefault("source_phase", operation.get("phase"))
+        _upsert(row)
+    return [by_key[key] for key in ordered]
+
+
+def _specialist_role(
+    row: dict[str, Any],
+    candidate_map: dict[str, str],
+    source_task_ids: set[str],
+) -> str:
+    task_id = str(row.get("task_id") or "")
+    domain = str(row.get("domain") or "").strip().lower()
+    task_kind = str(row.get("task_kind") or "").strip().lower()
+    if (
+        row.get("candidate_discovery")
+        or task_kind == "candidate_discovery"
+        or domain == "candidate_discovery_specialist"
+    ):
+        return "discovery"
+    authoring_marker = _optional_bool(row.get("framework_agent_authoring")) is True
+    candidate_id = str(_first(row.get("framework_agent_candidate_id"), row.get("candidate_id")) or "")
+    if (
+        task_id in candidate_map
+        or task_id in source_task_ids
+        or authoring_marker
+        or candidate_id
+        or task_kind in _AUTHORING_TASK_KINDS
+        or bool(_patch_refs(row))
+    ):
+        return "authoring"
+    return "config"
+
+
+def _specialist_status(row: dict[str, Any]) -> str:
+    raw = str(row.get("status") or "").strip().lower()
+    if raw in {"failed", "error", "timed_out", "timeout"} or row.get("error"):
+        return "failed"
+    proposals = row.get("proposal_set")
+    if bool(row.get("empty")) or isinstance(proposals, list) and not proposals:
+        return "empty"
+    if raw in {"empty", "skipped"}:
+        return "empty"
+    return "succeeded"
+
+
+def _proposal_names(row: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    for proposal in _dict_rows(row.get("proposal_set")):
+        name = str(_first(proposal.get("name"), proposal.get("variant_name"), proposal.get("proposal_id")) or "")
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
+def _config_specialist_run(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "round_id": str(_first(row.get("round_id"), row.get("task_id")) or ""),
+        "task_id": str(row.get("task_id") or ""),
+        "status": _specialist_status(row),
+        "domain": str(row.get("domain") or ""),
+        "scope": _first(row.get("scope"), None),
+        "tags": _string_list(row.get("tags")),
+        "gap_canonical_id": _first(row.get("gap_canonical_id"), None),
+        "proposal_msg_id": _first(row.get("proposal_msg_id"), None),
+        "proposal_names": _proposal_names(row),
+        "reason": _first(row.get("reason"), row.get("error"), None),
+    }
+
+
+def _config_source_index(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        info = {
+            "specialist_round_id": _first(row.get("round_id"), row.get("task_id"), None),
+            "proposal_msg_id": _first(row.get("proposal_msg_id"), None),
+        }
+        for proposal in _dict_rows(row.get("proposal_set")):
+            for key in (
+                proposal.get("fingerprint"),
+                proposal.get("name"),
+                proposal.get("variant_name"),
+                proposal.get("proposal_id"),
+            ):
+                text = str(key or "").strip()
+                if text:
+                    index.setdefault(text, info)
+    return index
+
+
+def _config_variant(raw: dict[str, Any], source_index: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    metrics = _mapping(raw.get("metrics"))
+    variant = _mapping(raw.get("variant"))
+    combined = dict(metrics)
+    combined.update(variant)
+    combined.update(raw)
+    name = str(_first(combined.get("name"), combined.get("variant_name")) or "")
+    fingerprint = str(combined.get("fingerprint") or "")
+    source = source_index.get(fingerprint) or source_index.get(name) or {}
+    outcome = str(combined.get("outcome") or "").strip().upper()
+    stack_tput = _optional_float(combined.get("stack_rebench_tput"))
+    stack_ran = _optional_bool(combined.get("stack_rebench_ran"))
+    if stack_ran is None and (stack_tput is not None or combined.get("stack_rebench_workspace")):
+        stack_ran = True
+    stack_stable = _optional_bool(combined.get("stack_rebench_stable"))
+    if stack_stable is None and stack_ran:
+        if outcome == "KEEP_UNSTABLE":
+            stack_stable = False
+        elif outcome == "KEEP":
+            stack_stable = True
+    return {
+        "name": name,
+        "fingerprint": fingerprint,
+        "source": {
+            "provenance": str(combined.get("provenance") or ""),
+            "scope": _first(combined.get("scope"), None),
+            "specialist_round_id": _first(combined.get("specialist_round_id"), source.get("specialist_round_id")),
+            "proposal_msg_id": _first(combined.get("proposal_msg_id"), source.get("proposal_msg_id")),
+            "critic_iteration": _optional_int(combined.get("critic_iteration")),
+        },
+        "config_delta": {
+            "extra_server_args": str(combined.get("extra_server_args") or ""),
+            "extra_envs": dict(_mapping(combined.get("extra_envs"))),
+            "remove_args": _string_list(combined.get("remove_args")),
+            "unset_envs": _string_list(combined.get("unset_envs")),
+            "args_mode": _first(combined.get("args_mode"), None),
+        },
+        "accepted_kernels": _string_list(combined.get("accepted_kernels")),
+        "measurement": {
+            "base_tput": _optional_float(combined.get("base_tput")),
+            "decision_tput": _optional_float(_first(combined.get("decision_tput"), combined.get("tput"))),
+            "gain_pct": _optional_float(combined.get("gain_pct")),
+            "runtime_sec": _optional_float(combined.get("runtime_sec")),
+            "estimated_output_throughput": _optional_float(combined.get("estimated_output_throughput")),
+        },
+        "accuracy": {
+            "required": _optional_bool(_first(combined.get("accuracy_required"), combined.get("require_accuracy"))),
+            "reference": _optional_float(_first(combined.get("accuracy_reference"), combined.get("accuracy_baseline"))),
+            "value": _optional_float(combined.get("accuracy")),
+            "passed": _optional_bool(_first(combined.get("accuracy_pass"), combined.get("accuracy_passed"))),
+        },
+        "stack_rebench": {
+            "ran": stack_ran,
+            "tput": stack_tput,
+            "stable": stack_stable,
+        },
+        "outcome": outcome,
+        "reason": _first(combined.get("reason"), None),
+        "stage": _first(combined.get("stage"), None),
+        "failure": {
+            "error_class": _first(combined.get("error_class"), None),
+            "error_excerpt": _first(combined.get("error_excerpt"), combined.get("error"), None),
+        },
+        "artifacts": {
+            "workspace": _first(combined.get("workspace"), combined.get("single_workspace"), None),
+            "stack_rebench_workspace": _first(combined.get("stack_rebench_workspace"), None),
+            "server_log_path": _first(combined.get("server_log_path"), None),
+            "raw_result_path": _first(combined.get("raw_result_path"), None),
+        },
+    }
+
+
+def _round_variant_rows(outputs: dict[str, Any]) -> list[dict[str, Any]]:
+    tested = _nested(outputs, "explore_search_update", "tested")
+    tested_by_fingerprint = tested if isinstance(tested, dict) else {}
+    round_id = str(outputs.get("round_id") or "")
+    ordered: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for outcome in _dict_rows(outputs.get("per_variant_outcomes")):
+        fingerprint = str(outcome.get("fingerprint") or "")
+        merged = dict(_mapping(tested_by_fingerprint.get(fingerprint)))
+        merged.update(outcome)
+        key = fingerprint or str(outcome.get("variant_name") or len(ordered))
+        seen.add(key)
+        ordered.append(merged)
+    for fingerprint, tested_row in tested_by_fingerprint.items():
+        if not isinstance(tested_row, dict):
+            continue
+        if round_id and str(tested_row.get("round_id") or "") not in {"", round_id}:
+            continue
+        key = str(fingerprint or tested_row.get("name") or len(ordered))
+        if key in seen:
+            continue
+        merged = dict(tested_row)
+        merged.setdefault("fingerprint", str(fingerprint))
+        ordered.append(merged)
+    return ordered
+
+
+def _config_round_from_operation(
+    operation: dict[str, Any],
+    source_index: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    outputs = _mapping(operation.get("outputs"))
+    inputs = _mapping(operation.get("inputs"))
+    last_round = _mapping(_nested(outputs, "explore_search_update", "last_round"))
+    input_stack = _mapping(_first(outputs.get("input_stack"), inputs.get("input_stack")))
+    variants = [_config_variant(row, source_index) for row in _round_variant_rows(outputs)]
+    decision_mode = _first(outputs.get("decision_mode"), inputs.get("decision_mode"))
+    if decision_mode is None:
+        modes = {
+            str(_nested(row, "metrics", "overtime_anchor_kind") or row.get("overtime_anchor_kind") or "")
+            for row in _dict_rows(outputs.get("per_variant_outcomes"))
+        }
+        modes.discard("")
+        decision_mode = next(iter(modes)) if len(modes) == 1 else None
+    return {
+        "round_id": str(
+            _first(
+                outputs.get("round_id"),
+                _nested(operation, "metadata", "extras", "round_id"),
+                operation.get("operation_id"),
+            )
+            or ""
+        ),
+        "task_id": _operation_task_id(operation),
+        "status": "succeeded"
+        if str(_first(outputs.get("status"), operation.get("status")) or "").lower()
+        in {"succeeded", "success", "completed", "kept", "keep"}
+        else "failed",
+        "framework": str(
+            _first(outputs.get("framework"), _nested(outputs, "workload", "framework"), inputs.get("framework")) or ""
+        ),
+        "workload_signature": str(
+            _first(
+                outputs.get("workload_signature"),
+                next(
+                    (
+                        row.get("workload_signature")
+                        for row in _mapping(_nested(outputs, "explore_search_update", "tested")).values()
+                        if isinstance(row, dict) and row.get("workload_signature")
+                    ),
+                    None,
+                ),
+            )
+            or ""
+        ),
+        "throughput_unit": _first(outputs.get("throughput_unit"), inputs.get("throughput_unit"), None),
+        "decision_mode": decision_mode,
+        "input_stack": {
+            "throughput": _optional_float(
+                _first(input_stack.get("throughput"), outputs.get("base_tput"), last_round.get("base_tput"))
+            ),
+            "accuracy": _optional_float(
+                _first(input_stack.get("accuracy"), outputs.get("accuracy_baseline"), inputs.get("accuracy_baseline"))
+            ),
+            "extra_server_args": str(
+                _first(
+                    input_stack.get("extra_server_args"),
+                    outputs.get("base_extra_args"),
+                    last_round.get("base_extra_args"),
+                    "",
+                )
+                or ""
+            ),
+            "extra_envs": dict(_mapping(_first(input_stack.get("extra_envs"), outputs.get("base_extra_envs")))),
+            "remove_args": _string_list(_first(input_stack.get("remove_args"), outputs.get("base_remove_args"), [])),
+            "unset_envs": _string_list(_first(input_stack.get("unset_envs"), outputs.get("base_unset_envs"), [])),
+            "args_mode": _first(input_stack.get("args_mode"), outputs.get("base_args_mode"), None),
+        },
+        "variants": variants,
+    }
+
+
+def _fallback_config_rounds(
+    state: dict[str, Any],
+    window: dict[str, Any],
+    window_count: int,
+    source_index: dict[str, dict[str, Any]],
+    existing_ids: set[str],
+) -> list[dict[str, Any]]:
+    explore_search = _mapping(state.get("explore_search"))
+    tested = explore_search.get("tested")
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    if isinstance(tested, dict):
+        for fingerprint, row in tested.items():
+            if not isinstance(row, dict) or not _row_in_window(row, window, window_count):
+                continue
+            round_id = str(row.get("round_id") or "")
+            if not round_id or round_id in existing_ids:
+                continue
+            item = dict(row)
+            item.setdefault("fingerprint", str(fingerprint))
+            grouped.setdefault(round_id, []).append(item)
+    rounds: list[dict[str, Any]] = []
+    for round_id, rows in grouped.items():
+        measured_outcomes = {"KEEP", "REVERT", "KEEP_UNSTABLE", "KILLED_OVERTIME"}
+        rounds.append(
+            {
+                "round_id": round_id,
+                "task_id": "",
+                "status": (
+                    "succeeded"
+                    if any(str(row.get("outcome") or "").upper() in measured_outcomes for row in rows)
+                    else "failed"
+                ),
+                "framework": str(next((row.get("framework") for row in rows if row.get("framework")), "")),
+                "workload_signature": str(
+                    next((row.get("workload_signature") for row in rows if row.get("workload_signature")), "")
+                ),
+                "throughput_unit": None,
+                "decision_mode": None,
+                "input_stack": {
+                    "throughput": _optional_float(next((row.get("base_tput") for row in rows), None)),
+                    "accuracy": None,
+                    "extra_server_args": "",
+                    "extra_envs": {},
+                    "remove_args": [],
+                    "unset_envs": [],
+                    "args_mode": None,
+                },
+                "variants": [_config_variant(row, source_index) for row in rows],
+            }
+        )
+    return rounds
+
+
+def _config_arm(
+    state: dict[str, Any],
+    operations: list[dict[str, Any]],
+    specialist_rows: list[dict[str, Any]],
+    specialist_roles: dict[str, str],
+    window: dict[str, Any],
+    window_count: int,
+    evidence: dict[str, Any],
+    policy: dict[str, Any],
+) -> dict[str, Any]:
+    config_rows = [
+        row
+        for row in specialist_rows
+        if specialist_roles.get(str(_first(row.get("task_id"), row.get("round_id")) or "")) == "config"
+    ]
+    specialist_runs = [_config_specialist_run(row) for row in config_rows]
+    source_index = _config_source_index(config_rows)
+    rounds = [
+        _config_round_from_operation(operation, source_index)
+        for operation in operations
+        if _operation_name(operation) == "explore"
+    ]
+    existing_ids = {str(row.get("round_id") or "") for row in rounds}
+    rounds.extend(_fallback_config_rounds(state, window, window_count, source_index, existing_ids))
+    recorded_task_ids = {str(row.get("task_id") or "") for row in rounds}
+    for row in _window_state_rows(state, "framework_config_exploration_results", window, window_count):
+        task_id = str(row.get("task_id") or "")
+        round_id = str(_first(row.get("round_id"), task_id) or "")
+        if not round_id or task_id in recorded_task_ids or round_id in existing_ids:
+            continue
+        rounds.append(
+            {
+                "round_id": round_id,
+                "task_id": task_id,
+                "status": "succeeded" if str(row.get("status") or "succeeded").lower() != "failed" else "failed",
+                "framework": str(row.get("framework") or ""),
+                "workload_signature": str(row.get("workload_signature") or ""),
+                "throughput_unit": _first(row.get("throughput_unit"), None),
+                "decision_mode": _first(row.get("decision_mode"), None),
+                "input_stack": {
+                    "throughput": None,
+                    "accuracy": None,
+                    "extra_server_args": "",
+                    "extra_envs": {},
+                    "remove_args": [],
+                    "unset_envs": [],
+                    "args_mode": None,
+                },
+                "variants": [],
+            }
+        )
+    policy_config = _mapping(policy.get("config_arm"))
+    explore_search = _mapping(state.get("explore_search"))
+    tested_rows = [
+        row for row in _dict_value_rows(explore_search.get("tested")) if _row_in_window(row, window, window_count)
+    ]
+    winner_rows = [
+        row for row in _dict_rows(explore_search.get("winners_history")) if _row_in_window(row, window, window_count)
+    ]
+    recent_keep_gain = _optional_float(evidence.get("recent_keep_gain_pct"))
+    lookback = _optional_int(policy_config.get("lookback"))
+    if recent_keep_gain is None and lookback is not None and lookback > 0:
+        recent_keep_gain = round(
+            sum(_optional_float(row.get("gain_pct")) or 0.0 for row in winner_rows[-lookback:]),
+            4,
+        )
+    empty_streak = _optional_int(evidence.get("empty_streak"))
+    if empty_streak is None:
+        empty_streak = 0
+        for row in reversed(specialist_runs):
+            if row["status"] != "empty":
+                break
+            empty_streak += 1
+    tested_this_cycle = _optional_int(evidence.get("tested_this_cycle"))
+    if tested_this_cycle is None:
+        tested_this_cycle = len(tested_rows)
+    triggered_value = _optional_bool(evidence.get("config_arm_plateaued"))
+    if triggered_value is None:
+        keep_gain_threshold = _optional_float(policy_config.get("keep_gain_threshold_pct"))
+        empty_streak_threshold = _optional_int(policy_config.get("empty_streak_threshold"))
+        if recent_keep_gain is not None and keep_gain_threshold is not None and empty_streak_threshold is not None:
+            exhausted = empty_streak >= empty_streak_threshold or (
+                not specialist_runs and tested_this_cycle >= empty_streak_threshold
+            )
+            triggered_value = recent_keep_gain < keep_gain_threshold and exhausted
+    return {
+        "plateau": {
+            "triggered": triggered_value,
+            "recent_keep_gain_pct": recent_keep_gain,
+            "empty_streak": empty_streak,
+            "tested_this_cycle": tested_this_cycle,
+        },
+        "specialist_runs": specialist_runs,
+        "rounds": rounds,
+    }
+
+
+def _candidate_row(candidate: dict[str, Any]) -> dict[str, Any]:
+    audit = _mapping(candidate.get("audit"))
+    raw_verdict = str(_first(candidate.get("verdict"), audit.get("verdict"), candidate.get("applicability")) or "")
+    verdict = raw_verdict.strip().lower()
+    if verdict not in {"worth_a_bench", "already_present", "not_applicable"}:
+        verdict = ""
+    route = str(_first(candidate.get("route"), audit.get("recommended_next_step")) or "").strip()
+    if route in {"direct_apply", "direct"}:
+        route = "direct_framework"
+    if route not in {"direct_framework", "author_via_specialist"}:
+        route = ""
+    return {
+        "candidate_id": _candidate_id(candidate),
+        "source_ref": str(
+            _first(candidate.get("pr_url"), candidate.get("ref"), candidate.get("head_sha"), candidate.get("diff_url"))
+            or ""
+        ),
+        "repo": str(
+            _first(candidate.get("repo"), candidate.get("repo_url"), candidate.get("discovered_repo_url")) or ""
+        ),
+        "title": str(candidate.get("title") or ""),
+        "changed_files": _string_list(candidate.get("changed_files")),
+        "verdict": verdict,
+        "route": route,
+        "gap_canonical_id": _first(candidate.get("gap_canonical_id"), None),
+        "reason": _first(candidate.get("reason"), audit.get("reason"), candidate.get("rationale"), None),
+    }
+
+
+def _candidate_index(state: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+    for batch in _dict_rows(state.get("framework_agent_batches")):
+        for candidate in _dict_rows(batch.get("candidates")):
+            candidate_id = _candidate_id(candidate)
+            if candidate_id:
+                index[candidate_id] = candidate
+    return index
+
+
+def _candidate_discovery_runs(
+    state: dict[str, Any],
+    specialist_rows: list[dict[str, Any]],
+    specialist_roles: dict[str, str],
+    window: dict[str, Any],
+    window_count: int,
+) -> list[dict[str, Any]]:
+    discovery_rows = [
+        row
+        for row in specialist_rows
+        if specialist_roles.get(str(_first(row.get("task_id"), row.get("round_id")) or "")) == "discovery"
+    ]
+    used_tasks: set[str] = set()
+    timestamped_runs: list[tuple[str, dict[str, Any]]] = []
+
+    def _append_run(run: dict[str, Any], source: dict[str, Any]) -> None:
+        timestamped_runs.append((_row_timestamp(source), run))
+
+    for batch in _dict_rows(state.get("framework_agent_batches")):
+        batch_candidates = _dict_rows(batch.get("candidates"))
+        batch_ids = {_candidate_id(candidate) for candidate in batch_candidates if _candidate_id(candidate)}
+        task_id = str(batch.get("task_id") or "")
+        matched: dict[str, Any] | None = None
+        for row in discovery_rows:
+            row_task_id = str(row.get("task_id") or "")
+            proposal_ids = {_candidate_id(proposal) for proposal in _dict_rows(row.get("proposal_set"))}
+            if task_id and row_task_id == task_id:
+                matched = row
+                break
+            if row_task_id and str(batch.get("batch_id") or "").endswith(row_task_id[:8]):
+                matched = row
+                break
+            if batch_ids and proposal_ids.intersection(batch_ids):
+                matched = row
+                break
+        if matched is not None:
+            task_id = task_id or str(matched.get("task_id") or "")
+            used_tasks.add(str(matched.get("task_id") or ""))
+        elif not _row_in_window(batch, window, window_count):
+            continue
+        discovered_candidates = _dict_rows((matched or {}).get("proposal_set")) or batch_candidates
+        _append_run(
+            {
+                "task_id": task_id,
+                "status": _specialist_status(matched or batch)
+                if matched is not None
+                else ("succeeded" if batch_candidates else "empty"),
+                "batch_id": _first(batch.get("batch_id"), None),
+                "gap_canonical_id": _first(
+                    batch.get("gap_canonical_id"),
+                    (matched or {}).get("gap_canonical_id"),
+                    None,
+                ),
+                "reason": _first(batch.get("reason"), (matched or {}).get("reason"), None),
+                "candidates": [_candidate_row(candidate) for candidate in discovered_candidates],
+            },
+            matched or batch,
+        )
+    for row in discovery_rows:
+        task_id = str(row.get("task_id") or "")
+        if task_id in used_tasks:
+            continue
+        _append_run(
+            {
+                "task_id": task_id,
+                "status": _specialist_status(row),
+                "batch_id": _first(row.get("batch_id"), None),
+                "gap_canonical_id": _first(row.get("gap_canonical_id"), None),
+                "reason": _first(row.get("reason"), row.get("error"), None),
+                "candidates": [_candidate_row(candidate) for candidate in _dict_rows(row.get("proposal_set"))],
+            },
+            row,
+        )
+
+    failed_markers = 0
+    terminal_retry_rows: list[dict[str, Any]] = []
+    for row in _dict_rows(window.get("rows")):
+        evidence = _mapping(row.get("evidence"))
+        event = str(evidence.get("event") or "").strip()
+        reason = str(row.get("reason") or "").strip()
+        if event == "framework_agent_discover_failed":
+            failed_markers += 1
+            _append_run(
+                {
+                    "task_id": str(_first(evidence.get("task_id"), evidence.get("failed_task_id")) or ""),
+                    "status": "failed",
+                    "batch_id": _first(evidence.get("batch_id"), None),
+                    "gap_canonical_id": _first(evidence.get("gap_canonical_id"), None),
+                    "reason": _first(evidence.get("error"), reason, None),
+                    "candidates": [],
+                },
+                row,
+            )
+        elif event == "framework_agent_phase_done" and reason == "discover_empty_payload":
+            _append_run(
+                {
+                    "task_id": str(evidence.get("task_id") or ""),
+                    "status": "empty",
+                    "batch_id": _first(evidence.get("batch_id"), None),
+                    "gap_canonical_id": _first(evidence.get("gap_canonical_id"), None),
+                    "reason": reason,
+                    "candidates": [],
+                },
+                row,
+            )
+        elif event == "framework_agent_phase_done" and reason == "discover_retries_exhausted":
+            terminal_retry_rows.append(row)
+
+    if failed_markers == 0:
+        for row in terminal_retry_rows:
+            evidence = _mapping(row.get("evidence"))
+            _append_run(
+                {
+                    "task_id": str(_first(evidence.get("task_id"), evidence.get("failed_task_id")) or ""),
+                    "status": "failed",
+                    "batch_id": _first(evidence.get("batch_id"), None),
+                    "gap_canonical_id": _first(evidence.get("gap_canonical_id"), None),
+                    "reason": str(row.get("reason") or "discover_retries_exhausted"),
+                    "candidates": [],
+                },
+                row,
+            )
+
+    if timestamped_runs and all(_timestamp_number(timestamp) is not None for timestamp, _ in timestamped_runs):
+        timestamped_runs.sort(key=lambda item: _timestamp_number(item[0]) or 0.0)
+    return [run for _, run in timestamped_runs]
+
+
+def _patch_refs(row: dict[str, Any]) -> list[str]:
+    refs: list[str] = []
+    for key in ("patch_refs", "patches_written", "patches", "artifacts_written"):
+        values = row.get(key)
+        if not isinstance(values, list):
+            continue
+        for value in values:
+            if isinstance(value, dict):
+                value = _first(value.get("path"), value.get("patch_path"), value.get("target"), value.get("rel_target"))
+            text = str(value or "").strip()
+            if text and text not in refs:
+                refs.append(text)
+    for proposal in _dict_rows(row.get("proposal_set")):
+        for value in _patch_refs(proposal):
+            if value not in refs:
+                refs.append(value)
+    return refs
+
+
+def _authoring_runs(
+    state: dict[str, Any],
+    specialist_rows: list[dict[str, Any]],
+    specialist_roles: dict[str, str],
+    progress_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    candidate_map = {
+        str(key): str(value)
+        for key, value in _mapping(state.get("framework_agent_specialist_candidate_map")).items()
+        if key and value
+    }
+    progress_by_task = {
+        str(row.get("specialist_task_id") or ""): row for row in progress_rows if row.get("specialist_task_id")
+    }
+    runs: list[dict[str, Any]] = []
+    used_tasks: set[str] = set()
+    for row in specialist_rows:
+        key = str(_first(row.get("task_id"), row.get("round_id")) or "")
+        if specialist_roles.get(key) != "authoring":
+            continue
+        task_id = str(row.get("task_id") or "")
+        progress = progress_by_task.get(task_id, {})
+        candidate_id = str(
+            _first(
+                row.get("candidate_id"),
+                row.get("framework_agent_candidate_id"),
+                candidate_map.get(task_id),
+                progress.get("candidate_id"),
+            )
+            or ""
+        )
+        reauthor_attempt = _optional_int(
+            _first(
+                row.get("reauthor_attempt"),
+                row.get("apply_retry_attempt"),
+                progress.get("reauthor_attempt"),
+            )
+        )
+        kind = (
+            "reauthor"
+            if reauthor_attempt is not None and reauthor_attempt > 0
+            else "local_authoring"
+            if candidate_id.startswith("local_explore:") or bool(row.get("framework_local_explore"))
+            else "candidate_authoring"
+            if candidate_id
+            else ""
+        )
+        runs.append(
+            {
+                "task_id": task_id,
+                "candidate_id": candidate_id,
+                "kind": kind,
+                "status": _specialist_status(row),
+                "reauthor_attempt": reauthor_attempt,
+                "specialist_domain": str(row.get("domain") or ""),
+                "gap_canonical_id": _first(row.get("gap_canonical_id"), None),
+                "patch_refs": _patch_refs(row),
+                "reason": _first(row.get("reason"), row.get("error"), progress.get("rationale"), None),
+            }
+        )
+        if task_id:
+            used_tasks.add(task_id)
+    for progress in progress_rows:
+        task_id = str(progress.get("specialist_task_id") or "")
+        if not task_id or task_id in used_tasks:
+            continue
+        candidate_id = str(progress.get("candidate_id") or candidate_map.get(task_id) or "")
+        runs.append(
+            {
+                "task_id": task_id,
+                "candidate_id": candidate_id,
+                "kind": "local_authoring" if candidate_id.startswith("local_explore:") else "candidate_authoring",
+                "status": "failed"
+                if str(progress.get("status") or "").lower() in {"dispatch_failed", "author_failed", "recovery_failed"}
+                else "empty"
+                if str(progress.get("provenance") or "").lower() == "authored_empty"
+                else "succeeded",
+                "reauthor_attempt": _optional_int(progress.get("reauthor_attempt")),
+                "specialist_domain": str(progress.get("domain") or ""),
+                "gap_canonical_id": _first(progress.get("gap_canonical_id"), None),
+                "patch_refs": _patch_refs(progress),
+                "reason": _first(progress.get("rationale"), progress.get("error"), None),
+            }
+        )
+    return runs
+
+
+def _source_attempt_status(value: Any, *, kept: Any = None) -> str:
+    status = str(value or "").strip().lower()
+    if status in {"keep", "kept", "promoted", "adopted"} or kept is True:
+        return "KEEP"
+    if status in {"kept_inert", "keep_inert"}:
+        return "KEEP_INERT"
+    if status in {"revert", "reverted", "rejected", "accuracy_unavailable_reject"}:
+        return "REVERT"
+    if status in {"critic_denied", "rejected_by_critic", "needs_review_no_evidence", "reauthor_cap"}:
+        return "CRITIC_DENIED"
+    if status in {"skipped", "already_present", "not_applicable", "author_empty", "no_patch", "no_patches"}:
+        return "SKIPPED"
+    if status in {
+        "failed",
+        "error",
+        "apply_failed",
+        "bench_reverted",
+        "enqueue_failed",
+        "dispatch_failed",
+        "materialize_failed",
+        "no_result_failed",
+        "apply_fail_cap",
+        "recovery_failed",
+        "repeated_review_abort",
+    }:
+        return "FAILED"
+    return ""
+
+
+def _source_attempt(
+    operation: dict[str, Any] | None,
+    progress: dict[str, Any],
+    candidate_index: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    operation = operation or {}
+    outputs = _mapping(operation.get("outputs"))
+    inputs = _mapping(operation.get("inputs"))
+    candidate = _mapping(_first(outputs.get("candidate"), inputs.get("candidate")))
+    candidate_id = str(
+        _first(
+            _candidate_id(candidate),
+            outputs.get("framework_agent_candidate_id"),
+            inputs.get("framework_agent_candidate_id"),
+            _nested(operation, "metadata", "extras", "candidate_id"),
+            progress.get("candidate_id"),
+        )
+        or ""
+    )
+    known_candidate = candidate_index.get(candidate_id, {})
+    if not candidate:
+        candidate = known_candidate
+    task_id = str(_first(_operation_task_id(operation), progress.get("integrate_task_id")) or "")
+    source_task_id = str(
+        _first(outputs.get("specialist_task_id"), inputs.get("specialist_task_id"), progress.get("specialist_task_id"))
+        or ""
+    )
+    reauthor_attempt = _optional_int(
+        _first(outputs.get("reauthor_attempt"), inputs.get("reauthor_attempt"), progress.get("reauthor_attempt"))
+    )
+    route = str(
+        _first(
+            outputs.get("route"),
+            inputs.get("route"),
+            candidate.get("route"),
+            known_candidate.get("route"),
+        )
+        or ""
+    ).strip()
+    if route in {"direct", "direct_apply"}:
+        route = "direct_framework"
+    patch_source = str(_first(outputs.get("patch_source"), inputs.get("patch_source")) or "").strip().lower()
+    if patch_source not in {"specialist_authored", "upstream_pr"}:
+        patch_source = ""
+    provenance = str(_first(outputs.get("provenance"), inputs.get("provenance")) or "").strip().lower()
+    if not patch_source and provenance == "upstream_pr":
+        patch_source = "upstream_pr"
+    authoring_marker = _optional_bool(
+        _first(outputs.get("framework_agent_authoring"), inputs.get("framework_agent_authoring"))
+    )
+    if not patch_source and (route == "direct_framework" or source_task_id and task_id and source_task_id == task_id):
+        patch_source = "upstream_pr"
+    if not patch_source and (
+        route in {"author_via_specialist", "local_authoring", "reauthor"}
+        or source_task_id
+        and source_task_id != task_id
+    ):
+        patch_source = "specialist_authored"
+    if not patch_source and _operation_name(operation) == "framework_agent":
+        patch_source = "upstream_pr"
+    if not patch_source and authoring_marker is True and not source_task_id:
+        patch_source = "specialist_authored"
+    lever_kind = str(_first(outputs.get("lever_kind"), inputs.get("lever_kind")) or "").strip().lower()
+    if not lever_kind:
+        lever_kind = "upstream_pr" if patch_source == "upstream_pr" else "source_patch" if patch_source else ""
+    if lever_kind not in {"config", "source_patch", "upstream_pr", "enablement"}:
+        lever_kind = ""
+    if not route:
+        if reauthor_attempt and reauthor_attempt > 0:
+            route = "reauthor"
+        elif candidate_id.startswith("local_explore:"):
+            route = "local_authoring"
+        elif patch_source == "upstream_pr":
+            route = "direct_framework"
+        elif patch_source == "specialist_authored":
+            route = "author_via_specialist"
+    parity = _mapping(outputs.get("switch_off_parity"))
+    stack_rebench = _mapping(outputs.get("stack_rebench"))
+    files = _string_list(_first(outputs.get("target_files"), candidate.get("changed_files"), []))
+    applied_artifacts = _dict_rows(outputs.get("artifacts_applied"))
+    if not files:
+        files = [
+            str(_first(row.get("rel_target"), row.get("target")) or "")
+            for row in applied_artifacts
+            if _first(row.get("rel_target"), row.get("target"))
+        ]
+    raw_status = _first(outputs.get("status"), progress.get("status"), operation.get("status"))
+    return {
+        "attempt_id": str(_first(operation.get("operation_id"), task_id, candidate_id) or ""),
+        "task_id": task_id or None,
+        "candidate_id": candidate_id or None,
+        "source_task_id": source_task_id or None,
+        "patch_source": patch_source or None,
+        "lever_kind": lever_kind or None,
+        "route": route or None,
+        "status": _source_attempt_status(raw_status, kept=progress.get("kept")),
+        "before_tput": _optional_float(_first(outputs.get("base_tput"), progress.get("pre_tput"))),
+        "after_tput": _optional_float(_first(outputs.get("output_throughput"), progress.get("post_tput"))),
+        "local_gain_pct": _optional_float(
+            _first(outputs.get("delta_pct"), outputs.get("gain_pct"), progress.get("gain_pct"))
+        ),
+        "ts": str(_first(operation.get("ended_at"), progress.get("ts")) or ""),
+        "source_ref": _first(
+            candidate.get("pr_url"),
+            candidate.get("ref"),
+            candidate.get("head_sha"),
+            candidate.get("diff_url"),
+            None,
+        ),
+        "files": files,
+        "reason": _first(outputs.get("reason"), progress.get("rationale"), outputs.get("error"), None),
+        "gates": {
+            "accuracy_passed": _optional_bool(outputs.get("accuracy_pass")),
+            "keep_threshold_pct": _optional_float(outputs.get("keep_threshold_pct")),
+            "switch_off_parity_passed": _optional_bool(_first(parity.get("ok"), parity.get("passed"))),
+            "stack_rebench_passed": _optional_bool(_first(stack_rebench.get("stable"), stack_rebench.get("ok"))),
+        },
+        "framework_levers": _dict_rows(outputs.get("framework_levers")),
+        "config_delta": {
+            "extra_server_args": str(outputs.get("extra_server_args_applied") or ""),
+            "extra_envs": dict(
+                _mapping(_first(outputs.get("extra_envs_applied"), outputs.get("config_changes_applied")))
+            ),
+        },
+        "artifacts": {
+            "patches_applied": _string_list(outputs.get("patches_applied")),
+            "source_snapshot": _first(outputs.get("source_snapshot"), None),
+            "source_manifest": _first(outputs.get("source_manifest"), None),
+            "workspace": _first(outputs.get("workspace"), None),
+        },
+        "failure": {
+            "error_class": _first(outputs.get("error_class"), progress.get("error_class"), None),
+            "error": _first(outputs.get("error"), progress.get("error"), None),
+        },
+    }
+
+
+def _source_attempts(
+    state: dict[str, Any],
+    operations: list[dict[str, Any]],
+    progress_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    candidates = _candidate_index(state)
+    progress_by_integrate = {
+        str(row.get("integrate_task_id") or ""): row for row in progress_rows if row.get("integrate_task_id")
+    }
+    progress_by_candidate = {
+        str(row.get("candidate_id") or ""): row for row in progress_rows if row.get("candidate_id")
+    }
+    progress_by_source = {
+        str(row.get("specialist_task_id") or ""): row for row in progress_rows if row.get("specialist_task_id")
+    }
+    used_progress: set[int] = set()
+    attempts: list[dict[str, Any]] = []
+    for operation in operations:
+        if _operation_name(operation) not in {"framework_agent", "integrate", "integrate_patch"}:
+            continue
+        outputs = _mapping(operation.get("outputs"))
+        candidate_id = str(
+            _first(
+                _candidate_id(outputs.get("candidate")),
+                outputs.get("framework_agent_candidate_id"),
+                _nested(operation, "metadata", "extras", "candidate_id"),
+            )
+            or ""
+        )
+        task_id = _operation_task_id(operation)
+        source_task_id = str(outputs.get("specialist_task_id") or "")
+        progress = (
+            progress_by_integrate.get(task_id)
+            or progress_by_candidate.get(candidate_id)
+            or progress_by_source.get(source_task_id)
+            or {}
+        )
+        if progress:
+            used_progress.add(id(progress))
+        attempts.append(_source_attempt(operation, progress, candidates))
+    for progress in progress_rows:
+        if id(progress) in used_progress or str(progress.get("status") or "").lower() == "cycle_boundary":
+            continue
+        attempts.append(_source_attempt(None, progress, candidates))
+    attempts.sort(key=lambda row: row.get("ts") or "")
+    return attempts
+
+
+def _critic_cycle_indexes(
+    session_dir: Path,
+    warnings: list[str],
+    state: dict[str, Any],
+    operations: list[dict[str, Any]],
+) -> tuple[dict[str, int], dict[str, int]]:
+    task_cycles: dict[str, int] = {}
+    proposal_cycles: dict[str, int] = {}
+    candidate_cycles: dict[str, int] = {}
+
+    def _index_row(row: dict[str, Any]) -> None:
+        cycle = _row_cycle(row)
+        if cycle is None:
+            return
+        task_id = str(
+            _first(
+                _operation_task_id(row),
+                row.get("task_id"),
+                row.get("integrate_task_id"),
+                row.get("specialist_task_id"),
+            )
+            or ""
+        )
+        if task_id:
+            task_cycles.setdefault(task_id, cycle)
+        proposal_id = str(
+            _first(
+                row.get("proposal_msg_id"),
+                _nested(row, "inputs", "proposal_msg_id"),
+                _nested(row, "outputs", "proposal_msg_id"),
+                _nested(row, "metadata", "extras", "proposal_msg_id"),
+            )
+            or ""
+        )
+        if proposal_id:
+            proposal_cycles.setdefault(proposal_id, cycle)
+        candidate_id = str(
+            _first(
+                row.get("candidate_id"),
+                row.get("framework_agent_candidate_id"),
+                _nested(row, "inputs", "framework_agent_candidate_id"),
+                _nested(row, "outputs", "framework_agent_candidate_id"),
+                _candidate_id(_nested(row, "inputs", "candidate")),
+                _candidate_id(_nested(row, "outputs", "candidate")),
+            )
+            or ""
+        )
+        if candidate_id:
+            candidate_cycles.setdefault(candidate_id, cycle)
+
+    for operation in operations:
+        _index_row(operation)
+    for field in (
+        "framework_agent_phase_progress",
+        "framework_agent_batches",
+        "specialist_rounds",
+    ):
+        for row in _dict_rows(state.get(field)):
+            _index_row(row)
+            cycle = _row_cycle(row)
+            if cycle is None:
+                continue
+            for candidate in _dict_rows(row.get("candidates")):
+                candidate_id = _candidate_id(candidate)
+                if candidate_id:
+                    candidate_cycles.setdefault(candidate_id, cycle)
+
+    map_path = session_dir / "reports" / "trace" / "proposal_task_map.jsonl"
+    if map_path.is_file():
+        map_rows = read_jsonl(
+            map_path,
+            require_dict=True,
+            skip_malformed=True,
+            on_error=lambda exc: warnings.append(
+                f"timeline.framework_agent.critic: failed to parse {map_path}: {exc!r}"
+            ),
+        )
+        for row in map_rows:
+            proposal_id = str(row.get("proposal_msg_id") or "")
+            task_id = str(row.get("task_id") or "")
+            cycle = task_cycles.get(task_id)
+            if proposal_id and cycle is not None:
+                proposal_cycles.setdefault(proposal_id, cycle)
+    return proposal_cycles, candidate_cycles
+
+
+def _critic_review_rows(
+    session_dir: Path,
+    warnings: list[str],
+    state: dict[str, Any],
+    operations: list[dict[str, Any]],
+    window: dict[str, Any],
+    window_count: int,
+) -> list[dict[str, Any]]:
+    root = session_dir / "critic-workdir"
+    if not root.is_dir():
+        return []
+    proposal_cycles, candidate_cycles = _critic_cycle_indexes(session_dir, warnings, state, operations)
+    rows: list[dict[str, Any]] = []
+    for workdir in sorted(root.iterdir(), key=lambda path: path.name):
+        if not workdir.is_dir():
+            continue
+        loaded: dict[str, dict[str, Any]] = {}
+        failed = False
+        for name in ("request", "judge_bundle", "review", "emit"):
+            path = workdir / f"{name}.json"
+            if not path.is_file():
+                loaded[name] = {}
+                continue
+            try:
+                loaded[name] = read_json(path, require_dict=True, strict=True)
+            except Exception as exc:
+                warnings.append(f"timeline.framework_agent.critic: failed to parse {path}: {exc!r}")
+                failed = True
+                break
+        if failed:
+            continue
+        request = loaded["request"]
+        judge = loaded["judge_bundle"]
+        review = loaded["review"]
+        emit = loaded["emit"]
+        review_phase = (
+            str(
+                _first(
+                    judge.get("phase"),
+                    _nested(request, "context", "phase"),
+                    _nested(judge, "merged_context", "phase"),
+                )
+                or ""
+            )
+            .strip()
+            .upper()
+        )
+        if review_phase and review_phase not in _FRAMEWORK_PHASES:
+            continue
+        proposals = {
+            str(proposal.get("msg_id") or ""): proposal
+            for proposal in _dict_rows(judge.get("proposals"))
+            if proposal.get("msg_id")
+        }
+        effective = {}
+        envelope = _mapping(emit.get("intent_envelope"))
+        for intent in _dict_rows(envelope.get("intents")):
+            if str(intent.get("intent_type") or "") != "review_verdict":
+                continue
+            payload = _mapping(intent.get("payload"))
+            target = str(payload.get("target_proposal_msg_id") or "")
+            if target:
+                effective[target] = payload
+        for verdict_row in _dict_rows(review.get("review_verdicts")):
+            proposal_id = str(verdict_row.get("target_proposal_msg_id") or "")
+            proposal = proposals.get(proposal_id, {})
+            payload = _mapping(proposal.get("payload"))
+            params = _mapping(payload.get("params"))
+            candidate = _mapping(_first(payload.get("candidate"), params.get("candidate")))
+            action = str(
+                _first(proposal.get("action_name"), payload.get("action_name"), payload.get("kind")) or ""
+            ).lower()
+            candidate_id = str(
+                _first(
+                    payload.get("framework_agent_candidate_id"),
+                    params.get("framework_agent_candidate_id"),
+                    _candidate_id(candidate),
+                )
+                or ""
+            )
+            if action in {"params", "backends", "explore"}:
+                arm = "config"
+                target_action = "explore"
+            elif action in {"framework_agent", "integrate", "integrate_patch"}:
+                arm = "source"
+                target_action = "integrate_patch"
+            elif action == "specialist":
+                task_kind = str(params.get("task_kind") or "").strip().lower()
+                source_marker = bool(
+                    candidate_id
+                    or _optional_bool(params.get("framework_agent_authoring")) is True
+                    or _optional_bool(params.get("candidate_discovery")) is True
+                    or task_kind in _AUTHORING_TASK_KINDS
+                    or bool(_patch_refs(params))
+                )
+                arm = "source" if source_marker else "config"
+                target_action = "specialist"
+            else:
+                continue
+            cycle_row = {
+                "cycle": _first(
+                    payload.get("cycle"),
+                    payload.get("macro_cycle"),
+                    params.get("cycle"),
+                    params.get("macro_cycle"),
+                    proposal.get("cycle"),
+                    proposal.get("macro_cycle"),
+                    proposal_cycles.get(proposal_id),
+                    candidate_cycles.get(candidate_id),
+                    _nested(request, "context", "macro_cycle"),
+                    _nested(request, "context", "cycle"),
+                    _prompt_macro_cycle(request.get("raw_prompt")),
+                    _nested(judge, "merged_context", "macro_cycle"),
+                    _nested(judge, "merged_context", "cycle"),
+                ),
+                "ts": _first(verdict_row.get("ts"), emit.get("ts"), review.get("ts")),
+            }
+            if not _row_in_window(cycle_row, window, window_count):
+                continue
+            effective_row = _mapping(effective.get(proposal_id))
+            risks = [
+                {
+                    "severity": str(risk.get("severity") or ""),
+                    "risk": str(_first(risk.get("risk"), risk.get("summary"), risk.get("reason")) or ""),
+                }
+                for risk in _dict_rows(verdict_row.get("risks"))
+            ]
+            followup_task_ids = _string_list(
+                _first(effective_row.get("followup_task_ids"), verdict_row.get("followup_task_ids"), [])
+            )
+            rows.append(
+                {
+                    "proposal_msg_id": proposal_id,
+                    "candidate_id": candidate_id or None,
+                    "variant_name": _first(payload.get("variant_name"), params.get("variant_name"), None),
+                    "arm": arm,
+                    "target_action": target_action,
+                    "source": "critic"
+                    if str(verdict_row.get("source") or "critic") == "critic"
+                    else "critic_unavailable",
+                    "verdict": str(verdict_row.get("verdict") or ""),
+                    "effective_verdict": str(
+                        _first(
+                            effective_row.get("verdict"),
+                            verdict_row.get("effective_verdict"),
+                            verdict_row.get("verdict"),
+                        )
+                        or ""
+                    ),
+                    "reasoning": str(verdict_row.get("reasoning") or ""),
+                    "confidence": _first(verdict_row.get("confidence"), None),
+                    "failure_reason_code": _first(verdict_row.get("failure_reason_code"), None),
+                    "required_evidence": _string_list(verdict_row.get("required_evidence")),
+                    "risks": risks,
+                    "advice_text": _first(verdict_row.get("advice_text"), effective_row.get("advice_text"), None),
+                    "alternative_action": _first(verdict_row.get("alternative_action"), None),
+                    "followup_task_ids": followup_task_ids,
+                    "ts": str(_first(verdict_row.get("ts"), emit.get("ts"), review.get("ts")) or ""),
+                    "review_path": (workdir / "review.json").relative_to(session_dir).as_posix(),
+                }
+            )
+    rows.sort(key=lambda row: row.get("ts") or "")
+    return rows
+
+
+def _source_arm(
+    state: dict[str, Any],
+    operations: list[dict[str, Any]],
+    specialist_rows: list[dict[str, Any]],
+    specialist_roles: dict[str, str],
+    progress_rows: list[dict[str, Any]],
+    window: dict[str, Any],
+    window_count: int,
+    evidence: dict[str, Any],
+) -> dict[str, Any]:
+    consecutive_no_keep = _optional_int(
+        _first(evidence.get("source_consecutive_no_keep"), evidence.get("consecutive_no_keep"))
+    )
+    if consecutive_no_keep is None:
+        consecutive_no_keep = 0
+        for row in reversed(progress_rows):
+            if str(row.get("status") or "").lower() == "cycle_boundary":
+                break
+            if bool(row.get("kept")) or str(row.get("status") or "").lower() == "kept":
+                break
+            if str(row.get("status") or "").lower() == "dispatch_failed":
+                continue
+            consecutive_no_keep += 1
+    candidates_exhausted = _optional_bool(
+        _first(evidence.get("source_candidates_exhausted"), evidence.get("candidates_exhausted"))
+    )
+    if candidates_exhausted is None:
+        state_cycle = _optional_int(state.get("macro_cycle"))
+        if window_count == 1 or state_cycle == int(window["cycle"]):
+            candidates_exhausted = _optional_bool(state.get("framework_agent_phase_done"))
+    triggered = _optional_bool(evidence.get("source_arm_plateaued"))
+    if triggered is None:
+        threshold = _optional_int(_first(evidence.get("source_threshold"), evidence.get("threshold")))
+        if candidates_exhausted is True:
+            triggered = True
+        elif threshold is not None:
+            triggered = consecutive_no_keep >= threshold
+    return {
+        "plateau": {
+            "triggered": triggered,
+            "consecutive_no_keep": consecutive_no_keep,
+            "candidates_exhausted": candidates_exhausted,
+        },
+        "candidate_discovery_runs": _candidate_discovery_runs(
+            state,
+            specialist_rows,
+            specialist_roles,
+            window,
+            window_count,
+        ),
+        "authoring_runs": _authoring_runs(state, specialist_rows, specialist_roles, progress_rows),
+        "attempts": _source_attempts(state, operations, progress_rows),
+    }
+
+
+def _framework_exit(
+    window: dict[str, Any],
+    config_arm: dict[str, Any],
+    source_arm: dict[str, Any],
+) -> dict[str, Any]:
+    exit_row = _mapping(window.get("exit_row"))
+    evidence = _mapping(exit_row.get("evidence"))
+    raw_reason = str(_first(evidence.get("passed_through_reason"), exit_row.get("reason")) or "")
+    reason = _FRAMEWORK_EXIT_REASON_MAP.get(raw_reason, raw_reason) or None
+    trigger = _first(evidence.get("trigger"), evidence.get("evidence"), None)
+    if trigger == "phase_budget_cap":
+        trigger = "budget_cap"
+    if trigger is None:
+        trigger = {
+            "optimize_no_more_leverage": "both_arms_plateaued",
+            "optimize_phase_budget_exhausted": "phase_budget_exhausted",
+            "optimize_budget_cap": "budget_cap",
+            "optimize_force_exit_low_budget": "force_exit",
+        }.get(str(reason or ""))
+    switch_bottleneck = _optional_bool(evidence.get("switch_bottleneck"))
+    if switch_bottleneck is None:
+        plateau_values = (
+            _nested(config_arm, "plateau", "triggered"),
+            _nested(source_arm, "plateau", "triggered"),
+        )
+        if any(value is True for value in plateau_values):
+            switch_bottleneck = True
+        elif all(value is False for value in plateau_values):
+            switch_bottleneck = False
+    return {
+        "reason": reason,
+        "trigger": trigger,
+        "hint": _first(evidence.get("hint"), None),
+        "switch_bottleneck": switch_bottleneck,
+    }
+
+
+def _framework_failure(window: dict[str, Any]) -> dict[str, Any]:
+    exit_row = _mapping(window.get("exit_row"))
+    evidence = _mapping(exit_row.get("evidence"))
+    reason = str(exit_row.get("reason") or "").lower()
+    is_failure = bool(evidence.get("error") or evidence.get("error_class") or reason.endswith("_failed"))
+    if is_failure:
+        return {
+            "failed_task_id": _first(evidence.get("failed_task_id"), evidence.get("task_id"), None),
+            "error_class": _first(evidence.get("error_class"), None),
+            "error": _first(evidence.get("error"), None),
+        }
+
+    rows = _dict_rows(window.get("rows"))
+    terminal_discovery_failure = next(
+        (
+            row
+            for row in reversed(rows)
+            if _nested(row, "evidence", "event") == "framework_agent_phase_done"
+            and str(row.get("reason") or "") == "discover_retries_exhausted"
+        ),
+        None,
+    )
+    if terminal_discovery_failure is None:
+        return {"failed_task_id": None, "error_class": None, "error": None}
+
+    failed_discovery = next(
+        (row for row in reversed(rows) if _nested(row, "evidence", "event") == "framework_agent_discover_failed"),
+        terminal_discovery_failure,
+    )
+    failure_evidence = _mapping(failed_discovery.get("evidence"))
+    return {
+        "failed_task_id": _first(
+            failure_evidence.get("failed_task_id"),
+            failure_evidence.get("task_id"),
+            None,
+        ),
+        "error_class": _first(failure_evidence.get("error_class"), None),
+        "error": _first(
+            failure_evidence.get("error"),
+            terminal_discovery_failure.get("reason"),
+            None,
+        ),
+    }
+
+
+def _framework_event(
+    session_dir: Path,
+    state: dict[str, Any],
+    recorded_operations: list[dict[str, Any]],
+    warnings: list[str],
+    window: dict[str, Any],
+    window_count: int,
+) -> dict[str, Any]:
+    operations = _window_operations(recorded_operations, window, window_count)
+    progress_rows = _window_state_rows(state, "framework_agent_phase_progress", window, window_count)
+    candidate_map = {
+        str(key): str(value)
+        for key, value in _mapping(state.get("framework_agent_specialist_candidate_map")).items()
+        if key and value
+    }
+    source_task_ids = {
+        str(row.get("specialist_task_id") or "") for row in progress_rows if row.get("specialist_task_id")
+    }
+    specialist_rows = _specialist_rows(state, operations, window, window_count)
+    specialist_roles = {
+        str(_first(row.get("task_id"), row.get("round_id")) or ""): _specialist_role(
+            row,
+            candidate_map,
+            source_task_ids,
+        )
+        for row in specialist_rows
+    }
+    evidence = _window_evidence(window)
+    policy = _framework_policy(state, operations, evidence)
+    config_arm = _config_arm(
+        state,
+        operations,
+        specialist_rows,
+        specialist_roles,
+        window,
+        window_count,
+        evidence,
+        policy,
+    )
+    source_arm = _source_arm(
+        state,
+        operations,
+        specialist_rows,
+        specialist_roles,
+        progress_rows,
+        window,
+        window_count,
+        evidence,
+    )
+    exit_details = _framework_exit(window, config_arm, source_arm)
+    failure = _framework_failure(window)
+    has_work = bool(
+        config_arm["specialist_runs"]
+        or config_arm["rounds"]
+        or any(run["candidates"] for run in source_arm["candidate_discovery_runs"])
+        or source_arm["authoring_runs"]
+        or source_arm["attempts"]
+    )
+    if any(value is not None for value in failure.values()):
+        status = "failed"
+    elif not window.get("end_time"):
+        status = "degraded"
+    elif has_work:
+        status = "succeeded"
+    else:
+        status = "skipped"
+    return {
+        "type": "framework_agent",
+        "kind": "agent",
+        "status": status,
+        "start_time": str(window.get("start_time") or ""),
+        "end_time": str(window.get("end_time") or ""),
+        "ext": {
+            "macro_cycle": int(window["cycle"]),
+            "policy": policy,
+            "critic_reviews": _critic_review_rows(
+                session_dir,
+                warnings,
+                state,
+                recorded_operations,
+                window,
+                window_count,
+            ),
+            "config_arm": config_arm,
+            "source_arm": source_arm,
+            "exit": exit_details,
+            "failure": failure,
+        },
+    }
+
+
 def collect_v6_timeline(
     session_dir: Path,
     warnings: list[str],
@@ -147,9 +2030,31 @@ def collect_v6_timeline(
     state: dict[str, Any] | None = None,
     recorded_operations: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
-    """Load durable install and model-gate events without mutating V5 state."""
-    del state, recorded_operations
-    return read_timeline_events(session_dir, warnings=warnings)
+    """Load durable events and project framework work without mutating V5 state."""
+    timeline = read_timeline_events(session_dir, warnings=warnings)
+    state = state if isinstance(state, dict) else {}
+    operations = [row for row in recorded_operations or [] if isinstance(row, dict)]
+    windows = _framework_windows(state, operations)
+    for window in windows:
+        timeline.append(
+            _framework_event(
+                session_dir,
+                state,
+                operations,
+                warnings,
+                window,
+                len(windows),
+            )
+        )
+    indexed = list(enumerate(timeline))
+    indexed.sort(
+        key=lambda row: (
+            _timestamp_number(_first(row[1].get("start_time"), row[1].get("end_time"))) is None,
+            _timestamp_number(_first(row[1].get("start_time"), row[1].get("end_time"))) or 0.0,
+            row[0],
+        )
+    )
+    return [event for _, event in indexed]
 
 
 def _outcome_status(stop_reason: str) -> str:

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/v6.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/v6.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 from hyperloom.common.jsonio import read_json, read_jsonl
 
+from ..critic_reviews import FRAMEWORK_REVIEW_FIELDS, normalize_framework_reviews
 from ...session.sbd_v6 import SCHEMA_VERSION_V6, read_timeline_events
 
 
@@ -45,7 +45,6 @@ _AUTHORING_TASK_KINDS = frozenset(
         "framework_local_explore",
     }
 )
-_MACRO_CYCLE_RE = re.compile(r"(?:^|\s)macro_cycle\s*=\s*(-?\d+)(?=\s|$)")
 
 
 def _tool_versions(versions: Any) -> dict[str, str | None]:
@@ -255,11 +254,6 @@ def _row_timestamp(row: dict[str, Any]) -> str:
     )
 
 
-def _prompt_macro_cycle(value: Any) -> int | None:
-    match = _MACRO_CYCLE_RE.search(str(value or ""))
-    return _optional_int(match.group(1)) if match else None
-
-
 def _timestamp_number(value: Any) -> float | None:
     text = str(value or "").strip()
     if not text:
@@ -306,28 +300,35 @@ def _specialist_payloads(row: dict[str, Any]) -> tuple[dict[str, Any], ...]:
 def _is_framework_specialist(row: dict[str, Any], *, allow_legacy: bool) -> bool:
     declared_phase = _declared_source_phase(row)
     phase = declared_phase or str(row.get("phase") or "").strip().upper()
-    if not declared_phase and str(row.get("source") or "").strip().lower() == "specialist_recorder_hook":
+    legacy_recorder_hook = (
+        not declared_phase and str(row.get("source") or "").strip().lower() == "specialist_recorder_hook"
+    )
+    if legacy_recorder_hook:
         phase = ""
     if phase:
         return phase in _FRAMEWORK_PHASES
 
     agent = str(row.get("agent") or "").strip().lower()
-    if agent in {"framework_agent", "explore"}:
-        return True
-    if agent in {"enablement", "kernel", "kernel_agent", "prelude", "internal"}:
-        return False
+    if not legacy_recorder_hook:
+        if agent in {"framework_agent", "explore"}:
+            return True
+        if agent in {"enablement", "kernel", "kernel_agent", "prelude", "internal"}:
+            return False
 
     payloads = _specialist_payloads(row)
     if any(_optional_bool(payload.get("enablement")) is True for payload in payloads):
         return False
     if any(
         _optional_bool(payload.get("framework_agent_authoring")) is True
+        or _optional_bool(payload.get("candidate_discovery")) is True
         or bool(payload.get("framework_agent_candidate_id"))
         or bool(payload.get("framework_batch_id"))
-        or str(payload.get("task_kind") or "").strip().lower() in _AUTHORING_TASK_KINDS
+        or str(payload.get("task_kind") or "").strip().lower() in {*_AUTHORING_TASK_KINDS, "candidate_discovery"}
         for payload in payloads
     ):
         return True
+    if legacy_recorder_hook:
+        return False
     return allow_legacy
 
 
@@ -536,15 +537,6 @@ def _framework_policy(
     evidence: dict[str, Any],
 ) -> dict[str, Any]:
     overrides = _mapping(state.get("plateau_overrides"))
-    stack_rebench_enabled = _optional_bool(
-        _operation_value(
-            operations,
-            ("outputs", "stack_rebench_enabled"),
-            ("outputs", "enable_stack_rebench"),
-            ("inputs", "stack_rebench_enabled"),
-            ("inputs", "enable_stack_rebench"),
-        )
-    )
     return {
         "keep_threshold_pct": _optional_float(
             _first(
@@ -557,14 +549,6 @@ def _framework_policy(
                 evidence.get("keep_threshold_pct"),
             )
         ),
-        "stack_stable_threshold_pct": _optional_float(
-            _operation_value(
-                operations,
-                ("outputs", "stack_stable_threshold_pct"),
-                ("inputs", "stack_stable_threshold_pct"),
-            )
-        ),
-        "stack_rebench_enabled": stack_rebench_enabled,
         "variant_timeout_sec": _optional_int(
             _first(
                 _operation_value(
@@ -742,17 +726,11 @@ def _config_variant(raw: dict[str, Any], source_index: dict[str, dict[str, Any]]
     name = str(_first(combined.get("name"), combined.get("variant_name")) or "")
     fingerprint = str(combined.get("fingerprint") or "")
     source = source_index.get(fingerprint) or source_index.get(name) or {}
-    outcome = str(combined.get("outcome") or "").strip().upper()
-    stack_tput = _optional_float(combined.get("stack_rebench_tput"))
-    stack_ran = _optional_bool(combined.get("stack_rebench_ran"))
-    if stack_ran is None and (stack_tput is not None or combined.get("stack_rebench_workspace")):
-        stack_ran = True
-    stack_stable = _optional_bool(combined.get("stack_rebench_stable"))
-    if stack_stable is None and stack_ran:
-        if outcome == "KEEP_UNSTABLE":
-            stack_stable = False
-        elif outcome == "KEEP":
-            stack_stable = True
+    raw_outcome = str(combined.get("outcome") or "").strip().upper()
+    outcome = "REVERT" if raw_outcome == "KEEP_UNSTABLE" else raw_outcome
+    stage = _first(combined.get("stage"), None)
+    if str(stage or "").strip().lower() == "stack_rebench":
+        stage = None
     return {
         "name": name,
         "fingerprint": fingerprint,
@@ -784,21 +762,15 @@ def _config_variant(raw: dict[str, Any], source_index: dict[str, dict[str, Any]]
             "value": _optional_float(combined.get("accuracy")),
             "passed": _optional_bool(_first(combined.get("accuracy_pass"), combined.get("accuracy_passed"))),
         },
-        "stack_rebench": {
-            "ran": stack_ran,
-            "tput": stack_tput,
-            "stable": stack_stable,
-        },
         "outcome": outcome,
         "reason": _first(combined.get("reason"), None),
-        "stage": _first(combined.get("stage"), None),
+        "stage": stage,
         "failure": {
             "error_class": _first(combined.get("error_class"), None),
             "error_excerpt": _first(combined.get("error_excerpt"), combined.get("error"), None),
         },
         "artifacts": {
             "workspace": _first(combined.get("workspace"), combined.get("single_workspace"), None),
-            "stack_rebench_workspace": _first(combined.get("stack_rebench_workspace"), None),
             "server_log_path": _first(combined.get("server_log_path"), None),
             "raw_result_path": _first(combined.get("raw_result_path"), None),
         },
@@ -1170,7 +1142,7 @@ def _candidate_discovery_runs(
             row,
         )
 
-    failed_markers = 0
+    failed_markers = sum(_specialist_status(row) == "failed" for row in discovery_rows)
     terminal_retry_rows: list[dict[str, Any]] = []
     for row in _dict_rows(window.get("rows")):
         evidence = _mapping(row.get("evidence"))
@@ -1201,7 +1173,12 @@ def _candidate_discovery_runs(
                 },
                 row,
             )
-        elif event == "framework_agent_phase_done" and reason == "discover_retries_exhausted":
+        elif event == "framework_agent_phase_done" and reason in {
+            "discover_retries_exhausted",
+            "no_candidates_and_discovery_exhausted",
+        }:
+            if _optional_int(evidence.get("failure_count")) in {None, 0}:
+                continue
             terminal_retry_rows.append(row)
 
     if failed_markers == 0:
@@ -1310,17 +1287,24 @@ def _authoring_runs(
         if not task_id or task_id in used_tasks:
             continue
         candidate_id = str(progress.get("candidate_id") or candidate_map.get(task_id) or "")
+        reauthor_attempt = _optional_int(progress.get("reauthor_attempt"))
         runs.append(
             {
                 "task_id": task_id,
                 "candidate_id": candidate_id,
-                "kind": "local_authoring" if candidate_id.startswith("local_explore:") else "candidate_authoring",
+                "kind": (
+                    "reauthor"
+                    if reauthor_attempt is not None and reauthor_attempt > 0
+                    else "local_authoring"
+                    if candidate_id.startswith("local_explore:")
+                    else "candidate_authoring"
+                ),
                 "status": "failed"
                 if str(progress.get("status") or "").lower() in {"dispatch_failed", "author_failed", "recovery_failed"}
                 else "empty"
                 if str(progress.get("provenance") or "").lower() == "authored_empty"
                 else "succeeded",
-                "reauthor_attempt": _optional_int(progress.get("reauthor_attempt")),
+                "reauthor_attempt": reauthor_attempt,
                 "specialist_domain": str(progress.get("domain") or ""),
                 "gap_canonical_id": _first(progress.get("gap_canonical_id"), None),
                 "patch_refs": _patch_refs(progress),
@@ -1436,7 +1420,6 @@ def _source_attempt(
         elif patch_source == "specialist_authored":
             route = "author_via_specialist"
     parity = _mapping(outputs.get("switch_off_parity"))
-    stack_rebench = _mapping(outputs.get("stack_rebench"))
     files = _string_list(_first(outputs.get("target_files"), candidate.get("changed_files"), []))
     applied_artifacts = _dict_rows(outputs.get("artifacts_applied"))
     if not files:
@@ -1474,7 +1457,6 @@ def _source_attempt(
             "accuracy_passed": _optional_bool(outputs.get("accuracy_pass")),
             "keep_threshold_pct": _optional_float(outputs.get("keep_threshold_pct")),
             "switch_off_parity_passed": _optional_bool(_first(parity.get("ok"), parity.get("passed"))),
-            "stack_rebench_passed": _optional_bool(_first(stack_rebench.get("stable"), stack_rebench.get("ok"))),
         },
         "framework_levers": _dict_rows(outputs.get("framework_levers")),
         "config_delta": {
@@ -1660,160 +1642,83 @@ def _critic_review_rows(
     operations: list[dict[str, Any]],
     window: dict[str, Any],
     window_count: int,
+    critic_iterations: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    root = session_dir / "critic-workdir"
-    if not root.is_dir():
-        return []
     proposal_cycles, candidate_cycles = _critic_cycle_indexes(session_dir, warnings, state, operations)
     rows: list[dict[str, Any]] = []
-    for workdir in sorted(root.iterdir(), key=lambda path: path.name):
-        if not workdir.is_dir():
-            continue
-        loaded: dict[str, dict[str, Any]] = {}
-        failed = False
-        for name in ("request", "judge_bundle", "review", "emit"):
-            path = workdir / f"{name}.json"
-            if not path.is_file():
-                loaded[name] = {}
-                continue
-            try:
-                loaded[name] = read_json(path, require_dict=True, strict=True)
-            except Exception as exc:
-                warnings.append(f"timeline.framework_agent.critic: failed to parse {path}: {exc!r}")
-                failed = True
-                break
-        if failed:
-            continue
-        request = loaded["request"]
-        judge = loaded["judge_bundle"]
-        review = loaded["review"]
-        emit = loaded["emit"]
-        review_phase = (
-            str(
-                _first(
-                    judge.get("phase"),
-                    _nested(request, "context", "phase"),
-                    _nested(judge, "merged_context", "phase"),
-                )
-                or ""
-            )
-            .strip()
-            .upper()
-        )
-        if review_phase and review_phase not in _FRAMEWORK_PHASES:
-            continue
-        proposals = {
-            str(proposal.get("msg_id") or ""): proposal
-            for proposal in _dict_rows(judge.get("proposals"))
-            if proposal.get("msg_id")
+    seen: set[tuple[str, ...]] = set()
+
+    def _append_review(row: dict[str, Any]) -> None:
+        proposal_id = str(row.get("proposal_msg_id") or "")
+        candidate_id = str(row.get("candidate_id") or "")
+        cycle_row = {
+            "cycle": _first(
+                row.get("macro_cycle"),
+                row.get("cycle"),
+                proposal_cycles.get(proposal_id),
+                candidate_cycles.get(candidate_id),
+            ),
+            "ts": row.get("ts"),
         }
-        effective = {}
-        envelope = _mapping(emit.get("intent_envelope"))
-        for intent in _dict_rows(envelope.get("intents")):
-            if str(intent.get("intent_type") or "") != "review_verdict":
-                continue
-            payload = _mapping(intent.get("payload"))
-            target = str(payload.get("target_proposal_msg_id") or "")
-            if target:
-                effective[target] = payload
-        for verdict_row in _dict_rows(review.get("review_verdicts")):
-            proposal_id = str(verdict_row.get("target_proposal_msg_id") or "")
-            proposal = proposals.get(proposal_id, {})
-            payload = _mapping(proposal.get("payload"))
-            params = _mapping(payload.get("params"))
-            candidate = _mapping(_first(payload.get("candidate"), params.get("candidate")))
-            action = str(
-                _first(proposal.get("action_name"), payload.get("action_name"), payload.get("kind")) or ""
-            ).lower()
-            candidate_id = str(
-                _first(
-                    payload.get("framework_agent_candidate_id"),
-                    params.get("framework_agent_candidate_id"),
-                    _candidate_id(candidate),
-                )
-                or ""
+        if not _row_in_window(cycle_row, window, window_count):
+            return
+        projected = {field: row.get(field) for field in FRAMEWORK_REVIEW_FIELDS}
+        if projected.get("review_path"):
+            projected["review_path"] = str(projected["review_path"]).replace("\\", "/")
+        identity = tuple(
+            str(projected.get(field) or "")
+            for field in (
+                "proposal_msg_id",
+                "candidate_id",
+                "variant_name",
+                "arm",
+                "target_action",
+                "verdict",
+                "effective_verdict",
+                "ts",
             )
-            if action in {"params", "backends", "explore"}:
-                arm = "config"
-                target_action = "explore"
-            elif action in {"framework_agent", "integrate", "integrate_patch"}:
-                arm = "source"
-                target_action = "integrate_patch"
-            elif action == "specialist":
-                task_kind = str(params.get("task_kind") or "").strip().lower()
-                source_marker = bool(
-                    candidate_id
-                    or _optional_bool(params.get("framework_agent_authoring")) is True
-                    or _optional_bool(params.get("candidate_discovery")) is True
-                    or task_kind in _AUTHORING_TASK_KINDS
-                    or bool(_patch_refs(params))
-                )
-                arm = "source" if source_marker else "config"
-                target_action = "specialist"
-            else:
+        )
+        if identity in seen:
+            return
+        seen.add(identity)
+        rows.append(projected)
+
+    for iteration in critic_iterations:
+        for durable_row in _dict_rows(iteration.get("framework_reviews")):
+            durable_row.setdefault("ts", iteration.get("ts"))
+            durable_row.setdefault("review_path", iteration.get("review_path"))
+            durable_row.setdefault("phase", iteration.get("phase"))
+            durable_row.setdefault("macro_cycle", _first(iteration.get("macro_cycle"), iteration.get("cycle")))
+            _append_review(durable_row)
+
+    root = session_dir / "critic-workdir"
+    if root.is_dir():
+        for workdir in sorted(root.iterdir(), key=lambda path: path.name):
+            if not workdir.is_dir():
                 continue
-            cycle_row = {
-                "cycle": _first(
-                    payload.get("cycle"),
-                    payload.get("macro_cycle"),
-                    params.get("cycle"),
-                    params.get("macro_cycle"),
-                    proposal.get("cycle"),
-                    proposal.get("macro_cycle"),
-                    proposal_cycles.get(proposal_id),
-                    candidate_cycles.get(candidate_id),
-                    _nested(request, "context", "macro_cycle"),
-                    _nested(request, "context", "cycle"),
-                    _prompt_macro_cycle(request.get("raw_prompt")),
-                    _nested(judge, "merged_context", "macro_cycle"),
-                    _nested(judge, "merged_context", "cycle"),
-                ),
-                "ts": _first(verdict_row.get("ts"), emit.get("ts"), review.get("ts")),
-            }
-            if not _row_in_window(cycle_row, window, window_count):
+            loaded: dict[str, dict[str, Any]] = {}
+            failed = False
+            for name in ("request", "judge_bundle", "review", "emit"):
+                path = workdir / f"{name}.json"
+                if not path.is_file():
+                    loaded[name] = {}
+                    continue
+                try:
+                    loaded[name] = read_json(path, require_dict=True, strict=True)
+                except Exception as exc:
+                    warnings.append(f"timeline.framework_agent.critic: failed to parse {path}: {exc!r}")
+                    failed = True
+                    break
+            if failed:
                 continue
-            effective_row = _mapping(effective.get(proposal_id))
-            risks = [
-                {
-                    "severity": str(risk.get("severity") or ""),
-                    "risk": str(_first(risk.get("risk"), risk.get("summary"), risk.get("reason")) or ""),
-                }
-                for risk in _dict_rows(verdict_row.get("risks"))
-            ]
-            followup_task_ids = _string_list(
-                _first(effective_row.get("followup_task_ids"), verdict_row.get("followup_task_ids"), [])
-            )
-            rows.append(
-                {
-                    "proposal_msg_id": proposal_id,
-                    "candidate_id": candidate_id or None,
-                    "variant_name": _first(payload.get("variant_name"), params.get("variant_name"), None),
-                    "arm": arm,
-                    "target_action": target_action,
-                    "source": "critic"
-                    if str(verdict_row.get("source") or "critic") == "critic"
-                    else "critic_unavailable",
-                    "verdict": str(verdict_row.get("verdict") or ""),
-                    "effective_verdict": str(
-                        _first(
-                            effective_row.get("verdict"),
-                            verdict_row.get("effective_verdict"),
-                            verdict_row.get("verdict"),
-                        )
-                        or ""
-                    ),
-                    "reasoning": str(verdict_row.get("reasoning") or ""),
-                    "confidence": _first(verdict_row.get("confidence"), None),
-                    "failure_reason_code": _first(verdict_row.get("failure_reason_code"), None),
-                    "required_evidence": _string_list(verdict_row.get("required_evidence")),
-                    "risks": risks,
-                    "advice_text": _first(verdict_row.get("advice_text"), effective_row.get("advice_text"), None),
-                    "alternative_action": _first(verdict_row.get("alternative_action"), None),
-                    "followup_task_ids": followup_task_ids,
-                    "ts": str(_first(verdict_row.get("ts"), emit.get("ts"), review.get("ts")) or ""),
-                    "review_path": (workdir / "review.json").relative_to(session_dir).as_posix(),
-                }
-            )
+            for review_row in normalize_framework_reviews(
+                request=loaded["request"],
+                judge_bundle=loaded["judge_bundle"],
+                review=loaded["review"],
+                emit=loaded["emit"],
+                review_path=(workdir / "review.json").relative_to(session_dir).as_posix(),
+            ):
+                _append_review(review_row)
     rows.sort(key=lambda row: row.get("ts") or "")
     return rows
 
@@ -1910,7 +1815,10 @@ def _framework_exit(
     }
 
 
-def _framework_failure(window: dict[str, Any]) -> dict[str, Any]:
+def _framework_failure(
+    window: dict[str, Any],
+    specialist_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
     exit_row = _mapping(window.get("exit_row"))
     evidence = _mapping(exit_row.get("evidence"))
     reason = str(exit_row.get("reason") or "").lower()
@@ -1928,7 +1836,8 @@ def _framework_failure(window: dict[str, Any]) -> dict[str, Any]:
             row
             for row in reversed(rows)
             if _nested(row, "evidence", "event") == "framework_agent_phase_done"
-            and str(row.get("reason") or "") == "discover_retries_exhausted"
+            and str(row.get("reason") or "") in {"discover_retries_exhausted", "no_candidates_and_discovery_exhausted"}
+            and _optional_int(_nested(row, "evidence", "failure_count")) not in {None, 0}
         ),
         None,
     )
@@ -1936,19 +1845,34 @@ def _framework_failure(window: dict[str, Any]) -> dict[str, Any]:
         return {"failed_task_id": None, "error_class": None, "error": None}
 
     failed_discovery = next(
+        (
+            row
+            for row in reversed(specialist_rows)
+            if _specialist_role(row, {}, set()) == "discovery" and _specialist_status(row) == "failed"
+        ),
+        None,
+    ) or next(
         (row for row in reversed(rows) if _nested(row, "evidence", "event") == "framework_agent_discover_failed"),
         terminal_discovery_failure,
     )
     failure_evidence = _mapping(failed_discovery.get("evidence"))
     return {
         "failed_task_id": _first(
+            failed_discovery.get("task_id"),
             failure_evidence.get("failed_task_id"),
             failure_evidence.get("task_id"),
             None,
         ),
-        "error_class": _first(failure_evidence.get("error_class"), None),
+        "error_class": _first(
+            failed_discovery.get("error_class"),
+            failure_evidence.get("error_class"),
+            "candidate_discovery_failed",
+        ),
         "error": _first(
+            failed_discovery.get("error"),
+            failed_discovery.get("run_error"),
             failure_evidence.get("error"),
+            failed_discovery.get("reason"),
             terminal_discovery_failure.get("reason"),
             None,
         ),
@@ -1959,6 +1883,7 @@ def _framework_event(
     session_dir: Path,
     state: dict[str, Any],
     recorded_operations: list[dict[str, Any]],
+    critic_iterations: list[dict[str, Any]],
     warnings: list[str],
     window: dict[str, Any],
     window_count: int,
@@ -2011,9 +1936,10 @@ def _framework_event(
         recorded_operations,
         window,
         window_count,
+        critic_iterations,
     )
     exit_details = _framework_exit(window, config_arm, source_arm)
-    failure = _framework_failure(window)
+    failure = _framework_failure(window, specialist_rows)
     has_work = bool(
         config_arm["specialist_runs"]
         or config_arm["rounds"]
@@ -2054,11 +1980,13 @@ def collect_v6_timeline(
     *,
     state: dict[str, Any] | None = None,
     recorded_operations: list[dict[str, Any]] | None = None,
+    critic_iterations: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """Load durable events and project framework work without mutating V5 state."""
     timeline = read_timeline_events(session_dir, warnings=warnings)
     state = state if isinstance(state, dict) else {}
     operations = [row for row in recorded_operations or [] if isinstance(row, dict)]
+    critic_iterations = [row for row in critic_iterations or [] if isinstance(row, dict)]
     windows = _framework_windows(state, operations)
     for window in windows:
         timeline.append(
@@ -2066,6 +1994,7 @@ def collect_v6_timeline(
                 session_dir,
                 state,
                 operations,
+                critic_iterations,
                 warnings,
                 window,
                 len(windows),

--- a/src/hyperloom/inference_optimizer/breakdown/critic_reviews.py
+++ b/src/hyperloom/inference_optimizer/breakdown/critic_reviews.py
@@ -1,0 +1,244 @@
+"""Normalize durable Framework Agent critic-review evidence."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+FRAMEWORK_REVIEW_FIELDS = (
+    "proposal_msg_id",
+    "candidate_id",
+    "variant_name",
+    "arm",
+    "target_action",
+    "source",
+    "verdict",
+    "effective_verdict",
+    "reasoning",
+    "confidence",
+    "failure_reason_code",
+    "required_evidence",
+    "risks",
+    "advice_text",
+    "alternative_action",
+    "followup_task_ids",
+    "ts",
+    "review_path",
+)
+
+_FRAMEWORK_PHASES = frozenset({"FRAMEWORK_AGENT", "EXPLORE"})
+_AUTHORING_TASK_KINDS = frozenset(
+    {
+        "explore_apply_retry",
+        "framework_authoring",
+        "framework_local_explore",
+    }
+)
+_MACRO_CYCLE_RE = re.compile(r"(?:^|\s)macro_cycle\s*=\s*(-?\d+)(?=\s|$)")
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _dict_rows(value: Any) -> list[dict[str, Any]]:
+    return [dict(row) for row in value or [] if isinstance(row, dict)] if isinstance(value, list) else []
+
+
+def _first(*values: Any) -> Any:
+    return next((value for value in values if value is not None and value != ""), None)
+
+
+def _nested(value: Any, *keys: str) -> Any:
+    current = value
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _optional_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return None
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _candidate_id(value: Any) -> str:
+    candidate = _mapping(value)
+    return str(
+        _first(
+            candidate.get("candidate_id"),
+            candidate.get("pr_url"),
+            candidate.get("url"),
+            candidate.get("ref"),
+            candidate.get("head_sha"),
+        )
+        or ""
+    )
+
+
+def _prompt_macro_cycle(value: Any) -> int | None:
+    match = _MACRO_CYCLE_RE.search(str(value or ""))
+    if match is None:
+        return None
+    try:
+        return int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def _has_patch_refs(params: dict[str, Any]) -> bool:
+    return any(isinstance(params.get(key), list) and bool(params.get(key)) for key in ("patch_refs", "patches_written"))
+
+
+def normalize_framework_reviews(
+    *,
+    request: dict[str, Any] | None,
+    judge_bundle: dict[str, Any] | None,
+    review: dict[str, Any] | None,
+    emit: dict[str, Any] | None,
+    review_path: str | None,
+) -> list[dict[str, Any]]:
+    """Return compact V6 Framework review rows from one Critic iteration."""
+    request = _mapping(request)
+    judge = _mapping(judge_bundle)
+    review = _mapping(review)
+    emit = _mapping(emit)
+    normalized_review_path = str(review_path or "").replace("\\", "/") or None
+    review_phase = (
+        str(
+            _first(
+                judge.get("phase"),
+                _nested(request, "context", "phase"),
+                _nested(judge, "merged_context", "phase"),
+            )
+            or ""
+        )
+        .strip()
+        .upper()
+    )
+    if review_phase and review_phase not in _FRAMEWORK_PHASES:
+        return []
+
+    proposals = {
+        str(proposal.get("msg_id") or ""): proposal
+        for proposal in _dict_rows(judge.get("proposals"))
+        if proposal.get("msg_id")
+    }
+    effective: dict[str, dict[str, Any]] = {}
+    for intent in _dict_rows(_nested(emit, "intent_envelope", "intents")):
+        if str(intent.get("intent_type") or "") != "review_verdict":
+            continue
+        payload = _mapping(intent.get("payload"))
+        target = str(payload.get("target_proposal_msg_id") or "")
+        if target:
+            effective[target] = payload
+
+    rows: list[dict[str, Any]] = []
+    for verdict_row in _dict_rows(review.get("review_verdicts")):
+        proposal_id = str(verdict_row.get("target_proposal_msg_id") or "")
+        proposal = proposals.get(proposal_id, {})
+        payload = _mapping(proposal.get("payload"))
+        params = _mapping(payload.get("params"))
+        candidate = _mapping(_first(payload.get("candidate"), params.get("candidate")))
+        action = str(_first(proposal.get("action_name"), payload.get("action_name"), payload.get("kind")) or "").lower()
+        candidate_id = str(
+            _first(
+                payload.get("framework_agent_candidate_id"),
+                params.get("framework_agent_candidate_id"),
+                _candidate_id(candidate),
+            )
+            or ""
+        )
+        if action in {"params", "backends", "explore"}:
+            arm = "config"
+            target_action = "explore"
+        elif action in {"framework_agent", "integrate", "integrate_patch"}:
+            arm = "source"
+            target_action = "integrate_patch"
+        elif action == "specialist":
+            task_kind = str(params.get("task_kind") or "").strip().lower()
+            source_marker = bool(
+                candidate_id
+                or _optional_bool(params.get("framework_agent_authoring")) is True
+                or _optional_bool(params.get("candidate_discovery")) is True
+                or task_kind in _AUTHORING_TASK_KINDS
+                or _has_patch_refs(params)
+            )
+            arm = "source" if source_marker else "config"
+            target_action = "specialist"
+        else:
+            continue
+
+        effective_row = effective.get(proposal_id, {})
+        rows.append(
+            {
+                "proposal_msg_id": proposal_id,
+                "candidate_id": candidate_id or None,
+                "variant_name": _first(payload.get("variant_name"), params.get("variant_name"), None),
+                "arm": arm,
+                "target_action": target_action,
+                "source": "critic" if str(verdict_row.get("source") or "critic") == "critic" else "critic_unavailable",
+                "verdict": str(verdict_row.get("verdict") or ""),
+                "effective_verdict": str(
+                    _first(
+                        effective_row.get("verdict"),
+                        verdict_row.get("effective_verdict"),
+                        verdict_row.get("verdict"),
+                    )
+                    or ""
+                ),
+                "reasoning": str(verdict_row.get("reasoning") or ""),
+                "confidence": _first(verdict_row.get("confidence"), None),
+                "failure_reason_code": _first(verdict_row.get("failure_reason_code"), None),
+                "required_evidence": _string_list(verdict_row.get("required_evidence")),
+                "risks": [
+                    {
+                        "severity": str(risk.get("severity") or ""),
+                        "risk": str(_first(risk.get("risk"), risk.get("summary"), risk.get("reason")) or ""),
+                    }
+                    for risk in _dict_rows(verdict_row.get("risks"))
+                ],
+                "advice_text": _first(verdict_row.get("advice_text"), effective_row.get("advice_text"), None),
+                "alternative_action": _first(verdict_row.get("alternative_action"), None),
+                "followup_task_ids": _string_list(
+                    _first(effective_row.get("followup_task_ids"), verdict_row.get("followup_task_ids"), [])
+                ),
+                "ts": str(_first(verdict_row.get("ts"), emit.get("ts"), review.get("ts")) or ""),
+                "review_path": normalized_review_path,
+                "phase": review_phase,
+                "macro_cycle": _first(
+                    payload.get("cycle"),
+                    payload.get("macro_cycle"),
+                    params.get("cycle"),
+                    params.get("macro_cycle"),
+                    proposal.get("cycle"),
+                    proposal.get("macro_cycle"),
+                    _nested(request, "context", "macro_cycle"),
+                    _nested(request, "context", "cycle"),
+                    _prompt_macro_cycle(request.get("raw_prompt")),
+                    _nested(judge, "merged_context", "macro_cycle"),
+                    _nested(judge, "merged_context", "cycle"),
+                ),
+            }
+        )
+    return rows
+
+
+__all__ = ["FRAMEWORK_REVIEW_FIELDS", "normalize_framework_reviews"]

--- a/src/hyperloom/inference_optimizer/breakdown/exporter.py
+++ b/src/hyperloom/inference_optimizer/breakdown/exporter.py
@@ -568,6 +568,9 @@ def build(
             v6_warnings,
             state=state,
             recorded_operations=recorded_operations,
+            critic_iterations=(
+                critic_robustness.get("critic_iterations", []) if isinstance(critic_robustness, dict) else []
+            ),
         ),
         v6_warnings,
         default=[],

--- a/src/hyperloom/inference_optimizer/breakdown/recorder/instrument.py
+++ b/src/hyperloom/inference_optimizer/breakdown/recorder/instrument.py
@@ -3662,6 +3662,7 @@ def record_specialist_round(
             domains.append(str(entry.get("domain")))
         domains.extend(str(tag) for tag in (entry.get("tags") or []) if str(tag))
         domains = list(dict.fromkeys(domain for domain in domains if domain))
+        source_phase = str(entry.get("source_phase") or "EXPLORE").strip().upper()
         record_subject(
             session_dir,
             subject_id=round_subject_id,
@@ -3713,7 +3714,7 @@ def record_specialist_round(
             root_operation_id=operation_id,
             kind="specialist",
             name=f"specialist round {round_id}",
-            phase=phase or str(entry.get("phase") or ""),
+            phase=source_phase,
             status="succeeded" if entry.get("completed_at") else "partial",
             source="specialist_recorder_hook",
             executor_class="llm_agent",

--- a/src/hyperloom/inference_optimizer/breakdown/recorder/instrument.py
+++ b/src/hyperloom/inference_optimizer/breakdown/recorder/instrument.py
@@ -42,6 +42,7 @@ from hyperloom.common.jsonio import read_json
 from hyperloom.common.timeutil import iso_z, now_iso
 
 from ..agent_ownership import UNATTRIBUTED, agent_from_phase, patch_author
+from ..critic_reviews import normalize_framework_reviews
 from .trace import trace_skip
 
 log = logging.getLogger(__name__)
@@ -3750,6 +3751,8 @@ def record_critic_iteration(
     session_dir: Path | str | None,
     *,
     iter_n: int,
+    request: dict[str, Any] | None = None,
+    judge_bundle: dict[str, Any] | None = None,
     review: dict[str, Any] | None,
     emit: dict[str, Any] | None,
     workdir: Path | str | None,
@@ -3758,9 +3761,10 @@ def record_critic_iteration(
 ) -> None:
     """Record one ``critic_robustness.critic_iterations`` item.
 
-    Recorded per-iteration (idempotent on ``iter_n``) so the critic backend's
-    workdir pruning never erases history; payload mirrors
-    ``collectors.collect_critic_robustness``.
+    Recorded per-iteration under a session-unique identity so workdir pruning
+    and resume-time turn-index reuse never erase history; payload mirrors
+    ``collectors.collect_critic_robustness`` and retains normalized Framework
+    review rows for the V6 timeline.
 
     ``kb_priors`` (when provided) carries the per-iteration KB integration
     trace: whether the historical priors were used, the request, the response,
@@ -3770,7 +3774,9 @@ def record_critic_iteration(
     Args:
         session_dir (Path | str | None): the session directory; a falsy value is
             a no-op.
-        iter_n (int): the critic iteration number (idempotency key).
+        iter_n (int): the process-local critic iteration number.
+        request (dict[str, Any] | None): the critic request payload.
+        judge_bundle (dict[str, Any] | None): the proposal bundle reviewed.
         review (dict[str, Any] | None): the critic review payload.
         emit (dict[str, Any] | None): the critic emit payload.
         workdir (Path | str | None): the critic backend workdir holding the
@@ -3786,6 +3792,14 @@ def record_critic_iteration(
         review = review if isinstance(review, dict) else {}
         emit = emit if isinstance(emit, dict) else {}
         wd = Path(workdir) if workdir else None
+        request = request if isinstance(request, dict) else read_json(wd / "request.json", default={}) if wd else {}
+        judge_bundle = (
+            judge_bundle
+            if isinstance(judge_bundle, dict)
+            else read_json(wd / "judge_bundle.json", default={})
+            if wd
+            else {}
+        )
         payload = {
             "iter": int(iter_n),
             "ts": str(emit.get("ts") or review.get("ts") or ""),
@@ -3798,14 +3812,35 @@ def record_critic_iteration(
             "review_path": _rel(wd / "review.json", session_dir) if wd else None,
             "kb_writes": list(emit.get("kb_writes") or []) if isinstance(emit.get("kb_writes"), list) else [],
         }
+        framework_reviews = normalize_framework_reviews(
+            request=request,
+            judge_bundle=judge_bundle,
+            review=review,
+            emit=emit,
+            review_path=_rel(wd / "review.json", session_dir).replace("\\", "/") if wd else None,
+        )
+        if framework_reviews:
+            payload["framework_reviews"] = framework_reviews
         if isinstance(kb_priors, dict) and kb_priors:
             payload["kb_priors"] = kb_priors
+        iteration_id = _stable_id(
+            "critic-iteration",
+            iter_n,
+            payload.get("ts"),
+            [row.get("proposal_msg_id") for row in framework_reviews],
+            payload.get("topic"),
+            request,
+            judge_bundle,
+            review,
+            emit,
+        )
+        payload["iteration_id"] = iteration_id
         _recorder(session_dir, producer).record_item(
             "critic_iterations",
             payload,
-            key=str(iter_n),
+            key=iteration_id,
         )
-        operation_id = _stable_id("op", "critic", iter_n)
+        operation_id = _stable_id("op", iteration_id)
         artifact_refs: list[str] = []
         for name in ("request_path", "judge_bundle_path", "emit_path", "review_path"):
             path = payload.get(name)
@@ -3864,7 +3899,7 @@ def record_critic_iteration(
             write_key = (
                 write.get("write_id") or write.get("point_id") or write.get("edge_id") or write.get("kind") or index
             )
-            write_operation_id = _stable_id("op", "kb-write", iter_n, write_key)
+            write_operation_id = _stable_id("op", "kb-write", iteration_id, write_key)
             result_payload = write.get("result") if isinstance(write.get("result"), Mapping) else {}
             write_status = _operation_status(result_payload.get("status") or write.get("status") or "succeeded")
             record_operation(

--- a/src/hyperloom/inference_optimizer/breakdown/recorder/instrument.py
+++ b/src/hyperloom/inference_optimizer/breakdown/recorder/instrument.py
@@ -3637,10 +3637,9 @@ def record_specialist_round(
             a no-op.
         entry (dict[str, Any]): the specialist round entry (keyed by
             ``round_id``); an empty/non-dict value is a no-op.
-        phase (str): the phase the round ran in; falls back to
-            ``entry["phase"]``, then to the reader's timestamp backfill. A
-            specialist runs in more than one phase, so this cannot be a
-            constant.
+        phase (str): the runtime phase used when the entry does not already
+            declare ``source_phase``. A specialist runs in more than one phase,
+            so this cannot be a constant.
         producer (str): the breakdown producer label (defaults to the
             Coordinator).
     """
@@ -3648,21 +3647,24 @@ def record_specialist_round(
         trace_skip(reason="no session_dir" if not session_dir else "empty entry", section="specialist_rounds")
         return
     try:
-        key = str(entry.get("round_id") or "") or None
+        source_phase = str(entry.get("source_phase") or phase or entry.get("phase") or "").strip().upper()
+        recorded_entry = dict(entry)
+        if source_phase:
+            recorded_entry.setdefault("source_phase", source_phase)
+        key = str(recorded_entry.get("round_id") or "") or None
         _recorder(session_dir, producer).record_item(
             "specialist_runs",
-            dict(entry),
+            recorded_entry,
             key=key,
         )
-        round_id = str(entry.get("round_id") or key or entry.get("task_id") or "unknown")
+        round_id = str(recorded_entry.get("round_id") or key or recorded_entry.get("task_id") or "unknown")
         operation_id = _stable_id("op", "specialist", round_id)
         round_subject_id = _stable_id("subject", "specialist-round", round_id)
-        domains = list(entry.get("domains") or [])
-        if entry.get("domain"):
-            domains.append(str(entry.get("domain")))
-        domains.extend(str(tag) for tag in (entry.get("tags") or []) if str(tag))
+        domains = list(recorded_entry.get("domains") or [])
+        if recorded_entry.get("domain"):
+            domains.append(str(recorded_entry.get("domain")))
+        domains.extend(str(tag) for tag in (recorded_entry.get("tags") or []) if str(tag))
         domains = list(dict.fromkeys(domain for domain in domains if domain))
-        source_phase = str(entry.get("source_phase") or "EXPLORE").strip().upper()
         record_subject(
             session_dir,
             subject_id=round_subject_id,
@@ -3671,7 +3673,7 @@ def record_specialist_round(
             name=round_id,
             attributes={
                 "domains": domains,
-                "proposals_total": entry.get("proposals_total"),
+                "proposals_total": recorded_entry.get("proposals_total"),
             },
             producer=producer,
         )
@@ -3689,7 +3691,7 @@ def record_specialist_round(
             )
             domain_subjects.append({"subject_id": domain_id, "subject_type": "specialist_domain"})
         proposal_subjects: list[dict[str, Any]] = []
-        proposals = entry.get("proposal_set")
+        proposals = recorded_entry.get("proposal_set")
         if isinstance(proposals, list):
             for index, proposal in enumerate(proposals):
                 if not isinstance(proposal, Mapping):
@@ -3715,18 +3717,18 @@ def record_specialist_round(
             kind="specialist",
             name=f"specialist round {round_id}",
             phase=source_phase,
-            status="succeeded" if entry.get("completed_at") else "partial",
+            status="succeeded" if recorded_entry.get("completed_at") else "partial",
             source="specialist_recorder_hook",
             executor_class="llm_agent",
             purpose="proposal",
-            scope=str(entry.get("scope") or ""),
+            scope=str(recorded_entry.get("scope") or ""),
             strategy_group="specialist",
             strategy="multi_domain",
             producer=producer,
-            ended_at=str(entry.get("completed_at") or entry.get("dispatched_at") or ""),
+            ended_at=str(recorded_entry.get("completed_at") or recorded_entry.get("dispatched_at") or ""),
             subject={"subject_id": round_subject_id, "subject_type": "specialist_round"},
             subjects=domain_subjects + proposal_subjects,
-            outputs=dict(entry),
+            outputs=recorded_entry,
             adoption_refs=[],
             extensions={"downstream_relation": "proposal_only"},
         )

--- a/src/hyperloom/inference_optimizer/breakdown/schema.py
+++ b/src/hyperloom/inference_optimizer/breakdown/schema.py
@@ -1064,6 +1064,8 @@ class CriticIteration(TypedDict, total=False):
     """One critic-agent review pass over a proposed change.
 
     Attributes:
+        iteration_id (str): Stable session-unique identity for this persisted
+            review pass, including resume-time reuse of ``iter``.
         iter (int): Iteration index.
         ts (str): ISO UTC timestamp of the review.
         topic (str): What was reviewed (e.g. ``kernel_opt:k001`` / ``backends:flag_X``).
@@ -1074,8 +1076,11 @@ class CriticIteration(TypedDict, total=False):
         judge_bundle_path (str): Path to the judge bundle.
         emit_path (str): Path to the emitted review output.
         review_path (str): Path to the review record.
+        framework_reviews (list[dict[str, Any]]): Durable normalized V6
+            Framework review rows.
     """
 
+    iteration_id: str
     iter: int
     ts: str
     topic: str  # what was reviewed (kernel_opt:k001, backends:flag_X, ...)
@@ -1085,6 +1090,7 @@ class CriticIteration(TypedDict, total=False):
     judge_bundle_path: str
     emit_path: str
     review_path: str
+    framework_reviews: list[dict[str, Any]]
 
 
 class RobustnessSignal(TypedDict, total=False):

--- a/src/hyperloom/inference_optimizer/tests/test_enablement_coordinator_wiring_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_enablement_coordinator_wiring_unit.py
@@ -92,6 +92,7 @@ def test_build_params_actionable_failure_tags_enablement(monkeypatch):
     params = Coordinator._build_enablement_specialist_params(fake, _MISSING_ARCH_LOG)
     assert params is not None
     assert params["domain"] == "enablement_specialist"
+    assert params["source_phase"] == "ENABLEMENT"
     # Reuses FRAMEWORK authoring machinery + tags the objective.
     assert params["framework_agent_authoring"] is True
     assert params["enablement"] is True

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_authoring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_authoring.py
@@ -246,6 +246,33 @@ def test_materialize_authoring_disabled_runs_diff_track_only(
     assert kinds == ["integrate_patch"]
 
 
+def test_reauthor_attempt_propagates_into_specialist_and_integrate_params(tmp_path: Path):
+    from hyperloom.orchestrator.phases.explore import _forward_integrate_source
+
+    stub = _Stub(tmp_path, authoring=True)
+
+    task_id = asyncio.run(
+        stub._enqueue_framework_agent_authoring_specialist(
+            dict(_CANDIDATE),
+            {},
+            reauthor_attempt=1,
+        )
+    )
+
+    specialist_task = stub.tasks._queued[-1]
+    assert task_id == specialist_task.task_id
+    assert specialist_task.params["reauthor_attempt"] == 1
+    round_entry = stub._build_specialist_round_entry(
+        task=specialist_task,
+        done_payload={"proposal_set": [], "empty": True},
+        source=f"specialist:{task_id}",
+    )
+    assert round_entry["reauthor_attempt"] == 1
+    integrate_params: dict[str, Any] = {}
+    _forward_integrate_source(specialist_task.params, integrate_params)
+    assert integrate_params["reauthor_attempt"] == 1
+
+
 @pytest.mark.parametrize(
     ("route", "authoring", "kinds"),
     [
@@ -378,6 +405,7 @@ def test_record_authored_outcome_writes_progress_and_rolls_max_gain(
             "framework_agent_candidate_id": "pr-42",
             "framework_batch_id": "b1",
             "specialist_task_id": "s-1",
+            "reauthor_attempt": 1,
         },
     )
     result = SimpleNamespace(
@@ -398,6 +426,7 @@ def test_record_authored_outcome_writes_progress_and_rolls_max_gain(
     assert row["provenance"] == "authored"
     assert row["candidate_id"] == "pr-42"
     assert row["gain_pct"] == pytest.approx(6.5)
+    assert row["reauthor_attempt"] == 1
     assert stub.shared_state.framework_agent_batches[0]["max_gain_pct_observed_in_batch"] == pytest.approx(6.5)
 
 
@@ -621,7 +650,7 @@ async def test_dispatcher_records_authored_outcome_after_phase_transition(tmp_pa
     task = SimpleNamespace(
         task_id="integrate-cross-phase",
         kind="integrate_patch",
-        params={"framework_agent_authoring": True},
+        params={"framework_agent_authoring": True, "reauthor_attempt": 1},
     )
     result = SubAgentResult(
         task_id=task.task_id,
@@ -632,6 +661,7 @@ async def test_dispatcher_records_authored_outcome_after_phase_transition(tmp_pa
     await DispatcherCollaborator(stub)._reap_dispatched_task(task, result, None)
 
     assert recorded == ["reverted"]
+    assert result.result["reauthor_attempt"] == 1
 
 
 def test_empty_outcome_fires_when_patch_dropped_by_vetting(tmp_path: Path):

--- a/src/hyperloom/inference_optimizer/tests/test_framework_agent_authoring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_agent_authoring.py
@@ -226,6 +226,7 @@ def test_materialize_unknown_route_dispatches_both_tracks(
     params = spec["params"]
     assert params["framework_agent_authoring"] is True
     assert params["domain"] == "serving_specialist"
+    assert params["source_phase"] == "FRAMEWORK_AGENT"
     assert params["framework_agent_candidate_id"] == _CANDIDATE["pr_url"]
     assert params.get("task_kind") == "framework_authoring"
     pr_lead = params.get("pr_lead") or {}

--- a/src/hyperloom/inference_optimizer/tests/test_research_scout.py
+++ b/src/hyperloom/inference_optimizer/tests/test_research_scout.py
@@ -161,6 +161,7 @@ async def test_internal_research_scout_task_is_readonly(tmp_path: Path):
 
     assert task is not None
     assert task.params["mode"] == "research"
+    assert task.params["source_phase"] == "PRELUDE"
     assert task.side_effects == ["writes_results"]
     assert task.params["seen_pr_ids"] == ["https://pr/seen"]
     assert "Does this vLLM version support the backend?" in task.params["notes"]

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_v6_initial.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_v6_initial.py
@@ -6,7 +6,9 @@ import argparse
 import asyncio
 import json
 import os
+import shutil
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -1018,11 +1020,11 @@ def test_framework_timeline_merges_legacy_framework_and_explore(tmp_path):
     assert event["start_time"] == "2026-08-27T01:00:00+00:00"
     assert event["end_time"] == "2026-08-27T01:20:00+00:00"
     assert "summary" not in event
-    assert event["ext"]["policy"]["stack_rebench_enabled"] is None
+    assert "stack_rebench_enabled" not in event["ext"]["policy"]
     assert event["ext"]["config_arm"]["rounds"][0]["workload_signature"] == "qwen-tp8-c64"
     assert event["ext"]["config_arm"]["rounds"][0]["input_stack"]["extra_server_args"] == "--base-flag"
     variant = event["ext"]["config_arm"]["rounds"][0]["variants"][0]
-    assert variant["stack_rebench"] == {"ran": True, "tput": 104.0, "stable": True}
+    assert "stack_rebench" not in variant
     attempt = event["ext"]["source_arm"]["attempts"][0]
     assert attempt["patch_source"] == "upstream_pr"
     assert attempt["lever_kind"] == "upstream_pr"
@@ -1101,6 +1103,10 @@ def test_framework_timeline_projects_pr1301_source_and_critic_data(tmp_path):
                 "cycle": 2,
                 "completed_at": "2026-08-27T02:08:00+00:00",
                 "proposal_set": [{"patches_written": ["patches/pr-9.patch"]}],
+                "task_kind": "framework_authoring",
+                "framework_agent_authoring": True,
+                "framework_agent_candidate_id": "https://example.test/pr/9",
+                "reauthor_attempt": 1,
             },
         ],
         "framework_agent_batches": [
@@ -1129,6 +1135,7 @@ def test_framework_timeline_projects_pr1301_source_and_critic_data(tmp_path):
                 "post_tput": 104.0,
                 "specialist_task_id": "author-task-1",
                 "integrate_task_id": "integrate-task-1",
+                "reauthor_attempt": 1,
                 "cycle": 2,
                 "ts": "2026-08-27T02:15:00+00:00",
             }
@@ -1147,6 +1154,7 @@ def test_framework_timeline_projects_pr1301_source_and_critic_data(tmp_path):
                 "status": "kept",
                 "framework_agent_authoring": True,
                 "specialist_task_id": "author-task-1",
+                "reauthor_attempt": 1,
                 "base_tput": 100.0,
                 "output_throughput": 104.0,
                 "delta_pct": 4.0,
@@ -1227,6 +1235,8 @@ def test_framework_timeline_projects_pr1301_source_and_critic_data(tmp_path):
     ]
     authoring = event["ext"]["source_arm"]["authoring_runs"][0]
     assert authoring["candidate_id"] == "https://example.test/pr/9"
+    assert authoring["kind"] == "reauthor"
+    assert authoring["reauthor_attempt"] == 1
     assert authoring["patch_refs"] == ["patches/pr-9.patch"]
     attempt = event["ext"]["source_arm"]["attempts"][0]
     assert attempt["patch_source"] == "specialist_authored"
@@ -1237,7 +1247,6 @@ def test_framework_timeline_projects_pr1301_source_and_critic_data(tmp_path):
         "accuracy_passed": True,
         "keep_threshold_pct": 1.0,
         "switch_off_parity_passed": True,
-        "stack_rebench_passed": True,
     }
     review = event["ext"]["critic_reviews"][0]
     assert review["arm"] == "source"
@@ -1364,6 +1373,7 @@ def test_framework_timeline_ignores_kernel_specialist_without_framework_evidence
             "kind": "specialist",
             "name": "specialist round kernel-specialist",
             "phase": "EXPLORE",
+            "agent": "explore",
             "source": "specialist_recorder_hook",
             "macro_cycle": 4,
             "status": "succeeded",
@@ -1690,7 +1700,7 @@ def test_framework_timeline_marks_exhausted_discovery_retries_failed(tmp_path):
     assert event["status"] == "failed"
     assert event["ext"]["failure"] == {
         "failed_task_id": None,
-        "error_class": None,
+        "error_class": "candidate_discovery_failed",
         "error": "TimeoutError('last')",
     }
 
@@ -1964,3 +1974,181 @@ def test_framework_timeline_does_not_copy_final_progress_into_earlier_retry(tmp_
     assert attempts[1]["before_tput"] == 100.0
     assert attempts[1]["after_tput"] == 120.0
     assert attempts[1]["local_gain_pct"] == 20.0
+
+
+def test_failed_discovery_uses_task_params_and_actual_terminal_reason(tmp_path):
+    from hyperloom.orchestrator.phases.explore import ExplorePhase
+
+    phase = object.__new__(ExplorePhase)
+    phase.shared_state = SimpleNamespace(phase="KERNEL_AGENT")
+    task = SimpleNamespace(
+        task_id="discovery-task",
+        params={
+            "source_phase": "FRAMEWORK_AGENT",
+            "domain": "candidate_discovery_specialist",
+            "task_kind": "candidate_discovery",
+            "candidate_discovery": True,
+            "gap_canonical_id": "gap.framework.candidate_discovery.sglang",
+        },
+    )
+    entry = phase._build_specialist_round_entry(
+        task=task,
+        done_payload={},
+        source="specialist:discovery-task",
+        run_error="TimeoutError('upstream unavailable')",
+    )
+    state = {
+        "phase": "FRAMEWORK_AGENT",
+        "macro_cycle": 0,
+        "phase_history": [
+            {
+                "from_phase": "PRELUDE",
+                "to_phase": "FRAMEWORK_AGENT",
+                "cycle": 0,
+                "ts": "2026-08-28T00:00:00+00:00",
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "FRAMEWORK_AGENT",
+                "cycle": 0,
+                "reason": "no_candidates_and_discovery_exhausted",
+                "evidence": {
+                    "event": "framework_agent_phase_done",
+                    "failure_count": 1,
+                    "retry_limit": 3,
+                },
+                "ts": "2026-08-28T00:05:00+00:00",
+            },
+        ],
+        "specialist_rounds": [entry],
+    }
+
+    event = collect_v6_timeline(tmp_path, [], state=state, recorded_operations=[])[0]
+
+    assert entry["domain"] == "candidate_discovery_specialist"
+    assert entry["task_kind"] == "candidate_discovery"
+    assert entry["candidate_discovery"] is True
+    assert entry["status"] == "failed"
+    assert entry["run_error"] == "TimeoutError('upstream unavailable')"
+    assert event["ext"]["source_arm"]["candidate_discovery_runs"] == [
+        {
+            "task_id": "discovery-task",
+            "status": "failed",
+            "batch_id": None,
+            "gap_canonical_id": "gap.framework.candidate_discovery.sglang",
+            "reason": "TimeoutError('upstream unavailable')",
+            "candidates": [],
+        }
+    ]
+    assert event["status"] == "failed"
+    assert event["ext"]["failure"] == {
+        "failed_task_id": "discovery-task",
+        "error_class": "candidate_discovery_failed",
+        "error": "TimeoutError('upstream unavailable')",
+    }
+
+
+def test_framework_critic_reviews_survive_pruning_and_reused_iteration_number(tmp_path):
+    from hyperloom.inference_optimizer.breakdown.recorder import instrument
+    from hyperloom.inference_optimizer.breakdown.recorder.assembler import assemble_parts
+
+    state = {
+        "session_id": "durable-critic",
+        "phase": "KERNEL_AGENT",
+        "macro_cycle": 0,
+        "phase_history": [
+            {
+                "from_phase": "PRELUDE",
+                "to_phase": "FRAMEWORK_AGENT",
+                "cycle": 0,
+                "ts": "2026-08-28T01:00:00+00:00",
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "KERNEL_AGENT",
+                "cycle": 0,
+                "ts": "2026-08-28T01:10:00+00:00",
+            },
+        ],
+    }
+    _write_json(tmp_path / "state.json", state)
+    _write_json(tmp_path / "manifest.json", {"session_id": "durable-critic"})
+    workdir = tmp_path / "critic-workdir" / "000000"
+
+    for index in (1, 2):
+        proposal_id = f"proposal-{index}"
+        timestamp = f"2026-08-28T01:0{index}:00+00:00"
+        request = {"context": {"phase": "FRAMEWORK_AGENT", "macro_cycle": 0}}
+        judge_bundle = {
+            "phase": "FRAMEWORK_AGENT",
+            "proposals": [
+                {
+                    "msg_id": proposal_id,
+                    "action_name": "integrate_patch",
+                    "payload": {"framework_agent_candidate_id": f"candidate-{index}"},
+                }
+            ],
+        }
+        review = {
+            "ts": timestamp,
+            "review_verdicts": [
+                {
+                    "target_proposal_msg_id": proposal_id,
+                    "verdict": "approve",
+                    "reasoning": f"review {index}",
+                }
+            ],
+        }
+        emit = {
+            "ts": timestamp,
+            "intent_envelope": {
+                "intents": [
+                    {
+                        "intent_type": "review_verdict",
+                        "payload": {
+                            "target_proposal_msg_id": proposal_id,
+                            "verdict": "approve",
+                        },
+                    }
+                ]
+            },
+        }
+        for name, payload in (
+            ("request", request),
+            ("judge_bundle", judge_bundle),
+            ("review", review),
+            ("emit", emit),
+        ):
+            _write_json(workdir / f"{name}.json", payload)
+        instrument.record_critic_iteration(
+            tmp_path,
+            iter_n=0,
+            request=request,
+            judge_bundle=judge_bundle,
+            review=review,
+            emit=emit,
+            workdir=workdir,
+        )
+
+    assembled = assemble_parts(tmp_path)
+    critic_iterations = assembled["critic_robustness"]["critic_iterations"]
+    assert len(critic_iterations) == 2
+    assert len({row["iteration_id"] for row in critic_iterations}) == 2
+
+    timeline = collect_v6_timeline(
+        tmp_path,
+        [],
+        state=state,
+        recorded_operations=assembled.get("operations", []),
+        critic_iterations=critic_iterations,
+    )
+    assert [row["proposal_msg_id"] for row in timeline[0]["ext"]["critic_reviews"]] == [
+        "proposal-1",
+        "proposal-2",
+    ]
+
+    shutil.rmtree(tmp_path / "critic-workdir")
+    breakdown = exporter.build(tmp_path)
+    reviews = breakdown["timeline"][0]["ext"]["critic_reviews"]
+    assert [row["proposal_msg_id"] for row in reviews] == ["proposal-1", "proposal-2"]
+    assert all("\\" not in row["review_path"] for row in reviews)

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_v6_initial.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_v6_initial.py
@@ -842,3 +842,968 @@ def test_fresh_model_gate_with_only_soft_skips_succeeds(tmp_path):
     assert event is not None
     assert event["status"] == "succeeded"
     assert event["ext"]["skip_reason"] is None
+
+
+def test_framework_timeline_merges_legacy_framework_and_explore(tmp_path):
+    state = {
+        "phase": "KERNEL_AGENT",
+        "macro_cycle": 0,
+        "framework_agent_phase_done": True,
+        "phase_history": [
+            {
+                "from_phase": "PRELUDE",
+                "to_phase": "FRAMEWORK_AGENT",
+                "reason": "prelude_complete",
+                "ts": "2026-08-27T01:00:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "EXPLORE",
+                "reason": "framework_agent_phase_done",
+                "ts": "2026-08-27T01:10:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "EXPLORE",
+                "to_phase": "KERNEL_AGENT",
+                "reason": "explore_no_more_leverage",
+                "ts": "2026-08-27T01:20:00+00:00",
+                "cycle": 0,
+                "evidence": {
+                    "recent_keep_gain_pct": 5.0,
+                    "keep_gain_threshold_pct": 6.0,
+                    "empty_streak": 2,
+                    "empty_streak_threshold": 2,
+                    "lookback": 6,
+                    "tested_this_cycle": 1,
+                    "config_arm_plateaued": True,
+                    "source_consecutive_no_keep": 1,
+                    "source_threshold": 3,
+                    "source_candidates_exhausted": True,
+                    "source_arm_plateaued": True,
+                    "switch_bottleneck": True,
+                    "evidence": "both_arms_plateaued",
+                },
+            },
+        ],
+        "specialist_rounds": [
+            {
+                "round_id": "spec-config-1",
+                "task_id": "spec-config-task",
+                "domain": "serving_specialist",
+                "cycle": 0,
+                "completed_at": "2026-08-27T01:04:00+00:00",
+                "proposal_set": [
+                    {
+                        "name": "chunked-prefill",
+                        "fingerprint": "fp-config-1",
+                    }
+                ],
+            }
+        ],
+        "explore_search": {
+            "tested": {
+                "fp-config-1": {
+                    "fingerprint": "fp-config-1",
+                    "name": "chunked-prefill",
+                    "outcome": "KEEP",
+                    "tput": 105.0,
+                    "base_tput": 100.0,
+                    "gain_pct": 5.0,
+                    "round_id": "config-round-1",
+                    "cycle": 0,
+                    "workload_signature": "qwen-tp8-c64",
+                    "framework": "sglang",
+                    "stack_rebench_tput": 104.0,
+                    "stack_rebench_workspace": "runs/config-round-1/rebench",
+                }
+            },
+            "winners_history": [{"gain_pct": 5.0, "cycle": 0}],
+        },
+        "framework_agent_batches": [
+            {
+                "batch_id": "legacy-batch",
+                "candidates": [
+                    {
+                        "pr_url": "https://example.test/pr/7",
+                        "route": "direct_framework",
+                        "audit": {"verdict": "worth_a_bench"},
+                    }
+                ],
+            }
+        ],
+        "framework_agent_phase_progress": [
+            {
+                "candidate_id": "https://example.test/pr/7",
+                "status": "kept",
+                "kept": True,
+                "pre_tput": 105.0,
+                "post_tput": 108.0,
+                "gain_pct": 2.857,
+                "cycle": 0,
+                "ts": "2026-08-27T01:08:00+00:00",
+            }
+        ],
+    }
+    operations = [
+        {
+            "operation_id": "op-source-1",
+            "name": "framework_agent",
+            "phase": "FRAMEWORK_AGENT",
+            "macro_cycle": 0,
+            "status": "succeeded",
+            "ended_at": "2026-08-27T01:08:00+00:00",
+            "outputs": {
+                "status": "kept",
+                "candidate": {
+                    "pr_url": "https://example.test/pr/7",
+                    "route": "direct_framework",
+                    "changed_files": ["python/server.py"],
+                },
+                "base_tput": 105.0,
+                "output_throughput": 108.0,
+                "delta_pct": 2.857,
+                "accuracy_pass": True,
+                "keep_threshold_pct": 1.0,
+                "patches_applied": ["patches/pr-7.patch"],
+                "target_files": ["python/server.py"],
+                "workspace": "runs/framework/pr-7",
+            },
+            "extensions": {"task_id": "source-task-1"},
+        },
+        {
+            "operation_id": "op-config-1",
+            "name": "explore",
+            "phase": "EXPLORE",
+            "macro_cycle": 0,
+            "status": "succeeded",
+            "ended_at": "2026-08-27T01:16:00+00:00",
+            "outputs": {
+                "status": "succeeded",
+                "round_id": "config-round-1",
+                "framework": "sglang",
+                "base_tput": 100.0,
+                "per_variant_outcomes": [
+                    {
+                        "variant_name": "chunked-prefill",
+                        "outcome": "KEEP",
+                        "fingerprint": "fp-config-1",
+                        "provenance": "specialist:serving_specialist",
+                        "scope": "domain",
+                        "metrics": {"tput": 105.0, "gain_pct": 5.0},
+                        "variant": {
+                            "extra_server_args": "--enable-chunked-prefill",
+                            "extra_envs": {"SGLANG_CHUNKED_PREFILL": "1"},
+                        },
+                    }
+                ],
+                "explore_search_update": {
+                    "tested": state["explore_search"]["tested"],
+                    "last_round": {
+                        "round_id": "config-round-1",
+                        "base_tput": 100.0,
+                        "base_extra_args": "--base-flag",
+                    },
+                },
+            },
+            "extensions": {"task_id": "config-task-1"},
+        },
+    ]
+
+    timeline = collect_v6_timeline(tmp_path, [], state=state, recorded_operations=operations)
+
+    assert [event["type"] for event in timeline] == ["framework_agent"]
+    event = timeline[0]
+    assert event["start_time"] == "2026-08-27T01:00:00+00:00"
+    assert event["end_time"] == "2026-08-27T01:20:00+00:00"
+    assert "summary" not in event
+    assert event["ext"]["policy"]["stack_rebench_enabled"] is None
+    assert event["ext"]["config_arm"]["rounds"][0]["workload_signature"] == "qwen-tp8-c64"
+    assert event["ext"]["config_arm"]["rounds"][0]["input_stack"]["extra_server_args"] == "--base-flag"
+    variant = event["ext"]["config_arm"]["rounds"][0]["variants"][0]
+    assert variant["stack_rebench"] == {"ran": True, "tput": 104.0, "stable": True}
+    attempt = event["ext"]["source_arm"]["attempts"][0]
+    assert attempt["patch_source"] == "upstream_pr"
+    assert attempt["lever_kind"] == "upstream_pr"
+    assert attempt["route"] == "direct_framework"
+    assert attempt["status"] == "KEEP"
+    assert event["ext"]["exit"] == {
+        "reason": "optimize_no_more_leverage",
+        "trigger": "both_arms_plateaued",
+        "hint": None,
+        "switch_bottleneck": True,
+    }
+
+
+def test_framework_timeline_projects_pr1301_source_and_critic_data(tmp_path):
+    state = {
+        "phase": "KERNEL_AGENT",
+        "macro_cycle": 2,
+        "framework_agent_authoring_enabled": True,
+        "framework_agent_phase_done": False,
+        "phase_history": [
+            {
+                "from_phase": "SWEEP",
+                "to_phase": "FRAMEWORK_AGENT",
+                "reason": "cycle_reloop",
+                "ts": "2026-08-27T02:00:00+00:00",
+                "cycle": 2,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "KERNEL_AGENT",
+                "reason": "optimize_phase_budget_exhausted",
+                "ts": "2026-08-27T02:20:00+00:00",
+                "cycle": 2,
+                "evidence": {
+                    "source_consecutive_no_keep": 0,
+                    "source_threshold": 3,
+                    "source_candidates_exhausted": False,
+                    "source_arm_plateaued": False,
+                    "recent_keep_gain_pct": 0.0,
+                    "keep_gain_threshold_pct": 1.0,
+                    "empty_streak": 0,
+                    "empty_streak_threshold": 3,
+                    "lookback": 6,
+                    "tested_this_cycle": 0,
+                    "config_arm_plateaued": False,
+                    "switch_bottleneck": False,
+                },
+            },
+        ],
+        "specialist_rounds": [
+            {
+                "round_id": "discover-round",
+                "task_id": "discover-task-1234",
+                "domain": "candidate_discovery_specialist",
+                "cycle": 2,
+                "completed_at": "2026-08-27T02:04:00+00:00",
+                "proposal_set": [
+                    {
+                        "pr_url": "https://example.test/pr/9",
+                        "title": "Fuse host copies",
+                        "verdict": "worth_a_bench",
+                        "route": "author_via_specialist",
+                    },
+                    {
+                        "pr_url": "https://example.test/pr/10",
+                        "title": "Unrelated backend",
+                        "verdict": "not_applicable",
+                        "reason": "wrong framework",
+                    },
+                ],
+            },
+            {
+                "round_id": "author-round",
+                "task_id": "author-task-1",
+                "domain": "serving_specialist",
+                "cycle": 2,
+                "completed_at": "2026-08-27T02:08:00+00:00",
+                "proposal_set": [{"patches_written": ["patches/pr-9.patch"]}],
+            },
+        ],
+        "framework_agent_batches": [
+            {
+                "batch_id": "discovery-0-discover",
+                "candidates": [
+                    {
+                        "pr_url": "https://example.test/pr/9",
+                        "route": "author_via_specialist",
+                        "audit": {"verdict": "worth_a_bench"},
+                    }
+                ],
+            }
+        ],
+        "framework_agent_specialist_candidate_map": {
+            "author-task-1": "https://example.test/pr/9",
+        },
+        "framework_agent_phase_progress": [
+            {
+                "candidate_id": "https://example.test/pr/9",
+                "batch_id": "discovery-0-discover",
+                "status": "kept",
+                "kept": True,
+                "gain_pct": 4.0,
+                "pre_tput": 100.0,
+                "post_tput": 104.0,
+                "specialist_task_id": "author-task-1",
+                "integrate_task_id": "integrate-task-1",
+                "cycle": 2,
+                "ts": "2026-08-27T02:15:00+00:00",
+            }
+        ],
+    }
+    operations = [
+        {
+            "operation_id": "op-integrate-1",
+            "name": "integrate_patch",
+            "phase": "FRAMEWORK_AGENT",
+            "agent": "framework_agent",
+            "macro_cycle": 2,
+            "status": "succeeded",
+            "ended_at": "2026-08-27T02:15:00+00:00",
+            "outputs": {
+                "status": "kept",
+                "framework_agent_authoring": True,
+                "specialist_task_id": "author-task-1",
+                "base_tput": 100.0,
+                "output_throughput": 104.0,
+                "delta_pct": 4.0,
+                "accuracy_pass": True,
+                "keep_threshold_pct": 1.0,
+                "patches_applied": ["patches/pr-9.patch"],
+                "target_files": ["python/worker.py"],
+                "source_snapshot": "optimization_stack/src/author-task-1",
+                "source_manifest": "optimization_stack/src/author-task-1/manifest.json",
+                "workspace": "runs/integrate-task-1",
+                "switch_off_parity": {"ran": True, "ok": True},
+                "stack_rebench": {"stable": True},
+                "framework_levers": [{"switch": "SGLANG_FAST_COPY", "default_on": True}],
+            },
+            "extensions": {"task_id": "integrate-task-1"},
+        }
+    ]
+    critic_dir = tmp_path / "critic-workdir" / "000000"
+    _write_json(
+        critic_dir / "judge_bundle.json",
+        {
+            "merged_context": {"macro_cycle": 2},
+            "proposals": [
+                {
+                    "msg_id": "proposal-1",
+                    "action_name": "integrate_patch",
+                    "payload": {
+                        "params": {
+                            "framework_agent_candidate_id": "https://example.test/pr/9",
+                        }
+                    },
+                }
+            ],
+        },
+    )
+    _write_json(
+        critic_dir / "review.json",
+        {
+            "review_verdicts": [
+                {
+                    "target_proposal_msg_id": "proposal-1",
+                    "verdict": "needs_review",
+                    "source": "critic",
+                    "reasoning": "needs parity evidence",
+                    "confidence": "high",
+                    "required_evidence": ["switch-off parity"],
+                    "risks": [{"severity": "major", "risk": "default behavior may change"}],
+                }
+            ]
+        },
+    )
+    _write_json(
+        critic_dir / "emit.json",
+        {
+            "intent_envelope": {
+                "intents": [
+                    {
+                        "intent_type": "review_verdict",
+                        "payload": {
+                            "target_proposal_msg_id": "proposal-1",
+                            "verdict": "approve",
+                            "advice_text": "retain the switch-off check",
+                        },
+                    }
+                ]
+            }
+        },
+    )
+
+    timeline = collect_v6_timeline(tmp_path, [], state=state, recorded_operations=operations)
+
+    event = timeline[0]
+    discovery = event["ext"]["source_arm"]["candidate_discovery_runs"][0]
+    assert discovery["task_id"] == "discover-task-1234"
+    assert [candidate["verdict"] for candidate in discovery["candidates"]] == [
+        "worth_a_bench",
+        "not_applicable",
+    ]
+    authoring = event["ext"]["source_arm"]["authoring_runs"][0]
+    assert authoring["candidate_id"] == "https://example.test/pr/9"
+    assert authoring["patch_refs"] == ["patches/pr-9.patch"]
+    attempt = event["ext"]["source_arm"]["attempts"][0]
+    assert attempt["patch_source"] == "specialist_authored"
+    assert attempt["lever_kind"] == "source_patch"
+    assert attempt["route"] == "author_via_specialist"
+    assert attempt["status"] == "KEEP"
+    assert attempt["gates"] == {
+        "accuracy_passed": True,
+        "keep_threshold_pct": 1.0,
+        "switch_off_parity_passed": True,
+        "stack_rebench_passed": True,
+    }
+    review = event["ext"]["critic_reviews"][0]
+    assert review["arm"] == "source"
+    assert review["target_action"] == "integrate_patch"
+    assert review["verdict"] == "needs_review"
+    assert review["effective_verdict"] == "approve"
+    assert "token" not in json.dumps(event).lower()
+
+
+def test_framework_timeline_keeps_config_serving_specialist_out_of_source_arm(tmp_path):
+    state = {
+        "phase": "KERNEL_AGENT",
+        "macro_cycle": 0,
+        "phase_history": [
+            {
+                "from_phase": "PRELUDE",
+                "to_phase": "FRAMEWORK_AGENT",
+                "ts": "2026-08-27T03:00:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "KERNEL_AGENT",
+                "ts": "2026-08-27T03:10:00+00:00",
+                "cycle": 0,
+            },
+        ],
+        "specialist_rounds": [
+            {
+                "round_id": "config-round",
+                "task_id": "config-task",
+                "domain": "serving_specialist",
+                "source_phase": "FRAMEWORK_AGENT",
+                "cycle": 0,
+                "proposal_set": [
+                    {
+                        "name": "larger-page-size",
+                        "extra_server_args": "--page-size 32",
+                    }
+                ],
+            }
+        ],
+    }
+    critic_dir = tmp_path / "critic-workdir" / "000000"
+    _write_json(
+        critic_dir / "request.json",
+        {
+            "context": {"phase": "FRAMEWORK_AGENT"},
+            "raw_prompt": "=== Shared session state ===\nmacro_cycle=0\n",
+        },
+    )
+    _write_json(
+        critic_dir / "judge_bundle.json",
+        {
+            "phase": "FRAMEWORK_AGENT",
+            "proposals": [
+                {
+                    "msg_id": "config-proposal",
+                    "action_name": "specialist",
+                    "payload": {
+                        "params": {
+                            "domain": "serving_specialist",
+                            "source_phase": "FRAMEWORK_AGENT",
+                        }
+                    },
+                }
+            ],
+        },
+    )
+    _write_json(
+        critic_dir / "review.json",
+        {
+            "review_verdicts": [
+                {
+                    "target_proposal_msg_id": "config-proposal",
+                    "verdict": "approve",
+                }
+            ]
+        },
+    )
+    _write_json(
+        critic_dir / "emit.json",
+        {
+            "intent_envelope": {
+                "intents": [
+                    {
+                        "intent_type": "review_verdict",
+                        "payload": {
+                            "target_proposal_msg_id": "config-proposal",
+                            "verdict": "approve",
+                        },
+                    }
+                ]
+            }
+        },
+    )
+
+    event = collect_v6_timeline(tmp_path, [], state=state, recorded_operations=[])[0]
+
+    assert [row["task_id"] for row in event["ext"]["config_arm"]["specialist_runs"]] == ["config-task"]
+    assert event["ext"]["source_arm"]["authoring_runs"] == []
+    assert event["ext"]["critic_reviews"][0]["arm"] == "config"
+
+
+def test_framework_timeline_ignores_kernel_specialist_without_framework_evidence(tmp_path):
+    state = {
+        "phase": "KERNEL_AGENT",
+        "macro_cycle": 4,
+        "specialist_rounds": [
+            {
+                "round_id": "kernel-specialist",
+                "task_id": "kernel-specialist",
+                "domain": "kernel_specialist",
+                "cycle": 4,
+                "completed_at": "2026-08-27T04:00:00+00:00",
+                "proposal_set": [{"name": "kernel-rewrite"}],
+            }
+        ],
+    }
+
+    operations = [
+        {
+            "operation_id": "op-kernel-specialist",
+            "kind": "specialist",
+            "name": "specialist round kernel-specialist",
+            "phase": "EXPLORE",
+            "source": "specialist_recorder_hook",
+            "macro_cycle": 4,
+            "status": "succeeded",
+            "outputs": state["specialist_rounds"][0],
+        }
+    ]
+
+    assert collect_v6_timeline(tmp_path, [], state=state, recorded_operations=operations) == []
+
+
+def test_framework_timeline_recovers_direct_upstream_patch_source(tmp_path):
+    candidate_id = "https://example.test/pr/11"
+    state = {
+        "phase": "KERNEL_AGENT",
+        "macro_cycle": 0,
+        "phase_history": [
+            {
+                "from_phase": "PRELUDE",
+                "to_phase": "FRAMEWORK_AGENT",
+                "ts": "2026-08-27T03:00:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "KERNEL_AGENT",
+                "ts": "2026-08-27T03:10:00+00:00",
+                "cycle": 0,
+            },
+        ],
+        "framework_agent_batches": [
+            {
+                "batch_id": "discovery-0",
+                "candidates": [
+                    {
+                        "pr_url": candidate_id,
+                        "route": "direct_framework",
+                    }
+                ],
+            }
+        ],
+        "framework_agent_phase_progress": [
+            {
+                "candidate_id": candidate_id,
+                "integrate_task_id": "integrate-direct-1",
+                "status": "kept",
+                "kept": True,
+                "cycle": 0,
+            }
+        ],
+    }
+    operations = [
+        {
+            "operation_id": "op-integrate-direct",
+            "name": "integrate_patch",
+            "phase": "FRAMEWORK_AGENT",
+            "macro_cycle": 0,
+            "status": "succeeded",
+            "outputs": {
+                "status": "kept",
+                "framework_agent_authoring": True,
+                "specialist_task_id": "integrate-direct-1",
+            },
+            "extensions": {"task_id": "integrate-direct-1"},
+        }
+    ]
+
+    event = collect_v6_timeline(tmp_path, [], state=state, recorded_operations=operations)[0]
+    attempt = event["ext"]["source_arm"]["attempts"][0]
+
+    assert attempt["candidate_id"] == candidate_id
+    assert attempt["patch_source"] == "upstream_pr"
+    assert attempt["lever_kind"] == "upstream_pr"
+    assert attempt["route"] == "direct_framework"
+
+
+def test_framework_timeline_keeps_macro_cycles_isolated(tmp_path):
+    state = {
+        "phase": "KERNEL_AGENT",
+        "macro_cycle": 1,
+        "phase_history": [
+            {
+                "from_phase": "PRELUDE",
+                "to_phase": "FRAMEWORK_AGENT",
+                "reason": "prelude_complete",
+                "ts": "2026-08-27T03:00:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "KERNEL_AGENT",
+                "reason": "optimize_no_more_leverage",
+                "ts": "2026-08-27T03:10:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "SWEEP",
+                "to_phase": "FRAMEWORK_AGENT",
+                "reason": "cycle_reloop",
+                "ts": "2026-08-27T04:00:00+00:00",
+                "cycle": 1,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "KERNEL_AGENT",
+                "reason": "optimize_no_more_leverage",
+                "ts": "2026-08-27T04:10:00+00:00",
+                "cycle": 1,
+            },
+        ],
+    }
+    operations = [
+        {
+            "operation_id": "cycle-0",
+            "name": "explore",
+            "phase": "FRAMEWORK_AGENT",
+            "macro_cycle": 0,
+            "status": "succeeded",
+            "outputs": {"status": "succeeded", "round_id": "round-0"},
+        },
+        {
+            "operation_id": "cycle-1",
+            "name": "explore",
+            "phase": "FRAMEWORK_AGENT",
+            "macro_cycle": 1,
+            "status": "succeeded",
+            "outputs": {"status": "succeeded", "round_id": "round-1"},
+        },
+    ]
+
+    timeline = collect_v6_timeline(tmp_path, [], state=state, recorded_operations=operations)
+
+    assert [event["ext"]["macro_cycle"] for event in timeline] == [0, 1]
+    assert [event["ext"]["config_arm"]["rounds"][0]["round_id"] for event in timeline] == [
+        "round-0",
+        "round-1",
+    ]
+
+
+def test_framework_timeline_excludes_kernel_phase_explore_rebench(tmp_path):
+    state = {
+        "phase": "KERNEL_AGENT",
+        "macro_cycle": 0,
+        "phase_history": [
+            {
+                "from_phase": "PRELUDE",
+                "to_phase": "FRAMEWORK_AGENT",
+                "ts": "2026-08-27T03:00:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "KERNEL_AGENT",
+                "ts": "2026-08-27T03:10:00+00:00",
+                "cycle": 0,
+            },
+        ],
+    }
+    operations = [
+        {
+            "operation_id": "framework-round",
+            "name": "explore",
+            "phase": "FRAMEWORK_AGENT",
+            "agent": "explore",
+            "macro_cycle": 0,
+            "status": "succeeded",
+            "ended_at": "2026-08-27T03:05:00+00:00",
+            "outputs": {"status": "succeeded", "round_id": "framework-round"},
+        },
+        {
+            "operation_id": "kernel-rebench",
+            "name": "explore",
+            "phase": "KERNEL_AGENT",
+            "agent": "explore",
+            "macro_cycle": 0,
+            "status": "succeeded",
+            "ended_at": "2026-08-27T03:06:00+00:00",
+            "outputs": {"status": "succeeded", "round_id": "kernel-rebench"},
+        },
+    ]
+
+    event = collect_v6_timeline(tmp_path, [], state=state, recorded_operations=operations)[0]
+
+    assert [row["round_id"] for row in event["ext"]["config_arm"]["rounds"]] == ["framework-round"]
+
+
+def test_framework_timeline_projects_discovery_history_outcomes_in_order(tmp_path):
+    state = {
+        "phase": "KERNEL_AGENT",
+        "macro_cycle": 0,
+        "phase_history": [
+            {
+                "from_phase": "PRELUDE",
+                "to_phase": "FRAMEWORK_AGENT",
+                "ts": "2026-08-27T03:00:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "FRAMEWORK_AGENT",
+                "reason": "framework_agent_discover_failed",
+                "evidence": {
+                    "event": "framework_agent_discover_failed",
+                    "attempt": 1,
+                    "limit": 3,
+                    "error": "TimeoutError('upstream unavailable')",
+                },
+                "ts": "2026-08-27T03:01:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "FRAMEWORK_AGENT",
+                "reason": "discover_empty_payload",
+                "evidence": {
+                    "event": "framework_agent_phase_done",
+                    "failure_count": 0,
+                    "retry_limit": 3,
+                },
+                "ts": "2026-08-27T03:03:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "KERNEL_AGENT",
+                "reason": "framework_agent_phase_done",
+                "ts": "2026-08-27T03:04:00+00:00",
+                "cycle": 0,
+            },
+        ],
+        "framework_agent_batches": [
+            {
+                "batch_id": "discovery-0",
+                "ts": "2026-08-27T03:02:00+00:00",
+                "cycle": 0,
+                "candidates": [
+                    {
+                        "pr_url": "https://example.test/pr/12",
+                        "route": "direct_framework",
+                    }
+                ],
+            }
+        ],
+    }
+
+    event = collect_v6_timeline(tmp_path, [], state=state, recorded_operations=[])[0]
+    runs = event["ext"]["source_arm"]["candidate_discovery_runs"]
+
+    assert [run["status"] for run in runs] == ["failed", "succeeded", "empty"]
+    assert runs[0]["reason"] == "TimeoutError('upstream unavailable')"
+    assert runs[1]["batch_id"] == "discovery-0"
+    assert runs[1]["candidates"][0]["candidate_id"] == "https://example.test/pr/12"
+    assert runs[2]["reason"] == "discover_empty_payload"
+    assert event["status"] == "succeeded"
+    assert event["ext"]["failure"] == {
+        "failed_task_id": None,
+        "error_class": None,
+        "error": None,
+    }
+
+
+def test_framework_timeline_marks_exhausted_discovery_retries_failed(tmp_path):
+    state = {
+        "phase": "KERNEL_AGENT",
+        "macro_cycle": 0,
+        "phase_history": [
+            {
+                "from_phase": "PRELUDE",
+                "to_phase": "FRAMEWORK_AGENT",
+                "ts": "2026-08-27T03:00:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "FRAMEWORK_AGENT",
+                "reason": "framework_agent_discover_failed",
+                "evidence": {
+                    "event": "framework_agent_discover_failed",
+                    "attempt": 1,
+                    "limit": 3,
+                    "error": "TimeoutError('first')",
+                },
+                "ts": "2026-08-27T03:01:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "FRAMEWORK_AGENT",
+                "reason": "framework_agent_discover_failed",
+                "evidence": {
+                    "event": "framework_agent_discover_failed",
+                    "attempt": 3,
+                    "limit": 3,
+                    "error": "TimeoutError('last')",
+                },
+                "ts": "2026-08-27T03:02:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "FRAMEWORK_AGENT",
+                "reason": "discover_retries_exhausted",
+                "evidence": {
+                    "event": "framework_agent_phase_done",
+                    "failure_count": 3,
+                    "retry_limit": 3,
+                },
+                "ts": "2026-08-27T03:03:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "KERNEL_AGENT",
+                "reason": "framework_agent_phase_done",
+                "ts": "2026-08-27T03:04:00+00:00",
+                "cycle": 0,
+            },
+        ],
+    }
+
+    event = collect_v6_timeline(tmp_path, [], state=state, recorded_operations=[])[0]
+    runs = event["ext"]["source_arm"]["candidate_discovery_runs"]
+
+    assert [run["status"] for run in runs] == ["failed", "failed"]
+    assert event["status"] == "failed"
+    assert event["ext"]["failure"] == {
+        "failed_task_id": None,
+        "error_class": None,
+        "error": "TimeoutError('last')",
+    }
+
+
+def test_framework_timeline_assigns_critic_reviews_from_request_cycle(tmp_path):
+    state = {
+        "phase": "KERNEL_AGENT",
+        "macro_cycle": 1,
+        "phase_history": [
+            {
+                "from_phase": "PRELUDE",
+                "to_phase": "FRAMEWORK_AGENT",
+                "ts": "2026-08-27T03:00:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "KERNEL_AGENT",
+                "ts": "2026-08-27T03:10:00+00:00",
+                "cycle": 0,
+            },
+            {
+                "from_phase": "SWEEP",
+                "to_phase": "FRAMEWORK_AGENT",
+                "ts": "2026-08-27T04:00:00+00:00",
+                "cycle": 1,
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "KERNEL_AGENT",
+                "ts": "2026-08-27T04:10:00+00:00",
+                "cycle": 1,
+            },
+        ],
+    }
+    for cycle in (0, 1):
+        proposal_id = f"proposal-cycle-{cycle}"
+        critic_dir = tmp_path / "critic-workdir" / f"{cycle:06d}"
+        _write_json(
+            critic_dir / "request.json",
+            {
+                "context": {"phase": "FRAMEWORK_AGENT"},
+                "raw_prompt": (
+                    f"=== Shared session state ===\nmacro_cycle={cycle}\n"
+                    if cycle == 0
+                    else "=== Shared session state ===\n"
+                ),
+            },
+        )
+        _write_json(
+            critic_dir / "judge_bundle.json",
+            {
+                "phase": "FRAMEWORK_AGENT",
+                "proposals": [
+                    {
+                        "msg_id": proposal_id,
+                        "action_name": "integrate_patch",
+                        "payload": {
+                            "framework_agent_candidate_id": f"candidate-{cycle}",
+                        },
+                    }
+                ],
+            },
+        )
+        _write_json(
+            critic_dir / "review.json",
+            {
+                "review_verdicts": [
+                    {
+                        "target_proposal_msg_id": proposal_id,
+                        "verdict": "approve",
+                    }
+                ]
+            },
+        )
+        _write_json(
+            critic_dir / "emit.json",
+            {
+                "intent_envelope": {
+                    "intents": [
+                        {
+                            "intent_type": "review_verdict",
+                            "payload": {
+                                "target_proposal_msg_id": proposal_id,
+                                "verdict": "approve",
+                            },
+                        }
+                    ]
+                }
+            },
+        )
+
+    _write_json(
+        tmp_path / "reports" / "trace" / "proposal_task_map.jsonl",
+        {
+            "proposal_msg_id": "proposal-cycle-1",
+            "task_id": "integrate-cycle-1",
+        },
+    )
+    operations = [
+        {
+            "operation_id": "op-cycle-1",
+            "name": "integrate_patch",
+            "phase": "FRAMEWORK_AGENT",
+            "macro_cycle": 1,
+            "extensions": {"task_id": "integrate-cycle-1"},
+            "outputs": {"status": "reverted"},
+        }
+    ]
+
+    timeline = collect_v6_timeline(tmp_path, [], state=state, recorded_operations=operations)
+
+    assert [[review["proposal_msg_id"] for review in event["ext"]["critic_reviews"]] for event in timeline] == [
+        ["proposal-cycle-0"],
+        ["proposal-cycle-1"],
+    ]

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_v6_initial.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_v6_initial.py
@@ -1807,3 +1807,160 @@ def test_framework_timeline_assigns_critic_reviews_from_request_cycle(tmp_path):
         ["proposal-cycle-0"],
         ["proposal-cycle-1"],
     ]
+
+
+def test_specialist_recorder_preserves_runtime_phase_when_entry_has_no_source_phase(tmp_path, monkeypatch):
+    from hyperloom.inference_optimizer.breakdown.recorder import instrument
+
+    captured: dict[str, dict] = {}
+
+    class Recorder:
+        def record_item(self, stream, item, *, key=None):
+            captured["ledger"] = {"stream": stream, "item": item, "key": key}
+
+    monkeypatch.setattr(instrument, "_recorder", lambda *_args, **_kwargs: Recorder())
+    monkeypatch.setattr(instrument, "record_subject", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        instrument,
+        "record_operation",
+        lambda *_args, **kwargs: captured.setdefault("operation", kwargs),
+    )
+    monkeypatch.setattr(instrument, "record_trace_event", lambda *_args, **_kwargs: None)
+
+    instrument.record_specialist_round(
+        tmp_path,
+        {
+            "round_id": "kernel-specialist",
+            "task_id": "kernel-task",
+            "completed_at": "2026-08-28T01:00:00+00:00",
+        },
+        phase="KERNEL_AGENT",
+    )
+
+    assert captured["ledger"]["item"]["source_phase"] == "KERNEL_AGENT"
+    assert captured["operation"]["phase"] == "KERNEL_AGENT"
+    assert captured["operation"]["outputs"]["source_phase"] == "KERNEL_AGENT"
+
+
+def test_framework_timeline_treats_empty_discovery_as_executed_work(tmp_path):
+    state = {
+        "phase": "KERNEL_AGENT",
+        "macro_cycle": 1,
+        "phase_history": [
+            {
+                "from_phase": "PRELUDE",
+                "to_phase": "FRAMEWORK_AGENT",
+                "cycle": 1,
+                "ts": "2026-08-28T01:00:00+00:00",
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "KERNEL_AGENT",
+                "cycle": 1,
+                "ts": "2026-08-28T01:05:00+00:00",
+                "reason": "optimize_no_more_leverage",
+            },
+        ],
+        "specialist_rounds": [
+            {
+                "round_id": "discovery-empty",
+                "task_id": "discovery-task",
+                "source_phase": "FRAMEWORK_AGENT",
+                "cycle": 1,
+                "task_kind": "candidate_discovery",
+                "domain": "candidate_discovery_specialist",
+                "proposal_set": [],
+                "empty": True,
+                "completed_at": "2026-08-28T01:03:00+00:00",
+            }
+        ],
+    }
+
+    events = collect_v6_timeline(tmp_path, [], state=state, recorded_operations=[])
+
+    assert len(events) == 1
+    assert events[0]["status"] == "succeeded"
+    assert events[0]["ext"]["source_arm"]["candidate_discovery_runs"] == [
+        {
+            "task_id": "discovery-task",
+            "status": "empty",
+            "batch_id": None,
+            "gap_canonical_id": None,
+            "reason": None,
+            "candidates": [],
+        }
+    ]
+
+
+def test_framework_timeline_does_not_copy_final_progress_into_earlier_retry(tmp_path):
+    state = {
+        "phase": "KERNEL_AGENT",
+        "macro_cycle": 1,
+        "phase_history": [
+            {
+                "from_phase": "PRELUDE",
+                "to_phase": "FRAMEWORK_AGENT",
+                "cycle": 1,
+                "ts": "2026-08-28T01:00:00+00:00",
+            },
+            {
+                "from_phase": "FRAMEWORK_AGENT",
+                "to_phase": "KERNEL_AGENT",
+                "cycle": 1,
+                "ts": "2026-08-28T01:10:00+00:00",
+            },
+        ],
+        "framework_agent_phase_progress": [
+            {
+                "candidate_id": "candidate-1",
+                "integrate_task_id": "integrate-2",
+                "status": "kept",
+                "kept": True,
+                "pre_tput": 100.0,
+                "post_tput": 120.0,
+                "gain_pct": 20.0,
+                "cycle": 1,
+                "ts": "2026-08-28T01:08:00+00:00",
+            }
+        ],
+    }
+    operations = [
+        {
+            "operation_id": "operation-1",
+            "name": "integrate_patch",
+            "phase": "FRAMEWORK_AGENT",
+            "macro_cycle": 1,
+            "extensions": {"task_id": "integrate-1"},
+            "outputs": {
+                "framework_agent_candidate_id": "candidate-1",
+                "specialist_task_id": "specialist-1",
+                "status": "apply_failed",
+            },
+            "ended_at": "2026-08-28T01:04:00+00:00",
+        },
+        {
+            "operation_id": "operation-2",
+            "name": "integrate_patch",
+            "phase": "FRAMEWORK_AGENT",
+            "macro_cycle": 1,
+            "extensions": {"task_id": "integrate-2"},
+            "outputs": {
+                "framework_agent_candidate_id": "candidate-1",
+                "specialist_task_id": "specialist-1",
+                "status": "kept",
+            },
+            "ended_at": "2026-08-28T01:08:00+00:00",
+        },
+    ]
+
+    event = collect_v6_timeline(tmp_path, [], state=state, recorded_operations=operations)[0]
+    attempts = event["ext"]["source_arm"]["attempts"]
+
+    assert attempts[0]["status"] == "FAILED"
+    assert attempts[0]["before_tput"] is None
+    assert attempts[0]["after_tput"] is None
+    assert attempts[0]["local_gain_pct"] is None
+    assert attempts[1]["status"] == "KEEP"
+    assert attempts[1]["before_tput"] == 100.0
+    assert attempts[1]["after_tput"] == 120.0
+    assert attempts[1]["local_gain_pct"] == 20.0

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_lifecycle.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_lifecycle.py
@@ -259,7 +259,7 @@ async def test_build_specialist_round_entry_carries_full_payload(coord):
     coord_obj = Coordinator.__new__(Coordinator)
     task = _StubTask(
         task_id="t-build",
-        params={"round_id": "round-9"},
+        params={"round_id": "round-9", "source_phase": "KERNEL_AGENT"},
     )
     payload = _done_payload(
         domain="serving_specialist",
@@ -290,6 +290,7 @@ async def test_build_specialist_round_entry_carries_full_payload(coord):
         "confidence",
         "new_findings",
         "residual_questions",
+        "source_phase",
     }
     assert expected_keys.issubset(entry.keys())
     assert entry["round_id"] == "round-9"
@@ -297,6 +298,7 @@ async def test_build_specialist_round_entry_carries_full_payload(coord):
     assert entry["proposals_total"] == 2
     assert entry["empty"] is False
     assert entry["confidence"] == 0.62
+    assert entry["source_phase"] == "KERNEL_AGENT"
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/orchestrator/enablement/params.py
+++ b/src/hyperloom/orchestrator/enablement/params.py
@@ -265,6 +265,7 @@ class EnablementParams(CoordinatorCollaborator):
 
         params_out: dict[str, Any] = {
             "domain": "enablement_specialist",
+            "source_phase": "ENABLEMENT",
             "gap_canonical_id": gap_cid,
             "gap_symptom": (f"{framework or '?'} cannot launch {model or 'the target model'}: {signature.kind}"),
             "gap_layer": "framework",

--- a/src/hyperloom/orchestrator/loop/dispatcher.py
+++ b/src/hyperloom/orchestrator/loop/dispatcher.py
@@ -1186,6 +1186,10 @@ class DispatcherCollaborator:
                         "specialist auto-retry hook failed for task=%s",
                         task.task_id,
                     )
+            if isinstance(result.result, dict):
+                reauthor_attempt = (getattr(task, "params", None) or {}).get("reauthor_attempt")
+                if reauthor_attempt not in (None, ""):
+                    result.result.setdefault("reauthor_attempt", reauthor_attempt)
             try:
                 await self.bus.append_and_seq(
                     Message.new(
@@ -1221,6 +1225,7 @@ class DispatcherCollaborator:
                             task=task,
                             done_payload=done_payload,
                             source=(f"{SPECIALIST_FROM_AGENT_PREFIX}{task.task_id}"),
+                            run_error=str(result.error or ""),
                         )
                     except Exception:  # noqa: BLE001 — defensive
                         log.exception(

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -2244,6 +2244,7 @@ class WritebackCollaborator:
         task: Task,
         done_payload: dict[str, Any],
         source: str,
+        run_error: str = "",
     ) -> None:
         """Common bookkeeping for any specialist task termination (dispatcher loop + intent routing); idempotent on round_id, failures logged not raised.
 
@@ -2252,8 +2253,11 @@ class WritebackCollaborator:
             done_payload: The specialist's done payload (proposal_set, domain,
                 summary, etc.).
             source: The emitting agent string (``specialist:<task_id>``).
+            run_error: Dispatch failure text when the specialist produced no
+                usable payload.
         """
-        domain = str(done_payload.get("domain") or "").strip()
+        task_params = task.params or {}
+        domain = str(done_payload.get("domain") or task_params.get("domain") or "").strip()
         proposals = done_payload.get("proposal_set") or []
         if not isinstance(proposals, list):
             proposals = []
@@ -2263,6 +2267,7 @@ class WritebackCollaborator:
             task=task,
             done_payload=done_payload,
             source=source,
+            run_error=run_error,
         )
         # Advisory multi-model scoring of the proposal_set; informational only, gates nothing. Defensive.
         _scorer = getattr(self, "_proposal_scorer", None)
@@ -2272,8 +2277,8 @@ class WritebackCollaborator:
                     gap={
                         "domain": domain,
                         "gap_canonical_id": done_payload.get("gap_canonical_id", ""),
-                        "gap_symptom": (task.params or {}).get("gap_symptom"),
-                        "gap_evidence": (task.params or {}).get("gap_evidence"),
+                        "gap_symptom": task_params.get("gap_symptom"),
+                        "gap_evidence": task_params.get("gap_evidence"),
                         "summary": done_payload.get("summary", ""),
                     },
                     proposals=proposals,
@@ -2320,12 +2325,14 @@ class WritebackCollaborator:
                 {
                     "task_id": task.task_id,
                     "domain": domain,
-                    "gap_canonical_id": str(done_payload.get("gap_canonical_id") or ""),
+                    "gap_canonical_id": str(
+                        done_payload.get("gap_canonical_id") or task_params.get("gap_canonical_id") or ""
+                    ),
                     "empty": is_empty,
                     "proposals_total": len(proposals),
                     "confidence": done_payload.get("confidence"),
                     "summary": str(done_payload.get("summary") or "")[:480],
-                    "reason": str(done_payload.get("reason") or "")[:480],
+                    "reason": str(run_error or done_payload.get("reason") or "")[:480],
                     "ts": datetime.now(timezone.utc).isoformat(),
                 }
             )

--- a/src/hyperloom/orchestrator/phases/explore.py
+++ b/src/hyperloom/orchestrator/phases/explore.py
@@ -1868,7 +1868,18 @@ class ExplorePhase(CoordinatorCollaborator):
         proposals = done_payload.get("proposal_set") or []
         if not isinstance(proposals, list):
             proposals = []
-        round_id = str((task.params or {}).get("round_id") or task.task_id)
+        task_params = task.params or {}
+        round_id = str(task_params.get("round_id") or task.task_id)
+        source_phase = (
+            str(
+                task_params.get("source_phase")
+                or done_payload.get("source_phase")
+                or getattr(getattr(self, "shared_state", None), "phase", "")
+                or ""
+            )
+            .strip()
+            .upper()
+        )
         from ..specialists.domains import normalize_dispatch_tags
 
         # Knowledge-domain tags; reported tags win over dispatch params.
@@ -1892,6 +1903,8 @@ class ExplorePhase(CoordinatorCollaborator):
             "new_findings": list(done_payload.get("new_findings") or []),
             "residual_questions": list(done_payload.get("residual_questions") or []),
         }
+        if source_phase:
+            entry["source_phase"] = source_phase
         gpu_ids = done_payload.get("allocated_gpu_ids") or []
         if isinstance(gpu_ids, list) and gpu_ids:
             entry["allocated_gpu_ids"] = [

--- a/src/hyperloom/orchestrator/phases/explore.py
+++ b/src/hyperloom/orchestrator/phases/explore.py
@@ -85,7 +85,7 @@ def _forward_integrate_source(
     # ``lever_kind`` travels with the proposal: the patch that lands moved the
     # same lever the specialist was dispatched against, and re-deriving it at
     # writeback time is how attribution drifts.
-    for key in ("gap_canonical_id", "gap_layer", "lever_kind"):
+    for key in ("gap_canonical_id", "gap_layer", "lever_kind", "reauthor_attempt", "apply_retry_attempt"):
         value = src.get(key)
         if value not in (None, "", [], {}):
             dst[key] = value
@@ -1852,6 +1852,7 @@ class ExplorePhase(CoordinatorCollaborator):
         task: Task,
         done_payload: dict[str, Any],
         source: str,
+        run_error: str = "",
     ) -> dict[str, Any]:
         """Translate a specialist done payload into a SharedState.specialist_rounds[] row; round_id defaults to task_id for idempotent overwrite.
 
@@ -1860,6 +1861,7 @@ class ExplorePhase(CoordinatorCollaborator):
             done_payload: The specialist done payload (proposal_set, domain,
                 tags, summary, etc.).
             source: The emitting agent string, recorded on the row.
+            run_error: Dispatch failure text when no valid payload was produced.
 
         Returns:
             A specialist-round row dict suitable for
@@ -1891,18 +1893,41 @@ class ExplorePhase(CoordinatorCollaborator):
             "task_id": task.task_id,
             "source": source or "coordinator",
             "completed_at": datetime.now(timezone.utc).isoformat(),
-            "domain": str(done_payload.get("domain") or ""),
+            "domain": str(done_payload.get("domain") or task_params.get("domain") or ""),
             "tags": list(tags),
-            "gap_canonical_id": str(done_payload.get("gap_canonical_id") or ""),
+            "gap_canonical_id": str(done_payload.get("gap_canonical_id") or task_params.get("gap_canonical_id") or ""),
             "empty": bool(done_payload.get("empty")) or len(proposals) == 0,
             "proposals_total": len(proposals),
             "proposal_set": list(proposals),
             "summary": str(done_payload.get("summary") or "")[:480],
-            "reason": str(done_payload.get("reason") or "")[:480],
+            "reason": str(run_error or done_payload.get("reason") or "")[:480],
             "confidence": done_payload.get("confidence"),
             "new_findings": list(done_payload.get("new_findings") or []),
             "residual_questions": list(done_payload.get("residual_questions") or []),
         }
+        for key in (
+            "task_kind",
+            "scope",
+            "proposal_msg_id",
+            "framework_agent_candidate_id",
+            "framework_batch_id",
+            "reauthor_attempt",
+            "apply_retry_attempt",
+        ):
+            value = done_payload.get(key)
+            if value in (None, "", [], {}):
+                value = task_params.get(key)
+            if value not in (None, "", [], {}):
+                entry[key] = value
+        for key in ("candidate_discovery", "framework_agent_authoring"):
+            if bool(done_payload.get(key) or task_params.get(key)):
+                entry[key] = True
+        if run_error:
+            entry["status"] = "failed"
+            entry["error"] = str(run_error)[:1000]
+            entry["run_error"] = str(run_error)[:1000]
+        elif done_payload.get("status") not in (None, ""):
+            entry["status"] = str(done_payload.get("status"))
         if source_phase:
             entry["source_phase"] = source_phase
         gpu_ids = done_payload.get("allocated_gpu_ids") or []

--- a/src/hyperloom/orchestrator/phases/framework.py
+++ b/src/hyperloom/orchestrator/phases/framework.py
@@ -149,7 +149,7 @@ class FrameworkPhase(CoordinatorCollaborator):
                 return
             self._record_framework_agent_phase_done(
                 reason="no_candidates_and_discovery_exhausted",
-                failure_count=int(getattr(state, "framework_agent_empty_discoveries", 0) or 0),
+                failure_count=int(getattr(state, "framework_agent_discover_failures", 0) or 0),
             )
             state.framework_agent_phase_done = True
             state.save(self.session_dir)
@@ -366,6 +366,7 @@ class FrameworkPhase(CoordinatorCollaborator):
             "framework_agent_authoring": True,
             "framework_agent_candidate_id": cand_id,
             "framework_batch_id": batch_id,
+            "reauthor_attempt": int(reauthor_attempt),
             "framework_audit": (audit if isinstance(audit, dict) else {}),
             "source": "coordinator_internal",
             "notes": notes,
@@ -1439,6 +1440,7 @@ class FrameworkPhase(CoordinatorCollaborator):
                 evidence={
                     "event": "framework_agent_phase_done",
                     "failure_count": int(failure_count),
+                    "empty_count": int(getattr(state, "framework_agent_empty_discoveries", 0) or 0),
                     "retry_limit": int(_fa_client.DISCOVER_FAILURE_RETRY_LIMIT),
                     "batches_discovered": len(getattr(state, "framework_agent_batches", None) or []),
                     "outcome_class": outcome_class,
@@ -2151,6 +2153,7 @@ class FrameworkPhase(CoordinatorCollaborator):
                 "accuracy_pass": res.get("accuracy_pass"),
                 "specialist_task_id": spec_tid,
                 "integrate_task_id": str(getattr(task, "task_id", "") or ""),
+                "reauthor_attempt": res.get("reauthor_attempt", params.get("reauthor_attempt")),
             },
         )
         if not recorded:
@@ -2250,7 +2253,10 @@ class FrameworkPhase(CoordinatorCollaborator):
             rationale=run_error[:500],
             provenance="dispatch_failed",
             gain_pct=0.0,
-            extra={"specialist_task_id": str(getattr(task, "task_id", "") or "")},
+            extra={
+                "specialist_task_id": str(getattr(task, "task_id", "") or ""),
+                "reauthor_attempt": params.get("reauthor_attempt"),
+            },
         )
         if not recorded:
             return
@@ -2365,7 +2371,10 @@ class FrameworkPhase(CoordinatorCollaborator):
             rationale=reason,
             provenance="authored_empty",
             gain_pct=0.0,
-            extra={"specialist_task_id": str(getattr(task, "task_id", "") or "")},
+            extra={
+                "specialist_task_id": str(getattr(task, "task_id", "") or ""),
+                "reauthor_attempt": params.get("reauthor_attempt"),
+            },
         )
         if not recorded:
             return

--- a/src/hyperloom/orchestrator/phases/framework.py
+++ b/src/hyperloom/orchestrator/phases/framework.py
@@ -359,6 +359,7 @@ class FrameworkPhase(CoordinatorCollaborator):
             "gap_layer": "framework",
             "framework": str(candidate.get("framework") or getattr(state, "framework", "") or "").strip().lower(),
             "task_kind": "framework_authoring",
+            "source_phase": "FRAMEWORK_AGENT",
             "pr_lead": {"title": title, "url": pr_url, "diff_url": diff_url},
             "lever_kind": LEVER_UPSTREAM_PR,
             # Provenance markers for the dispatcher-side authored-patch bridge.

--- a/src/hyperloom/orchestrator/phases/internal.py
+++ b/src/hyperloom/orchestrator/phases/internal.py
@@ -47,6 +47,7 @@ class InternalTasksPhase(PhaseHandler):
         )
         params: dict[str, Any] = {
             "domain": "research_scout_specialist",
+            "source_phase": str(getattr(self.shared_state, "phase", "") or "PRELUDE").strip().upper(),
             "gap_canonical_id": f"gap.research_scout.round{int(round_id)}",
             "gap_symptom": (
                 "Collect proven priors (reference launch scripts, model "
@@ -180,6 +181,7 @@ class InternalTasksPhase(PhaseHandler):
         idempotency_key = "internal-static-recon-prelude"
         params: dict[str, Any] = {
             "domain": "static_recon_specialist",
+            "source_phase": str(getattr(state, "phase", "") or "PRELUDE").strip().upper(),
             "gap_canonical_id": "gap.static_recon.prelude",
             "gap_symptom": (
                 "Grep the framework source for un-bridged capability switches "
@@ -287,6 +289,7 @@ class InternalTasksPhase(PhaseHandler):
         domain = hint[0] if hint else "serving_specialist"
         params: dict[str, Any] = {
             "domain": domain,
+            "source_phase": str(getattr(state, "phase", "") or "INTERNAL").strip().upper(),
             "gap_canonical_id": f"gap.trajectory_review.cycle{cycle}",
             "gap_symptom": (
                 "The search has plateaued. Review the optimization trajectory "

--- a/src/hyperloom/orchestrator/roles/critic_agent.py
+++ b/src/hyperloom/orchestrator/roles/critic_agent.py
@@ -867,6 +867,8 @@ class CriticAgentBackend:
             instrument.record_critic_iteration(
                 self.session_dir,
                 iter_n=turn_idx,
+                request=request,
+                judge_bundle=judge_bundle,
                 review=review,
                 emit=emit,
                 workdir=workdir,


### PR DESCRIPTION
## Summary
- add the merged Framework Agent timeline projection for SBD V6
- preserve Framework ownership for specialist, discovery, authoring, integrate, and critic evidence
- persist critic reviews outside the prunable scratch workdir
- propagate reauthor attempts through specialist and integration records
- align the projection with the removal of stack rebench

## Review fixes
- exclude legacy non-Framework specialist records even when recorder defaults label them as Explore
- recognize the production discovery terminal reason and preserve failed discovery task metadata
- export critic-triggered reauthor attempts as `kind=reauthor`
- retain normalized critic review rows across pruning and resume

## Compatibility
- additive SBD V6 projection only; existing V5 output remains unchanged
- depends on #1331

## Validation
- 188 targeted tests passed
- 2,179 broader Framework/SBD tests passed
- Ruff and `git diff --check` passed
- remaining broad-suite failures are Windows/optional-SDK environment failures unrelated to this change
