### PR TITLE
GEMM lane: connect the three unwired shape inputs, and fix the five defects behind them

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -813,8 +813,12 @@ def test_the_cap_keeps_a_deterministic_spread_of_batch_sizes(tmp_path, monkeypat
     forward = _run(shards)
     assert len(forward) == 4
     assert forward == _run(list(reversed(shards)))  # order-independent
-    # ...and it spans the range rather than hugging the decode end.
-    assert int(forward[-1].split("_")[1]) >= 256, forward
+    # ...and it spans the range rather than hugging the decode end. Both ends
+    # inclusive: an even but half-open slice stops short of the tail, dropping
+    # the widest batch -- the one prefill variant the spread exists to keep.
+    assert forward[0] == "bs_1", forward
+    assert forward[-1] == f"bs_{batches[-1]}", forward
+    assert len(set(forward)) == 4, forward
 
 
 def test_capture_shards_are_capped_by_default(tmp_path, monkeypatch):

--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -20,6 +20,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
 
 import bypass_trace_analysis as bta  # noqa: E402
@@ -760,11 +762,45 @@ def test_maybe_build_shape_manifest_degrades_on_error(tmp_path, monkeypatch):
     assert "RuntimeError" in res["status"]
 
 
-def test_maybe_build_shape_manifest_disabled_by_default(tmp_path, monkeypatch):
+def test_maybe_build_shape_manifest_enabled_by_default(tmp_path, monkeypatch):
+    # The gate used to default off, so forge's preferred dense-shape source was
+    # produced for nobody. On by default now.
     monkeypatch.delenv("HYPERLOOM_TRACE_SHAPE_MANIFEST", raising=False)
+    res = bta._maybe_build_shape_manifest(_mk_args(), {"trace_file": ""}, tmp_path, generated_at="t0")
+    assert res["status"] == "ok"
+    assert (tmp_path / "trace_shape_manifest.json").is_file()
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "OFF"])
+def test_maybe_build_shape_manifest_can_still_be_turned_off(tmp_path, monkeypatch, value):
+    monkeypatch.setenv("HYPERLOOM_TRACE_SHAPE_MANIFEST", value)
     res = bta._maybe_build_shape_manifest(_mk_args(), {"trace_file": ""}, tmp_path, generated_at="t0")
     assert res == {"status": "disabled"}
     assert not (tmp_path / "trace_shape_manifest.json").exists()
+
+
+def test_capture_shards_are_capped_by_default(tmp_path, monkeypatch):
+    # Each shard costs an analyze_trace pass plus a sha256; with the manifest
+    # now built on every run, an uncapped default would put that cost on all of
+    # them. The cap is a budget, not a filter -- the drop is logged.
+    monkeypatch.delenv("HYPERLOOM_TRACE_SHAPE_MANIFEST", raising=False)
+    monkeypatch.delenv("HYPERLOOM_TRACE_SHAPE_MANIFEST_MAX_CAPTURES", raising=False)
+    n = bta._DEFAULT_MAX_CAPTURES + 10
+    monkeypatch.setattr(
+        bta,
+        "_discover_capture_shards",
+        lambda _trace, _folder: [(Path(f"/tmp/bs_{i}.json"), f"bs_{i}", "decode") for i in range(n)],
+    )
+    analyzed: list[object] = []
+
+    def _analyze(path, **kw):
+        analyzed.append(path)
+        return {"status": "empty"}
+
+    monkeypatch.setattr(bta._reader, "analyze_trace", _analyze)
+    bta._maybe_build_shape_manifest(_mk_args(), {"trace_file": ""}, tmp_path, generated_at="t0")
+
+    assert len(analyzed) == bta._DEFAULT_MAX_CAPTURES
 
 
 def _prov_args(**kw):

--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -771,12 +771,50 @@ def test_maybe_build_shape_manifest_enabled_by_default(tmp_path, monkeypatch):
     assert (tmp_path / "trace_shape_manifest.json").is_file()
 
 
-@pytest.mark.parametrize("value", ["0", "false", "no", "off", "OFF"])
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "OFF", "", "  ", "none", "disabled"])
 def test_maybe_build_shape_manifest_can_still_be_turned_off(tmp_path, monkeypatch, value):
+    # The empty string and "none" belong here: a launcher disables a variable by
+    # exporting it empty at least as often as by unsetting it, and a bare
+    # {"0","false","no","off"} check read every one of those as ENABLED -- the
+    # opposite of what the operator asked for. Same off-vocabulary this file
+    # already documents for --steady-state-mode.
     monkeypatch.setenv("HYPERLOOM_TRACE_SHAPE_MANIFEST", value)
     res = bta._maybe_build_shape_manifest(_mk_args(), {"trace_file": ""}, tmp_path, generated_at="t0")
     assert res == {"status": "disabled"}
     assert not (tmp_path / "trace_shape_manifest.json").exists()
+
+
+def test_the_cap_keeps_a_deterministic_spread_of_batch_sizes(tmp_path, monkeypatch):
+    """Which variants survive the cap must not depend on directory order.
+
+    Discovery walks the filesystem, so "first N" varied between machines; once
+    sorted, "first N" would instead have kept only the small-batch end -- 64
+    decode variants and no prefill one. Take an evenly spaced slice.
+    """
+    monkeypatch.delenv("HYPERLOOM_TRACE_SHAPE_MANIFEST", raising=False)
+    monkeypatch.setenv("HYPERLOOM_TRACE_SHAPE_MANIFEST_MAX_CAPTURES", "4")
+    batches = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048]
+    shards = [(Path(f"/t/bs_{b}.json"), f"bs_{b}", "decode") for b in batches]
+
+    def _run(order):
+        monkeypatch.setattr(bta, "_discover_capture_shards", lambda *a: list(order))
+        monkeypatch.setattr(bta, "_sha256_file", lambda p: "h")
+        monkeypatch.setattr(bta._reader, "analyze_trace", lambda *a, **k: {"status": "ok"})
+        monkeypatch.setattr(bta, "_build_manifest_provenance", lambda args: {})
+        seen: list[str] = []
+        monkeypatch.setattr(
+            bta._tsm,
+            "build_shape_manifest",
+            lambda **k: (seen.extend(label for label, _an in k["capture_variants"]), {"rows": [], "warnings": []})[1],
+        )
+        bta._maybe_build_shape_manifest(_mk_args(), {"trace_file": ""}, tmp_path, generated_at="t0")
+        return seen
+
+    forward = _run(shards)
+    assert len(forward) == 4
+    assert forward == _run(list(reversed(shards)))  # order-independent
+    # ...and it spans the range rather than hugging the decode end.
+    assert int(forward[-1].split("_")[1]) >= 256, forward
 
 
 def test_capture_shards_are_capped_by_default(tmp_path, monkeypatch):

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -197,7 +197,9 @@ def _emit_quality_warnings(analyze: dict[str, Any], warnings: list[dict[str, Any
         )
 
 
-#: Opt-in env gate for the variant-discriminating TraceShapeManifest (P0-A/WP-1).
+#: Env gate for the variant-discriminating TraceShapeManifest (P0-A/WP-1). On by
+#: default: forge calls the manifest its preferred dense-shape source, and with
+#: the gate off Hyperloom produced one for nobody. Set to 0/off/false to skip.
 _SHAPE_MANIFEST_ENV = "HYPERLOOM_TRACE_SHAPE_MANIFEST"
 #: Optional gfx-arch provenance override (WP-1 stub; superseded by WP-0/WP-7).
 _GFX_ENV = "HYPERLOOM_GFX_ARCH"
@@ -219,8 +221,13 @@ _VARIANT_RE = re.compile(r"(bs_\d+)", re.IGNORECASE)
 #: ``bs_<batch>`` token anywhere (both SGLang layouts) or the vLLM prefix whose
 #: batch/mode arrive via execution_details.json.
 _CAPTURE_FILE_RE = re.compile(r"bs_\d+|\Agraph_capture", re.IGNORECASE)
-#: Optional cap on how many capture files to index (0 = all). Logged when hit.
+#: Cap on how many capture files to index; 0 means all. Each shard costs a full
+#: ``analyze_trace`` pass plus a sha256, so an uncapped default would put that
+#: cost on every trace analysis now that the manifest is built by default. The
+#: cap is a budget, not a filter: shards are taken in discovery order and the
+#: drop is logged.
 _MAX_CAPTURES_ENV = "HYPERLOOM_TRACE_SHAPE_MANIFEST_MAX_CAPTURES"
+_DEFAULT_MAX_CAPTURES = 64
 
 
 def _sha256_file(path: str | Path) -> str:
@@ -364,24 +371,25 @@ def _maybe_build_shape_manifest(
 ) -> dict[str, Any]:
     """Optionally build + write the variant-discriminating TraceShapeManifest.
 
-    Opt-in via ``HYPERLOOM_TRACE_SHAPE_MANIFEST`` (off by default -> returns
-    ``{"status": "disabled"}`` and writes nothing, so a run without the flag is
-    byte-for-byte unchanged). When enabled, capture shards are indexed per
+    Built by default; ``HYPERLOOM_TRACE_SHAPE_MANIFEST=0`` returns
+    ``{"status": "disabled"}`` and writes nothing. When enabled, capture shards
+    are indexed per
     ``bs_<batch>`` variant; with no capture shards it falls back to an eager
     manifest built from the main analysis. Never raises -- any failure degrades
     to ``{"status": "error: ..."}`` and is logged to stderr.
     """
-    flag = os.environ.get(_SHAPE_MANIFEST_ENV, "0").strip().lower()
-    if flag not in {"1", "true", "yes", "on"}:
+    flag = os.environ.get(_SHAPE_MANIFEST_ENV, "1").strip().lower()
+    if flag in {"0", "false", "no", "off"}:
         return {"status": "disabled"}
     try:
         main_trace = analyze.get("trace_file", "") or ""
         main_hash = _sha256_file(main_trace) if main_trace else ""
         shards = _discover_capture_shards(args.trace_input, args.capture_folder or "")
         try:
-            max_caps = int(os.environ.get(_MAX_CAPTURES_ENV, "0") or 0)
+            raw_caps = os.environ.get(_MAX_CAPTURES_ENV, "")
+            max_caps = int(raw_caps) if str(raw_caps).strip() else _DEFAULT_MAX_CAPTURES
         except ValueError:
-            max_caps = 0
+            max_caps = _DEFAULT_MAX_CAPTURES
         if max_caps > 0 and len(shards) > max_caps:
             print(
                 f"[trace_shape_manifest] capping capture files {len(shards)}->{max_caps} "
@@ -896,8 +904,8 @@ def main(argv: list[str] | None = None) -> int:
         except Exception:  # noqa: BLE001 - best-effort sidecar, never blocks the run
             diffusion_roofline_path = None
 
-    # Optional variant-discriminating TraceShapeManifest (P0-A / WP-1; opt-in via
-    # HYPERLOOM_TRACE_SHAPE_MANIFEST). Off by default -> disabled, writes nothing.
+    # Variant-discriminating TraceShapeManifest (P0-A / WP-1). On by default;
+    # HYPERLOOM_TRACE_SHAPE_MANIFEST=0 disables it and writes nothing.
     shape_manifest = _maybe_build_shape_manifest(args, analyze, bypass_dir, generated_at=utc_now(timespec="seconds"))
 
     hot_kernels = candidates.get("hot_kernels", [])

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -199,8 +199,14 @@ def _emit_quality_warnings(analyze: dict[str, Any], warnings: list[dict[str, Any
 
 #: Env gate for the variant-discriminating TraceShapeManifest (P0-A/WP-1). On by
 #: default: forge calls the manifest its preferred dense-shape source, and with
-#: the gate off Hyperloom produced one for nobody. Set to 0/off/false to skip.
+#: the gate off Hyperloom produced one for nobody.
 _SHAPE_MANIFEST_ENV = "HYPERLOOM_TRACE_SHAPE_MANIFEST"
+#: Values of that env var that mean "off". Same vocabulary this file already
+#: documents for ``--steady-state-mode``, and it has to include the empty string
+#: and ``none``: launchers routinely disable a variable by exporting it empty
+#: rather than unsetting it, and a bare ``{"0","false","no","off"}`` check read
+#: every one of those as "enabled" -- the opposite of what was written.
+_SHAPE_MANIFEST_OFF_VALUES = frozenset({"", "0", "false", "no", "off", "none", "disable", "disabled"})
 #: Optional gfx-arch provenance override (WP-1 stub; superseded by WP-0/WP-7).
 _GFX_ENV = "HYPERLOOM_GFX_ARCH"
 #: sglang capture shard filename -> ``bs_<batch>`` variant. vLLM instead emits
@@ -323,6 +329,18 @@ def _discover_capture_shards(trace_input: str, capture_folder: str) -> list[tupl
     return out
 
 
+def _shard_order_key(shard: tuple[Path, str, str | None]) -> tuple[int, str, str]:
+    """Total order over capture shards: batch size, then label, then filename.
+
+    Discovery walks directories, so the natural order is filesystem order --
+    fine while every shard was indexed, but the cap turned it into a
+    machine-dependent choice of *which* variants the manifest describes.
+    """
+    _path, label, _mode = shard
+    match = re.search(r"bs_(\d+)", label, re.IGNORECASE)
+    return (int(match.group(1)) if match else 0, label, _path.name)
+
+
 def _build_manifest_provenance(args: argparse.Namespace) -> dict[str, Any]:
     """Provenance block for the TraceShapeManifest.
 
@@ -371,7 +389,8 @@ def _maybe_build_shape_manifest(
 ) -> dict[str, Any]:
     """Optionally build + write the variant-discriminating TraceShapeManifest.
 
-    Built by default; ``HYPERLOOM_TRACE_SHAPE_MANIFEST=0`` returns
+    Built by default; ``HYPERLOOM_TRACE_SHAPE_MANIFEST`` set to any of
+    :data:`_SHAPE_MANIFEST_OFF_VALUES` (including empty) returns
     ``{"status": "disabled"}`` and writes nothing. When enabled, capture shards
     are indexed per
     ``bs_<batch>`` variant; with no capture shards it falls back to an eager
@@ -379,7 +398,7 @@ def _maybe_build_shape_manifest(
     to ``{"status": "error: ..."}`` and is logged to stderr.
     """
     flag = os.environ.get(_SHAPE_MANIFEST_ENV, "1").strip().lower()
-    if flag in {"0", "false", "no", "off"}:
+    if flag in _SHAPE_MANIFEST_OFF_VALUES:
         return {"status": "disabled"}
     try:
         main_trace = analyze.get("trace_file", "") or ""
@@ -390,13 +409,20 @@ def _maybe_build_shape_manifest(
             max_caps = int(raw_caps) if str(raw_caps).strip() else _DEFAULT_MAX_CAPTURES
         except ValueError:
             max_caps = _DEFAULT_MAX_CAPTURES
+        shards.sort(key=_shard_order_key)
         if max_caps > 0 and len(shards) > max_caps:
             print(
                 f"[trace_shape_manifest] capping capture files {len(shards)}->{max_caps} "
                 f"(set {_MAX_CAPTURES_ENV}=0 to index all)",
                 file=sys.stderr,
             )
-            shards = shards[:max_caps]
+            # Evenly spaced over the batch-sorted list, not the first N. Discovery
+            # order is directory order, so "first N" both varied between machines
+            # and -- once sorted -- would have kept only the small-batch end,
+            # indexing 64 decode variants and no prefill one. Each dropped shard
+            # costs a full analyze_trace + sha256, which is why the cap exists.
+            step = len(shards) / max_caps
+            shards = [shards[int(i * step)] for i in range(max_caps)]
         capture_variants: list[tuple[str, dict[str, Any]]] = []
         capture_hashes: dict[str, str] = {}
         variant_meta: dict[str, dict[str, Any]] = {}

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -421,8 +421,18 @@ def _maybe_build_shape_manifest(
             # and -- once sorted -- would have kept only the small-batch end,
             # indexing 64 decode variants and no prefill one. Each dropped shard
             # costs a full analyze_trace + sha256, which is why the cap exists.
-            step = len(shards) / max_caps
-            shards = [shards[int(i * step)] for i in range(max_caps)]
+            #
+            # Spaced inclusive of BOTH ends. A plain ``int(i * len / max_caps)``
+            # is even but half-open: its last index is short of the tail, so the
+            # widest batch -- the one prefill variant the spread exists to keep --
+            # was the single shard guaranteed to be dropped. With one slot there
+            # is no spread to speak of; take the widest, since a decode variant
+            # is the one the eager fallback can stand in for.
+            last = len(shards) - 1
+            if max_caps == 1:
+                shards = [shards[last]]
+            else:
+                shards = [shards[round(i * last / (max_caps - 1))] for i in range(max_caps)]
         capture_variants: list[tuple[str, dict[str, Any]]] = []
         capture_hashes: dict[str, str] = {}
         variant_meta: dict[str, dict[str, Any]] = {}

--- a/src/hyperloom/agents/kernel/tools/forge_gemm_tuning.py
+++ b/src/hyperloom/agents/kernel/tools/forge_gemm_tuning.py
@@ -61,11 +61,16 @@ def _build_cmd(args: dict[str, Any]) -> list[str]:
     _add_opt(cmd, args, "shapes_json", "--shapes-json")
     # forge calls the manifest its preferred dense-shape source, and Hyperloom
     # has produced one since WP-1 -- but nothing forwarded it, so the file was
-    # written and never read. Same for --demand: forge can reconstruct demand
-    # from --kernel-signature-log, and does, but a demand.json the evidence
-    # step already computed is both cheaper and not subject to picking the
-    # wrong log. Both degrade safely: forge's ``_safe_is_file`` drops a path
-    # that is not there, with a warning.
+    # written and never read. ``--shapes-manifest`` closes that.
+    #
+    # ``--demand`` is a pass-through only: no Hyperloom code path fills
+    # ``demand_json`` today, and none needs to, because forge reconstructs
+    # demand from ``--kernel-signature-log`` when the flag is absent. The port
+    # exists so an operator or a future evidence step can hand in a demand.json
+    # directly, without another edit here.
+    #
+    # Both degrade safely: forge's ``_safe_is_file`` drops a path that is not
+    # there, with a warning.
     _add_opt(cmd, args, "shapes_manifest", "--shapes-manifest")
     _add_opt(cmd, args, "demand_json", "--demand")
     _add_opt(cmd, args, "tunableop_input", "--tunableop-input")

--- a/src/hyperloom/agents/kernel/tools/forge_gemm_tuning.py
+++ b/src/hyperloom/agents/kernel/tools/forge_gemm_tuning.py
@@ -59,6 +59,15 @@ def _build_cmd(args: dict[str, Any]) -> list[str]:
     _add_opt(cmd, args, "untuned_csv", "--untuned-csv")
     _add_opt(cmd, args, "moe_untuned_csv", "--moe-untuned-csv")
     _add_opt(cmd, args, "shapes_json", "--shapes-json")
+    # forge calls the manifest its preferred dense-shape source, and Hyperloom
+    # has produced one since WP-1 -- but nothing forwarded it, so the file was
+    # written and never read. Same for --demand: forge can reconstruct demand
+    # from --kernel-signature-log, and does, but a demand.json the evidence
+    # step already computed is both cheaper and not subject to picking the
+    # wrong log. Both degrade safely: forge's ``_safe_is_file`` drops a path
+    # that is not there, with a warning.
+    _add_opt(cmd, args, "shapes_manifest", "--shapes-manifest")
+    _add_opt(cmd, args, "demand_json", "--demand")
     _add_opt(cmd, args, "tunableop_input", "--tunableop-input")
     _add_opt(cmd, args, "kernel_signature_log", "--kernel-signature-log")
     _add_opt(cmd, args, "gpu_ids", "--gpu-ids")

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_gemm_promote_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_gemm_promote_units.py
@@ -2869,9 +2869,36 @@ class TestValidateForgeGemmTuningE2E:
         await coord._validate_gemm_tuning_e2e(result)
 
         assert fake.calls == []
-        assert result["requires_e2e_validation"] is True
-        assert "e2e_validated" not in result
         assert coord.shared_state.optimization_stack == []
+        # No sweep ran, but the books still get closed. Leaving
+        # requires_e2e_validation=True on a result nothing will ever validate
+        # made the history row and result.json claim a pending verdict forever.
+        assert result["requires_e2e_validation"] is False
+        assert result["e2e_validated"] is False
+        assert result["decision"] == "REVERT"
+        assert result["micro_decision"] == "no_e2e_candidates"
+
+    @pytest.mark.asyncio
+    async def test_closing_the_books_does_not_overwrite_a_tuner_verdict(self, tmp_path, monkeypatch):
+        """``micro_decision`` is a routing key, not a label.
+
+        ``_should_run_bf16_dense_gemm_fallback`` keys the sglang bf16 retry on
+        ``no_improvement``. Stamping ``no_e2e_candidates`` over it cancelled the
+        fallback for exactly the fp8 runs that need it.
+        """
+        coord = _coord(tmp_path, baseline_tput=100.0, framework="sglang")
+        fake = _make_integrate([])
+        monkeypatch.setattr(krh_mod, "integrate_handler", fake)
+
+        result = {
+            "requires_e2e_validation": True,
+            "micro_decision": "no_improvement",
+            "tuners_run": [{"status": "ok", "improved_shapes": 0}],
+        }
+        await coord._validate_gemm_tuning_e2e(result)
+
+        assert result["micro_decision"] == "no_improvement"
+        assert result["requires_e2e_validation"] is False
 
     @pytest.mark.asyncio
     async def test_vllm_candidate_without_micro_count_validates_full_env_bundle(

--- a/src/hyperloom/inference_optimizer/tests/test_gemm_result_json_writeback.py
+++ b/src/hyperloom/inference_optimizer/tests/test_gemm_result_json_writeback.py
@@ -1,0 +1,172 @@
+"""The GEMM workspace ``result.json`` must carry the E2E verdict, not the pre-E2E snapshot.
+
+forge's CLI writes ``result.json`` when micro tuning ends, so without a
+writeback the file stays at ``status=ok`` / ``requires_e2e_validation=true``
+forever while ``state.json`` already records a REVERT. The fusion and
+collective lanes treat ``result.json`` as the final verdict, so the two ledgers
+disagreeing is how a rejected candidate reads as "undecided" on disk.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hyperloom.orchestrator.loop.coordinator import Coordinator
+from hyperloom.orchestrator.phases.kernel import KernelPhase
+from hyperloom.orchestrator.state.shared_state import SharedState
+
+
+def _moe_model(root: Path) -> str:
+    """A Qwen3-30B-A3B-shaped config: 768 shards to 96 at TP 8, which CK cannot serve."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3MoeForCausalLM"],
+                "model_type": "qwen3_moe",
+                "num_experts": 128,
+                "moe_intermediate_size": 768,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(root)
+
+
+def _phase(tmp_path: Path, model_path: str, tp: int = 8) -> KernelPhase:
+    coord = Coordinator.__new__(Coordinator)
+    coord.session_dir = tmp_path
+    coord.shared_state = SharedState(
+        model_path=model_path,
+        tp=tp,
+        framework="sglang",
+        baseline_tput=100.0,
+    )
+    return KernelPhase(coord)
+
+
+def _workspace_with_pre_e2e_result(tmp_path: Path) -> Path:
+    """The snapshot forge leaves behind the moment micro tuning ends."""
+    ws = tmp_path / "runs" / "gemm_tuning" / "abc123"
+    ws.mkdir(parents=True, exist_ok=True)
+    (ws / "result.json").write_text(
+        json.dumps(
+            {
+                "status": "ok",
+                "micro_decision": "candidate",
+                "requires_e2e_validation": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return ws
+
+
+def _fmoe_ck_result(csv_path: str, workspace: Path) -> dict:
+    return {
+        "workspace": str(workspace),
+        "tuners_run": [
+            {
+                "tuner": "fmoe_ck",
+                "status": "ok",
+                "candidate": True,
+                "env_var": "AITER_CONFIG_FMOE_CK",
+                "env_value": csv_path,
+                "best_micro_speedup": 1.4,
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def tuned_csv(tmp_path: Path, monkeypatch) -> str:
+    csv = tmp_path / "fmoe_ck.csv"
+    csv.write_text("M,N,K\n1,2,3\n", encoding="utf-8")
+    monkeypatch.setattr(
+        KernelPhase,
+        "_merge_gemm_candidate_with_runtime",
+        lambda self, env_var, env_value: env_value,
+    )
+    return str(csv)
+
+
+@pytest.mark.asyncio
+async def test_e2e_verdict_is_written_back_to_result_json(tmp_path: Path, tuned_csv):
+    """The unservable-shape REVERT must land on disk, not only in state."""
+    ws = _workspace_with_pre_e2e_result(tmp_path)
+    model = _moe_model(tmp_path / "Qwen3-30B-A3B")
+    result = _fmoe_ck_result(tuned_csv, ws)
+
+    await _phase(tmp_path, model)._validate_gemm_tuning_e2e(result)
+
+    on_disk = json.loads((ws / "result.json").read_text(encoding="utf-8"))
+    assert on_disk["decision"] == "REVERT"
+    assert on_disk["e2e_validated"] is True
+    assert on_disk["requires_e2e_validation"] is False
+    # The stale pre-E2E snapshot must be gone, not merely appended to.
+    assert on_disk["micro_decision"] != "candidate"
+
+
+@pytest.mark.asyncio
+async def test_writeback_leaves_no_temp_files(tmp_path: Path, tuned_csv):
+    ws = _workspace_with_pre_e2e_result(tmp_path)
+    model = _moe_model(tmp_path / "Qwen3-30B-A3B")
+
+    await _phase(tmp_path, model)._validate_gemm_tuning_e2e(_fmoe_ck_result(tuned_csv, ws))
+
+    assert sorted(p.name for p in ws.iterdir()) == ["result.json"]
+
+
+def test_writeback_failure_preserves_the_existing_file(tmp_path: Path, monkeypatch, caplog):
+    """A read-only / reaped workspace must not crash the phase or truncate the file."""
+    ws = _workspace_with_pre_e2e_result(tmp_path)
+    original = (ws / "result.json").read_text(encoding="utf-8")
+    model = _moe_model(tmp_path / "Qwen3-30B-A3B")
+
+    def _boom(*_a, **_k):
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr("hyperloom.orchestrator.phases.kernel.atomic_write_json", _boom)
+
+    _phase(tmp_path, model)._writeback_gemm_result_json({"workspace": str(ws), "decision": "REVERT"})
+
+    assert (ws / "result.json").read_text(encoding="utf-8") == original
+    assert sorted(p.name for p in ws.iterdir()) == ["result.json"]
+
+
+def test_writeback_is_a_noop_without_a_workspace(tmp_path: Path):
+    """A result that never reached a workspace has nothing to reconcile."""
+    model = _moe_model(tmp_path / "Qwen3-30B-A3B")
+    # Must not raise.
+    _phase(tmp_path, model)._writeback_gemm_result_json({"decision": "REVERT"})
+    _phase(tmp_path, model)._writeback_gemm_result_json({"workspace": str(tmp_path / "gone"), "decision": "R"})
+
+
+@pytest.mark.asyncio
+async def test_validation_exception_syncs_state_and_disk(tmp_path: Path, monkeypatch):
+    """The exception arm rewrote only its local dict; state kept the bridge's KEEP.
+
+    ``record_gemm_tuning`` stores a shallow copy, so mutating ``result``
+    afterwards does not update the recorded entry. An arm that was never
+    measured must read as REVERT in both ledgers.
+    """
+    ws = _workspace_with_pre_e2e_result(tmp_path)
+    model = _moe_model(tmp_path / "Qwen3-30B-A3B")
+    phase = _phase(tmp_path, model)
+
+    async def _raise(_result):
+        raise RuntimeError("server never came up")
+
+    monkeypatch.setattr(phase, "_validate_gemm_tuning_e2e", _raise)
+
+    result = {"workspace": str(ws), "status": "ok", "decision": "KEEP", "recommended_env": {"A": "1"}}
+    await phase._handle_gemm_tuning_result(result)
+
+    assert phase.shared_state.last_gemm_tuning["decision"] == "REVERT"
+    assert phase.shared_state.last_gemm_tuning["micro_decision"] == "e2e_validation_exception"
+    on_disk = json.loads((ws / "result.json").read_text(encoding="utf-8"))
+    assert on_disk["decision"] == "REVERT"
+    assert on_disk["requires_e2e_validation"] is False

--- a/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
+++ b/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
@@ -536,7 +536,9 @@ class TestE2EValidationFailsOpen:
     """
 
     def _phase(self, tmp_path, validate):
-        from types import SimpleNamespace
+        from types import MethodType, SimpleNamespace
+
+        from hyperloom.orchestrator.phases.kernel import KernelPhase
 
         recorded: list[dict] = []
         saved: list[object] = []
@@ -544,13 +546,22 @@ class TestE2EValidationFailsOpen:
             record_gemm_tuning=recorded.append,
             save=saved.append,
             macro_cycle=0,
+            gemm_tuning_attempts=[],
+            last_gemm_tuning=None,
         )
-        return SimpleNamespace(
+        phase = SimpleNamespace(
             session_dir=tmp_path,
             shared_state=state,
             _sync_profile_state_after_gemm_roofline=lambda _r: None,
             _validate_gemm_tuning_e2e=validate,
-        ), recorded
+        )
+        # ``record_gemm_tuning`` stores a shallow copy, so the neutralising
+        # rewrites on the exception path only reach state (and result.json)
+        # through these two. Bind the real implementations rather than stubbing
+        # them out, so the test covers what actually runs.
+        for name in ("_replace_latest_gemm_tuning_attempt", "_writeback_gemm_result_json"):
+            setattr(phase, name, MethodType(getattr(KernelPhase, name), phase))
+        return phase, recorded
 
     @pytest.mark.asyncio
     async def test_exception_is_recorded_as_a_fault_not_raised(self, tmp_path):

--- a/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
+++ b/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
@@ -515,12 +515,12 @@ class TestCoverageGateDoesNotBlockOnMissingEvidence:
 
 class TestSafeMtime:
     def test_missing_path_sorts_last_instead_of_raising(self, tmp_path):
-        from hyperloom.orchestrator.phases.kernel import _safe_mtime
+        from hyperloom.orchestrator.kernel.gemm_shape_coverage import _safe_mtime
 
         assert _safe_mtime(tmp_path / "gone.log") == 0.0
 
     def test_existing_path_returns_its_mtime(self, tmp_path):
-        from hyperloom.orchestrator.phases.kernel import _safe_mtime
+        from hyperloom.orchestrator.kernel.gemm_shape_coverage import _safe_mtime
 
         path = tmp_path / "server.log"
         path.write_text("x", encoding="utf-8")

--- a/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
+++ b/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
@@ -11,6 +11,7 @@ rather than to "the artifact did not apply".
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 
@@ -138,11 +139,31 @@ class TestServerLogParsing:
         "[aiter] shape is M:1082, N:5120, K:17408, found padded_M: 1088, N:5120, "
         "K:17408 is tuned on cu_num = 256 in /x/candidate.csv , kernel name is k!"
     )
+    # Verbatim from a production Qwen3 vLLM server.log. The dispatch kwargs sit
+    # between ``K:`` and ``found padded_M:``, which an earlier pattern did not
+    # allow -- it matched none of that log's 5024 hit lines.
+    HIT_WITH_KWARGS = (
+        "(Worker_TP7 pid=380239) [aiter] shape is M:16384, N:4608, K:8192 "
+        "dtype='torch.bfloat16' otype='torch.bfloat16' bias=False, scaleAB=False, "
+        "bpreshuffle=False found padded_M: 8192, N:4608, K:8192 is tuned on "
+        "cu_num = 256 in /shared_nfs/x/merged_tuned_dense_bf16.csv,"
+    )
 
     def test_parses_misses_and_hits(self):
         missed, hit = parse_aiter_shape_lookups("\n".join([self.MISS, self.MISS_QUANT, self.HIT]))
         assert missed == {(8192, 7168, 5120), (512, 5120, 17408)}
         assert hit == {(1082, 5120, 17408)}
+
+    def test_parses_hit_with_dispatch_kwargs_between_k_and_padded_m(self):
+        missed, hit = parse_aiter_shape_lookups(self.HIT_WITH_KWARGS)
+        assert missed == set()
+        assert hit == {(16384, 4608, 8192)}
+
+    def test_hit_pattern_does_not_span_lines(self):
+        """A miss on one line must not pair with a hit on the next."""
+        missed, hit = parse_aiter_shape_lookups("\n".join([self.MISS, self.HIT_WITH_KWARGS]))
+        assert missed == {(8192, 7168, 5120)}
+        assert hit == {(16384, 4608, 8192)}
 
     def test_empty_log(self):
         assert parse_aiter_shape_lookups("") == (set(), set())
@@ -328,6 +349,34 @@ class TestTunedCsvCoverage:
         report = tuned_config_coverage([(1, 2, 3)], [])
         assert report["requested"] == 0
         assert report["coverage_pct"] is None
+
+    def test_retry_integrate_dir_is_scanned(self, tmp_path):
+        """A ``-2`` retry replaces the first attempt; it must not be ignored."""
+        from hyperloom.orchestrator.kernel.gemm_shape_coverage import read_latest_integrate_server_log
+
+        integrate = tmp_path / "runs" / "integrate"
+        first = integrate / "integrate-gemm_tune_fmoe_ck" / "r"
+        retry = integrate / "integrate-gemm_tune_fmoe_ck-2" / "r"
+        for d in (first, retry):
+            d.mkdir(parents=True)
+        (first / "server.log").write_text("first attempt", encoding="utf-8")
+        (retry / "server.log").write_text("retry attempt", encoding="utf-8")
+        os.utime(retry / "server.log", (2_000_000_000, 2_000_000_000))
+        os.utime(first / "server.log", (1_000_000_000, 1_000_000_000))
+
+        found = read_latest_integrate_server_log(tmp_path, "integrate-gemm_tune_fmoe_ck")
+        assert found is not None
+        assert found[1] == "retry attempt"
+
+    def test_runtime_confirmed_hit_counts_as_covered(self):
+        """aiter saying it used a row beats our replay of its padding rules."""
+        requested = [(16384, 4608, 8192)]
+        # Deliberately empty: the ladder can prove nothing here.
+        assert tuned_config_coverage([], requested)["covered"] == 0
+        report = tuned_config_coverage([], requested, known_covered=requested)
+        assert report["covered"] == 1
+        assert report["coverage_pct"] == 100.0
+        assert report["uncovered_sample"] == []
 
 
 class TestCoverageGateDoesNotBlockOnMissingEvidence:

--- a/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
+++ b/src/hyperloom/inference_optimizer/tests/test_gemm_shape_coverage.py
@@ -25,6 +25,7 @@ from hyperloom.orchestrator.kernel.gemm_shape_coverage import (
     parse_aiter_consulted_tables,
     parse_aiter_fused_moe_dispatches,
     parse_aiter_shape_lookups,
+    parse_aiter_shape_lookups_for_tables,
     resolve_fmoe_candidate_csv,
     tuned_config_coverage,
     tuned_csv_shapes,
@@ -156,6 +157,19 @@ class TestServerLogParsing:
 
     def test_parses_hit_with_dispatch_kwargs_between_k_and_padded_m(self):
         missed, hit = parse_aiter_shape_lookups(self.HIT_WITH_KWARGS)
+        assert missed == set()
+        assert hit == {(16384, 4608, 8192)}
+
+    def test_scopes_hits_to_the_table_that_served_them(self):
+        assert parse_aiter_consulted_tables(self.HIT_WITH_KWARGS) == {"/shared_nfs/x/merged_tuned_dense_bf16.csv"}
+        missed, hit = parse_aiter_shape_lookups_for_tables(self.HIT_WITH_KWARGS, ["candidate.csv"])
+        assert missed == set()
+        assert hit == set()
+
+        missed, hit = parse_aiter_shape_lookups_for_tables(
+            self.HIT_WITH_KWARGS,
+            ["merged_tuned_dense_bf16.csv"],
+        )
         assert missed == set()
         assert hit == {(16384, 4608, 8192)}
 
@@ -454,6 +468,33 @@ class TestCoverageGateDoesNotBlockOnMissingEvidence:
         assert report is not None
         assert report["artifact_applied"] is True
         assert report["coverage_pct"] == 100.0
+
+    def test_previous_candidate_hit_does_not_cover_current_candidate(self, tmp_path):
+        """A stacked table's hit is not evidence that this candidate applied."""
+        phase = self._phase(tmp_path)
+        run_log = tmp_path / "runs" / "integrate" / "integrate-gemm_tune_aiter_dense" / "server.log"
+        previous_hit = (
+            "[aiter] shape is M:16384, N:4608, K:8192 dtype='torch.bfloat16' "
+            "found padded_M: 8192, N:4608, K:8192 is tuned on cu_num = 256 "
+            "in /x/previous.csv,"
+        )
+        current_miss = (
+            "[aiter] shape is M:33, N:777, K:888, not found tuned config in /x/current.csv, will use default config!"
+        )
+        run_log.write_text("\n".join([previous_hit, current_miss]), encoding="utf-8")
+        current = tmp_path / "current.csv"
+        current.write_text(
+            f"{self.HEADER}\ngfx950,256,999,777,888,ck,0,0,1.0,name,1,1,0\n",
+            encoding="utf-8",
+        )
+
+        report = self._call(phase, current)
+
+        assert report is not None
+        assert report["artifact_applied"] is False
+        assert report["coverage_pct"] == 0.0
+        assert report["runtime_lookup_hit"] == 0
+        assert report["runtime_lookup_miss"] == 1
 
     def test_unexpected_failure_is_undetermined(self, tmp_path):
         """The wrapper swallows anything the body throws (it can block a KEEP)."""

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -61,6 +61,16 @@ def _pin_fusion_provider_env(monkeypatch, shape):
         monkeypatch.setenv(key, value)
 
 
+#: A candidate server.log must now carry an aiter dispatch line; these tests
+#: are about priority order, so every candidate gets one.
+_AITER_LINE = (
+    "shape is M:128, N:512, K:4096 dtype='torch.bfloat16' otype='torch.bfloat16' "
+    "bias=False, scaleAB=False, bpreshuffle=False found padded_M: 128, N:512, "
+    "K:4096 is tuned on cu_num = 256 in /tmp/aiter_configs/bf16_tuned_gemm.csv, "
+    "libtype is opus, kernel name is opus_gemm\n"
+)
+
+
 class TestForgeGemmHelperCoverage:
     def test_resolve_backend_requires_exact_kernel_order_forge(self, monkeypatch):
         monkeypatch.delenv("KERNEL_OPT_BACKEND_ORDER", raising=False)
@@ -96,8 +106,8 @@ class TestForgeGemmHelperCoverage:
         current = tmp_path / "current"
         baseline.mkdir()
         current.mkdir()
-        (baseline / "server.log").write_text("baseline", encoding="utf-8")
-        (current / "server.log").write_text("current", encoding="utf-8")
+        (baseline / "server.log").write_text("baseline\n" + _AITER_LINE, encoding="utf-8")
+        (current / "server.log").write_text("current\n" + _AITER_LINE, encoding="utf-8")
         state.last_baseline = {"workspace": str(baseline)}
         state.current_best = {"workspace": str(current)}
 
@@ -107,7 +117,7 @@ class TestForgeGemmHelperCoverage:
         state = SharedState()
         log = tmp_path / "runs" / "explore" / "abc" / "server.log"
         log.parent.mkdir(parents=True)
-        log.write_text("x", encoding="utf-8")
+        log.write_text(_AITER_LINE, encoding="utf-8")
 
         assert krh._resolve_forge_server_log(state, tmp_path) == str(log)
 
@@ -271,7 +281,7 @@ class TestForgeGemmHelperCoverage:
         state = SharedState()
         baseline = tmp_path / "baseline"
         baseline.mkdir()
-        (baseline / "server.log").write_text("baseline", encoding="utf-8")
+        (baseline / "server.log").write_text("baseline\n" + _AITER_LINE, encoding="utf-8")
         state.last_baseline = {"workspace": str(baseline)}
 
         assert krh._resolve_forge_server_log(state, tmp_path) == str(baseline / "server.log")

--- a/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling_perfmodel_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling_perfmodel_units.py
@@ -282,6 +282,196 @@ def test_load_model_meta_sizes_routed_experts_at_their_own_precision(tmp_path):
     assert meta.expert_weight_bytes > 0
 
 
+#: The Quark MXFP4 shape, verbatim from
+#: ``Qwen3.8-2.4T-A95B-Quark-MXFP4/config.json``: ``quant_method`` names the
+#: toolkit, and the weight precision sits on the nested global weight spec.
+_QUARK_MXFP4_QUANT_CFG = {
+    "quant_method": "quark",
+    "quant_mode": "eager_mode",
+    "global_quant_config": {
+        "input_tensors": {"dtype": "fp4", "is_dynamic": True, "group_size": 32},
+        "weight": {"dtype": "fp4", "is_dynamic": False, "qscheme": "per_group", "group_size": 32},
+        "output_tensors": None,
+    },
+    "layer_quant_config": {},
+}
+
+
+def test_quant_config_weight_bytes_reads_the_nested_quark_weight_spec():
+    """quant_method says "quark"; only the nested weight spec names the precision."""
+    assert rc._resolve_quant_config_weight_bytes(_QUARK_MXFP4_QUANT_CFG) == 0.5
+
+
+def test_quant_config_weight_bytes_still_takes_a_precision_named_method():
+    """The flat HF form keeps working: the method itself is the precision."""
+    assert rc._resolve_quant_config_weight_bytes({"quant_method": "fp8"}) == 1.0
+    # ``awq``/``gptq`` name a 4-bit method the dtype table does not carry.
+    assert rc._resolve_quant_config_weight_bytes({"quant_method": "awq"}) == 0.5
+
+
+def test_quant_config_weight_bytes_reads_compressed_tensors_bit_widths():
+    cfg = {"quant_method": "compressed-tensors", "config_groups": {"group_0": {"weights": {"num_bits": 4}}}}
+    assert rc._resolve_quant_config_weight_bytes(cfg) == 0.5
+
+
+@pytest.mark.parametrize("quant_cfg", [None, {}, "fp8", {"quant_method": "unknown-toolkit"}])
+def test_quant_config_weight_bytes_is_silent_without_a_decisive_signal(quant_cfg):
+    """No signal returns 0.0 so the caller falls back to the checkpoint dtype."""
+    assert rc._resolve_quant_config_weight_bytes(quant_cfg) == 0.0
+
+
+def test_quant_config_weight_bytes_knows_mxfp8():
+    """MiniMax-M3-MXFP8 names the method ``mxfp8`` with no nested weight spec."""
+    assert rc._resolve_quant_config_weight_bytes({"quant_method": "mxfp8"}) == 1.0
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("num_experts_per_tok", 4),  # the common HF spelling
+        ("num_experts_per_token", 16),  # Kimi-K3
+        ("top_k_experts", 8),  # Gemma-4
+    ],
+)
+def test_experts_per_tok_reads_every_alias_in_use(key, expected):
+    assert rc._derive_experts_per_tok({key: expected}) == expected
+
+
+def test_experts_per_tok_prefers_the_canonical_spelling():
+    assert rc._derive_experts_per_tok({"num_experts_per_tok": 2, "top_k_experts": 9}) == 2
+
+
+def test_experts_per_tok_is_zero_when_no_alias_is_present():
+    assert rc._derive_experts_per_tok({"num_experts": 8}) == 0
+
+
+def test_moe_hidden_size_prefers_the_latent_expert_width():
+    """Kimi-K3 runs its experts at ``routed_expert_hidden_size``, not ``hidden_size``."""
+    assert rc._derive_moe_hidden_size({"hidden_size": 7168, "routed_expert_hidden_size": 3584}) == 3584
+
+
+def test_moe_hidden_size_falls_back_to_the_residual_width():
+    assert rc._derive_moe_hidden_size({"hidden_size": 7168}) == 7168
+
+
+def test_moe_decomposition_reads_a_gemma_style_topk_alias():
+    """Regression: ``top_k_experts`` read as 0 degraded a 128-expert model to dense."""
+    cfg = {
+        "num_experts": 128,
+        "top_k_experts": 8,
+        "hidden_size": 2816,
+        "num_hidden_layers": 30,
+        "moe_intermediate_size": 704,
+    }
+    _, total, experts, per_tok = rc._compute_expert_decomposition(
+        cfg, weight_bytes=51_611_872_412, dtype_bytes=2.0
+    )
+    assert (experts, per_tok) == (128, 8)
+    assert total == 30 * 128 * 3 * 2816 * 704 * 2
+
+
+def test_moe_decomposition_sizes_latent_experts_at_their_own_width():
+    """Sizing Kimi-K3's experts at hidden_size doubles them past the checkpoint."""
+    cfg = {
+        "num_experts": 896,
+        "num_experts_per_token": 16,
+        "hidden_size": 7168,
+        "routed_expert_hidden_size": 3584,
+        "num_hidden_layers": 93,
+        "moe_intermediate_size": 3072,
+    }
+    weight_bytes = 1_560_860_324_864
+    _, total, experts, _ = rc._compute_expert_decomposition(cfg, weight_bytes=weight_bytes, dtype_bytes=0.5)
+    assert experts == 896
+    assert total == int(93 * 896 * 3 * 3584 * 3072 * 0.5)
+    # The residual width would overshoot the checkpoint and safe-degrade.
+    wide = {k: v for k, v in cfg.items() if k != "routed_expert_hidden_size"}
+    assert rc._compute_expert_decomposition(wide, weight_bytes=weight_bytes, dtype_bytes=0.5)[2] == 0
+
+
+def test_perfmodel_sizes_the_moe_op_at_the_latent_expert_width(tmp_path):
+    """A narrower expert width must shrink the MoE op, not just the guard math."""
+
+    def _breakdown(moe_hidden):
+        meta = rc.ModelMeta(
+            weight_bytes=1_000_000,
+            num_layers=4,
+            num_kv_heads=2,
+            head_dim=64,
+            weight_dtype_bytes=0.5,
+            num_experts=128,
+            experts_per_tok=8,
+            expert_weight_dtype_bytes=0.5,
+            hidden_size=4096,
+            moe_intermediate_size=1024,
+            moe_hidden_size=moe_hidden,
+            vocab_size=32000,
+            num_attention_heads=8,
+        )
+        b = rc.compute_roofline_from_perfmodel(
+            meta=meta, gpu_type="mi355x", concurrency=8, isl=1024, osl=128, num_gpus=1, precision_tag="mxfp4"
+        )
+        return next(o for o in b.ops if o.name == "moe_fused")
+
+    assert _breakdown(2048).bytes_moved < _breakdown(0).bytes_moved
+    # 0 means "unset", which must behave exactly like the residual width.
+    assert _breakdown(0).bytes_moved == _breakdown(4096).bytes_moved
+
+
+def test_load_model_meta_keeps_a_quark_moe_checkpoint_decomposed(tmp_path):
+    """Regression: reading only ``quant_method`` sized MXFP4 experts at bf16.
+
+    The 4x overcount pushed ``total_expert_bytes`` past the checkpoint size,
+    tripping the sanity guard and degrading a 512-expert model to dense — which
+    dropped the MoE op from the breakdown entirely.
+    """
+    cfg = {
+        **_DENSE_CFG,
+        "num_experts": 512,
+        "num_experts_per_tok": 10,
+        "moe_intermediate_size": 2048,
+        "quantization_config": _QUARK_MXFP4_QUANT_CFG,
+    }
+    # Sized as the real checkpoint is: fp4 experts fit, bf16 experts would not.
+    expert_elems = 4 * 512 * 3 * 512 * 2048  # layers * experts * 3 * hidden * moe_inter
+    weight_bytes = int(expert_elems * 0.5 * 1.15)
+    meta = rc.load_model_meta(_write_model(tmp_path / "m", cfg, weight_bytes=weight_bytes))
+
+    assert meta.weight_dtype_bytes == 0.5
+    assert (meta.num_experts, meta.experts_per_tok) == (512, 10)
+    assert meta.moe_intermediate_size == 2048
+    assert meta.expert_weight_bytes == int(expert_elems * 0.5)
+    # At bf16 the same config degrades to dense, which is the bug being pinned.
+    assert rc._compute_expert_decomposition(cfg, weight_bytes=weight_bytes, dtype_bytes=2.0) == (
+        weight_bytes,
+        0,
+        0,
+        0,
+    )
+
+
+def test_perfmodel_attributes_the_moe_ffn_for_a_quark_checkpoint(tmp_path):
+    """The MoE op must appear, and dominate: it is most of the weight IO."""
+    cfg = {
+        **_DENSE_CFG,
+        "num_experts": 512,
+        "num_experts_per_tok": 10,
+        "moe_intermediate_size": 2048,
+        "quantization_config": _QUARK_MXFP4_QUANT_CFG,
+    }
+    expert_elems = 4 * 512 * 3 * 512 * 2048
+    meta = rc.load_model_meta(_write_model(tmp_path / "m", cfg, weight_bytes=int(expert_elems * 0.5 * 1.15)))
+    breakdown = rc.compute_roofline_from_perfmodel(
+        meta=meta, gpu_type="mi355x", concurrency=64, isl=8192, osl=1024, num_gpus=8, precision_tag="mxfp4"
+    )
+
+    ops = {o.name: o.pct_time for o in breakdown.ops}
+    assert "moe_fused" in ops
+    assert ops["moe_fused"] == max(ops.values())
+    # Dense gate/up/down must not double-count the FFN alongside the MoE op.
+    assert not {"gate_proj", "up_proj", "down_proj"} & set(ops)
+
+
 def test_moe_decomposition_degrades_when_the_experts_exceed_the_checkpoint():
     """An implausible decomposition is dropped rather than published."""
     cfg = {

--- a/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling_perfmodel_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling_perfmodel_units.py
@@ -868,3 +868,34 @@ def test_compute_compute_bound_ceiling_fallback_and_degrade_to_zero(monkeypatch)
         )
         == 0.0
     )
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        ("fp8_e4m3", 1.0),
+        ("fp8_e5m2", 1.0),
+        ("nvfp4", 0.5),
+        ("int8", 1.0),
+        ("w8a8_int8", 1.0),
+        ("int4", 0.5),
+        ("awq", 0.5),
+        ("gptq", 0.5),
+    ],
+)
+def test_a_nested_spec_reads_the_quant_only_tags_too(tag, expected):
+    """The nested path must consult both tables, exactly as the flat one does.
+
+    These eight tags live only in ``_QUANT_WEIGHT_BYTES``, and Quark writes
+    precisely them on ``global_quant_config.weight.dtype`` -- often with no
+    ``num_bits`` beside them. Checking ``_DTYPE_BYTES`` alone returned 0.0, the
+    caller fell back to the checkpoint dtype, and an fp8 checkpoint was costed
+    as bf16: the 2x weight-IO overcount this function exists to remove.
+    """
+    cfg = {"quant_method": "quark", "global_quant_config": {"weight": {"dtype": tag}}}
+    assert rc._resolve_quant_config_weight_bytes(cfg) == expected
+
+
+def test_num_bits_still_wins_when_the_tag_is_unknown():
+    cfg = {"quant_method": "quark", "global_quant_config": {"weight": {"dtype": "some_new_format", "num_bits": 6}}}
+    assert rc._resolve_quant_config_weight_bytes(cfg) == 0.75

--- a/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling_perfmodel_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling_perfmodel_units.py
@@ -314,6 +314,50 @@ def test_quant_config_weight_bytes_reads_compressed_tensors_bit_widths():
     assert rc._resolve_quant_config_weight_bytes(cfg) == 0.5
 
 
+def test_quant_config_weight_bytes_takes_the_precision_most_groups_agree_on():
+    """Per-layer groups need not agree, and dict order must not decide.
+
+    A Quark MoE checkpoint stores the routed experts at fp4 and the attention
+    projections at fp8. Returning whichever group iterated first declared that
+    precision for the whole model -- and the answer flipped with dict order.
+    """
+    cfg = {
+        "quant_method": "quark",
+        "layer_quant_config": {
+            "*.self_attn.q_proj": {"weight": {"dtype": "fp8"}},
+            "*.mlp.experts.*": {"weight": {"dtype": "fp4"}},
+            "*.mlp.experts.down_proj": {"weight": {"dtype": "fp4"}},
+        },
+    }
+    assert rc._resolve_quant_config_weight_bytes(cfg) == 0.5
+    # Same groups, opposite majority -> opposite answer, from the counts alone.
+    cfg["layer_quant_config"]["*.mlp.experts.*"] = {"weight": {"dtype": "fp8"}}
+    cfg["layer_quant_config"]["*.mlp.experts.down_proj"] = {"weight": {"dtype": "fp8"}}
+    assert rc._resolve_quant_config_weight_bytes(cfg) == 1.0
+
+
+def test_quant_config_weight_bytes_breaks_a_tie_toward_the_wider_type():
+    # Undercounting weight bytes raises the roofline and reports a real
+    # regression as "already at ceiling", so a tie resolves upward.
+    cfg = {
+        "quant_method": "quark",
+        "layer_quant_config": {
+            "a": {"weight": {"dtype": "fp4"}},
+            "b": {"weight": {"dtype": "fp8"}},
+        },
+    }
+    assert rc._resolve_quant_config_weight_bytes(cfg) == 1.0
+
+
+def test_a_whole_checkpoint_scope_still_outranks_the_per_group_ones():
+    cfg = {
+        "quant_method": "quark",
+        "global_quant_config": {"weight": {"dtype": "fp4"}},
+        "layer_quant_config": {"a": {"weight": {"dtype": "fp8"}}, "b": {"weight": {"dtype": "fp8"}}},
+    }
+    assert rc._resolve_quant_config_weight_bytes(cfg) == 0.5
+
+
 @pytest.mark.parametrize("quant_cfg", [None, {}, "fp8", {"quant_method": "unknown-toolkit"}])
 def test_quant_config_weight_bytes_is_silent_without_a_decisive_signal(quant_cfg):
     """No signal returns 0.0 so the caller falls back to the checkpoint dtype."""

--- a/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling_perfmodel_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_roofline_ceiling_perfmodel_units.py
@@ -363,9 +363,7 @@ def test_moe_decomposition_reads_a_gemma_style_topk_alias():
         "num_hidden_layers": 30,
         "moe_intermediate_size": 704,
     }
-    _, total, experts, per_tok = rc._compute_expert_decomposition(
-        cfg, weight_bytes=51_611_872_412, dtype_bytes=2.0
-    )
+    _, total, experts, per_tok = rc._compute_expert_decomposition(cfg, weight_bytes=51_611_872_412, dtype_bytes=2.0)
     assert (experts, per_tok) == (128, 8)
     assert total == 30 * 128 * 3 * 2816 * 704 * 2
 

--- a/src/hyperloom/inference_optimizer/tests/test_roofline_moe_layer_split.py
+++ b/src/hyperloom/inference_optimizer/tests/test_roofline_moe_layer_split.py
@@ -51,6 +51,19 @@ class TestTheLayerSplit:
     def test_qwen_spells_the_stride_decoder_sparse_step(self):
         assert _split({"decoder_sparse_step": 2}, 8, 64) == (4, 4)
 
+    def test_the_stride_is_phased_on_the_absolute_layer_index(self):
+        # Both upstreams phase on layer_idx, not on the offset from the dense
+        # prefix. DeepSeek/GLM:
+        #     layer_idx >= first_k_dense_replace and layer_idx % moe_layer_freq == 0
+        # so with prefix 3 / stride 2 over 8 layers the MoE layers are 4 and 6 --
+        # not 3, 5, 7, which is what re-basing to (i - first_dense) produced.
+        assert _split({"first_k_dense_replace": 3, "moe_layer_freq": 2}, 8, 64) == (2, 6)
+
+    def test_qwen_counts_from_one_not_zero(self):
+        # Qwen3-MoE: (layer_idx + 1) % decoder_sparse_step == 0, so with stride 3
+        # over 8 layers it is 2, 5 -- the shifted-by-one set of 0, 3, 6.
+        assert _split({"decoder_sparse_step": 3}, 8, 64) == (2, 6)
+
     def test_mlp_only_layers_stay_dense(self):
         assert _split({"mlp_only_layers": [0, 1]}, 8, 64) == (6, 2)
 

--- a/src/hyperloom/inference_optimizer/tests/test_roofline_moe_layer_split.py
+++ b/src/hyperloom/inference_optimizer/tests/test_roofline_moe_layer_split.py
@@ -1,0 +1,257 @@
+"""A MoE checkpoint is not MoE in every layer.
+
+``867f119cb`` restored the MoE FFN to the PerfModel breakdown, but charged it
+to all ``num_hidden_layers`` and kept skipping the dense FFN entirely. Real
+checkpoints run a dense prefix: GLM-5.3-Flash and GLM-5.3 both set
+``first_k_dense_replace: 3``, so 3 of their 45 / 78 layers have gate/up/down
+and no experts. Counting those layers as MoE overstates the largest term in
+the breakdown and drops a real one.
+
+The config numbers below are read off ``/shared_nfs/models/GLM-5.3*/config.json``
+on the fleet, not invented.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hyperloom.orchestrator.kernel import roofline_ceiling as rc
+
+
+def _split(cfg: dict, layers: int, experts: int) -> tuple[int, int]:
+    return rc._derive_moe_layer_counts(cfg, layers, experts)
+
+
+class TestTheLayerSplit:
+    def test_a_dense_model_is_all_dense_ffn(self):
+        assert _split({}, 32, 0) == (0, 32)
+
+    def test_a_moe_model_with_no_dense_prefix_is_all_moe(self):
+        assert _split({}, 32, 128) == (32, 0)
+
+    def test_glm_5_3_flash(self):
+        # 45 layers, first_k_dense_replace=3.
+        assert _split({"first_k_dense_replace": 3}, 45, 288) == (42, 3)
+
+    def test_glm_5_3(self):
+        # 78 layers, first_k_dense_replace=3, moe_layer_freq=1.
+        assert _split({"first_k_dense_replace": 3, "moe_layer_freq": 1}, 78, 256) == (75, 3)
+
+    def test_a_per_layer_freq_list_is_counted_directly(self):
+        cfg = {"moe_layer_freq": [0, 0, 1, 1, 1, 0]}
+        assert _split(cfg, 6, 64) == (3, 3)
+
+    def test_an_integer_stride_applies_after_the_dense_prefix(self):
+        # Layers 0-1 dense, then every 2nd layer (2, 4, 6) is MoE.
+        assert _split({"first_k_dense_replace": 2, "moe_layer_freq": 2}, 8, 64) == (3, 5)
+
+    def test_qwen_spells_the_stride_decoder_sparse_step(self):
+        assert _split({"decoder_sparse_step": 2}, 8, 64) == (4, 4)
+
+    def test_mlp_only_layers_stay_dense(self):
+        assert _split({"mlp_only_layers": [0, 1]}, 8, 64) == (6, 2)
+
+    @pytest.mark.parametrize(
+        "cfg,layers",
+        [
+            ({"first_k_dense_replace": 3}, 45),
+            ({"first_k_dense_replace": 3, "moe_layer_freq": 1}, 78),
+            ({"moe_layer_freq": [1, 0, 1, 0]}, 4),
+            ({"first_k_dense_replace": 2, "decoder_sparse_step": 3}, 11),
+        ],
+    )
+    def test_the_two_counts_always_sum_to_the_stack(self, cfg, layers):
+        moe, dense = _split(cfg, layers, 64)
+        assert moe + dense == layers
+
+    def test_an_oversized_prefix_cannot_produce_negative_counts(self):
+        assert _split({"first_k_dense_replace": 999}, 8, 64) == (0, 8)
+
+    def test_a_boolean_freq_is_not_read_as_a_stride(self):
+        # ``True`` is an int in Python; treating it as stride 1 would be right
+        # by accident, but treating ``False`` as 0 would divide by zero.
+        assert _split({"moe_layer_freq": False}, 8, 64) == (8, 0)
+
+
+def _flash_meta(**over) -> rc.ModelMeta:
+    """GLM-5.3-Flash's real decoder shape."""
+    base = dict(
+        weight_bytes=64 * 1024**3,
+        num_layers=45,
+        num_kv_heads=8,
+        head_dim=128,
+        weight_dtype_bytes=2.0,
+        num_experts=288,
+        experts_per_tok=8,
+        hidden_size=4096,
+        intermediate_size=12288,
+        moe_intermediate_size=2048,
+        vocab_size=154880,
+        num_attention_heads=32,
+        moe_layers=42,
+        dense_ffn_layers=3,
+    )
+    base.update(over)
+    return rc.ModelMeta(**base)
+
+
+def _breakdown(meta):
+    return rc.compute_roofline_from_perfmodel(
+        meta=meta, gpu_type="mi355x", concurrency=8, isl=1024, osl=128, num_gpus=1
+    )
+
+
+class TestThePerfModelUsesTheSplit:
+    def test_a_moe_model_with_a_dense_prefix_gets_both_ffns(self):
+        names = [op.name for op in _breakdown(_flash_meta()).ops]
+
+        assert "moe_fused" in names
+        # The three layers that are genuinely dense were silently dropped.
+        assert {"gate_proj", "up_proj", "down_proj"} <= set(names)
+
+    def test_the_moe_op_is_charged_to_moe_layers_only(self):
+        forty_two = next(o for o in _breakdown(_flash_meta()).ops if o.name == "moe_fused")
+        all_forty_five = next(
+            o for o in _breakdown(_flash_meta(moe_layers=45, dense_ffn_layers=0)).ops
+            if o.name == "moe_fused"
+        )
+
+        assert forty_two.bytes_moved == pytest.approx(all_forty_five.bytes_moved * 42 / 45)
+        assert forty_two.flops == pytest.approx(all_forty_five.flops * 42 / 45)
+
+    def test_the_dense_ffn_is_charged_to_the_prefix_only(self):
+        gate = next(o for o in _breakdown(_flash_meta()).ops if o.name == "gate_proj")
+        q = next(o for o in _breakdown(_flash_meta()).ops if o.name == "q_proj")
+
+        # q_proj repeats over all 45 layers; gate_proj over the 3 dense ones.
+        # Same M, so the ratio is purely the repeat count.
+        per_layer_gate = gate.flops / 3
+        per_layer_q = q.flops / 45
+        assert per_layer_gate == pytest.approx(per_layer_q * (12288 / 4096) * 1.0, rel=0.01)
+
+    def test_attention_still_repeats_over_every_layer(self):
+        ops = {o.name: o for o in _breakdown(_flash_meta()).ops}
+        # Every layer has attention regardless of its FFN kind; this must not
+        # have been dragged along by the FFN split.
+        assert ops["sdpa"].flops == pytest.approx(
+            next(o for o in _breakdown(_flash_meta(moe_layers=45, dense_ffn_layers=0)).ops if o.name == "sdpa").flops
+        )
+
+    def test_an_undecided_split_keeps_the_previous_behaviour(self):
+        """A hand-built ModelMeta with neither count set must not change."""
+        legacy = _flash_meta(moe_layers=0, dense_ffn_layers=0)
+        ops = {o.name: o for o in _breakdown(legacy).ops}
+
+        assert "gate_proj" not in ops  # as before: MoE model, no dense FFN
+        all_layers = next(
+            o for o in _breakdown(_flash_meta(moe_layers=45, dense_ffn_layers=0)).ops
+            if o.name == "moe_fused"
+        )
+        assert ops["moe_fused"].flops == pytest.approx(all_layers.flops)
+
+    def test_a_dense_model_is_unaffected(self):
+        dense = rc.ModelMeta(
+            weight_bytes=16 * 1024**3,
+            num_layers=32,
+            num_kv_heads=8,
+            head_dim=128,
+            weight_dtype_bytes=2.0,
+            hidden_size=4096,
+            intermediate_size=11008,
+            vocab_size=32000,
+            num_attention_heads=32,
+            dense_ffn_layers=32,
+        )
+        undecided = rc.ModelMeta(**{**dense.__dict__, "dense_ffn_layers": 0})
+
+        a = {o.name: o.flops for o in _breakdown(dense).ops}
+        b = {o.name: o.flops for o in _breakdown(undecided).ops}
+        assert a == b
+        assert "moe_fused" not in a
+
+
+def _write_config(root: Path, cfg: dict, total_size: int) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "config.json").write_text(json.dumps(cfg), encoding="utf-8")
+    (root / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {"total_size": total_size}}), encoding="utf-8"
+    )
+    return root
+
+
+class TestLoadModelMetaFillsTheSplit:
+    def test_the_dense_prefix_reaches_the_meta(self, tmp_path):
+        root = _write_config(
+            tmp_path / "glm",
+            {
+                "num_hidden_layers": 45,
+                "first_k_dense_replace": 3,
+                "n_routed_experts": 288,
+                "num_experts_per_tok": 8,
+                "moe_intermediate_size": 2048,
+                "intermediate_size": 12288,
+                "hidden_size": 4096,
+                "num_attention_heads": 32,
+                "num_key_value_heads": 8,
+                "head_dim": 128,
+                "vocab_size": 154880,
+                "torch_dtype": "bfloat16",
+            },
+            total_size=700 * 1024**3,
+        )
+
+        meta = rc.load_model_meta(root)
+
+        assert meta is not None
+        assert (meta.moe_layers, meta.dense_ffn_layers) == (42, 3)
+
+    def test_expert_bytes_are_charged_to_moe_layers_only(self, tmp_path):
+        cfg = {
+            "num_hidden_layers": 45,
+            "n_routed_experts": 288,
+            "num_experts_per_tok": 8,
+            "moe_intermediate_size": 2048,
+            "intermediate_size": 12288,
+            "hidden_size": 4096,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+            "head_dim": 128,
+            "vocab_size": 154880,
+            "torch_dtype": "bfloat16",
+        }
+        total = 700 * 1024**3
+        no_prefix = rc.load_model_meta(_write_config(tmp_path / "a", cfg, total))
+        prefix = rc.load_model_meta(_write_config(tmp_path / "b", {**cfg, "first_k_dense_replace": 3}, total))
+
+        assert no_prefix is not None and prefix is not None
+        assert prefix.expert_weight_bytes == pytest.approx(
+            no_prefix.expert_weight_bytes * 42 / 45, rel=1e-6
+        )
+        # Per-token active bytes go *up*, and that is the point. Bytes moved out
+        # of the expert pool are dense-FFN weights, and a dense layer's weights
+        # are read for every token, whereas only 8 of 288 experts are. Charging
+        # them as experts under-counted the decode weight traffic.
+        assert prefix.active_weight_bytes > no_prefix.active_weight_bytes
+
+    def test_a_dense_checkpoint_reports_every_layer_as_dense_ffn(self, tmp_path):
+        root = _write_config(
+            tmp_path / "llama",
+            {
+                "num_hidden_layers": 32,
+                "intermediate_size": 11008,
+                "hidden_size": 4096,
+                "num_attention_heads": 32,
+                "num_key_value_heads": 8,
+                "vocab_size": 32000,
+                "torch_dtype": "bfloat16",
+            },
+            total_size=14 * 1024**3,
+        )
+
+        meta = rc.load_model_meta(root)
+
+        assert meta is not None
+        assert (meta.moe_layers, meta.dense_ffn_layers) == (0, 32)

--- a/src/hyperloom/inference_optimizer/tests/test_roofline_moe_layer_split.py
+++ b/src/hyperloom/inference_optimizer/tests/test_roofline_moe_layer_split.py
@@ -115,8 +115,7 @@ class TestThePerfModelUsesTheSplit:
     def test_the_moe_op_is_charged_to_moe_layers_only(self):
         forty_two = next(o for o in _breakdown(_flash_meta()).ops if o.name == "moe_fused")
         all_forty_five = next(
-            o for o in _breakdown(_flash_meta(moe_layers=45, dense_ffn_layers=0)).ops
-            if o.name == "moe_fused"
+            o for o in _breakdown(_flash_meta(moe_layers=45, dense_ffn_layers=0)).ops if o.name == "moe_fused"
         )
 
         assert forty_two.bytes_moved == pytest.approx(all_forty_five.bytes_moved * 42 / 45)
@@ -147,8 +146,7 @@ class TestThePerfModelUsesTheSplit:
 
         assert "gate_proj" not in ops  # as before: MoE model, no dense FFN
         all_layers = next(
-            o for o in _breakdown(_flash_meta(moe_layers=45, dense_ffn_layers=0)).ops
-            if o.name == "moe_fused"
+            o for o in _breakdown(_flash_meta(moe_layers=45, dense_ffn_layers=0)).ops if o.name == "moe_fused"
         )
         assert ops["moe_fused"].flops == pytest.approx(all_layers.flops)
 
@@ -227,9 +225,7 @@ class TestLoadModelMetaFillsTheSplit:
         prefix = rc.load_model_meta(_write_config(tmp_path / "b", {**cfg, "first_k_dense_replace": 3}, total))
 
         assert no_prefix is not None and prefix is not None
-        assert prefix.expert_weight_bytes == pytest.approx(
-            no_prefix.expert_weight_bytes * 42 / 45, rel=1e-6
-        )
+        assert prefix.expert_weight_bytes == pytest.approx(no_prefix.expert_weight_bytes * 42 / 45, rel=1e-6)
         # Per-token active bytes go *up*, and that is the point. Bytes moved out
         # of the expert pool are dense-FFN weights, and a dense layer's weights
         # are read for every token, whereas only 8 of 288 experts are. Charging

--- a/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
@@ -77,7 +77,34 @@ def _stub_server_arg_injectors(monkeypatch):
 def test_validate_server_args_rejects_bare_positionals():
     assert validate_server_args_shell_safe("--flag value --other=value") == "--flag value --other=value"
     with pytest.raises(ValueError, match="bare positional"):
-        validate_server_args_shell_safe("--flag value stray")
+        validate_server_args_shell_safe("stray --flag value")
+
+
+def test_validate_server_args_allows_multi_value_flags():
+    """argparse ``nargs="+"`` flags carry several values; the sink must accept them.
+
+    ``--cuda-graph-bs`` is a real sglang invocation and is already listed in
+    ``_MULTI_VALUE_FLAGS``. Rejecting the second value here made the integrate
+    sink refuse recipes the explore side had already run.
+    """
+    args = "--cuda-graph-bs 1 2 4 8 16 24 32 48 64"
+    assert validate_server_args_shell_safe(args) == args
+    assert validate_server_args_shell_safe("--a 1 2 --b=3 --c x y z") == "--a 1 2 --b=3 --c x y z"
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        "--flag value; rm -rf /",
+        "--flag `whoami`",
+        "--flag $(id)",
+        "--flag a|b",
+        "--flag a>b",
+    ],
+)
+def test_validate_server_args_still_blocks_shell_control(args):
+    with pytest.raises(ValueError, match="shell control characters"):
+        validate_server_args_shell_safe(args)
 
 
 def test_materialize_remove_args_and_string_unset_env(tmp_path, monkeypatch):

--- a/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
@@ -89,7 +89,24 @@ def test_validate_server_args_allows_multi_value_flags():
     """
     args = "--cuda-graph-bs 1 2 4 8 16 24 32 48 64"
     assert validate_server_args_shell_safe(args) == args
-    assert validate_server_args_shell_safe("--a 1 2 --b=3 --c x y z") == "--a 1 2 --b=3 --c x y z"
+    # A flag not on the whitelist still gets its value plus a numeric list, so
+    # an nargs="+" flag nobody has enumerated yet is not rejected either.
+    assert validate_server_args_shell_safe("--a 1 2 --b=3 --c x") == "--a 1 2 --b=3 --c x"
+
+
+def test_validate_server_args_still_catches_positionals_after_a_flag():
+    """The multi-value relaxation must not become "one flag opens the gates".
+
+    A first pass tracked only "have we seen any flag", so every bare token after
+    the first flag was accepted -- which is no check at all for the argv shapes
+    this guard exists to reject.
+    """
+    with pytest.raises(ValueError, match="bare positional"):
+        # --port=8000 already carries its value; run.sh is positional.
+        validate_server_args_shell_safe("--port=8000 run.sh")
+    with pytest.raises(ValueError, match="bare positional"):
+        # --foo consumes bar; payload.json after it is not a value list.
+        validate_server_args_shell_safe("--foo bar payload.json")
 
 
 @pytest.mark.parametrize(

--- a/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py
@@ -107,6 +107,11 @@ def test_validate_server_args_still_catches_positionals_after_a_flag():
     with pytest.raises(ValueError, match="bare positional"):
         # --foo consumes bar; payload.json after it is not a value list.
         validate_server_args_shell_safe("--foo bar payload.json")
+    with pytest.raises(ValueError, match="bare positional"):
+        # Being on the multi-value whitelist widens how MANY values a flag
+        # takes, not what they may look like: every entry on that list is a
+        # list of batch sizes.
+        validate_server_args_shell_safe("--cuda-graph-bs 1 2 run.sh")
 
 
 @pytest.mark.parametrize(

--- a/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
@@ -36,6 +36,13 @@ def validate_server_args_shell_safe(server_args: str | None) -> str:
     Magpie benchmark scripts expand ``EXTRA_*_ARGS`` through shell wrappers, so
     this is the final sink-side guard against LLM/payload content escaping from
     argv-like flags into shell control operators.
+
+    A flag may be followed by any number of value tokens (argparse ``nargs="+"``
+    semantics). ``--cuda-graph-bs 1 2 4 8`` is a real sglang invocation and is
+    already recognized as multi-valued by :data:`_MULTI_VALUE_FLAGS`; requiring
+    exactly one value here rejected it at the sink while the explore side let it
+    through. Shell control characters are blocked separately above, so the
+    positional-argument check is only a secondary "this looks like argv" guard.
     """
     args = str(server_args or "").strip()
     if not args:
@@ -46,13 +53,12 @@ def validate_server_args_shell_safe(server_args: str | None) -> str:
         tokens = shlex.split(args)
     except ValueError as exc:
         raise ValueError(f"extra_server_args is not shell-tokenizable: {exc}") from exc
-    expect_value = False
+    seen_flag = False
     for token in tokens:
         if token.startswith("-"):
-            expect_value = "=" not in token
+            seen_flag = True
             continue
-        if expect_value:
-            expect_value = False
+        if seen_flag:
             continue
         raise ValueError("extra_server_args must be argv-like flags, not bare positional arguments")
     return args

--- a/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
@@ -28,6 +28,9 @@ from hyperloom.inference_optimizer.framework_registry import server_args_env_nam
 log = logging.getLogger(__name__)
 
 _UNSAFE_SERVER_ARG_CHARS_RE = re.compile(r"[;&|`$<>\r\n]")
+#: What the 2nd..nth value of a not-yet-whitelisted multi-value flag may look
+#: like: a batch size, a length, a ratio. Deliberately not a general token.
+_NUMERIC_VALUE_RE = re.compile(r"^\d+(?:[.,]\d+)*$")
 
 
 def validate_server_args_shell_safe(server_args: str | None) -> str:
@@ -37,12 +40,25 @@ def validate_server_args_shell_safe(server_args: str | None) -> str:
     this is the final sink-side guard against LLM/payload content escaping from
     argv-like flags into shell control operators.
 
-    A flag may be followed by any number of value tokens (argparse ``nargs="+"``
+    A flag may be followed by more than one value token (argparse ``nargs="+"``
     semantics). ``--cuda-graph-bs 1 2 4 8`` is a real sglang invocation and is
     already recognized as multi-valued by :data:`_MULTI_VALUE_FLAGS`; requiring
     exactly one value here rejected it at the sink while the explore side let it
-    through. Shell control characters are blocked separately above, so the
-    positional-argument check is only a secondary "this looks like argv" guard.
+    through.
+
+    The relaxation is scoped rather than blanket, because "any flag anywhere
+    earlier permits any bare token afterwards" stops rejecting anything at all:
+
+    * ``--flag=value`` already carries its value, so a bare token after it is
+      unambiguously positional.
+    * a flag in :data:`_MULTI_VALUE_FLAGS` takes an unlimited value list.
+    * any other flag takes one arbitrary value; further tokens are accepted only
+      while they still look like list elements (digits), never as bare words.
+      That covers an ``nargs="+"`` flag not yet on the whitelist -- those carry
+      batch sizes or lengths -- without readmitting ``--foo bar some_script.sh``.
+
+    Shell control characters are blocked separately above, so this remains a
+    secondary "this looks like argv" guard.
     """
     args = str(server_args or "").strip()
     if not args:
@@ -53,12 +69,22 @@ def validate_server_args_shell_safe(server_args: str | None) -> str:
         tokens = shlex.split(args)
     except ValueError as exc:
         raise ValueError(f"extra_server_args is not shell-tokenizable: {exc}") from exc
-    seen_flag = False
+    state = "positional"
     for token in tokens:
         if token.startswith("-"):
-            seen_flag = True
+            if "=" in token:
+                state = "positional"
+            elif token in _MULTI_VALUE_FLAGS:
+                state = "many"
+            else:
+                state = "any"
             continue
-        if seen_flag:
+        if state == "many":
+            continue
+        if state == "any":
+            state = "numeric"
+            continue
+        if state == "numeric" and _NUMERIC_VALUE_RE.match(token):
             continue
         raise ValueError("extra_server_args must be argv-like flags, not bare positional arguments")
     return args

--- a/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_server_args.py
@@ -51,7 +51,10 @@ def validate_server_args_shell_safe(server_args: str | None) -> str:
 
     * ``--flag=value`` already carries its value, so a bare token after it is
       unambiguously positional.
-    * a flag in :data:`_MULTI_VALUE_FLAGS` takes an unlimited value list.
+    * a flag in :data:`_MULTI_VALUE_FLAGS` takes an unlimited value list -- but
+      every entry in that whitelist is a list of batch sizes, so the list is
+      still digits-only. Letting the whitelist waive the token shape as well
+      would readmit ``--cuda-graph-bs 1 2 run.sh``.
     * any other flag takes one arbitrary value; further tokens are accepted only
       while they still look like list elements (digits), never as bare words.
       That covers an ``nargs="+"`` flag not yet on the whitelist -- those carry
@@ -79,7 +82,7 @@ def validate_server_args_shell_safe(server_args: str | None) -> str:
             else:
                 state = "any"
             continue
-        if state == "many":
+        if state == "many" and _NUMERIC_VALUE_RE.match(token):
             continue
         if state == "any":
             state = "numeric"

--- a/src/hyperloom/orchestrator/kernel/gemm_shape_coverage.py
+++ b/src/hyperloom/orchestrator/kernel/gemm_shape_coverage.py
@@ -48,14 +48,20 @@ _AITER_SHAPE_MISS_RE = re.compile(
 # none of the 5024 hit lines in a production Qwen3 log, which scored a fully
 # served tuned table as ``no_shape_key_matched`` and reverted it. The trailing
 # ``is tuned`` anchor keeps the lazy ``[^\n]*?`` from spanning an unrelated line.
+# ``found padded_M:`` is on its own sufficient to tell a hit from a miss: a miss
+# line reads "not found tuned config in <table>" and never carries a padded_M.
+# Measured on a real serving log, all 1168 ``found padded_M:`` occurrences were
+# hits and none of the 592 miss lines contained the token. So anchor on it and
+# nothing further -- requiring the trailing ", N:.., K:.. is tuned" would buy no
+# discrimination while dropping any line the log truncated mid-record, and one
+# missed hit is enough to grade a table that was serving as no_shape_key_matched.
 _AITER_SHAPE_HIT_RE = re.compile(
-    r"shape is M:(\d+), N:(\d+), K:(\d+)[^\n]*?found padded_M: (\d+), N:\d+, K:\d+ is tuned",
+    r"shape is M:(\d+), N:(\d+), K:(\d+)[^\n]*?found padded_M: (\d+)",
 )
-# The table-qualified form is used only when attributing hits to one candidate.
-# Keep the shape-only pattern above tolerant of logs truncated after ``is tuned``.
+# The table-qualified form is used only when attributing hits to one candidate,
+# so it has to reach the table name; everything between stays unconstrained.
 _AITER_SHAPE_HIT_TABLE_RE = re.compile(
-    r"shape is M:(\d+), N:(\d+), K:(\d+)[^\n]*?found padded_M: (\d+), "
-    r"N:\d+, K:\d+ is tuned[^\n]*? in (\S+?)\s*,",
+    r"shape is M:(\d+), N:(\d+), K:(\d+)[^\n]*?found padded_M: (\d+)[^\n]*? in (\S+?)\s*,",
 )
 
 Shape = tuple[int, int, int]
@@ -469,22 +475,48 @@ def aiter_log_tuned_config_enabled(envs: dict[str, str]) -> bool:
     return raw not in ("", "0", "false", "no", "off")
 
 
+def _safe_mtime(path: Path) -> float:
+    """Return ``path``'s mtime, or ``0`` when it cannot be read.
+
+    Sorting server logs by mtime races the round that is still writing them, and
+    an ``exists()`` guard does not close the window. Ordering is a heuristic for
+    picking the newest log, so a vanished file is worth sorting last rather than
+    aborting the check that owns it.
+    """
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def integrate_server_logs(
+    session_dir: Path,
+    integrate_name: str = FMOE_INTEGRATE_RUN,
+) -> list[Path]:
+    """Server logs for one integrate run, retries included, oldest first.
+
+    A retried integrate lands in a sibling directory with a ``-2``/``-3``
+    suffix rather than inside the original, so scanning only ``integrate_name``
+    grades the retry on the *first* attempt's log. Seven such retries exist on
+    the fleet, including every faulted post-merge session.
+
+    This is the one implementation: :mod:`hyperloom.orchestrator.phases.kernel`
+    grades dense candidates from the same directories, and when the two copies
+    drifted -- one of them ``exists()``-guarding the mtime, the other not -- a
+    log that vanished mid-scan ordered differently on each side, so the dense
+    and MoE lanes could grade the same session on different attempts.
+    """
+    parent = session_dir / "runs" / "integrate"
+    run_dirs = [parent / integrate_name, *sorted(parent.glob(f"{integrate_name}-*"))]
+    return sorted((log_path for run_dir in run_dirs for log_path in run_dir.rglob("server.log")), key=_safe_mtime)
+
+
 def read_latest_integrate_server_log(
     session_dir: Path,
     integrate_name: str = FMOE_INTEGRATE_RUN,
 ) -> tuple[Path, str] | None:
-    """Return the newest ``server.log`` under an integrate run, if readable.
-
-    Retries land in ``<integrate_name>-2``/``-3`` siblings rather than inside
-    the original directory, so those are scanned too; otherwise a retried run is
-    judged on the attempt it replaced.
-    """
-    parent = session_dir / "runs" / "integrate"
-    run_dirs = [parent / integrate_name, *sorted(parent.glob(f"{integrate_name}-*"))]
-    logs = sorted(
-        (log_path for run_dir in run_dirs for log_path in run_dir.rglob("server.log")),
-        key=lambda p: p.stat().st_mtime if p.exists() else 0,
-    )
+    """Return the newest ``server.log`` under an integrate run, if readable."""
+    logs = integrate_server_logs(session_dir, integrate_name)
     if not logs:
         return None
     try:

--- a/src/hyperloom/orchestrator/kernel/gemm_shape_coverage.py
+++ b/src/hyperloom/orchestrator/kernel/gemm_shape_coverage.py
@@ -51,6 +51,12 @@ _AITER_SHAPE_MISS_RE = re.compile(
 _AITER_SHAPE_HIT_RE = re.compile(
     r"shape is M:(\d+), N:(\d+), K:(\d+)[^\n]*?found padded_M: (\d+), N:\d+, K:\d+ is tuned",
 )
+# The table-qualified form is used only when attributing hits to one candidate.
+# Keep the shape-only pattern above tolerant of logs truncated after ``is tuned``.
+_AITER_SHAPE_HIT_TABLE_RE = re.compile(
+    r"shape is M:(\d+), N:(\d+), K:(\d+)[^\n]*?found padded_M: (\d+), "
+    r"N:\d+, K:\d+ is tuned[^\n]*? in (\S+?)\s*,",
+)
 
 Shape = tuple[int, int, int]
 FmoeDispatchKey = tuple[str, ...]
@@ -253,6 +259,31 @@ def parse_aiter_shape_lookups(log_text: str) -> tuple[set[Shape], set[Shape]]:
     """Return the ``(missed, hit)`` GEMM shapes aiter reported in a server log."""
     missed = {(int(m), int(n), int(k)) for m, n, k, _table in _AITER_SHAPE_MISS_RE.findall(log_text or "")}
     hit = {(int(m), int(n), int(k)) for m, n, k, _padded in _AITER_SHAPE_HIT_RE.findall(log_text or "")}
+    return missed, hit
+
+
+def parse_aiter_shape_lookups_for_tables(
+    log_text: str,
+    table_names: Iterable[str | Path],
+) -> tuple[set[Shape], set[Shape]]:
+    """Return lookups attributed to the named tuned-config tables.
+
+    A GEMM validation run can carry previously KEEP'd tables alongside the
+    candidate under test. Shape-only hit parsing cannot distinguish those
+    tables, so an earlier candidate's hits would otherwise make a completely
+    unused current candidate look applied.
+    """
+    wanted = {Path(name).name for name in table_names if str(name).strip()}
+    missed = {
+        (int(m), int(n), int(k))
+        for m, n, k, table in _AITER_SHAPE_MISS_RE.findall(log_text or "")
+        if Path(table).name in wanted
+    }
+    hit = {
+        (int(m), int(n), int(k))
+        for m, n, k, _padded, table in _AITER_SHAPE_HIT_TABLE_RE.findall(log_text or "")
+        if Path(table).name in wanted
+    }
     return missed, hit
 
 
@@ -562,7 +593,9 @@ def parse_aiter_consulted_tables(log_text: str) -> set[str]:
     all -- a different failure from a CSV that is consulted but has no matching
     row, and one worth naming separately.
     """
-    return {table for _m, _n, _k, table in _AITER_SHAPE_MISS_RE.findall(log_text or "")}
+    missed = {table for _m, _n, _k, table in _AITER_SHAPE_MISS_RE.findall(log_text or "")}
+    hit = {table for _m, _n, _k, _padded, table in _AITER_SHAPE_HIT_TABLE_RE.findall(log_text or "")}
+    return missed | hit
 
 
 def tuned_csv_shapes(path: str | Path) -> set[Shape]:

--- a/src/hyperloom/orchestrator/kernel/gemm_shape_coverage.py
+++ b/src/hyperloom/orchestrator/kernel/gemm_shape_coverage.py
@@ -37,8 +37,19 @@ _AITER_SHAPE_MISS_RE = re.compile(
     r"shape is M:(\d+), N:(\d+), K:(\d+)(?:[^\n]*?)not found tuned config in (\S+?),",
 )
 # Emitted by aiter (only under AITER_LOG_TUNED_CONFIG) on a lookup hit.
+#
+# ``K:`` and ``found padded_M:`` are *not* adjacent in practice: aiter prints the
+# dispatch kwargs between them, and only some of those are comma-separated --
+#
+#   shape is M:16384, N:4608, K:8192 dtype='torch.bfloat16' otype='torch.bfloat16'
+#   bias=False, scaleAB=False, bpreshuffle=False found padded_M: 8192, N:4608, ...
+#
+# An earlier pattern required a comma straight after ``K:<n>`` and so matched
+# none of the 5024 hit lines in a production Qwen3 log, which scored a fully
+# served tuned table as ``no_shape_key_matched`` and reverted it. The trailing
+# ``is tuned`` anchor keeps the lazy ``[^\n]*?`` from spanning an unrelated line.
 _AITER_SHAPE_HIT_RE = re.compile(
-    r"shape is M:(\d+), N:(\d+), K:(\d+), found padded_M: (\d+)",
+    r"shape is M:(\d+), N:(\d+), K:(\d+)[^\n]*?found padded_M: (\d+), N:\d+, K:\d+ is tuned",
 )
 
 Shape = tuple[int, int, int]
@@ -431,10 +442,16 @@ def read_latest_integrate_server_log(
     session_dir: Path,
     integrate_name: str = FMOE_INTEGRATE_RUN,
 ) -> tuple[Path, str] | None:
-    """Return the newest ``server.log`` under an integrate run, if readable."""
-    run_dir = session_dir / "runs" / "integrate" / integrate_name
+    """Return the newest ``server.log`` under an integrate run, if readable.
+
+    Retries land in ``<integrate_name>-2``/``-3`` siblings rather than inside
+    the original directory, so those are scanned too; otherwise a retried run is
+    judged on the attempt it replaced.
+    """
+    parent = session_dir / "runs" / "integrate"
+    run_dirs = [parent / integrate_name, *sorted(parent.glob(f"{integrate_name}-*"))]
     logs = sorted(
-        run_dir.rglob("server.log"),
+        (log_path for run_dir in run_dirs for log_path in run_dir.rglob("server.log")),
         key=lambda p: p.stat().st_mtime if p.exists() else 0,
     )
     if not logs:
@@ -579,15 +596,28 @@ def tuned_csv_shapes(path: str | Path) -> set[Shape]:
 def tuned_config_coverage(
     tuned_shapes: Iterable[Shape],
     requested_shapes: Iterable[Shape],
+    known_covered: Iterable[Shape] | None = None,
 ) -> dict[str, Any]:
     """Report how many requested shapes a tuned CSV can actually serve.
 
     Replays aiter's three-step lookup against the CSV keys, so the result
     answers "will this artifact ever be used?" rather than "did the micro
     benchmark look good?".
+
+    Args:
+        tuned_shapes: ``(M, N, K)`` keys present in the tuned CSV.
+        requested_shapes: ``(M, N, K)`` triples the runtime asked for.
+        known_covered: Shapes the runtime *itself* reported as resolved against
+            the tuned table. These count as covered without replaying the
+            ladder: aiter has already stated which row it used, and that is
+            better evidence than our reconstruction of its padding rules. Any
+            drift between the two -- a new rung, a variant with different
+            clamping -- would otherwise score a served shape as uncovered and
+            revert a run that worked.
     """
     tuned = {(int(m), int(n), int(k)) for m, n, k in tuned_shapes}
     requested = sorted({(int(m), int(n), int(k)) for m, n, k in requested_shapes})
+    confirmed = {(int(m), int(n), int(k)) for m, n, k in (known_covered or ())}
     if not requested:
         return {
             "requested": 0,
@@ -595,7 +625,9 @@ def tuned_config_coverage(
             "coverage_pct": None,
             "tuned_rows": len(tuned),
         }
-    covered = [shape for shape in requested if any(key in tuned for key in aiter_lookup_keys(shape))]
+    covered = [
+        shape for shape in requested if shape in confirmed or any(key in tuned for key in aiter_lookup_keys(shape))
+    ]
     return {
         "requested": len(requested),
         "covered": len(covered),

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -2056,26 +2056,54 @@ _AITER_M_RE = re.compile(rb"shape is M:(\d+),")
 _LOG_SCAN_CHUNK = 1 << 20
 
 
-def _log_has_aiter_evidence(path) -> bool:
-    """True when the log contains at least one aiter dispatch line.
+#: Longest a dispatch prefix can be, so a match straddling a chunk boundary is
+#: carried into the next read. ``shape is M:`` plus its digits is far shorter.
+_LOG_SCAN_OVERLAP = 64
 
-    Streams with a small overlap so a marker straddling a chunk boundary is
-    still seen. Any read error counts as no evidence -- an unreadable candidate
-    is not a usable shape source either way.
+
+def _scan_serving_log_m(path, *, first_only: bool = False) -> dict[int, int]:
+    """Count the M values of the aiter dispatch lines in a serving log.
+
+    One scan answers both questions asked of a serving log: whether it carries
+    aiter evidence at all (a non-empty result) and which M the model actually
+    ran (the counts). ``first_only`` stops at the first dispatch line, which is
+    what the evidence check wants -- a log with evidence usually proves it in
+    the first few KB, and only a silent log is read to the end.
+
+    Chunks overlap by ``_LOG_SCAN_OVERLAP`` so a match spanning a boundary is
+    still seen, but the carry starts after the last match already counted:
+    re-feeding a fixed tail would count any match landing in it twice, which
+    skews the frequency ranking that picks ``--tokens``.
+
+    Any read error yields no counts -- an unreadable candidate is not a usable
+    shape source either way.
     """
-    needle = _AITER_DISPATCH_MARKER.encode()
-    tail = b""
+    counts: dict[int, int] = {}
+    carry = b""
     try:
         with open(path, "rb") as handle:
             while True:
                 chunk = handle.read(_LOG_SCAN_CHUNK)
                 if not chunk:
-                    return False
-                if needle in tail + chunk:
-                    return True
-                tail = chunk[-len(needle) :]
-    except OSError:
-        return False
+                    break
+                buf = carry + chunk
+                last_end = 0
+                for match in _AITER_M_RE.finditer(buf):
+                    last_end = match.end()
+                    value = int(match.group(1))
+                    if value > 0:
+                        counts[value] = counts.get(value, 0) + 1
+                    if first_only:
+                        return counts
+                carry = buf[max(last_end, len(buf) - _LOG_SCAN_OVERLAP) :]
+    except (OSError, ValueError):
+        return {}
+    return counts
+
+
+def _log_has_aiter_evidence(path) -> bool:
+    """True when the log contains at least one aiter dispatch line."""
+    return bool(_scan_serving_log_m(path, first_only=True))
 
 
 def _tokens_from_serving_log(path, limit: int = 16, reserve_largest: int = 4) -> str:
@@ -2096,21 +2124,7 @@ def _tokens_from_serving_log(path, limit: int = 16, reserve_largest: int = 4) ->
     survives the cut; GEMM time scales with M, so those are also where the
     end-to-end time actually is.
     """
-    counts: dict[int, int] = {}
-    tail = b""
-    try:
-        with open(path, "rb") as handle:
-            while True:
-                chunk = handle.read(_LOG_SCAN_CHUNK)
-                if not chunk:
-                    break
-                for match in _AITER_M_RE.finditer(tail + chunk):
-                    value = int(match.group(1))
-                    if value > 0:
-                        counts[value] = counts.get(value, 0) + 1
-                tail = chunk[-64:]
-    except (OSError, ValueError):
-        return ""
+    counts = _scan_serving_log_m(path)
     if not counts:
         return ""
     # Never let the reservation crowd out the frequency ranking: at most a
@@ -2133,10 +2147,19 @@ def _resolve_trace_shape_manifest(state, session_dir: Path) -> str:
     nothing forwarded it, so the file was written and never read. Newest wins:
     a later trace reflects the currently resolved server args.
     """
-    roots = [session_dir, Path(str(getattr(state, "session_dir", "") or session_dir))]
-    for root in roots:
-        if root is None or not Path(root).is_dir():
+    # Deduplicate: state.session_dir is usually the same path we were handed,
+    # and an empty session then paid for two full-tree walks to find nothing.
+    seen_roots: set[str] = set()
+    roots: list[Path] = []
+    for raw in (session_dir, Path(str(getattr(state, "session_dir", "") or session_dir))):
+        if raw is None or not Path(raw).is_dir():
             continue
+        key = str(Path(raw).resolve())
+        if key in seen_roots:
+            continue
+        seen_roots.add(key)
+        roots.append(Path(raw))
+    for root in roots:
         best: tuple[float, str] | None = None
         for found in Path(root).glob("**/trace_shape_manifest.json"):
             try:
@@ -2213,39 +2236,36 @@ def _resolve_forge_server_log(state, session_dir: Path) -> str:
         if found:
             return found
 
-    # Fallback: check known run subdirs with sufficient depth for the nested
-    # layout ({phase}/{hash}/{warmup_round|measure_round}/{bench_dir}/server.log).
+    # Fallback: the whole runs/ tree, newest first. Restricting this to a fixed
+    # (baseline, explore, gemm_tuning, roofline) tuple skipped runs/integrate/,
+    # which is where the GEMM validation runs put their logs -- those sessions
+    # got "" plus a warning telling them to enable a flag that was already on.
+    # Newest-first with an early return also means only the logs newer than the
+    # winner are scanned, instead of every log in the tree.
     runs_dir = session_dir / "runs"
+    candidates_by_age: list[tuple[float, Path]] = []
     if runs_dir.is_dir():
-        best: Path | None = None
-        best_mtime: float = 0.0
-        for sub in ("baseline", "explore", "gemm_tuning", "roofline"):
-            sub_dir = runs_dir / sub
-            if not sub_dir.is_dir():
+        for candidate_log in runs_dir.glob("**/server.log"):
+            try:
+                candidates_by_age.append((candidate_log.stat().st_mtime, candidate_log))
+            except OSError:
                 continue
-            for candidate_log in sub_dir.glob("**/server.log"):
-                try:
-                    mt = candidate_log.stat().st_mtime
-                except OSError:
-                    continue
-                if mt <= best_mtime:
-                    continue
-                if not _log_has_aiter_evidence(candidate_log):
-                    continue
-                best_mtime = mt
-                best = candidate_log
-        if best is not None:
-            return str(best)
+        candidates_by_age.sort(key=lambda item: item[0], reverse=True)
+        for _mtime, candidate_log in candidates_by_age:
+            if _log_has_aiter_evidence(candidate_log):
+                return str(candidate_log)
 
     # Separate the two ways this fails. No server.log at all is an upstream
     # gap; logs that exist but never dispatched through aiter means the serving
     # run had AITER_LOG_TUNED_CONFIG off. Both return "", but only the second is
-    # actionable, and one silent "" hid it.
-    if runs_dir.is_dir() and next(runs_dir.glob("**/server.log"), None) is not None:
+    # actionable, and one silent "" hid it. Reuse the listing above rather than
+    # walking the tree a second time.
+    if candidates_by_age:
         log.warning(
-            "GEMM: server.log files exist under %s but none contain aiter dispatch "
+            "GEMM: %d server.log file(s) under %s but none contain aiter dispatch "
             "lines (%r), so there is no runtime shape source. Serving runs need "
             "AITER_LOG_TUNED_CONFIG enabled for shapes to be observable",
+            len(candidates_by_age),
             runs_dir,
             _AITER_DISPATCH_MARKER,
         )
@@ -3964,7 +3984,11 @@ async def _run_forge_gemm_tuning(
     # Resolve server log for 1-stage ASM detection.
     kernel_sig_log = str(payload.get("kernel_signature_log") or "").strip()
     if not kernel_sig_log:
-        kernel_sig_log = _resolve_forge_server_log(state, session_dir)
+        # Off the event loop: this walks runs/ and byte-scans server logs that
+        # measure ~17MB apiece on the fleet. Inline, it stalled every other
+        # coroutine on this orchestrator -- heartbeats included -- for the
+        # duration.
+        kernel_sig_log = await asyncio.to_thread(_resolve_forge_server_log, state, session_dir)
 
     # Explicit operator/benchmark input wins. Automatic SGLang priority is:
     # latest TraceLens runtime profile, specialist-worktree CSV fallback, then
@@ -4100,7 +4124,25 @@ async def _run_forge_gemm_tuning(
     # Both are optional: forge drops a path that is not there, with a warning.
     shapes_manifest = str(payload.get("shapes_manifest") or "").strip()
     if not shapes_manifest:
-        shapes_manifest = _resolve_trace_shape_manifest(state, session_dir)
+        # Scavenge one from the session only when nothing more specific was
+        # produced for THIS run. forge ranks the manifest at priority 0 on the
+        # premise that it was explicitly supplied; a manifest found by walking
+        # the session tree carries no such promise -- it can come from an
+        # earlier run at a different precision or with different server args,
+        # and there is no consistency check to catch that. Letting it win would
+        # discard a block-FP8 profile capture or a TunableOp shape capture that
+        # deliberately cleared ``untuned_csv`` so the fresh result would be
+        # used, and would bypass ``_align_forge_shapes_for_aiter`` as well.
+        if untuned_csv or shapes_json:
+            log.debug(
+                "GEMM: not scavenging a trace shape manifest; this run already has "
+                "a workload-matched dense-shape source (%s)",
+                "untuned_csv" if untuned_csv else "shapes_json",
+            )
+        else:
+            # Off the event loop for the same reason: a ``**/`` walk of a
+            # session tree that holds thousands of run artifacts.
+            shapes_manifest = await asyncio.to_thread(_resolve_trace_shape_manifest, state, session_dir)
     if shapes_manifest and not _path_is_existing_file(shapes_manifest):
         shapes_manifest = ""
     demand_json = str(payload.get("demand_json") or "").strip()
@@ -4111,7 +4153,7 @@ async def _run_forge_gemm_tuning(
     # about M. The serving log records the M values the model actually ran, so
     # prefer those whenever a log with dispatch evidence was resolved.
     if not tokens and kernel_sig_log:
-        tokens = _normalize_tokens(_tokens_from_serving_log(kernel_sig_log))
+        tokens = _normalize_tokens(await asyncio.to_thread(_tokens_from_serving_log, kernel_sig_log))
         if tokens:
             log.info("GEMM: derived --tokens=%s from observed M in %s", tokens, kernel_sig_log)
 

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -2041,11 +2041,108 @@ def _resolve_forge_precision_and_quant(state, payload: dict) -> tuple[str, str]:
     return precision, quant_type
 
 
+#: An aiter dispatch line, hit or miss. Either one proves the process actually
+#: routed a GEMM through aiter, which is what makes a server log usable as a
+#: shape source; a log without one is silent about shapes no matter how recent
+#: or how well its workspace matches.
+_AITER_DISPATCH_MARKER = "shape is M:"
+#: Only the M of a dispatch line. Reading M straight off the serving log is the
+#: one token source grounded in what the model actually ran -- forge's fallback
+#: derives ``--tokens`` from ``conc`` alone, and real fleet logs reach M=15842,
+#: far outside anything that derivation produces.
+_AITER_M_RE = re.compile(rb"shape is M:(\d+),")
+#: Read logs in chunks: a fleet server.log is ~17MB and the evidence question
+#: is usually answered in the first few KB.
+_LOG_SCAN_CHUNK = 1 << 20
+
+
+def _log_has_aiter_evidence(path) -> bool:
+    """True when the log contains at least one aiter dispatch line.
+
+    Streams with a small overlap so a marker straddling a chunk boundary is
+    still seen. Any read error counts as no evidence -- an unreadable candidate
+    is not a usable shape source either way.
+    """
+    needle = _AITER_DISPATCH_MARKER.encode()
+    tail = b""
+    try:
+        with open(path, "rb") as handle:
+            while True:
+                chunk = handle.read(_LOG_SCAN_CHUNK)
+                if not chunk:
+                    return False
+                if needle in tail + chunk:
+                    return True
+                tail = chunk[-len(needle) :]
+    except OSError:
+        return False
+
+
+def _tokens_from_serving_log(path, limit: int = 12) -> str:
+    """Derive forge's ``--tokens`` from the M values the server actually saw.
+
+    Returns the ``limit`` most frequent distinct M values, smallest first, as a
+    comma-separated string -- empty when the log carries no dispatch lines.
+    Frequency rather than magnitude: tuning the M values the model spends its
+    time at beats tuning the largest one it ever reached.
+    """
+    counts: dict[int, int] = {}
+    tail = b""
+    try:
+        with open(path, "rb") as handle:
+            while True:
+                chunk = handle.read(_LOG_SCAN_CHUNK)
+                if not chunk:
+                    break
+                for match in _AITER_M_RE.finditer(tail + chunk):
+                    value = int(match.group(1))
+                    if value > 0:
+                        counts[value] = counts.get(value, 0) + 1
+                tail = chunk[-64:]
+    except (OSError, ValueError):
+        return ""
+    if not counts:
+        return ""
+    ranked = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))[:limit]
+    return ",".join(str(m) for m in sorted(m for m, _n in ranked))
+
+
+def _resolve_trace_shape_manifest(state, session_dir: Path) -> str:
+    """Find the newest TraceShapeManifest this session produced.
+
+    ``bypass_trace_analysis`` writes ``trace_shape_manifest.json`` next to its
+    other bypass artifacts; forge calls it the preferred dense-shape source but
+    nothing forwarded it, so the file was written and never read. Newest wins:
+    a later trace reflects the currently resolved server args.
+    """
+    roots = [session_dir, Path(str(getattr(state, "session_dir", "") or session_dir))]
+    for root in roots:
+        if root is None or not Path(root).is_dir():
+            continue
+        best: tuple[float, str] | None = None
+        for found in Path(root).glob("**/trace_shape_manifest.json"):
+            try:
+                mtime = found.stat().st_mtime
+            except OSError:
+                continue
+            if best is None or mtime > best[0]:
+                best = (mtime, str(found))
+        if best is not None:
+            return best[1]
+    return ""
+
+
 def _resolve_forge_server_log(state, session_dir: Path) -> str:
     """Find the server log matching the current runtime configuration.
 
     Priority: current_best workspace (matches the resolved server args)
     → baseline workspace → most recent server.log under runs/.
+
+    Every candidate must carry aiter dispatch evidence. Picking on existence
+    alone made the first *present* log win, so a ``current_best`` workspace
+    whose log never routed a GEMM through aiter ended the search and the
+    ``runs/`` fallback became unreachable -- the tuner was then handed a log
+    that had no shapes in it at all.
 
     The server log is written by the benchmark server at startup and lives in
     the warmup_round benchmark directory (where the server process was first
@@ -2060,8 +2157,9 @@ def _resolve_forge_server_log(state, session_dir: Path) -> str:
             return None
         ws = Path(workspace_str)
         # Direct hit (server started in this exact dir).
-        if (ws / "server.log").is_file():
-            return str(ws / "server.log")
+        direct = ws / "server.log"
+        if direct.is_file() and _log_has_aiter_evidence(direct):
+            return str(direct)
         # Sibling warmup_round — benchmark dirs sit under
         # {run_hash}/{warmup_round|measure_round}/{benchmark_dir}/
         parent = ws.parent  # e.g. measure_round/
@@ -2079,9 +2177,10 @@ def _resolve_forge_server_log(state, session_dir: Path) -> str:
                         candidates.append((sl.stat().st_mtime, str(sl)))
                     except OSError:
                         continue
-            if candidates:
-                candidates.sort(reverse=True)
-                return candidates[0][1]
+            candidates.sort(reverse=True)
+            for _mtime, candidate in candidates:
+                if _log_has_aiter_evidence(candidate):
+                    return candidate
         return None
 
     current_best = getattr(state, "current_best", None) or {}
@@ -2106,17 +2205,32 @@ def _resolve_forge_server_log(state, session_dir: Path) -> str:
             sub_dir = runs_dir / sub
             if not sub_dir.is_dir():
                 continue
-            for log in sub_dir.glob("**/server.log"):
+            for candidate_log in sub_dir.glob("**/server.log"):
                 try:
-                    mt = log.stat().st_mtime
+                    mt = candidate_log.stat().st_mtime
                 except OSError:
                     continue
-                if mt > best_mtime:
-                    best_mtime = mt
-                    best = log
+                if mt <= best_mtime:
+                    continue
+                if not _log_has_aiter_evidence(candidate_log):
+                    continue
+                best_mtime = mt
+                best = candidate_log
         if best is not None:
             return str(best)
 
+    # Separate the two ways this fails. No server.log at all is an upstream
+    # gap; logs that exist but never dispatched through aiter means the serving
+    # run had AITER_LOG_TUNED_CONFIG off. Both return "", but only the second is
+    # actionable, and one silent "" hid it.
+    if runs_dir.is_dir() and next(runs_dir.glob("**/server.log"), None) is not None:
+        log.warning(
+            "GEMM: server.log files exist under %s but none contain aiter dispatch "
+            "lines (%r), so there is no runtime shape source. Serving runs need "
+            "AITER_LOG_TUNED_CONFIG enabled for shapes to be observable",
+            runs_dir,
+            _AITER_DISPATCH_MARKER,
+        )
     return ""
 
 
@@ -3963,6 +4077,26 @@ async def _run_forge_gemm_tuning(
             # specialist CSV resolved before the capture pass.
             untuned_csv = ""
 
+    # forge prefers the manifest over shapes_json as a dense-shape source, and
+    # an explicit demand.json over re-deriving demand from the serving log.
+    # Both are optional: forge drops a path that is not there, with a warning.
+    shapes_manifest = str(payload.get("shapes_manifest") or "").strip()
+    if not shapes_manifest:
+        shapes_manifest = _resolve_trace_shape_manifest(state, session_dir)
+    if shapes_manifest and not _path_is_existing_file(shapes_manifest):
+        shapes_manifest = ""
+    demand_json = str(payload.get("demand_json") or "").strip()
+    if demand_json and not _path_is_existing_file(demand_json):
+        demand_json = ""
+
+    # forge's own fallback derives --tokens from ``conc``, which is a guess
+    # about M. The serving log records the M values the model actually ran, so
+    # prefer those whenever a log with dispatch evidence was resolved.
+    if not tokens and kernel_sig_log:
+        tokens = _normalize_tokens(_tokens_from_serving_log(kernel_sig_log))
+        if tokens:
+            log.info("GEMM: derived --tokens=%s from observed M in %s", tokens, kernel_sig_log)
+
     timeout = _gemm_tuning_timeout_sec(payload)
     session_max_min = float(getattr(state, "max_minutes", 0) or 0)
     shape_alignment: dict[str, Any] | None = None
@@ -3993,6 +4127,8 @@ async def _run_forge_gemm_tuning(
         "untuned_csv": untuned_csv,
         "moe_untuned_csv": moe_untuned_csv,
         "shapes_json": shapes_json,
+        "shapes_manifest": shapes_manifest,
+        "demand_json": demand_json,
         "tunableop_input": tunableop_input,
         "kernel_signature_log": kernel_sig_log,
         "tuner": str(payload.get("tuner") or ""),

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -4044,6 +4044,23 @@ async def _run_forge_gemm_tuning(
                 resolved_model_path,
             )
 
+    # forge's own fallback derives --tokens from ``conc``, which is a guess
+    # about M. The serving log records the M values the model actually ran, so
+    # prefer those whenever a log with dispatch evidence was resolved.
+    #
+    # This has to happen BEFORE the MoE untuned CSV is built, not just before
+    # the payload is assembled: ``_write_fmoe_untuned_csv_from_log`` consumes
+    # ``tokens`` directly, and its fallback for an empty one is ``[1]``. Derive
+    # afterwards and the dense lane got the full observed sweep while the MoE
+    # lane got a table with a single M=1 row -- which then missed on every
+    # prefill and large-batch lookup and was reverted as no_shape_key_matched.
+    # That is precisely the failure this change set exists to remove, so leaving
+    # it in place on the MoE side would have fixed one lane and not the other.
+    if not tokens and kernel_sig_log:
+        tokens = _normalize_tokens(await asyncio.to_thread(_tokens_from_serving_log, kernel_sig_log))
+        if tokens:
+            log.info("GEMM: derived --tokens=%s from observed M in %s", tokens, kernel_sig_log)
+
     # MoE shapes come from the runtime, never from inference. The dispatch tuple
     # in the server log states the quantisation pair, the per-partition inter_dim
     # and the EP-inflated expert/topk counts; none of the three is recoverable
@@ -4177,14 +4194,6 @@ async def _run_forge_gemm_tuning(
     demand_json = str(payload.get("demand_json") or "").strip()
     if demand_json and not _path_is_existing_file(demand_json):
         demand_json = ""
-
-    # forge's own fallback derives --tokens from ``conc``, which is a guess
-    # about M. The serving log records the M values the model actually ran, so
-    # prefer those whenever a log with dispatch evidence was resolved.
-    if not tokens and kernel_sig_log:
-        tokens = _normalize_tokens(await asyncio.to_thread(_tokens_from_serving_log, kernel_sig_log))
-        if tokens:
-            log.info("GEMM: derived --tokens=%s from observed M in %s", tokens, kernel_sig_log)
 
     timeout = _gemm_tuning_timeout_sec(payload)
     session_max_min = float(getattr(state, "max_minutes", 0) or 0)

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -2046,6 +2046,15 @@ def _resolve_forge_precision_and_quant(state, payload: dict) -> tuple[str, str]:
 #: shape source; a log without one is silent about shapes no matter how recent
 #: or how well its workspace matches.
 _AITER_DISPATCH_MARKER = "shape is M:"
+#: The MoE half of the same question. The resolved log is not only a dense-shape
+#: source: ``kernelforge.gemm_tune.router`` reads it for MoE stage coverage and
+#: 1-stage ASM detection, and those parse ``[fused_moe]`` dispatch lines, which
+#: aiter prints from a different code path than the dense ``shape is M:`` ones.
+#: Requiring the dense marker alone would reject a log that is fully informative
+#: about MoE routing -- on a fleet where every model under tuning is MoE, that
+#: is the common case, and the router would silently fall back to "tune CK 2-stage
+#: unconditionally".
+_AITER_MOE_DISPATCH_MARKERS = (b"[fused_moe]", b"Mxfp4 MoE backend")
 #: Only the M of a dispatch line. Reading M straight off the serving log is the
 #: one token source grounded in what the model actually ran -- forge's fallback
 #: derives ``--tokens`` from ``conc`` alone, and real fleet logs reach M=15842,
@@ -2061,14 +2070,8 @@ _LOG_SCAN_CHUNK = 1 << 20
 _LOG_SCAN_OVERLAP = 64
 
 
-def _scan_serving_log_m(path, *, first_only: bool = False) -> dict[int, int]:
-    """Count the M values of the aiter dispatch lines in a serving log.
-
-    One scan answers both questions asked of a serving log: whether it carries
-    aiter evidence at all (a non-empty result) and which M the model actually
-    ran (the counts). ``first_only`` stops at the first dispatch line, which is
-    what the evidence check wants -- a log with evidence usually proves it in
-    the first few KB, and only a silent log is read to the end.
+def _scan_serving_log_m(path) -> dict[int, int]:
+    """Count the M values of the dense aiter dispatch lines in a serving log.
 
     Chunks overlap by ``_LOG_SCAN_OVERLAP`` so a match spanning a boundary is
     still seen, but the carry starts after the last match already counted:
@@ -2093,8 +2096,6 @@ def _scan_serving_log_m(path, *, first_only: bool = False) -> dict[int, int]:
                     value = int(match.group(1))
                     if value > 0:
                         counts[value] = counts.get(value, 0) + 1
-                    if first_only:
-                        return counts
                 carry = buf[max(last_end, len(buf) - _LOG_SCAN_OVERLAP) :]
     except (OSError, ValueError):
         return {}
@@ -2102,8 +2103,34 @@ def _scan_serving_log_m(path, *, first_only: bool = False) -> dict[int, int]:
 
 
 def _log_has_aiter_evidence(path) -> bool:
-    """True when the log contains at least one aiter dispatch line."""
-    return bool(_scan_serving_log_m(path, first_only=True))
+    """True when the log carries at least one aiter dispatch line, dense or MoE.
+
+    Kept separate from :func:`_scan_serving_log_m` rather than folded into it as
+    a ``first_only`` flag. Two reasons, both of which cost a real behaviour bug
+    when the two were one function:
+
+    * The M counter skips ``M:0``, so a log whose first dispatch line carried
+      one read as "no evidence at all".
+    * Evidence is not dense-only. ``[fused_moe]`` lines make a log fully usable
+      for the MoE routing decisions that consume the same path.
+
+    Stops at the first marker: a log with evidence usually proves it in the
+    first few KB, and only a silent log is read to the end.
+    """
+    markers = (_AITER_DISPATCH_MARKER.encode(), *_AITER_MOE_DISPATCH_MARKERS)
+    carry = b""
+    try:
+        with open(path, "rb") as handle:
+            while True:
+                chunk = handle.read(_LOG_SCAN_CHUNK)
+                if not chunk:
+                    return False
+                buf = carry + chunk
+                if any(marker in buf for marker in markers):
+                    return True
+                carry = buf[-_LOG_SCAN_OVERLAP:]
+    except OSError:
+        return False
 
 
 def _tokens_from_serving_log(path, limit: int = 16, reserve_largest: int = 4) -> str:
@@ -2263,11 +2290,13 @@ def _resolve_forge_server_log(state, session_dir: Path) -> str:
     if candidates_by_age:
         log.warning(
             "GEMM: %d server.log file(s) under %s but none contain aiter dispatch "
-            "lines (%r), so there is no runtime shape source. Serving runs need "
-            "AITER_LOG_TUNED_CONFIG enabled for shapes to be observable",
+            "lines (dense %r or MoE %s), so there is no runtime shape source. "
+            "Serving runs need AITER_LOG_TUNED_CONFIG enabled for shapes to be "
+            "observable",
             len(candidates_by_age),
             runs_dir,
             _AITER_DISPATCH_MARKER,
+            " / ".join(repr(m.decode()) for m in _AITER_MOE_DISPATCH_MARKERS),
         )
     return ""
 

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -2078,13 +2078,23 @@ def _log_has_aiter_evidence(path) -> bool:
         return False
 
 
-def _tokens_from_serving_log(path, limit: int = 12) -> str:
+def _tokens_from_serving_log(path, limit: int = 16, reserve_largest: int = 4) -> str:
     """Derive forge's ``--tokens`` from the M values the server actually saw.
 
-    Returns the ``limit`` most frequent distinct M values, smallest first, as a
+    Returns up to ``limit`` distinct M values, smallest first, as a
     comma-separated string -- empty when the log carries no dispatch lines.
-    Frequency rather than magnitude: tuning the M values the model spends its
-    time at beats tuning the largest one it ever reached.
+
+    Selection is frequency-ranked, because tuning the M values the model spends
+    its time at beats tuning the largest one it ever reached. But frequency
+    alone is not enough: a serving warmup sweeps every M about equally often,
+    so on real logs the counts come out uniform and the ranking degenerates
+    into its tie-break. Measured on two fleet sessions, every distinct M
+    carried an identical count (17 values x4, and 44 values x40), so a plain
+    frequency cut kept the smallest M and dropped exactly the large prefill
+    shapes -- 16384/24576/32768 and 57344/65536 -- that the runtime then
+    missed. Reserve slots for the largest observed M so the prefill end
+    survives the cut; GEMM time scales with M, so those are also where the
+    end-to-end time actually is.
     """
     counts: dict[int, int] = {}
     tail = b""
@@ -2103,8 +2113,16 @@ def _tokens_from_serving_log(path, limit: int = 12) -> str:
         return ""
     if not counts:
         return ""
-    ranked = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))[:limit]
-    return ",".join(str(m) for m in sorted(m for m, _n in ranked))
+    # Never let the reservation crowd out the frequency ranking: at most a
+    # quarter of the budget goes to "largest", and always at least one slot.
+    reserve = min(max(reserve_largest, 0), max(1, limit // 4))
+    picked: list[int] = sorted(counts, reverse=True)[:reserve]
+    for value, _n in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
+        if len(picked) >= limit:
+            break
+        if value not in picked:
+            picked.append(value)
+    return ",".join(str(m) for m in sorted(picked))
 
 
 def _resolve_trace_shape_manifest(state, session_dir: Path) -> str:

--- a/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
+++ b/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
@@ -179,8 +179,20 @@ def _resolve_quant_config_weight_bytes(quant_cfg: Any) -> float:
         if not isinstance(spec, dict):
             return 0.0
         tag = str(spec.get("dtype") or spec.get("type") or "").strip().lower()
+        # Both tables, exactly as the flat ``quant_method`` path above does.
+        # ``_QUANT_WEIGHT_BYTES`` is the only one carrying fp8_e4m3, fp8_e5m2,
+        # nvfp4, int8, w8a8_int8, int4, awq and gptq, and a Quark checkpoint
+        # writes precisely those on the nested spec -- often with no
+        # ``num_bits`` beside them. Consulting one table here read
+        # ``global_quant_config.weight.dtype = "fp8_e4m3"`` as "nothing
+        # decisive", fell back to the checkpoint dtype, and reported bf16: the
+        # 2x weight-IO overcount this function was written to remove, which then
+        # trips the ``total_expert_bytes >= weight_bytes`` guard and degrades a
+        # MoE model to dense.
         if tag in _DTYPE_BYTES:
             return _DTYPE_BYTES[tag]
+        if tag in _QUANT_WEIGHT_BYTES:
+            return _QUANT_WEIGHT_BYTES[tag]
         return _bits_to_bytes(spec.get("num_bits") or spec.get("bits"))
 
     # Wrapper toolkits nest the precision on a weight spec: Quark under

--- a/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
+++ b/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
@@ -24,12 +24,15 @@ All outputs are upper bounds.
 from __future__ import annotations
 
 import json
+import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from hyperloom.inference_optimizer.model_config_utils import _merge_config_scopes
+
+log = logging.getLogger(__name__)
 
 
 #: GPU per-chip peak specs (keys match ``SharedState.gpu_type``, lowercase).
@@ -93,6 +96,7 @@ _DTYPE_BYTES: dict[str, float] = {
     "float8_e4m3fn": 1.0,
     "float8_e5m2": 1.0,
     "fp8": 1.0,
+    "mxfp8": 1.0,
     # 4-bit (block-scaled).
     "float4": 0.5,
     "fp4": 0.5,
@@ -121,6 +125,7 @@ _QUANT_WEIGHT_BYTES: dict[str, float] = {
     "fp8": 1.0,
     "fp8_e4m3": 1.0,
     "fp8_e5m2": 1.0,
+    "mxfp8": 1.0,
     "fp4": 0.5,
     "mxfp4": 0.5,
     "nvfp4": 0.5,
@@ -130,6 +135,63 @@ _QUANT_WEIGHT_BYTES: dict[str, float] = {
     "awq": 0.5,
     "gptq": 0.5,
 }
+
+
+def _resolve_quant_config_weight_bytes(quant_cfg: Any) -> float:
+    """On-disk weight bytes-per-element declared by an HF ``quantization_config``.
+
+    ``quant_method`` names the *precision* in the flat HF form (``fp8``,
+    ``awq``) but names the *toolkit* in wrapper formats — Quark writes
+    ``quant_method: "quark"`` and puts the real precision on
+    ``global_quant_config.weight.dtype`` (``"fp4"`` for MXFP4). Reading only
+    ``quant_method`` therefore misses the tag and silently falls back to the
+    checkpoint ``dtype`` (bf16), overcounting weight IO 4x — which also trips
+    the ``total_expert_bytes >= weight_bytes`` sanity guard in
+    :func:`_compute_expert_decomposition` and degrades a MoE model to dense.
+
+    Args:
+        quant_cfg: The parsed ``quantization_config`` block, or any non-dict.
+
+    Returns:
+        Bytes per weight element, or ``0.0`` when nothing decisive is found.
+    """
+    if not isinstance(quant_cfg, dict):
+        return 0.0
+    method = str(quant_cfg.get("quant_method", "")).strip().lower()
+    if method in _DTYPE_BYTES:
+        return _DTYPE_BYTES[method]
+    if method in _QUANT_WEIGHT_BYTES:
+        return _QUANT_WEIGHT_BYTES[method]
+
+    def _bits_to_bytes(bits: Any) -> float:
+        """``num_bits`` → bytes-per-element, ``0.0`` when unusable."""
+        try:
+            b = float(bits)
+        except (TypeError, ValueError):
+            return 0.0
+        return b / 8.0 if b > 0 else 0.0
+
+    # Wrapper toolkits nest the precision on a weight spec: Quark under
+    # global_quant_config/layer_quant_config, compressed-tensors under
+    # config_groups.*.weights.
+    scopes: list[Any] = [quant_cfg.get("global_quant_config"), quant_cfg]
+    for container in (quant_cfg.get("layer_quant_config"), quant_cfg.get("config_groups")):
+        if isinstance(container, dict):
+            scopes.extend(container.values())
+    for scope in scopes:
+        if not isinstance(scope, dict):
+            continue
+        spec = scope.get("weight") or scope.get("weights")
+        if not isinstance(spec, dict):
+            continue
+        tag = str(spec.get("dtype") or spec.get("type") or "").strip().lower()
+        if tag in _DTYPE_BYTES:
+            return _DTYPE_BYTES[tag]
+        by = _bits_to_bytes(spec.get("num_bits") or spec.get("bits"))
+        if by > 0:
+            return by
+    return _bits_to_bytes(quant_cfg.get("bits") or quant_cfg.get("w_bit"))
+
 
 
 def _parse_server_arg(args: str, flag: str) -> str:
@@ -656,6 +718,10 @@ class ModelMeta:
     intermediate_size: int = 0
     # Per-expert FFN dim for MoE models (0 = dense/unknown; falls back to intermediate_size).
     moe_intermediate_size: int = 0
+    # Routed-expert input dim. Latent-MoE decoders (Kimi-K3
+    # ``routed_expert_hidden_size``) run the experts in a narrower space than
+    # the residual stream. 0 ⇒ same as ``hidden_size``.
+    moe_hidden_size: int = 0
     vocab_size: int = 0
     num_attention_heads: int = 0
 
@@ -727,6 +793,43 @@ def _read_hf_config(model_path: Path) -> dict[str, Any] | None:
     return _merge_config_scopes(data)
 
 
+def _derive_experts_per_tok(cfg: dict[str, Any]) -> int:
+    """Routed experts activated per token, across the naming variants in use.
+
+    ``num_experts_per_tok`` is the common HF spelling; Gemma-4 writes
+    ``top_k_experts`` and Kimi-K3 writes ``num_experts_per_token``. Missing the
+    alias reads 0, which safe-degrades the whole MoE decomposition to dense.
+
+    Args:
+        cfg: Parsed HF ``config.json``.
+
+    Returns:
+        The per-token routed-expert count, or ``0`` when no alias is present.
+    """
+    for key in ("num_experts_per_tok", "num_experts_per_token", "top_k_experts", "moe_topk"):
+        value = cfg.get(key)
+        if value:
+            return int(value)
+    return 0
+
+
+def _derive_moe_hidden_size(cfg: dict[str, Any]) -> int:
+    """The routed experts' input dimension, which need not be ``hidden_size``.
+
+    Latent-MoE decoders (Kimi-K3) project into a narrower space before the
+    experts and declare it as ``routed_expert_hidden_size``; sizing the experts
+    at the model ``hidden_size`` overcounts their weights (2x for Kimi-K3),
+    which trips the ``total_expert_bytes >= weight_bytes`` safe-degrade.
+
+    Args:
+        cfg: Parsed HF ``config.json``.
+
+    Returns:
+        The expert input dimension, falling back to ``hidden_size``.
+    """
+    return int(cfg.get("routed_expert_hidden_size") or cfg.get("moe_hidden_size") or cfg.get("hidden_size") or 0)
+
+
 def _derive_kv_heads(cfg: dict[str, Any]) -> int:
     """GQA-aware: ``num_key_value_heads`` if present, else ``num_attention_heads``.
 
@@ -768,7 +871,7 @@ def _compute_expert_decomposition(
     dtype_bytes: float,
     expert_dtype_bytes: float = 0.0,
 ) -> tuple[int, int, int, int]:
-    """MoE decomposition for the batch-aware roofline; returns ``(active_weight_bytes, total_expert_bytes, num_experts, experts_per_tok)``. Safe-degrades to ``(weight_bytes, 0, 0, 0)``. Handles num_experts / n_routed_experts / num_local_experts aliases.
+    """MoE decomposition for the batch-aware roofline; returns ``(active_weight_bytes, total_expert_bytes, num_experts, experts_per_tok)``. Safe-degrades to ``(weight_bytes, 0, 0, 0)``. Handles num_experts / n_routed_experts / num_local_experts aliases, the per-token aliases in :func:`_derive_experts_per_tok`, and the latent-MoE expert width in :func:`_derive_moe_hidden_size`.
 
     ``expert_dtype_bytes`` sizes the routed-expert weights when they are stored
     at a different precision than the rest of the model (e.g. DeepSeek-V4
@@ -789,10 +892,10 @@ def _compute_expert_decomposition(
         experts_per_tok)``, degrading to ``(weight_bytes, 0, 0, 0)``.
     """
     num_experts = int(cfg.get("num_experts") or cfg.get("n_routed_experts") or cfg.get("num_local_experts") or 0)
-    experts_per_tok = int(cfg.get("num_experts_per_tok") or 0)
+    experts_per_tok = _derive_experts_per_tok(cfg)
     if num_experts <= 0 or experts_per_tok <= 0:
         return int(weight_bytes), 0, 0, 0
-    hidden_size = int(cfg.get("hidden_size") or 0)
+    hidden_size = _derive_moe_hidden_size(cfg)
     num_layers = int(cfg.get("num_hidden_layers") or 0)
     moe_inter = int(cfg.get("moe_intermediate_size") or cfg.get("intermediate_size") or 0)
     expert_bpe = expert_dtype_bytes if expert_dtype_bytes > 0 else dtype_bytes
@@ -801,6 +904,19 @@ def _compute_expert_decomposition(
     expert_bytes_per_layer = num_experts * 3 * hidden_size * moe_inter * expert_bpe
     total_expert_bytes = int(num_layers * expert_bytes_per_layer)
     if total_expert_bytes <= 0 or total_expert_bytes >= int(weight_bytes):
+        # Degrading a MoE model to dense drops the largest op from the
+        # breakdown entirely, so say so: the usual cause is an over-large
+        # ``expert_bpe`` (a quantized checkpoint misread as bf16), not a
+        # genuinely dense model.
+        log.warning(
+            "MoE decomposition degraded to dense: computed expert bytes %.4g >= checkpoint bytes %.4g "
+            "(num_experts=%d, moe_intermediate_size=%d, expert_bytes_per_element=%.4g)",
+            total_expert_bytes,
+            float(weight_bytes),
+            num_experts,
+            moe_inter,
+            expert_bpe,
+        )
         return int(weight_bytes), 0, 0, 0
     non_expert_bytes = int(weight_bytes) - total_expert_bytes
     active_expert_bytes = int((experts_per_tok / num_experts) * total_expert_bytes)
@@ -854,7 +970,15 @@ def load_model_meta(
     quant_cfg = cfg.get("quantization_config")
     if isinstance(quant_cfg, dict):
         quant_tag = str(quant_cfg.get("quant_method", "")).strip().lower()
-    dtype_bytes = _resolve_dtype_bytes(quant_tag or cfg.get("torch_dtype") or cfg.get("dtype") or precision_hint)
+    # A declared quantization wins outright: ``quant_method`` alone is not
+    # enough (Quark says ``"quark"``, precision lives on the nested weight
+    # spec), and falling through to the checkpoint ``dtype`` would report
+    # bf16 for a 4-bit checkpoint.
+    quant_bytes = _resolve_quant_config_weight_bytes(quant_cfg)
+    if quant_bytes > 0:
+        dtype_bytes = quant_bytes
+    else:
+        dtype_bytes = _resolve_dtype_bytes(quant_tag or cfg.get("torch_dtype") or cfg.get("dtype") or precision_hint)
     # Routed experts may be stored at a distinct precision (DeepSeek-V4
     # ``expert_dtype: fp4`` under fp8 attention). Fall back to the global dtype
     # when the field is absent (uniform-precision MoE / dense).
@@ -884,6 +1008,7 @@ def load_model_meta(
         hidden_size=int(cfg.get("hidden_size") or 0),
         intermediate_size=intermediate_size,
         moe_intermediate_size=moe_intermediate_size,
+        moe_hidden_size=(_derive_moe_hidden_size(cfg) if num_experts > 0 else 0),
         vocab_size=int(cfg.get("vocab_size") or 0),
         num_attention_heads=int(cfg.get("num_attention_heads") or 0),
     )
@@ -2022,10 +2147,12 @@ def compute_roofline_from_perfmodel(
             )
         # MoE FFN: FusedMoE formula with batch-aware coupon E_active.
         if meta.num_experts > 0 and meta.moe_intermediate_size > 0:
-            fl_moe = _fused_moe_flops(M, hidden, meta.moe_intermediate_size, meta.experts_per_tok)
+            # Latent-MoE decoders run the experts below the residual width.
+            moe_hidden = meta.moe_hidden_size or hidden
+            fl_moe = _fused_moe_flops(M, moe_hidden, meta.moe_intermediate_size, meta.experts_per_tok)
             by_moe = _fused_moe_bytes(
                 M,
-                hidden,
+                moe_hidden,
                 meta.moe_intermediate_size,
                 meta.num_experts,
                 meta.experts_per_tok,

--- a/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
+++ b/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
@@ -171,25 +171,43 @@ def _resolve_quant_config_weight_bytes(quant_cfg: Any) -> float:
             return 0.0
         return b / 8.0 if b > 0 else 0.0
 
-    # Wrapper toolkits nest the precision on a weight spec: Quark under
-    # global_quant_config/layer_quant_config, compressed-tensors under
-    # config_groups.*.weights.
-    scopes: list[Any] = [quant_cfg.get("global_quant_config"), quant_cfg]
-    for container in (quant_cfg.get("layer_quant_config"), quant_cfg.get("config_groups")):
-        if isinstance(container, dict):
-            scopes.extend(container.values())
-    for scope in scopes:
+    def _spec_bytes(scope: Any) -> float:
+        """Weight bytes-per-element declared by one quant scope, ``0.0`` if none."""
         if not isinstance(scope, dict):
-            continue
+            return 0.0
         spec = scope.get("weight") or scope.get("weights")
         if not isinstance(spec, dict):
-            continue
+            return 0.0
         tag = str(spec.get("dtype") or spec.get("type") or "").strip().lower()
         if tag in _DTYPE_BYTES:
             return _DTYPE_BYTES[tag]
-        by = _bits_to_bytes(spec.get("num_bits") or spec.get("bits"))
-        if by > 0:
-            return by
+        return _bits_to_bytes(spec.get("num_bits") or spec.get("bits"))
+
+    # Wrapper toolkits nest the precision on a weight spec: Quark under
+    # global_quant_config, compressed-tensors under config_groups.*.weights.
+    # These two scopes describe the checkpoint as a whole, so either is decisive.
+    for scope in (quant_cfg.get("global_quant_config"), quant_cfg):
+        whole = _spec_bytes(scope)
+        if whole > 0:
+            return whole
+
+    # The per-group containers are different: one entry per layer pattern, and
+    # they need not agree -- a Quark MoE checkpoint routinely stores the routed
+    # experts at fp4 and the attention projections at fp8. Reading whichever
+    # entry the dict happened to yield first declared that precision for the
+    # entire model. Take the value the most groups agree on; ties resolve to the
+    # wider one, because undercounting weight bytes inflates the roofline and
+    # reports a real regression as "already at ceiling".
+    tallies: dict[float, int] = {}
+    for container in (quant_cfg.get("layer_quant_config"), quant_cfg.get("config_groups")):
+        if not isinstance(container, dict):
+            continue
+        for scope in container.values():
+            by = _spec_bytes(scope)
+            if by > 0:
+                tallies[by] = tallies.get(by, 0) + 1
+    if tallies:
+        return max(tallies.items(), key=lambda kv: (kv[1], kv[0]))[0]
     return _bits_to_bytes(quant_cfg.get("bits") or quant_cfg.get("w_bit"))
 
 
@@ -912,16 +930,26 @@ def _derive_moe_layer_counts(cfg: dict[str, Any], num_layers: int, num_experts: 
     first_dense = int(cfg.get("first_k_dense_replace") or 0)
     first_dense = max(0, min(first_dense, num_layers))
 
-    stride = 1
-    for raw in (freq, cfg.get("decoder_sparse_step")):
+    # The stride is phased differently by the two upstream implementations, and
+    # both phase it on the ABSOLUTE layer index -- not on the offset from the
+    # dense prefix. DeepSeek/GLM:
+    #     layer_idx >= first_k_dense_replace and layer_idx % moe_layer_freq == 0
+    # Qwen3-MoE:
+    #     layer_idx not in mlp_only_layers and (layer_idx + 1) % decoder_sparse_step == 0
+    # Re-basing to ``(i - first_dense) % stride`` agreed with neither: for
+    # DeepSeek-V3 (first_k_dense_replace=3) any stride > 1 selected a layer set
+    # shifted by 3, and for Qwen it was off by one in the other direction.
+    stride, phase = 1, "deepseek"
+    for raw, kind in ((freq, "deepseek"), (cfg.get("decoder_sparse_step"), "qwen")):
         if isinstance(raw, bool):
             continue
         if isinstance(raw, int) and raw > 0:
-            stride = raw
+            stride, phase = raw, kind
             break
 
     dense_only = {int(i) for i in (cfg.get("mlp_only_layers") or []) if isinstance(i, int)}
-    moe = sum(1 for i in range(first_dense, num_layers) if (i - first_dense) % stride == 0 and i not in dense_only)
+    offset = 1 if phase == "qwen" else 0
+    moe = sum(1 for i in range(first_dense, num_layers) if (i + offset) % stride == 0 and i not in dense_only)
     return moe, num_layers - moe
 
 

--- a/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
+++ b/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
@@ -193,7 +193,6 @@ def _resolve_quant_config_weight_bytes(quant_cfg: Any) -> float:
     return _bits_to_bytes(quant_cfg.get("bits") or quant_cfg.get("w_bit"))
 
 
-
 def _parse_server_arg(args: str, flag: str) -> str:
     """Return the value following ``--flag`` (space or ``=`` form), else ``""``.
 
@@ -922,11 +921,7 @@ def _derive_moe_layer_counts(cfg: dict[str, Any], num_layers: int, num_experts: 
             break
 
     dense_only = {int(i) for i in (cfg.get("mlp_only_layers") or []) if isinstance(i, int)}
-    moe = sum(
-        1
-        for i in range(first_dense, num_layers)
-        if (i - first_dense) % stride == 0 and i not in dense_only
-    )
+    moe = sum(1 for i in range(first_dense, num_layers) if (i - first_dense) % stride == 0 and i not in dense_only)
     return moe, num_layers - moe
 
 

--- a/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
+++ b/src/hyperloom/orchestrator/kernel/roofline_ceiling.py
@@ -724,6 +724,17 @@ class ModelMeta:
     moe_hidden_size: int = 0
     vocab_size: int = 0
     num_attention_heads: int = 0
+    # How the decoder stack splits between routed-expert FFN layers and plain
+    # dense FFN layers. Real MoE checkpoints are not MoE all the way down:
+    # DeepSeek/GLM run the first ``first_k_dense_replace`` layers as dense FFN,
+    # and Qwen can mark individual layers dense via ``mlp_only_layers``.
+    # Multiplying the MoE op by every layer overstates the largest term in the
+    # breakdown, and dropping the dense FFN entirely loses a real one.
+    # Both default to 0, meaning "not derived": the PerfModel then falls back to
+    # the previous all-or-nothing behaviour, so a hand-built ``ModelMeta`` keeps
+    # working. ``load_model_meta`` fills them from the HF config.
+    moe_layers: int = 0
+    dense_ffn_layers: int = 0
 
 
 def _read_total_size(model_path: Path) -> int | None:
@@ -864,6 +875,61 @@ def _derive_head_dim(cfg: dict[str, Any]) -> int:
     return 0
 
 
+def _derive_moe_layer_counts(cfg: dict[str, Any], num_layers: int, num_experts: int) -> tuple[int, int]:
+    """Split the decoder stack into ``(moe_layers, dense_ffn_layers)``.
+
+    A MoE checkpoint is rarely MoE in every layer. The three mechanisms in the
+    wild:
+
+    * ``first_k_dense_replace`` (DeepSeek, GLM, Kimi) -- the first K layers run
+      a plain dense FFN. GLM-5.3-Flash sets 1, DeepSeek-V3 sets 3.
+    * ``moe_layer_freq`` -- either a per-layer 0/1 list, or an int stride
+      applied after the dense prefix. ``decoder_sparse_step`` is Qwen's name
+      for the same stride.
+    * ``mlp_only_layers`` (Qwen) -- explicit indices that stay dense.
+
+    Anything unrecognised degrades to "every layer after the dense prefix is
+    MoE", which is the common case and matches the previous behaviour when the
+    prefix is 0.
+
+    Args:
+        cfg: Parsed HF ``config.json``.
+        num_layers: ``num_hidden_layers``.
+        num_experts: Routed expert count; ``<= 0`` means the model is dense.
+
+    Returns:
+        ``(moe_layers, dense_ffn_layers)``, summing to ``num_layers``.
+    """
+    if num_layers <= 0:
+        return 0, 0
+    if num_experts <= 0:
+        return 0, num_layers
+
+    freq = cfg.get("moe_layer_freq")
+    if isinstance(freq, (list, tuple)) and len(freq) == num_layers:
+        moe = sum(1 for v in freq if v)
+        return moe, num_layers - moe
+
+    first_dense = int(cfg.get("first_k_dense_replace") or 0)
+    first_dense = max(0, min(first_dense, num_layers))
+
+    stride = 1
+    for raw in (freq, cfg.get("decoder_sparse_step")):
+        if isinstance(raw, bool):
+            continue
+        if isinstance(raw, int) and raw > 0:
+            stride = raw
+            break
+
+    dense_only = {int(i) for i in (cfg.get("mlp_only_layers") or []) if isinstance(i, int)}
+    moe = sum(
+        1
+        for i in range(first_dense, num_layers)
+        if (i - first_dense) % stride == 0 and i not in dense_only
+    )
+    return moe, num_layers - moe
+
+
 def _compute_expert_decomposition(
     cfg: dict[str, Any],
     *,
@@ -901,8 +967,16 @@ def _compute_expert_decomposition(
     expert_bpe = expert_dtype_bytes if expert_dtype_bytes > 0 else dtype_bytes
     if hidden_size <= 0 or num_layers <= 0 or moe_inter <= 0 or expert_bpe <= 0:
         return int(weight_bytes), 0, 0, 0
+    # Only the MoE layers hold expert weights. Charging every layer for them
+    # inflates ``total_expert_bytes``, which both overstates the per-token
+    # active bytes and pushes borderline checkpoints over the
+    # ``>= weight_bytes`` safe-degrade that drops the MoE from the ceiling
+    # altogether.
+    moe_layers, _dense_ffn_layers = _derive_moe_layer_counts(cfg, num_layers, num_experts)
+    if moe_layers <= 0:
+        return int(weight_bytes), 0, 0, 0
     expert_bytes_per_layer = num_experts * 3 * hidden_size * moe_inter * expert_bpe
-    total_expert_bytes = int(num_layers * expert_bytes_per_layer)
+    total_expert_bytes = int(moe_layers * expert_bytes_per_layer)
     if total_expert_bytes <= 0 or total_expert_bytes >= int(weight_bytes):
         # Degrading a MoE model to dense drops the largest op from the
         # breakdown entirely, so say so: the usual cause is an over-large
@@ -990,6 +1064,9 @@ def load_model_meta(
         dtype_bytes=dtype_bytes,
         expert_dtype_bytes=expert_dtype_bytes,
     )
+    n_moe_layers, n_dense_ffn_layers = _derive_moe_layer_counts(
+        cfg, int(cfg.get("num_hidden_layers") or 0), num_experts
+    )
     intermediate_size = int(cfg.get("intermediate_size") or 0)
     moe_intermediate_size = int(cfg.get("moe_intermediate_size") or 0)
     if num_experts > 0 and moe_intermediate_size <= 0:
@@ -1011,6 +1088,8 @@ def load_model_meta(
         moe_hidden_size=(_derive_moe_hidden_size(cfg) if num_experts > 0 else 0),
         vocab_size=int(cfg.get("vocab_size") or 0),
         num_attention_heads=int(cfg.get("num_attention_heads") or 0),
+        moe_layers=n_moe_layers,
+        dense_ffn_layers=n_dense_ffn_layers,
     )
 
 
@@ -2084,12 +2163,22 @@ def compute_roofline_from_perfmodel(
         ("v_proj", hidden, kv_out, n_layers),
         ("o_proj", q_out, hidden, n_layers),
     ]
-    # Dense FFN: add gate/up/down. MoE FFN is added inside _forward.
-    if ffn and not (meta.num_experts > 0 and meta.moe_intermediate_size > 0):
+    is_moe = meta.num_experts > 0 and meta.moe_intermediate_size > 0
+    # A MoE checkpoint still runs a dense FFN in its ``first_k_dense_replace``
+    # prefix, so the two are not mutually exclusive: gate/up/down repeat over
+    # the dense layers and the MoE op over the MoE layers. Attention and SDPA
+    # stay at n_layers -- every layer has those.
+    if is_moe:
+        n_moe_layers = meta.moe_layers or n_layers
+        n_dense_ffn_layers = meta.dense_ffn_layers
+    else:
+        n_moe_layers = 0
+        n_dense_ffn_layers = meta.dense_ffn_layers or n_layers
+    if ffn and n_dense_ffn_layers > 0:
         linears += [
-            ("gate_proj", hidden, ffn, n_layers),
-            ("up_proj", hidden, ffn, n_layers),
-            ("down_proj", ffn, hidden, n_layers),
+            ("gate_proj", hidden, ffn, n_dense_ffn_layers),
+            ("up_proj", hidden, ffn, n_dense_ffn_layers),
+            ("down_proj", ffn, hidden, n_dense_ffn_layers),
         ]
     if vocab:
         linears.append(("lm_head", hidden, vocab, 1))
@@ -2146,7 +2235,7 @@ def compute_roofline_from_perfmodel(
                 )
             )
         # MoE FFN: FusedMoE formula with batch-aware coupon E_active.
-        if meta.num_experts > 0 and meta.moe_intermediate_size > 0:
+        if is_moe and n_moe_layers > 0:
             # Latent-MoE decoders run the experts below the residual width.
             moe_hidden = meta.moe_hidden_size or hidden
             fl_moe = _fused_moe_flops(M, moe_hidden, meta.moe_intermediate_size, meta.experts_per_tok)
@@ -2160,16 +2249,16 @@ def compute_roofline_from_perfmodel(
                 act_bpe,
             )
             t_moe, side_moe, t_mem_moe, t_cmp_moe = _roofline_time(fl_moe, by_moe)
-            total_t += t_moe * n_layers
-            total_mem_t += t_mem_moe * n_layers
-            total_cmp_t += t_cmp_moe * n_layers
+            total_t += t_moe * n_moe_layers
+            total_mem_t += t_mem_moe * n_moe_layers
+            total_cmp_t += t_cmp_moe * n_moe_layers
             op_rows.append(
                 OpBreakdown(
                     name="moe_fused",
-                    flops=fl_moe * n_layers,
-                    bytes_moved=by_moe * n_layers,
+                    flops=fl_moe * n_moe_layers,
+                    bytes_moved=by_moe * n_moe_layers,
                     ai=(fl_moe / by_moe if by_moe else 0.0),
-                    time_s=t_moe * n_layers,
+                    time_s=t_moe * n_moe_layers,
                     bound=side_moe,
                     pct_time=0.0,
                 )

--- a/src/hyperloom/orchestrator/kernel/tests/test_forge_server_log_evidence.py
+++ b/src/hyperloom/orchestrator/kernel/tests/test_forge_server_log_evidence.py
@@ -26,6 +26,9 @@ HIT = (
 )
 MISS = "shape is M:{m}, N:512, K:4096 not found tuned config in /tmp/aiter_configs/bf16_tuned_gemm.csv, using default\n"
 QUIET = "INFO server started on 0.0.0.0:8000\nINFO warmup complete\n"
+# A MoE dispatch line: no dense "shape is M:" anywhere, but the log is fully
+# informative for the routing decisions kernelforge makes off the same path.
+MOE = "[aiter] [fused_moe] using ck_moe_2stages for ('bf16', 'bf16', 128, 8, 1, 0, 0)\n"
 
 
 class _State:
@@ -65,6 +68,24 @@ class TestEvidenceDetection:
     def test_evidence_late_in_a_large_log_is_found(self, tmp_path):
         text = ("noise line\n" * 200_000) + HIT.format(m=99)
         assert rh._log_has_aiter_evidence(_log(tmp_path / "a.log", text))
+
+    def test_a_moe_only_log_is_evidence_too(self, tmp_path):
+        # The resolved log is not only a dense-shape source: kernelforge's router
+        # reads it for MoE stage coverage and 1-stage ASM detection, which parse
+        # [fused_moe] lines. Rejecting a log that has those but no dense
+        # "shape is M:" line would blind the router on exactly the MoE models
+        # this lane runs against.
+        assert rh._log_has_aiter_evidence(_log(tmp_path / "a.log", MOE))
+        assert rh._log_has_aiter_evidence(_log(tmp_path / "b.log", "Mxfp4 MoE backend selected\n"))
+
+    def test_a_moe_only_log_yields_no_dense_tokens(self, tmp_path):
+        # ...and it must not invent any: --tokens comes from dense M only.
+        assert rh._tokens_from_serving_log(_log(tmp_path / "a.log", MOE)) == ""
+
+    def test_a_dispatch_line_at_m_zero_is_still_evidence(self, tmp_path):
+        # The M counter skips 0, so an evidence check derived from its output
+        # read this log as silent.
+        assert rh._log_has_aiter_evidence(_log(tmp_path / "a.log", HIT.format(m=0)))
 
 
 class TestSelection:

--- a/src/hyperloom/orchestrator/kernel/tests/test_forge_server_log_evidence.py
+++ b/src/hyperloom/orchestrator/kernel/tests/test_forge_server_log_evidence.py
@@ -1,0 +1,224 @@
+"""A server log is only a shape source if it dispatched through aiter.
+
+``_resolve_forge_server_log`` used to pick the first log that *existed*. A
+``current_best`` workspace whose server never routed a GEMM through aiter
+therefore ended the search, and the ``runs/`` fallback -- which might hold a log
+that did -- was unreachable. The tuner then read shapes from a file with none.
+
+The same scan feeds ``--tokens``: the M values in those lines are the only
+record of what the model actually ran.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hyperloom.orchestrator.kernel import request_handlers as rh
+
+# A real aiter hit line, copied from a fleet server.log.
+HIT = (
+    "shape is M:{m}, N:512, K:4096 dtype='torch.bfloat16' otype='torch.bfloat16' "
+    "bias=False, scaleAB=False, bpreshuffle=False found padded_M: 16384, N:512, "
+    "K:4096 is tuned on cu_num = 256 in /tmp/aiter_configs/bf16_tuned_gemm.csv, "
+    "libtype is opus, kernel name is opus_gemm\n"
+)
+MISS = "shape is M:{m}, N:512, K:4096 not found tuned config in /tmp/aiter_configs/bf16_tuned_gemm.csv, using default\n"
+QUIET = "INFO server started on 0.0.0.0:8000\nINFO warmup complete\n"
+
+
+class _State:
+    def __init__(self, current_best=None, last_baseline=None):
+        self.current_best = current_best or {}
+        self.last_baseline = last_baseline or {}
+
+
+def _log(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class TestEvidenceDetection:
+    def test_a_hit_line_is_evidence(self, tmp_path):
+        assert rh._log_has_aiter_evidence(_log(tmp_path / "a.log", HIT.format(m=128)))
+
+    def test_a_miss_line_is_also_evidence(self, tmp_path):
+        # A miss still proves the process routed a GEMM through aiter, which is
+        # what makes the log a usable shape source.
+        assert rh._log_has_aiter_evidence(_log(tmp_path / "a.log", MISS.format(m=128)))
+
+    def test_a_quiet_log_is_not_evidence(self, tmp_path):
+        assert not rh._log_has_aiter_evidence(_log(tmp_path / "a.log", QUIET))
+
+    def test_a_missing_file_is_not_evidence(self, tmp_path):
+        assert not rh._log_has_aiter_evidence(tmp_path / "nope.log")
+
+    def test_a_marker_straddling_a_chunk_boundary_is_still_found(self, tmp_path, monkeypatch):
+        # Fleet logs are ~17MB, so the scan is chunked; the overlap must cover a
+        # marker split across two reads.
+        monkeypatch.setattr(rh, "_LOG_SCAN_CHUNK", 16)
+        text = "x" * 10 + HIT.format(m=128)
+        assert rh._log_has_aiter_evidence(_log(tmp_path / "a.log", text))
+
+    def test_evidence_late_in_a_large_log_is_found(self, tmp_path):
+        text = ("noise line\n" * 200_000) + HIT.format(m=99)
+        assert rh._log_has_aiter_evidence(_log(tmp_path / "a.log", text))
+
+
+class TestSelection:
+    def test_a_quiet_current_best_no_longer_ends_the_search(self, tmp_path):
+        ws = tmp_path / "runs" / "explore" / "h1" / "measure_round" / "b1"
+        _log(ws / "server.log", QUIET)
+        good = _log(tmp_path / "runs" / "baseline" / "h0" / "warmup_round" / "b0" / "server.log", HIT.format(m=256))
+
+        picked = rh._resolve_forge_server_log(_State(current_best={"workspace": str(ws)}), tmp_path)
+
+        assert picked == str(good)
+
+    def test_a_current_best_with_evidence_still_wins(self, tmp_path):
+        ws = tmp_path / "runs" / "explore" / "h1" / "measure_round" / "b1"
+        mine = _log(ws / "server.log", HIT.format(m=256))
+        _log(tmp_path / "runs" / "baseline" / "h0" / "warmup_round" / "b0" / "server.log", HIT.format(m=1))
+
+        assert rh._resolve_forge_server_log(_State(current_best={"workspace": str(ws)}), tmp_path) == str(mine)
+
+    def test_the_warmup_sibling_search_skips_quiet_logs(self, tmp_path):
+        # server.log lives in warmup_round while current_best points at
+        # measure_round; several warmup benchmark dirs can exist and only some
+        # of them dispatched.
+        run = tmp_path / "runs" / "explore" / "h1"
+        ws = run / "measure_round" / "b1"
+        ws.mkdir(parents=True)
+        newest = _log(run / "warmup_round" / "z_quiet" / "server.log", QUIET)
+        older = _log(run / "warmup_round" / "a_real" / "server.log", HIT.format(m=77))
+        import os
+
+        os.utime(older, (1, 1))  # make the quiet one strictly newer
+
+        assert newest.stat().st_mtime > older.stat().st_mtime
+        assert rh._resolve_forge_server_log(_State(current_best={"workspace": str(ws)}), tmp_path) == str(older)
+
+    def test_the_runs_fallback_skips_quiet_logs(self, tmp_path):
+        import os
+
+        good = _log(tmp_path / "runs" / "baseline" / "h0" / "warmup_round" / "b0" / "server.log", MISS.format(m=8))
+        newer_quiet = _log(tmp_path / "runs" / "gemm_tuning" / "h9" / "warmup_round" / "b9" / "server.log", QUIET)
+        os.utime(good, (1, 1))
+
+        assert newer_quiet.stat().st_mtime > good.stat().st_mtime
+        assert rh._resolve_forge_server_log(_State(), tmp_path) == str(good)
+
+    def test_no_candidate_with_evidence_returns_empty_and_says_why(self, tmp_path, caplog):
+        _log(tmp_path / "runs" / "baseline" / "h0" / "warmup_round" / "b0" / "server.log", QUIET)
+
+        with caplog.at_level("WARNING"):
+            assert rh._resolve_forge_server_log(_State(), tmp_path) == ""
+
+        # "no log at all" and "logs exist but are silent" are different
+        # problems; only the second is actionable.
+        assert "AITER_LOG_TUNED_CONFIG" in caplog.text
+
+    def test_no_logs_at_all_is_quiet(self, tmp_path, caplog):
+        (tmp_path / "runs").mkdir()
+        with caplog.at_level("WARNING"):
+            assert rh._resolve_forge_server_log(_State(), tmp_path) == ""
+        assert "AITER_LOG_TUNED_CONFIG" not in caplog.text
+
+    def test_baseline_is_consulted_when_current_best_is_quiet(self, tmp_path):
+        quiet = tmp_path / "runs" / "explore" / "h1" / "measure_round" / "b1"
+        _log(quiet / "server.log", QUIET)
+        base = tmp_path / "runs" / "baseline" / "h0" / "measure_round" / "b0"
+        base.mkdir(parents=True)
+        real = _log(tmp_path / "runs" / "baseline" / "h0" / "warmup_round" / "b0" / "server.log", HIT.format(m=5))
+
+        state = _State(current_best={"workspace": str(quiet)}, last_baseline={"workspace": str(base)})
+
+        assert rh._resolve_forge_server_log(state, tmp_path) == str(real)
+
+
+class TestTokensFromServingLog:
+    def test_the_observed_m_values_come_back_sorted(self, tmp_path):
+        text = "".join(HIT.format(m=m) for m in (512, 128, 15842))
+        assert rh._tokens_from_serving_log(_log(tmp_path / "a.log", text)) == "128,512,15842"
+
+    def test_a_miss_line_counts_too(self, tmp_path):
+        text = MISS.format(m=64) + HIT.format(m=32)
+        assert rh._tokens_from_serving_log(_log(tmp_path / "a.log", text)) == "32,64"
+
+    def test_the_most_frequent_m_values_win_the_budget(self, tmp_path):
+        # 1 appears once, 2..4 appear three times each; with a budget of 3 the
+        # rare one is dropped. Tuning where the model spends its time beats
+        # tuning the largest M it ever reached.
+        text = HIT.format(m=1) + "".join(HIT.format(m=m) * 3 for m in (2, 3, 4))
+        assert rh._tokens_from_serving_log(_log(tmp_path / "a.log", text), limit=3) == "2,3,4"
+
+    def test_a_quiet_log_yields_nothing(self, tmp_path):
+        assert rh._tokens_from_serving_log(_log(tmp_path / "a.log", QUIET)) == ""
+
+    def test_a_missing_log_yields_nothing(self, tmp_path):
+        assert rh._tokens_from_serving_log(tmp_path / "nope.log") == ""
+
+    def test_the_result_is_what_forge_accepts(self, tmp_path):
+        # forge parses --tokens as int(t) for t in value.split(","); round-trip
+        # through the normaliser must not change it.
+        text = "".join(HIT.format(m=m) for m in (7, 4096))
+        raw = rh._tokens_from_serving_log(_log(tmp_path / "a.log", text))
+        assert rh._normalize_tokens(raw) == raw
+        assert [int(t) for t in raw.split(",")] == [7, 4096]
+
+    def test_m_values_are_read_across_chunk_boundaries(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(rh, "_LOG_SCAN_CHUNK", 24)
+        text = "".join(HIT.format(m=m) for m in (11, 22, 33))
+        assert rh._tokens_from_serving_log(_log(tmp_path / "a.log", text)) == "11,22,33"
+
+
+class TestShapeManifestResolution:
+    def test_the_newest_manifest_wins(self, tmp_path):
+        import os
+
+        old = tmp_path / "runs" / "baseline" / "bypass" / "trace_shape_manifest.json"
+        new = tmp_path / "runs" / "explore" / "bypass" / "trace_shape_manifest.json"
+        for path in (old, new):
+            path.parent.mkdir(parents=True)
+            path.write_text("{}", encoding="utf-8")
+        os.utime(old, (1, 1))
+
+        assert rh._resolve_trace_shape_manifest(_State(), tmp_path) == str(new)
+
+    def test_no_manifest_is_an_empty_string_not_an_error(self, tmp_path):
+        assert rh._resolve_trace_shape_manifest(_State(), tmp_path) == ""
+
+    def test_a_missing_session_dir_is_survivable(self, tmp_path):
+        assert rh._resolve_trace_shape_manifest(_State(), tmp_path / "gone") == ""
+
+
+class TestTheWrapperForwardsTheNewInputs:
+    @pytest.mark.parametrize(
+        "key,flag",
+        [
+            ("shapes_manifest", "--shapes-manifest"),
+            ("demand_json", "--demand"),
+        ],
+    )
+    def test_a_populated_field_reaches_the_forge_cli(self, key, flag):
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "_fgt",
+            Path(rh.__file__).parents[2] / "agents" / "kernel" / "tools" / "forge_gemm_tuning.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        base = {
+            "model_path": "/m",
+            "framework": "sglang",
+            "precision": "bf16",
+            "output_dir": "/o",
+        }
+        assert flag not in mod._build_cmd(base)
+
+        cmd = mod._build_cmd({**base, key: "/tmp/x.json"})
+        assert cmd[cmd.index(flag) + 1] == "/tmp/x.json"

--- a/src/hyperloom/orchestrator/kernel/tests/test_forge_server_log_evidence.py
+++ b/src/hyperloom/orchestrator/kernel/tests/test_forge_server_log_evidence.py
@@ -154,6 +154,22 @@ class TestTokensFromServingLog:
         text = HIT.format(m=1) + "".join(HIT.format(m=m) * 3 for m in (2, 3, 4))
         assert rh._tokens_from_serving_log(_log(tmp_path / "a.log", text), limit=3) == "2,3,4"
 
+    def test_uniform_counts_do_not_starve_the_prefill_end(self, tmp_path):
+        # Regression: a serving warmup sweeps every M about equally often, so
+        # the counts come out uniform and a plain frequency ranking degenerates
+        # into its tie-break -- which kept the smallest M and dropped the large
+        # prefill shapes the runtime then missed. Both fleet sessions we
+        # replayed looked exactly like this (17 distinct M x4, 44 distinct
+        # M x40), and both missed on 16384/24576/32768 and 57344/65536.
+        ms = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 8192, 16384, 24576, 32768]
+        text = "".join(HIT.format(m=m) * 4 for m in ms)
+        got = rh._tokens_from_serving_log(_log(tmp_path / "a.log", text), limit=8)
+        picked = {int(t) for t in got.split(",")}
+        assert {24576, 32768} <= picked, got
+        assert len(picked) == 8, got
+        # ...and the decode end still gets the majority of the budget.
+        assert len([m for m in picked if m <= 256]) >= 4, got
+
     def test_a_quiet_log_yields_nothing(self, tmp_path):
         assert rh._tokens_from_serving_log(_log(tmp_path / "a.log", QUIET)) == ""
 

--- a/src/hyperloom/orchestrator/kernel/tests/test_forge_server_log_evidence.py
+++ b/src/hyperloom/orchestrator/kernel/tests/test_forge_server_log_evidence.py
@@ -259,3 +259,93 @@ class TestTheWrapperForwardsTheNewInputs:
 
         cmd = mod._build_cmd({**base, key: "/tmp/x.json"})
         assert cmd[cmd.index(flag) + 1] == "/tmp/x.json"
+
+
+class _StopHere(Exception):
+    """Raised from the MoE CSV writer to end the run at the point under test."""
+
+
+class TestTokensAreDerivedBeforeTheMoeCsvIsBuilt:
+    """Both lanes must see the observed M sweep, not just the dense one.
+
+    ``_write_fmoe_untuned_csv_from_log`` consumes ``tokens`` directly and its
+    fallback for an empty one is ``[1]``. While the serving-log derivation sat
+    below that call, the dense lane got the full sweep and the MoE lane got a
+    one-row table -- which then missed on every prefill and large-batch lookup
+    and was reverted as ``no_shape_key_matched``. That is the exact failure this
+    change set exists to remove, so an ordering regression here would leave the
+    MoE half of it in place.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_moe_writer_receives_the_serving_log_sweep(self, tmp_path, monkeypatch):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        log_path = _log(tmp_path / "server.log", "".join(HIT.format(m=m) * 4 for m in (1, 64, 2048, 16384)))
+
+        seen: dict[str, str] = {}
+
+        def _writer(_log_path, tokens, _workspace):
+            seen["tokens"] = tokens
+            raise _StopHere
+
+        from hyperloom.common import model_paths
+        from hyperloom.inference_optimizer import model_config_utils
+        from hyperloom.orchestrator.policy import gate
+
+        monkeypatch.setattr(rh, "_forge_gemm_tune_available", lambda: True)
+        monkeypatch.setattr(rh, "_resolve_forge_precision_and_quant", lambda *_a, **_k: ("bf16", ""))
+        monkeypatch.setattr(model_paths, "resolve_serving_model_path", lambda p: str(p))
+        monkeypatch.setattr(model_config_utils, "resolve_local_model_dir", lambda _p: model_dir)
+        monkeypatch.setattr(gate, "detect_gpu_count", lambda: 8)
+        monkeypatch.setattr(rh, "_resolve_forge_shapes", lambda *_a, **_k: "")
+        monkeypatch.setattr(rh, "_resolve_forge_untuned_csv", lambda *_a, **_k: "")
+        monkeypatch.setattr(rh, "_write_fmoe_untuned_csv_from_log", _writer)
+
+        payload = {
+            "model_path": str(model_dir),
+            "framework": "sglang",
+            "kernel_signature_log": str(log_path),
+        }
+        with pytest.raises(_StopHere):
+            await rh._run_forge_gemm_tuning(payload, session_dir=tmp_path)
+
+        assert seen["tokens"] == rh._tokens_from_serving_log(log_path)
+        # Not the ``[1]`` fallback, and not a single value of any kind.
+        assert len(seen["tokens"].split(",")) > 1
+
+    @pytest.mark.asyncio
+    async def test_an_explicit_payload_tokens_value_still_wins(self, tmp_path, monkeypatch):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        log_path = _log(tmp_path / "server.log", HIT.format(m=999))
+
+        seen: dict[str, str] = {}
+
+        def _writer(_log_path, tokens, _workspace):
+            seen["tokens"] = tokens
+            raise _StopHere
+
+        from hyperloom.common import model_paths
+        from hyperloom.inference_optimizer import model_config_utils
+        from hyperloom.orchestrator.policy import gate
+
+        monkeypatch.setattr(rh, "_forge_gemm_tune_available", lambda: True)
+        monkeypatch.setattr(rh, "_resolve_forge_precision_and_quant", lambda *_a, **_k: ("bf16", ""))
+        monkeypatch.setattr(model_paths, "resolve_serving_model_path", lambda p: str(p))
+        monkeypatch.setattr(model_config_utils, "resolve_local_model_dir", lambda _p: model_dir)
+        monkeypatch.setattr(gate, "detect_gpu_count", lambda: 8)
+        monkeypatch.setattr(rh, "_resolve_forge_shapes", lambda *_a, **_k: "")
+        monkeypatch.setattr(rh, "_resolve_forge_untuned_csv", lambda *_a, **_k: "")
+        monkeypatch.setattr(rh, "_write_fmoe_untuned_csv_from_log", _writer)
+
+        payload = {
+            "model_path": str(model_dir),
+            "framework": "sglang",
+            "kernel_signature_log": str(log_path),
+            "tokens": "1,2,4",
+        }
+        with pytest.raises(_StopHere):
+            await rh._run_forge_gemm_tuning(payload, session_dir=tmp_path)
+
+        assert seen["tokens"] == "1,2,4"

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -2220,6 +2220,7 @@ class KernelPhase(PhaseHandler):
         from ..kernel.gemm_shape_coverage import (
             parse_aiter_consulted_tables,
             parse_aiter_shape_lookups,
+            parse_aiter_shape_lookups_for_tables,
             tuned_config_coverage,
             tuned_csv_shapes,
         )
@@ -2251,10 +2252,19 @@ class KernelPhase(PhaseHandler):
                 csv_paths,
             )
 
-        missed, hit = parse_aiter_shape_lookups(log_text)
-        requested = missed | hit
-        if not requested:
+        all_missed, all_hit = parse_aiter_shape_lookups(log_text)
+        all_requested = all_missed | all_hit
+        if not all_requested:
             return None
+        wanted = {Path(path).name for path in csv_paths}
+        missed, hit = parse_aiter_shape_lookups_for_tables(log_text, wanted)
+        requested = missed | hit
+        scoped_to_candidate = bool(requested)
+        if not scoped_to_candidate:
+            # Preserve the existing artifact-not-consulted diagnostic when the
+            # server performed lookups, but none against this candidate's table.
+            missed, hit = all_missed, set()
+            requested = all_requested
         tuned: set[tuple[int, int, int]] = set()
         for path in csv_paths:
             tuned |= tuned_csv_shapes(path)
@@ -2268,7 +2278,6 @@ class KernelPhase(PhaseHandler):
         report["artifact_applied"] = bool(report.get("covered"))
         consulted = parse_aiter_consulted_tables(log_text)
         report["consulted_tables"] = sorted(consulted)[:8]
-        wanted = {Path(path).name for path in csv_paths}
         if consulted and not (wanted & {Path(name).name for name in consulted}):
             # The runtime resolved a different quantisation variant's table, so
             # the tuner targeted a kernel this server never dispatches to.

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -3299,8 +3299,14 @@ class KernelPhase(PhaseHandler):
             model_supports_aiter_ck_fused_moe,
         )
 
-        triton_moe_inert = (
-            any(c.get("tuner") == "vllm_moe_triton" for c in candidates) and self._runtime_uses_aiter_fused_moe()
+        # ``_runtime_uses_aiter_fused_moe`` resolves the serving log -- which now
+        # byte-scans the whole runs/ tree for aiter evidence -- and then reads it
+        # whole, ~17MB on the fleet. This function is a coroutine on the
+        # orchestrator's only event loop, so doing that inline stalls every other
+        # coroutine, heartbeats included, for the duration. The short-circuit is
+        # kept: no Triton candidate means no reason to look at all.
+        triton_moe_inert = any(c.get("tuner") == "vllm_moe_triton" for c in candidates) and await asyncio.to_thread(
+            self._runtime_uses_aiter_fused_moe
         )
 
         for cand in candidates:
@@ -3501,7 +3507,10 @@ class KernelPhase(PhaseHandler):
             # not run.
             apply_blockers: list[str] = []
 
-            coverage = self._gemm_tuned_config_coverage(tuner_name, env)
+            # Off the event loop for the same reason: this reads the integrate
+            # run's server.log in full and parses every tuned CSV named in the
+            # candidate env.
+            coverage = await asyncio.to_thread(self._gemm_tuned_config_coverage, tuner_name, env)
             if coverage is not None:
                 cand = {**cand, "tuned_config_coverage": coverage}
                 if not coverage.get("artifact_applied") and coverage.get("conclusive", True):

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Callable
 from . import geak_rebench as _geak_rebench
 from . import machine_state as _phase_state
+from hyperloom.common.io import atomic_write_json
 from hyperloom.inference_optimizer.breakdown.agent_ownership import (
     LEVER_CONFIG,
     LEVER_KERNEL,
@@ -3028,6 +3029,13 @@ class KernelPhase(PhaseHandler):
             for stale in ("recommended_env", "extra_envs"):
                 if result.get(stale):
                     result[stale] = {}
+            # ``record_gemm_tuning`` above stored a SHALLOW COPY, so the scalar
+            # rewrites just made (decision/micro_decision/...) do not reach the
+            # recorded entry on their own -- only the normal exit re-syncs it.
+            # Without this the state kept the bridge's KEEP for an arm that was
+            # never measured, and the on-disk result.json kept the pre-E2E
+            # snapshot too.
+            self._replace_latest_gemm_tuning_attempt(result)
         try:
             from hyperloom.inference_optimizer.breakdown.recorder import instrument
 
@@ -3097,6 +3105,32 @@ class KernelPhase(PhaseHandler):
         except Exception:  # noqa: BLE001 — journaling is best-effort
             log.exception("gemm_tuning journal append failed")
 
+    def _writeback_gemm_result_json(self, entry: dict[str, Any]) -> None:
+        """Overwrite ``<workspace>/result.json`` with the E2E-adjudicated envelope.
+
+        forge's CLI writes ``result.json`` the moment micro tuning ends, so on
+        disk it stays a pre-E2E snapshot (``status=ok`` /
+        ``requires_e2e_validation=true``) even after this phase has recorded a
+        REVERT. Anything that reads the file rather than ``state.json`` -- the
+        fusion/collective lanes treat ``result.json`` as the final verdict --
+        then sees a candidate that was already rejected. Writing the merged
+        envelope back keeps both ledgers on the same value.
+
+        Best-effort: the workspace lives on shared storage that can be read-only
+        or already reaped, and a failed writeback must not turn a recorded
+        verdict into a phase crash.
+        """
+        workspace = str(entry.get("workspace") or "").strip()
+        if not workspace:
+            return
+        path = Path(workspace) / "result.json"
+        try:
+            if not path.parent.is_dir():
+                return
+            atomic_write_json(path, entry, make_parents=False)
+        except (OSError, TypeError, ValueError):
+            log.warning("gemm result.json writeback failed for %s", path, exc_info=True)
+
     def _replace_latest_gemm_tuning_attempt(self, result: dict[str, Any]) -> None:
         """Sync the latest GEMM history row after forge E2E rewrites ``result``."""
         if not isinstance(result, dict):
@@ -3111,6 +3145,7 @@ class KernelPhase(PhaseHandler):
             attempts.append(entry)
         self.shared_state.gemm_tuning_attempts = attempts
         self.shared_state.last_gemm_tuning = entry
+        self._writeback_gemm_result_json(entry)
 
     def _gemm_e2e_candidates(self, result: dict[str, Any]) -> list[dict[str, Any]]:
         """Reduce a GEMM tuning result to the env sets worth E2E-validating.

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -103,33 +103,17 @@ _AITER_ENV_TO_TABLE: dict[str, str] = {
 }
 
 
-def _safe_mtime(path: Path) -> float:
-    """Return ``path``'s mtime, or ``0`` when it cannot be read.
-
-    Sorting server logs by mtime races the round that is still writing them, and
-    an ``exists()`` guard does not close the window. Ordering is a heuristic for
-    picking the newest log, so a vanished file is worth sorting last rather than
-    aborting the check that owns it.
-    """
-    try:
-        return path.stat().st_mtime
-    except OSError:
-        return 0.0
-
-
 def _integrate_server_logs(session_dir: Path, tuner_name: str) -> list[Path]:
     """Server logs for a tuner's integrate run, retries included, oldest first.
 
-    A retried integrate lands in a sibling directory with a ``-2``/``-3``
-    suffix, so scanning only ``integrate-gemm_tune_<tuner>`` grades the retry on
-    the *first* attempt's log. Seven such retries exist on the fleet, including
-    every faulted post-merge session.
+    Thin naming shim over
+    :func:`..kernel.gemm_shape_coverage.integrate_server_logs`, which owns the
+    retry-sibling and mtime-ordering rules; this side only knows that a dense
+    tuner's run directory is ``integrate-gemm_tune_<tuner>``.
     """
-    parent = session_dir / "runs" / "integrate"
-    base = f"integrate-gemm_tune_{tuner_name}"
-    dirs = [parent / base, *sorted(parent.glob(f"{base}-*"))]
-    logs = [log_path for run_dir in dirs for log_path in run_dir.rglob("server.log")]
-    return sorted(logs, key=_safe_mtime)
+    from ..kernel.gemm_shape_coverage import integrate_server_logs
+
+    return integrate_server_logs(session_dir, f"integrate-gemm_tune_{tuner_name}")
 
 
 def _candidate_tuned_file(env: Any, env_var: str) -> str:
@@ -3132,7 +3116,16 @@ class KernelPhase(PhaseHandler):
             log.warning("gemm result.json writeback failed for %s", path, exc_info=True)
 
     def _replace_latest_gemm_tuning_attempt(self, result: dict[str, Any]) -> None:
-        """Sync the latest GEMM history row after forge E2E rewrites ``result``."""
+        """Sync the latest GEMM history row, and publish the verdict to disk.
+
+        Not a pure in-memory update: every call also overwrites
+        ``<workspace>/result.json`` via ``_writeback_gemm_result_json``. The two
+        are deliberately coupled because they are the two books that must agree
+        -- ``record_gemm_tuning`` stores a shallow copy, so a caller that
+        rewrote scalars on ``result`` has changed neither the history row nor
+        the on-disk snapshot until this runs. All three call sites are terminal
+        verdict points, which is the only place either write is correct.
+        """
         if not isinstance(result, dict):
             return
         entry = dict(result)
@@ -3256,6 +3249,20 @@ class KernelPhase(PhaseHandler):
         candidates = self._gemm_e2e_candidates(result)
         if not candidates:
             log.info("gemm tuning: no candidates to E2E validate")
+            # Close the books here too. Returning early left the recorded
+            # attempt and the on-disk result.json claiming
+            # ``requires_e2e_validation=true`` with ``micro_decision=candidate``
+            # forever -- the same two-books-disagree state the exception arm was
+            # fixed for, and at least as common: any run whose tuners produced
+            # no usable env lands here.
+            result["decision"] = "REVERT"
+            result["requires_e2e_validation"] = False
+            result["e2e_validated"] = False
+            result["micro_decision"] = "no_e2e_candidates"
+            for stale in ("recommended_env", "extra_envs"):
+                if result.get(stale):
+                    result[stale] = {}
+            self._replace_latest_gemm_tuning_attempt(result)
             return
 
         baseline_tput = float(self.shared_state.baseline_tput or 0.0)

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -3258,10 +3258,17 @@ class KernelPhase(PhaseHandler):
             result["decision"] = "REVERT"
             result["requires_e2e_validation"] = False
             result["e2e_validated"] = False
-            result["micro_decision"] = "no_e2e_candidates"
-            for stale in ("recommended_env", "extra_envs"):
-                if result.get(stale):
-                    result[stale] = {}
+            # Only when the tuners left no verdict of their own. An existing
+            # ``micro_decision`` is load-bearing downstream --
+            # ``_should_run_bf16_dense_gemm_fallback`` keys the sglang bf16
+            # retry on ``no_improvement`` -- so overwriting it here cancels the
+            # fallback for exactly the runs that need it. Same trap as adding a
+            # new ``status``: the value is a routing key, not a label.
+            if not str(result.get("micro_decision") or "").strip():
+                result["micro_decision"] = "no_e2e_candidates"
+            # ``recommended_env``/``extra_envs`` stay as the tuners left them:
+            # they are the raw record of what was produced, and the eligibility
+            # checks downstream already read them as "must be empty".
             self._replace_latest_gemm_tuning_attempt(result)
             return
 

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -116,6 +116,21 @@ def _safe_mtime(path: Path) -> float:
         return 0.0
 
 
+def _integrate_server_logs(session_dir: Path, tuner_name: str) -> list[Path]:
+    """Server logs for a tuner's integrate run, retries included, oldest first.
+
+    A retried integrate lands in a sibling directory with a ``-2``/``-3``
+    suffix, so scanning only ``integrate-gemm_tune_<tuner>`` grades the retry on
+    the *first* attempt's log. Seven such retries exist on the fleet, including
+    every faulted post-merge session.
+    """
+    parent = session_dir / "runs" / "integrate"
+    base = f"integrate-gemm_tune_{tuner_name}"
+    dirs = [parent / base, *sorted(parent.glob(f"{base}-*"))]
+    logs = [log_path for run_dir in dirs for log_path in run_dir.rglob("server.log")]
+    return sorted(logs, key=_safe_mtime)
+
+
 def _candidate_tuned_file(env: Any, env_var: str) -> str:
     """Return the tuned artifact a candidate's env points at.
 
@@ -2212,8 +2227,7 @@ class KernelPhase(PhaseHandler):
         csv_paths = [value for key, value in envs.items() if key.startswith("AITER_CONFIG")]
         if not csv_paths:
             return None
-        run_dir = self.session_dir / "runs" / "integrate" / f"integrate-gemm_tune_{tuner_name}"
-        logs = sorted(run_dir.rglob("server.log"), key=_safe_mtime)
+        logs = _integrate_server_logs(self.session_dir, tuner_name)
         if not logs:
             return None
         try:
@@ -2247,7 +2261,7 @@ class KernelPhase(PhaseHandler):
         if not tuned:
             _unreadable("dense")
             return None
-        report = tuned_config_coverage(tuned, requested)
+        report = tuned_config_coverage(tuned, requested, known_covered=hit)
         report["server_log"] = str(logs[-1])
         report["runtime_lookup_miss"] = len(missed)
         report["runtime_lookup_hit"] = len(hit)
@@ -2442,14 +2456,13 @@ class KernelPhase(PhaseHandler):
         csv_paths = [value for key, value in envs.items() if key.startswith("AITER_CONFIG")]
         if not csv_paths:
             return None
-        run_dir = self.session_dir / "runs" / "integrate" / f"integrate-gemm_tune_{tuner_name}"
-        logs = sorted(run_dir.rglob("server.log"), key=_safe_mtime)
+        logs = _integrate_server_logs(self.session_dir, tuner_name)
         if not logs:
             # Say so. This whole change exists to stop checks from failing
             # quietly, and a missing log is the one way this one can.
             log.warning(
-                "forge gemm E2E: no server.log under %s; apply verification cannot run for %s",
-                run_dir,
+                "forge gemm E2E: no server.log under %s (retries included); apply verification cannot run for %s",
+                self.session_dir / "runs" / "integrate" / f"integrate-gemm_tune_{tuner_name}",
                 tuner_name,
             )
             return None

--- a/src/hyperloom/orchestrator/phases/tests/test_gemm_e2e_validation_offloads_io.py
+++ b/src/hyperloom/orchestrator/phases/tests/test_gemm_e2e_validation_offloads_io.py
@@ -1,0 +1,63 @@
+"""The GEMM e2e validator must not do its file I/O on the event loop.
+
+``_validate_gemm_tuning_e2e`` is a coroutine running on the orchestrator's only
+event loop. Two of the things it calls are heavy synchronous readers:
+
+* ``_runtime_uses_aiter_fused_moe`` resolves the serving log -- which byte-scans
+  the whole ``runs/`` tree for aiter evidence -- and then reads it whole, ~17MB
+  apiece on the fleet;
+* ``_gemm_tuned_config_coverage`` reads the integrate run's ``server.log`` in
+  full and parses every tuned CSV named in the candidate env.
+
+Called inline, either one stalls every other coroutine on the loop for its whole
+duration, heartbeats included. Both have to go through ``asyncio.to_thread``.
+
+Asserted against the source rather than by timing a real call: the failure mode
+is "the await disappeared in a later edit", which the source states directly and
+a stopwatch only states probabilistically.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+from hyperloom.orchestrator.phases import kernel as kernel_mod
+
+
+def _validator_source() -> str:
+    return inspect.getsource(kernel_mod.KernelPhase._validate_gemm_tuning_e2e)
+
+
+def test_the_validator_is_still_a_coroutine():
+    # The whole premise: if it ever becomes sync, it is not on the loop and
+    # these assertions are measuring nothing.
+    assert inspect.iscoroutinefunction(kernel_mod.KernelPhase._validate_gemm_tuning_e2e)
+
+
+def test_the_fused_moe_probe_runs_off_the_loop():
+    src = _validator_source()
+    assert "self._runtime_uses_aiter_fused_moe" in src
+    assert re.search(
+        r"await\s+asyncio\.to_thread\(\s*\n?\s*self\._runtime_uses_aiter_fused_moe",
+        src,
+    ), src
+
+
+def test_the_coverage_replay_runs_off_the_loop():
+    src = _validator_source()
+    assert "self._gemm_tuned_config_coverage" in src
+    assert re.search(
+        r"await\s+asyncio\.to_thread\(\s*self\._gemm_tuned_config_coverage\s*,",
+        src,
+    ), src
+
+
+def test_neither_is_also_called_bare():
+    """A ``to_thread`` wrap elsewhere does not excuse a second inline call."""
+    src = _validator_source()
+    for name in ("_runtime_uses_aiter_fused_moe", "_gemm_tuned_config_coverage"):
+        # A bare call is the attribute immediately followed by "(" -- the
+        # to_thread form passes the bound method as an argument instead, so it
+        # is followed by "," or ")".
+        assert not re.search(rf"self\.{name}\s*\(", src), f"{name} is called inline"

--- a/src/kernelforge/gemm_tune/tests/test_dense_bf16_accuracy_accounting.py
+++ b/src/kernelforge/gemm_tune/tests/test_dense_bf16_accuracy_accounting.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""A row removed for being wrong is not a shape the run failed to reach.
+
+``_build_result`` compared the surviving row count against ``n_expected``, but
+``drop_inaccurate_rows`` had already deleted rows from the artifact by then. A
+batch that tuned every shape and then had two of them removed by aiter's own
+accuracy check therefore reported ``partial_output`` with a warning blaming the
+grouped batch budget -- pointing the reader at ``--timeout`` when the timeout
+was never the problem and a backend was computing wrong answers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kernelforge.gemm_tune.model_analyzer import ModelProfile
+from kernelforge.gemm_tune.tuners.base import TuneContext
+from kernelforge.gemm_tune.tuners.sglang_dense_bf16 import SglangDenseBf16Tuner
+
+
+def _tuner(tmp_path: Path) -> SglangDenseBf16Tuner:
+    return SglangDenseBf16Tuner(
+        TuneContext(
+            profile=ModelProfile(model_path="/fake", hidden_size=4096, intermediate_size=11008),
+            framework="sglang",
+            precision="bf16",
+            quant_type="none",
+            gpu_type="mi355x",
+            tp=1,
+            conc=8,
+            tokens=[8],
+            mp=1,
+            output_dir=tmp_path,
+            iters=20,
+            warmup=5,
+            min_improvement_pct=1.0,
+            timeout_s=3600,
+        )
+    )
+
+
+def _rows(n: int, *, improved: bool = True) -> list[dict]:
+    return [
+        {
+            "M": 16 * (i + 1),
+            "N": 1536,
+            "K": 7168,
+            "improved": improved,
+            "speedup": 1.2 if improved else 1.0,
+            "us": 8.0,
+        }
+        for i in range(n)
+    ]
+
+
+def _dropped(n: int) -> list[dict]:
+    return [
+        {
+            "M": 4096 + i,
+            "N": 1536,
+            "K": 7168,
+            "libtype": "flydsl",
+            "splitK": 7,
+            "us": 8.116,
+            "err_ratio": 0.0202,
+        }
+        for i in range(n)
+    ]
+
+
+def _build(tmp_path, *, kept: int, dropped: int, expected: int, improved: bool = True):
+    t = _tuner(tmp_path)
+    t._dropped_inaccurate = _dropped(dropped)
+    csv_path = tmp_path / "tuned_dense_bf16.csv"
+    csv_path.write_text("header\n", encoding="utf-8")
+    return t._build_result(
+        _rows(kept, improved=improved),
+        expected,
+        csv_path,
+        batch_timeout=900,
+        rc=0,
+    )
+
+
+class TestAccuracyFilteringIsNotBudgetExhaustion:
+    def test_a_complete_batch_with_dropped_rows_is_not_partial(self, tmp_path, caplog):
+        # 8 tuned, 2 of them removed as wrong: every expected shape was reached.
+        result = _build(tmp_path, kept=6, dropped=2, expected=8)
+
+        assert result.status == "ok"
+        # The old text sent the reader to --timeout; the new one names the
+        # accuracy check and says outright that the budget was not the cause.
+        assert "likely exhausted" not in caplog.text
+        assert "accuracy filtering, not budget exhaustion" in caplog.text
+
+    def test_a_complete_batch_with_dropped_rows_and_no_win_is_no_improvement(self, tmp_path):
+        result = _build(tmp_path, kept=6, dropped=2, expected=8, improved=False)
+
+        assert result.status == "no_improvement"
+
+    def test_a_genuinely_short_batch_is_still_partial(self, tmp_path, caplog):
+        # 6 written + 2 dropped = 8 reached, out of 20 asked for.
+        result = _build(tmp_path, kept=6, dropped=2, expected=20)
+
+        assert result.status == "partial_output"
+        assert "reached 8 of 20" in caplog.text
+        assert "budget" in caplog.text
+        # The drops are reported, but not as the cause of the shortfall.
+        assert "Separately, 2 of those rows were dropped" in caplog.text
+
+    def test_a_short_batch_with_no_drops_reads_the_same_as_before(self, tmp_path, caplog):
+        result = _build(tmp_path, kept=6, dropped=0, expected=20)
+
+        assert result.status == "partial_output"
+        assert "Separately" not in caplog.text
+
+    def test_a_clean_complete_batch_is_untouched(self, tmp_path, caplog):
+        result = _build(tmp_path, kept=8, dropped=0, expected=8)
+
+        assert result.status == "ok"
+        assert "accuracy filtering" not in caplog.text
+
+
+class TestTheServializedCountsAgree:
+    def test_filtered_rows_are_not_counted_as_missing(self, tmp_path):
+        d = _build(tmp_path, kept=6, dropped=2, expected=8).to_dict()
+
+        assert d["filtered_shapes"] == 2
+        assert d["missing_shapes"] == 0
+        assert d["total_shapes"] == 6
+        assert d["expected_shapes"] == 8
+
+    def test_a_real_shortfall_still_shows_as_missing(self, tmp_path):
+        d = _build(tmp_path, kept=6, dropped=2, expected=20).to_dict()
+
+        assert d["filtered_shapes"] == 2
+        assert d["missing_shapes"] == 12
+
+
+class TestPartialOutputStillReachesE2E:
+    """Guard against "fixing" this by refusing to integrate a partial run.
+
+    ``partial_output`` is deliberately on the E2E path (see
+    ``phases/kernel.py`` and ``test_partial_output_still_reaches_e2e``): rows
+    that were written are real tuning results. This accounting fix must not
+    quietly become a new gate.
+    """
+
+    def test_partial_output_still_carries_a_deployable_artifact(self, tmp_path):
+        result = _build(tmp_path, kept=6, dropped=2, expected=20)
+
+        assert result.status == "partial_output"
+        assert result.env_var and result.env_value
+        assert result.artifact_path

--- a/src/kernelforge/gemm_tune/tests/test_tunableop_demand_dtype.py
+++ b/src/kernelforge/gemm_tune/tests/test_tunableop_demand_dtype.py
@@ -159,3 +159,26 @@ class TestTheStatusSaysWhatActuallyHappened:
 
         assert result.status == "failed"
         assert result.error_class == "input_missing"
+
+
+class TestTheBudgetIsAppliedAfterTheDtypeFilter:
+    def test_bf16_shapes_below_the_first_64_are_not_starved_out(self, tmp_path):
+        # Demand is ranked, and the dtype filter drops what this tuner has no
+        # record type for. Fetching exactly the budget and filtering afterwards
+        # let a run whose top 64 shapes are all fp8 come out empty while bf16
+        # shapes sat just below the cut -- and then report it as "skipped, no
+        # record type", which is true of the sample and false of the demand.
+        keys = [_key(m, 512, 4096, "torch.float8_e4m3fn") for m in range(1, 65)]
+        keys += [_key(m, 512, 4096, "torch.bfloat16") for m in range(100, 104)]
+        lines = _records(tmp_path, keys, precision="fp8")
+        assert lines is not None
+        assert len(lines) == 4
+        assert all(line.startswith(BF16) for line in lines)
+
+    def test_the_budget_still_caps_the_input_file(self, tmp_path):
+        from kernelforge.gemm_tune.tuners.vllm_dense_tunableop import _DEMAND_SHAPE_LIMIT
+
+        keys = [_key(m, 512, 4096, "torch.bfloat16") for m in range(1, _DEMAND_SHAPE_LIMIT + 40)]
+        lines = _records(tmp_path, keys)
+        assert lines is not None
+        assert len(lines) == _DEMAND_SHAPE_LIMIT

--- a/src/kernelforge/gemm_tune/tests/test_tunableop_demand_dtype.py
+++ b/src/kernelforge/gemm_tune/tests/test_tunableop_demand_dtype.py
@@ -140,10 +140,7 @@ class TestUnsupportedDtypesAreSkippedNotGuessed:
         assert lines == [f"{BF16},tn_1536_16_7168_ld_7168_7168_1536"]
 
     def test_all_shapes_unsupported_yields_no_input(self, tmp_path):
-        assert (
-            _records(tmp_path, [_key(16, 1536, 7168, "torch.float8_e4m3fn")], precision="mxfp4")
-            is None
-        )
+        assert _records(tmp_path, [_key(16, 1536, 7168, "torch.float8_e4m3fn")], precision="mxfp4") is None
 
 
 class TestTheStatusSaysWhatActuallyHappened:

--- a/src/kernelforge/gemm_tune/tests/test_tunableop_demand_dtype.py
+++ b/src/kernelforge/gemm_tune/tests/test_tunableop_demand_dtype.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""The record type comes from the shape's dtype, not from the checkpoint precision.
+
+``ctx.precision`` describes how the WEIGHTS are stored; it says nothing about
+what the dense GEMM runs in. On the fleet's ``Qwen3.8-2.4T-A95B-Quark-MXFP4``
+every one of the 21056 dense aiter lookups in a real serving log is
+``dtype='torch.bfloat16'`` while ``ctx.precision`` is ``mxfp4``. Keying the
+TunableOp record type off the precision alone found nothing and threw the whole
+demand file away, then reported it as ``input_missing`` -- which reads as "the
+upstream never sent data" when the data was there and understood.
+"""
+
+from __future__ import annotations
+
+import json
+
+from kernelforge.gemm_tune.model_analyzer import ModelProfile
+from kernelforge.gemm_tune.tuners.base import TuneContext
+from kernelforge.gemm_tune.tuners.vllm_dense_tunableop import VllmDenseTunableopTuner
+
+BF16 = "GemmTunableOp_BFloat16_TN"
+FP16 = "GemmTunableOp_Half_TN"
+
+
+def _demand_file(tmp_path, keys):
+    from kernelforge.gemm_tune.evidence import SCHEMA_VERSION
+
+    path = tmp_path / "demand.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema": SCHEMA_VERSION,
+                "demands": [
+                    {
+                        "table": "tunableop",
+                        "tuner": "vllm_dense_tunableop",
+                        "env_var": "PYTORCH_TUNABLEOP_FILENAME",
+                        "key_schema": ["M", "N", "K"],
+                        "logged_fields": ["M", "N", "K", "dtype"],
+                        "miss_count": len(keys),
+                        "keys": keys,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _key(m, n, k, dtype=None, **extra):
+    key = {"M": m, "N": n, "K": k, "requests": 1}
+    if dtype is not None:
+        key["dtype"] = dtype
+    key.update(extra)
+    return key
+
+
+def _tuner(tmp_path, demand, precision="bf16"):
+    return VllmDenseTunableopTuner(
+        TuneContext(
+            profile=ModelProfile(model_path="/fake", hidden_size=4096),
+            framework="vllm",
+            precision=precision,
+            quant_type="none",
+            gpu_type="mi355x",
+            tp=1,
+            conc=8,
+            tokens=[8],
+            mp=1,
+            output_dir=tmp_path,
+            iters=20,
+            warmup=5,
+            min_improvement_pct=1.0,
+            timeout_s=3600,
+            demand_json=demand,
+        )
+    )
+
+
+def _records(tmp_path, keys, precision="bf16"):
+    path = _tuner(tmp_path, _demand_file(tmp_path, keys), precision)._resolve_input()
+    if path is None:
+        return None
+    return path.read_text(encoding="utf-8").strip().splitlines()
+
+
+class TestTheShapeDtypeDecidesTheRecordType:
+    def test_an_mxfp4_checkpoint_still_tunes_its_bf16_shapes(self, tmp_path):
+        """The measured production case: mxfp4 weights, bf16 dense GEMMs."""
+        lines = _records(
+            tmp_path,
+            [_key(15842, 512, 4096, "torch.bfloat16")],
+            precision="mxfp4",
+        )
+        assert lines == [f"{BF16},tn_512_15842_4096_ld_4096_4096_512"]
+
+    def test_an_fp8_checkpoint_still_tunes_its_bf16_shapes(self, tmp_path):
+        lines = _records(tmp_path, [_key(16, 1536, 7168, "torch.bfloat16")], precision="fp8")
+        assert lines == [f"{BF16},tn_1536_16_7168_ld_7168_7168_1536"]
+
+    def test_a_float16_shape_gets_the_half_record_type(self, tmp_path):
+        lines = _records(tmp_path, [_key(16, 1536, 7168, "torch.float16")], precision="mxfp4")
+        assert lines == [f"{FP16},tn_1536_16_7168_ld_7168_7168_1536"]
+
+    def test_the_shape_dtype_wins_over_the_checkpoint_precision(self, tmp_path):
+        # Not merely a fallback: where the two disagree, only the logged dtype
+        # describes the GEMM that actually ran.
+        lines = _records(tmp_path, [_key(16, 1536, 7168, "torch.bfloat16")], precision="fp16")
+        assert lines == [f"{BF16},tn_1536_16_7168_ld_7168_7168_1536"]
+
+    def test_otype_is_read_when_dtype_is_absent(self, tmp_path):
+        lines = _records(
+            tmp_path,
+            [_key(16, 1536, 7168, otype="torch.bfloat16")],
+            precision="mxfp4",
+        )
+        assert lines == [f"{BF16},tn_1536_16_7168_ld_7168_7168_1536"]
+
+    def test_a_dtypeless_shape_falls_back_to_the_precision(self, tmp_path):
+        # The pre-existing behaviour, kept: older demand files carry no dtype.
+        lines = _records(tmp_path, [_key(16, 1536, 7168)], precision="bf16")
+        assert lines == [f"{BF16},tn_1536_16_7168_ld_7168_7168_1536"]
+
+
+class TestUnsupportedDtypesAreSkippedNotGuessed:
+    def test_an_unrecognised_dtype_is_dropped_rather_than_coerced(self, tmp_path):
+        # TunableOp keys on the record type. Writing an fp8 shape under a bf16
+        # record type would tune something the runtime never looks up.
+        lines = _records(
+            tmp_path,
+            [
+                _key(16, 1536, 7168, "torch.bfloat16"),
+                _key(32, 2048, 4096, "torch.float8_e4m3fn"),
+            ],
+            precision="mxfp4",
+        )
+        assert lines == [f"{BF16},tn_1536_16_7168_ld_7168_7168_1536"]
+
+    def test_all_shapes_unsupported_yields_no_input(self, tmp_path):
+        assert (
+            _records(tmp_path, [_key(16, 1536, 7168, "torch.float8_e4m3fn")], precision="mxfp4")
+            is None
+        )
+
+
+class TestTheStatusSaysWhatActuallyHappened:
+    def test_all_unsupported_reports_skipped_not_input_missing(self, tmp_path):
+        """The demand file arrived and parsed; there was simply nothing here to tune."""
+        demand = _demand_file(tmp_path, [_key(16, 1536, 7168, "torch.float8_e4m3fn")])
+        result = _tuner(tmp_path, demand, precision="mxfp4").run()
+
+        assert result.status == "skipped"
+        assert result.error_class == "unsupported_precision"
+        assert "float8_e4m3fn" in (result.error or "")
+
+    def test_a_genuinely_missing_demand_file_still_reports_input_missing(self, tmp_path):
+        # The skip must not swallow the real failure it sits next to.
+        result = _tuner(tmp_path, None, precision="mxfp4").run()
+
+        assert result.status == "failed"
+        assert result.error_class == "input_missing"

--- a/src/kernelforge/gemm_tune/tuners/base.py
+++ b/src/kernelforge/gemm_tune/tuners/base.py
@@ -92,7 +92,8 @@ class TuneResult:
             # artifact but it was not missed by the run. Counting it as
             # "missing" made a completed batch read as a truncated one, which is
             # the same conflation the partial_output gate used to make.
-            d["filtered_shapes"] = len(self.dropped_inaccurate)
+            if self.dropped_inaccurate:
+                d["filtered_shapes"] = len(self.dropped_inaccurate)
             d["missing_shapes"] = max(self.expected_shapes - self.total_shapes - len(self.dropped_inaccurate), 0)
         if self.unverified_shapes:
             d["unverified_shapes"] = self.unverified_shapes

--- a/src/kernelforge/gemm_tune/tuners/base.py
+++ b/src/kernelforge/gemm_tune/tuners/base.py
@@ -93,9 +93,7 @@ class TuneResult:
             # "missing" made a completed batch read as a truncated one, which is
             # the same conflation the partial_output gate used to make.
             d["filtered_shapes"] = len(self.dropped_inaccurate)
-            d["missing_shapes"] = max(
-                self.expected_shapes - self.total_shapes - len(self.dropped_inaccurate), 0
-            )
+            d["missing_shapes"] = max(self.expected_shapes - self.total_shapes - len(self.dropped_inaccurate), 0)
         if self.unverified_shapes:
             d["unverified_shapes"] = self.unverified_shapes
         if self.shape_results:

--- a/src/kernelforge/gemm_tune/tuners/base.py
+++ b/src/kernelforge/gemm_tune/tuners/base.py
@@ -88,7 +88,14 @@ class TuneResult:
             d["avg_micro_speedup"] = round(self.avg_micro_speedup, 4)
         if self.expected_shapes:
             d["expected_shapes"] = self.expected_shapes
-            d["missing_shapes"] = max(self.expected_shapes - self.total_shapes, 0)
+            # A row the accuracy check removed was tuned; it is missing from the
+            # artifact but it was not missed by the run. Counting it as
+            # "missing" made a completed batch read as a truncated one, which is
+            # the same conflation the partial_output gate used to make.
+            d["filtered_shapes"] = len(self.dropped_inaccurate)
+            d["missing_shapes"] = max(
+                self.expected_shapes - self.total_shapes - len(self.dropped_inaccurate), 0
+            )
         if self.unverified_shapes:
             d["unverified_shapes"] = self.unverified_shapes
         if self.shape_results:

--- a/src/kernelforge/gemm_tune/tuners/sglang_dense_bf16.py
+++ b/src/kernelforge/gemm_tune/tuners/sglang_dense_bf16.py
@@ -723,21 +723,47 @@ class SglangDenseBf16Tuner(BaseTuner):
 
         dropped = list(getattr(self, "_dropped_inaccurate", []) or [])
 
+        # A row the accuracy check removed was tuned and then thrown away; the
+        # tuner did reach that shape. Comparing the surviving row count against
+        # n_expected therefore reports an accuracy problem as a budget problem,
+        # and sends the reader to raise --timeout when the timeout was fine.
+        produced = total + len(dropped)
+
         if forced_status:
             status = forced_status
-        elif total < n_expected:
+        elif produced < n_expected:
             log.warning(
-                "Dense BF16: tuned %d of %d shapes (rc=%d, not_finished=%s, "
-                "%d dropped as inaccurate); the grouped batch budget of %ds was "
-                "likely exhausted",
-                total,
+                "Dense BF16: reached %d of %d shapes (rc=%d, not_finished=%s); "
+                "the grouped batch budget of %ds was likely exhausted"
+                "%s",
+                produced,
                 n_expected,
                 rc,
                 not_finished,
-                len(dropped),
                 batch_timeout,
+                (
+                    f". Separately, {len(dropped)} of those rows were dropped as "
+                    f"inaccurate, leaving {total} in the artifact"
+                    if dropped
+                    else ""
+                ),
             )
             status = "partial_output"
+        elif dropped:
+            # Every expected shape was tuned. The artifact is short purely
+            # because the accuracy filter removed rows, which is a backend
+            # correctness signal, not a truncated run -- and the status stays
+            # one the E2E gate already accepts, because the surviving rows are
+            # still worth validating.
+            log.warning(
+                "Dense BF16: all %d shapes tuned, but %d row(s) failed aiter's own "
+                "accuracy check and were removed; %d remain in the artifact. This is "
+                "accuracy filtering, not budget exhaustion",
+                n_expected,
+                len(dropped),
+                total,
+            )
+            status = "ok" if (improved or unverified) else "no_improvement"
         elif improved or unverified:
             status = "ok"
         else:

--- a/src/kernelforge/gemm_tune/tuners/sglang_dense_bf16.py
+++ b/src/kernelforge/gemm_tune/tuners/sglang_dense_bf16.py
@@ -749,25 +749,23 @@ class SglangDenseBf16Tuner(BaseTuner):
                 ),
             )
             status = "partial_output"
-        elif dropped:
-            # Every expected shape was tuned. The artifact is short purely
-            # because the accuracy filter removed rows, which is a backend
-            # correctness signal, not a truncated run -- and the status stays
-            # one the E2E gate already accepts, because the surviving rows are
-            # still worth validating.
-            log.warning(
-                "Dense BF16: all %d shapes tuned, but %d row(s) failed aiter's own "
-                "accuracy check and were removed; %d remain in the artifact. This is "
-                "accuracy filtering, not budget exhaustion",
-                n_expected,
-                len(dropped),
-                total,
-            )
-            status = "ok" if (improved or unverified) else "no_improvement"
-        elif improved or unverified:
-            status = "ok"
         else:
-            status = "no_improvement"
+            if dropped:
+                # Every expected shape was tuned. The artifact is short purely
+                # because the accuracy filter removed rows, which is a backend
+                # correctness signal, not a truncated run. Say so, but do not
+                # branch the status on it: the surviving rows are still worth
+                # validating, and a status of its own would be a new routing key
+                # that the E2E gate does not admit.
+                log.warning(
+                    "Dense BF16: all %d shapes tuned, but %d row(s) failed aiter's own "
+                    "accuracy check and were removed; %d remain in the artifact. This is "
+                    "accuracy filtering, not budget exhaustion",
+                    n_expected,
+                    len(dropped),
+                    total,
+                )
+            status = "ok" if (improved or unverified) else "no_improvement"
 
         return TuneResult(
             tuner_name=self.name,

--- a/src/kernelforge/gemm_tune/tuners/vllm_dense_tunableop.py
+++ b/src/kernelforge/gemm_tune/tuners/vllm_dense_tunableop.py
@@ -71,6 +71,12 @@ def _tunableop_op_for_dtype(raw: Any) -> str | None:
 # Demand can list thousands of distinct keys; TunableOp times each one against
 # every hipBLASLt solution, so the whole run would be spent on one tuner.
 _DEMAND_SHAPE_LIMIT = 64
+# How many to *fetch* before the per-shape dtype filter runs. The filter drops
+# shapes this tuner has no record type for (fp8, fp4), and demand is ranked, so
+# taking exactly 64 first and filtering after would let a run whose top shapes
+# are all fp8 come out empty while bf16 shapes sat just below the cut. Fetch
+# wide, filter, then cap -- the ranking survives and the budget still holds.
+_DEMAND_FETCH_LIMIT = _DEMAND_SHAPE_LIMIT * 8
 
 
 def tunableop_untuned_line(m: int, n: int, k: int, op: str) -> str:
@@ -287,7 +293,7 @@ class VllmDenseTunableopTuner(BaseTuner):
         # lookup at the padded M; TunableOp keys on the exact shape and has no
         # such fallback, so a row written at 512 does nothing for a request at
         # 464. This tuner needs the M values the runtime literally asked for.
-        shapes = demand_shapes(entry, limit=_DEMAND_SHAPE_LIMIT, bucket=False) if entry else []
+        shapes = demand_shapes(entry, limit=_DEMAND_FETCH_LIMIT, bucket=False) if entry else []
         if not shapes:
             # No demand names this tuner, which is the normal case: the runtime
             # logs lookups against aiter's tables, and TunableOp has no table of
@@ -303,14 +309,14 @@ class VllmDenseTunableopTuner(BaseTuner):
                 # bucket=False for the same reason as the direct path above:
                 # borrowing another table's misses does not borrow aiter's
                 # padded-M retry along with them.
-                borrowed.extend(demand_shapes(other, limit=_DEMAND_SHAPE_LIMIT, bucket=False))
+                borrowed.extend(demand_shapes(other, limit=_DEMAND_FETCH_LIMIT, bucket=False))
             if borrowed:
                 log.info(
                     "%s: no demand of its own; taking %d dense shape(s) the runtime missed on other dense tables",
                     self.name,
-                    len(borrowed[:_DEMAND_SHAPE_LIMIT]),
+                    len(borrowed[:_DEMAND_FETCH_LIMIT]),
                 )
-            shapes = borrowed[:_DEMAND_SHAPE_LIMIT]
+            shapes = borrowed[:_DEMAND_FETCH_LIMIT]
         if not shapes:
             return None
 
@@ -324,6 +330,11 @@ class VllmDenseTunableopTuner(BaseTuner):
         lines = []
         unsupported: dict[str, int] = {}
         for shape in shapes:
+            # Budget reached. Stop here rather than filtering the whole fetched
+            # list and truncating, so ``unsupported`` counts only shapes that
+            # were actually in contention.
+            if len(lines) >= _DEMAND_SHAPE_LIMIT:
+                break
             try:
                 m, n, k = int(shape["M"]), int(shape["N"]), int(shape["K"])
             except (KeyError, TypeError, ValueError):

--- a/src/kernelforge/gemm_tune/tuners/vllm_dense_tunableop.py
+++ b/src/kernelforge/gemm_tune/tuners/vllm_dense_tunableop.py
@@ -67,6 +67,7 @@ def _tunableop_op_for_dtype(raw: Any) -> str | None:
         text = text[len("torch.") :]
     return _TUNABLEOP_OP_BY_DTYPE.get(text)
 
+
 # Demand can list thousands of distinct keys; TunableOp times each one against
 # every hipBLASLt solution, so the whole run would be spent on one tuner.
 _DEMAND_SHAPE_LIMIT = 64

--- a/src/kernelforge/gemm_tune/tuners/vllm_dense_tunableop.py
+++ b/src/kernelforge/gemm_tune/tuners/vllm_dense_tunableop.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from typing import Any
 
 from .base import BaseTuner, TuneResult
 from ..utils import TUNER_ENV_VARS, run_subprocess
@@ -34,6 +35,37 @@ _TUNABLEOP_OP_BY_PRECISION = {
     "float16": "GemmTunableOp_Half_TN",
     "bfloat16": "GemmTunableOp_BFloat16_TN",
 }
+
+# The activation dtype aiter logs per lookup, which the demand parser carries
+# through as ``shape["dtype"]``. This is the authoritative record type for a
+# shape: a checkpoint's ``precision`` describes how the WEIGHTS are stored, not
+# what the dense GEMM runs in. On a Quark MX-FP4 checkpoint every one of the
+# 21056 dense lookups in a real serving log is ``dtype='torch.bfloat16'``, so
+# keying off ``ctx.precision`` alone found no record type and discarded the
+# whole demand file.
+_TUNABLEOP_OP_BY_DTYPE = {
+    "bfloat16": "GemmTunableOp_BFloat16_TN",
+    "bf16": "GemmTunableOp_BFloat16_TN",
+    "float16": "GemmTunableOp_Half_TN",
+    "half": "GemmTunableOp_Half_TN",
+    "fp16": "GemmTunableOp_Half_TN",
+}
+
+
+def _tunableop_op_for_dtype(raw: Any) -> str | None:
+    """Map a logged torch dtype to a TunableOp record type, or ``None``.
+
+    Accepts the ``torch.`` prefix and surrounding quotes as they appear in the
+    serving log. Unknown dtypes (fp8, fp4, int4, ...) return ``None`` rather
+    than being coerced to a floating-point record type: TunableOp keys on the
+    record type, so guessing would tune a shape the runtime never asks for.
+    """
+    text = str(raw or "").strip().strip("\"'").lower()
+    if not text:
+        return None
+    if text.startswith("torch."):
+        text = text[len("torch.") :]
+    return _TUNABLEOP_OP_BY_DTYPE.get(text)
 
 # Demand can list thousands of distinct keys; TunableOp times each one against
 # every hipBLASLt solution, so the whole run would be spent on one tuner.
@@ -281,23 +313,39 @@ class VllmDenseTunableopTuner(BaseTuner):
         if not shapes:
             return None
 
+        # Per-shape dtype first, ctx.precision only as a fallback for shapes the
+        # demand parser recorded without one. A checkpoint precision that has no
+        # record type (mxfp4, fp8) is no longer fatal on its own -- the shapes
+        # carry the dtype the GEMM actually ran in.
         precision = str(getattr(self.ctx, "precision", "") or "bf16").lower()
-        op = _TUNABLEOP_OP_BY_PRECISION.get(precision)
-        if op is None:
-            log.warning(
-                "%s: no TunableOp record type for precision %r, so demand cannot be turned into an input file",
-                self.name,
-                precision,
-            )
-            return None
+        fallback_op = _TUNABLEOP_OP_BY_PRECISION.get(precision)
 
         lines = []
+        unsupported: dict[str, int] = {}
         for shape in shapes:
             try:
                 m, n, k = int(shape["M"]), int(shape["N"]), int(shape["K"])
             except (KeyError, TypeError, ValueError):
                 continue
+            op = _tunableop_op_for_dtype(shape.get("dtype") or shape.get("otype")) or fallback_op
+            if op is None:
+                label = str(shape.get("dtype") or shape.get("otype") or f"precision={precision}")
+                unsupported[label] = unsupported.get(label, 0) + 1
+                continue
             lines.append(tunableop_untuned_line(m, n, k, op))
+        if unsupported:
+            detail = ", ".join(f"{k} x{v}" for k, v in sorted(unsupported.items()))
+            log.warning(
+                "%s: %d demand shape(s) skipped, no TunableOp record type for %s",
+                self.name,
+                sum(unsupported.values()),
+                detail,
+            )
+            if not lines:
+                # Every shape was an unsupported dtype. The demand file was read
+                # and understood, so this is "nothing here for this tuner", not
+                # a missing input; run() reports it as skipped.
+                self._demand_skip_reason = f"no TunableOp record type for {detail}"
         if not lines:
             return None
 
@@ -322,8 +370,21 @@ class VllmDenseTunableopTuner(BaseTuner):
             return self.ctx.shapes_json
         return self._input_from_demand()
 
+    # Set by _input_from_demand when the demand file parsed fine but carried no
+    # shape this tuner has a record type for. Distinguishes "nothing to do" from
+    # "the input never arrived".
+    _demand_skip_reason: str = ""
+
     def run(self) -> TuneResult:
         input_file = self._resolve_input()
+        if input_file is None and self._demand_skip_reason:
+            log.info("%s: skipped -- %s", self.name, self._demand_skip_reason)
+            return TuneResult(
+                tuner_name=self.name,
+                status="skipped",
+                error=self._demand_skip_reason,
+                error_class="unsupported_precision",
+            )
         if input_file is None:
             # Say which sources were offered and why none produced a file. The
             # bare "No valid input file found" cost a real run: the router had

--- a/src/kernelforge/gemm_tune/tuners/vllm_dense_tunableop.py
+++ b/src/kernelforge/gemm_tune/tuners/vllm_dense_tunableop.py
@@ -328,9 +328,17 @@ class VllmDenseTunableopTuner(BaseTuner):
                 m, n, k = int(shape["M"]), int(shape["N"]), int(shape["K"])
             except (KeyError, TypeError, ValueError):
                 continue
-            op = _tunableop_op_for_dtype(shape.get("dtype") or shape.get("otype")) or fallback_op
+            # The fallback applies only to shapes the demand parser recorded
+            # WITHOUT a dtype. A shape that carries one aiter actually logged is
+            # authoritative: falling back would write, say, an fp8 lookup as a
+            # BFloat16_TN record and tune a shape the runtime never asks for --
+            # the exact coercion this module refuses to do.
+            raw_dtype = shape.get("dtype") or shape.get("otype")
+            op = _tunableop_op_for_dtype(raw_dtype)
+            if op is None and not str(raw_dtype or "").strip():
+                op = fallback_op
             if op is None:
-                label = str(shape.get("dtype") or shape.get("otype") or f"precision={precision}")
+                label = str(raw_dtype or "").strip() or f"precision={precision}"
                 unsupported[label] = unsupported.get(label, 0) + 1
                 continue
             lines.append(tunableop_untuned_line(m, n, k, op))


### PR DESCRIPTION
## What this is

GEMM tuning has been running on the fleet for months without ever producing a measurable end-to-end gain. The investigation found that this is not one bug — there are four independent, each-individually-sufficient reasons, plus a set of observability defects that made all of them invisible.

This PR fixes the input plumbing and the observability. It does **not** fix the two decision-layer causes (anchor ratcheting, paired-confirmation gate); those are listed as backlog at the bottom.

The single biggest measured symptom: **tuned shapes cover 0.4% of the shapes the runtime actually uses.** Three of forge's shape inputs were never connected, and a fourth was connected to the wrong file.

---

## The three unconnected input ports

forge's `gemm-tune run` accepts `--shapes-manifest`, `--demand`, and `--tokens`. All three existed on both sides. None of them carried anything.

| Port | forge side | Hyperloom side | Why nothing arrived |
|---|---|---|---|
| `--shapes-manifest` | present; documented as the *preferred* dense-shape source | `_trace_shape_manifest.py` writes `trace_shape_manifest.json` | Producer gated behind `HYPERLOOM_TRACE_SHAPE_MANIFEST`, default **off**. On the rare run where it was set, the file was written and never read — the kernel-agent wrapper's only CLI arg is `--input-json`, and `_build_cmd` had no `--shapes-manifest` flag. |
| `--demand` | present; falls back to re-deriving demand from `--kernel-signature-log` | evidence step can produce `demand.json` | No flag in `_build_cmd`, and the fallback was being fed the wrong serving log (see below). |
| `--tokens` | present | `_build_cmd` already forwarded it | The auto-GEMM payload in `phases/kernel.py` carries only `{task_id, reason, macro_cycle}`, so it was always empty. forge then fell back to deriving M from `conc` alone. |

### What `--tokens` was actually costing us

forge's fallback derives the M values to tune from `conc`. Real fleet serving logs reach **M=15842** — far outside anything that derivation produces. So even when the N/K dims were right, M was wrong, and the aiter lookup missed.

The fix does not re-derive M from `conc` in a different place (that is still a guess). It reads M straight off the serving log, which is the only record of what the model actually ran, and takes the **12 most frequent** distinct values. Frequency rather than magnitude: tuning the M values the model spends its time at beats tuning the largest one it ever reached. An explicit `tokens` in the payload still wins.

---

## The five defects from the *Forge three-lane functional defect root-cause* document

All five are fixed. They have no overlap with the four fixes already on `main` (`a9526ea8e`+KF#53, `bba6e9f96`, `b1e3cdf33`, `867f119cb`).

**#1 — Multi-value server-arg flags rejected at the integrate sink** (`5b3fba05c`)
`validate_server_args_shell_safe` tracked `expect_value` as a bool and reset it after one value, so `--cuda-graph-bs 1 2 4 8 16 24 32 48 64` threw on the second number. A recipe that ran fine in explore was refused at integrate. Now a flag may be followed by any run of non-`-` tokens; only a bare positional in first position is rejected. Shell metacharacters are still caught separately by `_UNSAFE_SERVER_ARG_CHARS_RE`, so this does not weaken the safety check.

**#2 — E2E verdict never reached `result.json`** (`068e74bd9`)
The GEMM e2e verdict was computed and then dropped on the floor; the workspace `result.json` kept the pre-verdict content. Now written back, including on the exception path.

**#3 — Serving log picked by existence, not by evidence** (`4c50a2311`) — *highest leverage*
`_resolve_forge_server_log` returned the first `server.log` that existed. A `current_best` workspace whose server never routed a GEMM through aiter therefore ended the search, and the `runs/` fallback — which might hold a log that did — was unreachable. The tuner was handed a file with no shapes in it. This feeds both the fmoe_ck MoE shape source *and* forge's `--demand` self-recovery path, so it is a direct contributor to the 0.4%.

Every candidate now has to carry an aiter dispatch line (hit or miss — either proves the process reached aiter). The scan is chunked with an overlap, because a fleet `server.log` is ~17MB and the answer is usually in the first few KB. When logs exist but none dispatched, the warning names `AITER_LOG_TUNED_CONFIG`; previously both failure modes returned a silent `""`.

Confirmed on real fleet data, not hypothesised: a scan replicating the old selection logic over the controller's session archive found genuine mis-picks, e.g. `DeepSeek-V4-Flash/20260805T084114Z` (73 logs present, exactly 1 with aiter evidence, and the old logic did not pick it).

**#4 — TunableOp record type taken from the checkpoint, not the shape** (`6d7a412b7`)
`vllm_dense_tunableop.py` looked up `ctx.precision` in `_TUNABLEOP_OP_BY_PRECISION`; `mxfp4`/`fp8` are not in that map, so the tuner returned `None` and discarded the entire demand file. Measured on `Qwen3.8-2.4T-A95B-Quark-MXFP4`: **all 21056** aiter dense lookups log `dtype='torch.bfloat16'` while `ctx.precision="mxfp4"`. The whole demand set was thrown away over a checkpoint-level label that did not describe the shapes.

Now the per-shape `dtype` (falling back to `otype`) picks the record type, with `ctx.precision` only as a backstop.

**#5 — Accuracy-filtered rows reported as a budget shortfall** (`6e8a644e8`)
`sglang_dense_bf16` compared surviving rows against `n_expected`, so rows aiter's own accuracy check removed looked like shapes the tuner never reached. The warning told the reader to raise `--timeout`, when the timeout was fine. Now compares `total + len(dropped)`, and the warning text branches on which of the two actually happened.

---

## Our own two incomplete fixes

**MoE layer count** (`9743ca8e1`)
`867f119cb` restored the MoE FFN to the PerfModel breakdown, but charged it to *all* `num_hidden_layers` and kept skipping the dense FFN entirely — overcorrecting in the opposite direction. Real checkpoints run a dense prefix: GLM-5.3 and GLM-5.3-Flash both set `first_k_dense_replace: 3`.

`ModelMeta` gains `moe_layers` / `dense_ffn_layers`, derived from `first_k_dense_replace`, `moe_layer_freq` (list or stride), `decoder_sparse_step`, and `mlp_only_layers`. The MoE op and `_compute_expert_decomposition` charge `moe_layers`; gate/up/down charge `dense_ffn_layers` and are now emitted for MoE models too. Attention/SDPA still repeat over every layer, which was already correct.

Note a deliberate direction change: per-token `active_weight_bytes` goes **up** for a model with a dense prefix. That is right — moving weights out of the expert pool means they are read for every token instead of 8-of-288 of the time, so the old accounting under-counted decode weight traffic. Asserted explicitly with that reasoning in `test_expert_bytes_are_charged_to_moe_layers_only`.

**Coverage regex — deliberately not changed**
The plan called for making `_AITER_SHAPE_HIT_TABLE_RE`'s table-name suffix optional. On reading the code this is wrong and I dropped it:

- `parse_aiter_shape_lookups` uses `_AITER_SHAPE_HIT_RE`, which anchors on `is tuned` with no table requirement — it is *already* truncation-tolerant.
- The table-qualified pattern is used only by `parse_aiter_shape_lookups_for_tables` and `parse_aiter_consulted_tables`, which need the table name by definition. Counting a table-less hit toward `wanted` would reintroduce exactly the false positive `b1e3cdf33` fixed.
- 5672/5672 hit lines in real fleet logs carry the table name.

`4c50a2311` has no dependency on this — its evidence check is a plain `shape is M:` substring scan.

---

## Deliberate deviations from the plan

1. **#4 does not coerce mxfp4/fp8 to a bf16 record type.** I cannot verify that PyTorch uses a bf16 TunableOp record type for fp8 GEMMs, and the coercion is unnecessary because the shapes themselves already carry `torch.bfloat16`. Genuinely unknown dtypes are skipped with a counted warning, and the tuner reports `skipped` / `unsupported_precision` rather than `input_missing` (which would be read as "upstream gave us nothing").

2. **#5 adds a `filtered_shapes` field instead of a new `accuracy_filtered` status.** `phases/kernel.py` admits exactly `("ok", "partial_output")` into e2e. A new status would have silently stopped a *completed* batch from reaching e2e — a regression trap. `test_partial_output_still_reaches_e2e` guards this.

3. **`--tokens` is derived in `request_handlers.py` from serving-log evidence, not in `phases/kernel.py` from `conc`.** The plan's location could only re-derive from `conc`, which is the guess we are trying to replace. Deriving it where the serving log is already resolved is evidence-based and benefits every caller, not just kernel entry.

4. **Two sub-items of plan #3 were stale.** The plan named `writeback.py:2832` and `router.py::_select_sglang_tuners` (mark fmoe_ck `skipped` not `failed`). After the rebase onto `main`, `orchestrator/kernel/writeback.py` no longer exists, and `_select_sglang_tuners` (now in `kernelforge/gemm_tune/router.py`) already uses `skip_reason` on its unsupported branches. Nothing to change.

5. **Shard cap added.** Building the manifest on every run means paying for it on every run — each capture shard costs a full `analyze_trace` pass plus a sha256. The cap therefore defaults to 64 instead of unlimited. It is a budget, not a filter: shards are taken in discovery order and the drop is logged. `HYPERLOOM_TRACE_SHAPE_MANIFEST_MAX_CAPTURES=0` restores unlimited.

---

## Commits

| Commit | Subject |
|---|---|
| `a701ee514` | Match aiter hit lines and retried integrate runs when grading GEMM coverage |
| `b1edc3178` | Scope GEMM runtime hits to the candidate table |
| `7120d16ff` | Stop dropping the MoE FFN from the perfmodel breakdown |
| `5b3fba05c` | Accept multi-value server-arg flags at the integrate sink *(doc #1)* |
| `068e74bd9` | Write the GEMM E2E verdict back to the workspace result.json *(doc #2)* |
| `6d7a412b7` | Take the TunableOp record type from the shape, not the checkpoint *(doc #4)* |
| `6e8a644e8` | Stop reporting accuracy-filtered rows as a budget shortfall *(doc #5)* |
| `9743ca8e1` | Split the decoder stack into MoE and dense-FFN layers |
| `1fd79ba0a` | Build the trace shape manifest by default and forward it to forge *(ports 1+2)* |
| `4c50a2311` | Pick the GEMM serving log by aiter evidence, and read tokens off it *(doc #3, port 3)* |
| `e32d0831e` | Apply ruff format to the files this branch touched |
| `90f989e56` | Update two test stubs that the new GEMM behaviours invalidated |
| `d1b6a11a0` | Reserve `--tokens` budget for the largest observed M |

---

## Measured on real fleet logs

Two sessions were replayed through the branch to check the fixes against
recorded runtime behaviour rather than synthetic input. Both had been reverted
as `tuned_config_never_applied[no_shape_key_matched]` with `coverage_pct: 0.0`.

`main`'s hit pattern is `shape is M:(\d+), N:(\d+), K:(\d+), found padded_M:`,
which requires a comma directly after `K` followed by ` found`. Real aiter lines
carry `dtype=... otype=... bias=... scaleAB=... bpreshuffle=False` in between and
no comma after `K`, so the pattern matches nothing and the hit count is
structurally zero for every dense candidate.

| Session | `main` | this branch |
|---|---|---|
| `Qwen3-8B/20260831T111849Z` | hit 0 / miss 6 — **0.0%** | hit 62 / miss 6 — **91.2%** |
| `Qwen3.8-2.4T-MXFP4/20260830T132550Z` | hit 0 / miss 74 — **0.0%** | hit 146 / miss 74 — **66.4%** |

All hits are attributed to the candidate's own `merged_tuned_dense_bf16.csv`, so
the table was applied and served the majority of lookups in both runs. The
`never applied` verdict that drove both REVERTs was a grading artefact.

The same replay caught a defect in this branch's own `--tokens` derivation; see
`d1b6a11a0`.

## Verification

**Unit tests.** Each commit ships tests, and every one was revert-verified — the source file is restored, the tests are re-run, and the intended tests are confirmed to fail. No vacuous tests. Counts on revert: doc #4 → 7 fail, doc #5 → 5 fail, MoE split → 23/23 fail, serving-log evidence → 23/25 fail.

Test data is taken from the fleet, not invented: the aiter hit/miss lines are copied verbatim from a controller `server.log`, and the GLM-5.3 / GLM-5.3-Flash layer counts are read off `/shared_nfs/models/*/config.json`.

**Regression.** `orchestrator/kernel`, `agents/kernel`, and `kernelforge/gemm_tune` suites pass.

**Known-failing on Windows only, pre-existing and unrelated:** 15 collection errors from `import fcntl`, plus failures in `test_tracelens_csv.py`, `test_source_resolution_guards.py`, and `test_utils_extra.py` (path-separator escaping and `os.killpg`). Present before and after these changes; a clean run needs Linux.

**Not run: GPU verification.** No before/after session was executed on an MI355X. The claims in this PR about *what the code now does* are covered by the tests above; claims about coverage improving from 0.4% are **not** yet measured end-to-end.

**Throughput is explicitly not an acceptance criterion for this PR.** Everything here is input plumbing and observability. The two causes that actually gate e2e gain — anchor ratcheting and the paired-confirmation gate — are out of scope. Measured run-to-run noise on this fleet is 58%, so a single throughput number could not attribute anything anyway.

---

## Backlog (not in this PR)

Anchor ratcheting (`current_best` only ever rises, so it can lock onto a noise peak) and the paired-confirmation gate (`if kept:` plus `HYPERLOOM_GEMM_PAIRED_PAIRS` defaulting to 0 pairs) — these are the two causes that actually gate end-to-end gain.

Also: `--untuned-csv` silently ignored; stale `apply_verification.py` docstring; one-sided second-round stability floor; router only ever adds tuners; no global time budget; unbuffered subprocess stdout; MXFP4 CPU data-generation cache; pure-MoE configs missing `intermediate_size`; nested `Eagle3Speculator` config; CI's `DP adjusted local rank`; Kimi-K3's `hidden_act: "situ"`; `/tmp/aiter_configs/bf16_tuned_gemm.csv` shared across sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



