### PR TITLE
fix(phases): stop starving a phase of budget on every macro-cycle re-entry

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_phase_cumulative_budget.py
+++ b/src/hyperloom/inference_optimizer/tests/test_phase_cumulative_budget.py
@@ -1,25 +1,19 @@
 # SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Per-phase budgets are a share of the RUN, not a share of every entry.
+"""Per-phase time accounting across macro-cycle re-entries.
 
-``phase_started_unix`` is reset on every phase entry, so a budget guard reading
-it alone measures only the current entry. Because the pipeline is a macro-cycle
-(FRAMEWORK_AGENT -> EXPLORE -> KERNEL_AGENT -> SWEEP -> reloop), each phase is
-re-entered once per cycle and used to be handed its whole allotment again on
-every entry. A real 24h session entered KERNEL_AGENT three times, burned a fresh
-3.6h each time, and finished at 288% of a cap that never fired.
+``phase_started_unix`` is reset on every phase entry, so a guard reading it alone
+measures only the current entry. Because the pipeline reloops (FRAMEWORK_AGENT ->
+EXPLORE -> KERNEL_AGENT -> SWEEP -> reloop), each phase is re-entered once per
+cycle. A real 24h session entered KERNEL_AGENT three times, burned a fresh 3.6h
+each time, and finished at 288% of a cap that never fired.
 
-These tests pin the fixed contract: ``phase_cumulative_seconds`` totals every
-entry, the absolute cap (``phase_cap_exceeded``) reads that total, and
-``phase_elapsed_seconds`` keeps its per-entry meaning for renderers, evidence
-dicts, and the per-cycle budget.
-
-The lifetime ceiling is the cap's job alone. ``phase_budget_remaining_seconds``
-is subtracted from a charge-back allotment that is already reconstructed from
-the current entry, so charging it the cumulative total too billed earlier
-entries twice and starved every re-entry of budget — which skipped the phase on
-each macro-cycle instead of pacing it.
+These tests pin which guard reads which clock: the absolute cap
+(``phase_cap_exceeded``) totals every entry, while the per-cycle budget
+(``phase_budget_remaining_seconds``) charges only the current one — its allotment
+is already charge-back-reduced by earlier entries, so billing the total twice
+starved every re-entry.
 
 They also pin the resume half of it: a phase entry is not closed by the process
 exiting, so the current entry spans the idle gap between two run legs unless the
@@ -139,9 +133,8 @@ def test_phase_budget_remaining_charges_only_the_current_entry():
 
     total = ps._phase_budget_total_seconds(state, now_unix=now)
     assert total is not None and total > 0.0
-    # The allotment is already charged back against the clock at this entry, so
-    # the three banked entries are paid for by a smaller `total` — not by a
-    # second subtraction on top of it.
+    # Charge-back already pays for the three banked entries via a smaller
+    # `total`, not via a second subtraction on top of it.
     assert ps.phase_elapsed_seconds(state, now_unix=now) == 0.0
     assert ps.phase_budget_remaining_seconds(state, now_unix=now) == pytest.approx(total)
 
@@ -151,48 +144,32 @@ def test_phase_budget_remaining_charges_only_the_current_entry():
     )
 
 
-def test_the_absolute_cap_is_what_stops_a_phase_that_spent_its_share():
-    # The per-cycle budget no longer carries the lifetime ceiling, so the cap has
-    # to be the thing that ends a phase which already outspent its share.
+def test_the_absolute_cap_stops_a_phase_that_outspent_its_share():
+    # With charge-back active the per-cycle budget no longer ends such a phase,
+    # so the cap has to.
     state = _kernel_state()
     state.start_ts = T0_ISO
-    long_entry = 4 * 3600.0
     now = T0
     for _ in range(3):
         _enter(state, ps.PHASE_KERNEL_AGENT, now)
-        now += long_entry
+        now += 4 * 3600.0
         _enter(state, ps.PHASE_SWEEP, now)
         now += GAP_SEC
     _enter(state, ps.PHASE_KERNEL_AGENT, now)
 
-    assert ps.phase_cumulative_seconds(state, now_unix=now) == pytest.approx(3 * long_entry)
     assert ps.phase_cumulative_seconds(state, now_unix=now) > KERNEL_CAP_SEC
     assert ps.phase_cap_exceeded(state, now_unix=now) is True
-    # exit_normal_kernel checks both, so the phase still ends on this entry.
-    result = ps.exit_normal_kernel(state, now_unix=now)
-    assert result is not None and result[0] in {"kernel_budget_cap", "kernel_phase_budget_exhausted"}
+    assert ps.exit_normal_kernel(state, now_unix=now) is not None
 
 
 def test_a_macro_cycle_reentry_gets_budget_while_the_session_has_time_left():
-    """A re-entered phase under its absolute cap must be able to work again.
-
-    Reproduces an 18h AgentX session: FRAMEWORK_AGENT spent 27567s in cycle 0,
-    then `cycle_reloop` re-entered it with 27584s of session still unspent and
-    the 51840s absolute cap nowhere near. Charging the cumulative total against
-    a per-entry allotment returned 0, so the dispatcher paused new work
-    (`_dispatch_paused_for_phase_budget`) and the phase exited in ~60s on each
-    of the next two cycles — the run closed `global_converged` at 0.00% gain
-    with 7.5h unspent.
-    """
-    session_sec = 18 * 3600.0
-    prelude_sec = 9579.0
-    cycle0_sec = 27567.0
-    sweep_sec = 67.0
-
+    # An 18h --no-kernel session: FRAMEWORK_AGENT spent 27567s in cycle 0, then
+    # cycle_reloop re-entered it with 27584s of session left and the 51840s cap
+    # far away. Charging the cumulative total returned 0, so the dispatcher
+    # paused and the phase exited in ~60s on each of the next two cycles.
     state = SharedState()
-    state.max_minutes = session_sec / 60.0
+    state.max_minutes = 18 * 60.0
     state.start_ts = T0_ISO
-    # The shares a `--no-kernel` run lands on after redistribute_budget_pct.
     state.phase_budget_pct = {
         ps.PHASE_PRELUDE: 0.03,
         ps.PHASE_FRAMEWORK_AGENT: 0.80,
@@ -203,23 +180,16 @@ def test_a_macro_cycle_reentry_gets_budget_while_the_session_has_time_left():
 
     now = T0
     _enter(state, ps.PHASE_PRELUDE, now)
-    now += prelude_sec
+    now += 9579.0
     _enter(state, ps.PHASE_FRAMEWORK_AGENT, now)
-    now += cycle0_sec
+    now += 27567.0
     _enter(state, ps.PHASE_SWEEP, now)
-    now += sweep_sec
+    now += 67.0
     _enter(state, ps.PHASE_FRAMEWORK_AGENT, now)
 
-    assert ps.phase_cumulative_seconds(state, now_unix=now) == pytest.approx(cycle0_sec)
-    # Plenty of session left, and the phase is far from its absolute ceiling.
     assert ps.session_remaining_seconds(state, now_unix=now) > 7 * 3600.0
     assert ps.phase_cap_exceeded(state, now_unix=now) is False
-
-    remaining = ps.phase_budget_remaining_seconds(state, now_unix=now)
-    assert remaining is not None
-    # It gets its share of what is left, not zero.
-    assert remaining > 6 * 3600.0
-    # And the phase does not immediately exit on a budget it does have.
+    assert ps.phase_budget_remaining_seconds(state, now_unix=now) > 6 * 3600.0
     assert ps.exit_normal_optimize(state, now_unix=now) is None
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_phase_cumulative_budget.py
+++ b/src/hyperloom/inference_optimizer/tests/test_phase_cumulative_budget.py
@@ -11,8 +11,15 @@ every entry. A real 24h session entered KERNEL_AGENT three times, burned a fresh
 3.6h each time, and finished at 288% of a cap that never fired.
 
 These tests pin the fixed contract: ``phase_cumulative_seconds`` totals every
-entry, the cap/budget guards read that total, and ``phase_elapsed_seconds``
-keeps its per-entry meaning for renderers and evidence dicts.
+entry, the absolute cap (``phase_cap_exceeded``) reads that total, and
+``phase_elapsed_seconds`` keeps its per-entry meaning for renderers, evidence
+dicts, and the per-cycle budget.
+
+The lifetime ceiling is the cap's job alone. ``phase_budget_remaining_seconds``
+is subtracted from a charge-back allotment that is already reconstructed from
+the current entry, so charging it the cumulative total too billed earlier
+entries twice and starved every re-entry of budget — which skipped the phase on
+each macro-cycle instead of pacing it.
 
 They also pin the resume half of it: a phase entry is not closed by the process
 exiting, so the current entry spans the idle gap between two run legs unless the
@@ -124,23 +131,29 @@ def test_per_entry_elapsed_keeps_its_meaning():
     assert ps.phase_cumulative_seconds(state, now_unix=live) == pytest.approx(3 * ENTRY_SEC + 1800.0)
 
 
-def test_phase_budget_remaining_charges_every_entry():
+def test_phase_budget_remaining_charges_only_the_current_entry():
     state = _kernel_state()
     state.start_ts = T0_ISO
     now = _three_kernel_entries(state)
     _enter(state, ps.PHASE_KERNEL_AGENT, now)
 
     total = ps._phase_budget_total_seconds(state, now_unix=now)
-    remaining = ps.phase_budget_remaining_seconds(state, now_unix=now)
     assert total is not None and total > 0.0
-    # The per-entry numerator this used to subtract is zero at a fresh entry, so
-    # the old contract handed the phase its whole allotment back on re-entry.
+    # The allotment is already charged back against the clock at this entry, so
+    # the three banked entries are paid for by a smaller `total` — not by a
+    # second subtraction on top of it.
     assert ps.phase_elapsed_seconds(state, now_unix=now) == 0.0
-    assert remaining == pytest.approx(total - 3 * ENTRY_SEC)
-    assert remaining < total
+    assert ps.phase_budget_remaining_seconds(state, now_unix=now) == pytest.approx(total)
+
+    mid = now + 900.0
+    assert ps.phase_budget_remaining_seconds(state, now_unix=mid) == pytest.approx(
+        ps._phase_budget_total_seconds(state, now_unix=mid) - 900.0
+    )
 
 
-def test_phase_budget_remaining_hits_zero_once_the_share_is_spent():
+def test_the_absolute_cap_is_what_stops_a_phase_that_spent_its_share():
+    # The per-cycle budget no longer carries the lifetime ceiling, so the cap has
+    # to be the thing that ends a phase which already outspent its share.
     state = _kernel_state()
     state.start_ts = T0_ISO
     long_entry = 4 * 3600.0
@@ -152,7 +165,62 @@ def test_phase_budget_remaining_hits_zero_once_the_share_is_spent():
         now += GAP_SEC
     _enter(state, ps.PHASE_KERNEL_AGENT, now)
 
-    assert ps.phase_budget_remaining_seconds(state, now_unix=now) == 0.0
+    assert ps.phase_cumulative_seconds(state, now_unix=now) == pytest.approx(3 * long_entry)
+    assert ps.phase_cumulative_seconds(state, now_unix=now) > KERNEL_CAP_SEC
+    assert ps.phase_cap_exceeded(state, now_unix=now) is True
+    # exit_normal_kernel checks both, so the phase still ends on this entry.
+    result = ps.exit_normal_kernel(state, now_unix=now)
+    assert result is not None and result[0] in {"kernel_budget_cap", "kernel_phase_budget_exhausted"}
+
+
+def test_a_macro_cycle_reentry_gets_budget_while_the_session_has_time_left():
+    """A re-entered phase under its absolute cap must be able to work again.
+
+    Reproduces an 18h AgentX session: FRAMEWORK_AGENT spent 27567s in cycle 0,
+    then `cycle_reloop` re-entered it with 27584s of session still unspent and
+    the 51840s absolute cap nowhere near. Charging the cumulative total against
+    a per-entry allotment returned 0, so the dispatcher paused new work
+    (`_dispatch_paused_for_phase_budget`) and the phase exited in ~60s on each
+    of the next two cycles — the run closed `global_converged` at 0.00% gain
+    with 7.5h unspent.
+    """
+    session_sec = 18 * 3600.0
+    prelude_sec = 9579.0
+    cycle0_sec = 27567.0
+    sweep_sec = 67.0
+
+    state = SharedState()
+    state.max_minutes = session_sec / 60.0
+    state.start_ts = T0_ISO
+    # The shares a `--no-kernel` run lands on after redistribute_budget_pct.
+    state.phase_budget_pct = {
+        ps.PHASE_PRELUDE: 0.03,
+        ps.PHASE_FRAMEWORK_AGENT: 0.80,
+        ps.PHASE_KERNEL_AGENT: 0.0,
+        ps.PHASE_SWEEP: 0.10555555555555557,
+        ps.PHASE_CLOSE: 0.02,
+    }
+
+    now = T0
+    _enter(state, ps.PHASE_PRELUDE, now)
+    now += prelude_sec
+    _enter(state, ps.PHASE_FRAMEWORK_AGENT, now)
+    now += cycle0_sec
+    _enter(state, ps.PHASE_SWEEP, now)
+    now += sweep_sec
+    _enter(state, ps.PHASE_FRAMEWORK_AGENT, now)
+
+    assert ps.phase_cumulative_seconds(state, now_unix=now) == pytest.approx(cycle0_sec)
+    # Plenty of session left, and the phase is far from its absolute ceiling.
+    assert ps.session_remaining_seconds(state, now_unix=now) > 7 * 3600.0
+    assert ps.phase_cap_exceeded(state, now_unix=now) is False
+
+    remaining = ps.phase_budget_remaining_seconds(state, now_unix=now)
+    assert remaining is not None
+    # It gets its share of what is left, not zero.
+    assert remaining > 6 * 3600.0
+    # And the phase does not immediately exit on a budget it does have.
+    assert ps.exit_normal_optimize(state, now_unix=now) is None
 
 
 def test_totals_accumulate_for_every_phase_not_just_explore():

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -1101,9 +1101,9 @@ def phase_cumulative_seconds(
     """Return wall-clock seconds spent in ``phase``, summed over EVERY entry.
 
     :func:`phase_elapsed_seconds` measures the CURRENT entry only, because
-    ``phase_started_unix`` is reset on every phase entry. Each phase is re-entered
-    once per macro-cycle, so a budget guard built on it hands the phase a fresh
-    full allotment on every re-entry. This reads the durable
+    ``phase_started_unix`` is reset on every phase entry. The absolute cap
+    (:func:`phase_cap_exceeded`) bounds the whole run, so it needs this total
+    rather than one entry's clock. This reads the durable
     ``phase_elapsed_totals`` banked at each transition out of the phase and adds
     the live segment when ``phase`` is the phase currently running.
 
@@ -1239,27 +1239,16 @@ def phase_budget_remaining_seconds(
     budget_pct: dict[str, float] | None = None,
     now_unix: float | None = None,
 ) -> float | None:
-    """Return seconds remaining in the current phase's budget (``None`` when budget window 0 = unlimited).
+    """Return seconds left in the current phase ENTRY's budget (``None`` when budget window 0 = unlimited).
 
-    Charges the CURRENT entry (:func:`phase_elapsed_seconds`), because the
-    allotment it is subtracted from is itself a per-entry quantity:
+    Charges :func:`phase_elapsed_seconds`, matching the allotment's basis:
     :func:`_phase_budget_total_seconds` charges back against the clock at this
-    entry's start, so it already shrinks by whatever earlier entries spent.
-    Subtracting the cumulative total as well charges those entries twice, and a
-    phase whose first entry saturated its share then reads ``0`` on every later
-    one — no macro-cycle can hand it budget again no matter how much session is
-    left. Measured on an 18h run: at the cycle-1 re-entry the session still had
-    27584s and the phase's own allotment for that entry was 23842s, but the
-    27567s cycle-0 spend drove this to 0, so cycles 1 and 2 lasted 64s and 78s
-    and the run closed ``global_converged`` with 7.5h unspent.
+    entry's start, so earlier entries are already priced into it. Subtracting
+    the cumulative total as well bills them twice, which pins a re-entered phase
+    at ``0`` for the rest of the run however much session is left.
 
-    This is a per-cycle planning number, NOT the guard against a phase
-    monopolising the run. That guard is :func:`phase_cap_exceeded`, which
-    compares :func:`phase_cumulative_seconds` against the absolute
-    :func:`phase_cap_seconds` ceiling; every exit predicate that consumes this
-    function checks it in the same breath (``exit_normal_optimize`` /
-    ``exit_normal_kernel`` / ``exit_normal_sweep``), so lifetime spend stays
-    bounded across re-entries.
+    Lifetime spend is bounded by :func:`phase_cap_exceeded` instead; every exit
+    predicate that reads this checks that cap alongside it.
 
     Args:
         state (Any): Frozen SharedState view.
@@ -1268,9 +1257,9 @@ def phase_budget_remaining_seconds(
         now_unix (float | None): Override for the current time.
 
     Returns:
-        float | None: Non-negative seconds left in the current phase entry's
-        budget, or ``None`` when the budget window is unlimited or the phase has
-        no allocated fraction.
+        float | None: Non-negative seconds left in this entry's budget, or
+        ``None`` when the budget window is unlimited or the phase has no
+        allocated fraction.
     """
     total = _phase_budget_total_seconds(state, budget_pct=budget_pct, now_unix=now_unix)
     if total is None:

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -1241,13 +1241,25 @@ def phase_budget_remaining_seconds(
 ) -> float | None:
     """Return seconds remaining in the current phase's budget (``None`` when budget window 0 = unlimited).
 
-    Charges the phase's CUMULATIVE spend (:func:`phase_cumulative_seconds`), not
-    just the current entry: the budget fraction is the phase's share of the run,
-    so a phase re-entered on a later macro-cycle resumes from what it has already
-    spent instead of being handed its whole allotment again. Note the allotment
-    itself (:func:`_phase_budget_total_seconds`) still reconstructs the base from
-    the CURRENT entry — it charges back against the clock at this entry's start,
-    which is a per-entry quantity by construction.
+    Charges the CURRENT entry (:func:`phase_elapsed_seconds`), because the
+    allotment it is subtracted from is itself a per-entry quantity:
+    :func:`_phase_budget_total_seconds` charges back against the clock at this
+    entry's start, so it already shrinks by whatever earlier entries spent.
+    Subtracting the cumulative total as well charges those entries twice, and a
+    phase whose first entry saturated its share then reads ``0`` on every later
+    one — no macro-cycle can hand it budget again no matter how much session is
+    left. Measured on an 18h run: at the cycle-1 re-entry the session still had
+    27584s and the phase's own allotment for that entry was 23842s, but the
+    27567s cycle-0 spend drove this to 0, so cycles 1 and 2 lasted 64s and 78s
+    and the run closed ``global_converged`` with 7.5h unspent.
+
+    This is a per-cycle planning number, NOT the guard against a phase
+    monopolising the run. That guard is :func:`phase_cap_exceeded`, which
+    compares :func:`phase_cumulative_seconds` against the absolute
+    :func:`phase_cap_seconds` ceiling; every exit predicate that consumes this
+    function checks it in the same breath (``exit_normal_optimize`` /
+    ``exit_normal_kernel`` / ``exit_normal_sweep``), so lifetime spend stays
+    bounded across re-entries.
 
     Args:
         state (Any): Frozen SharedState view.
@@ -1256,14 +1268,14 @@ def phase_budget_remaining_seconds(
         now_unix (float | None): Override for the current time.
 
     Returns:
-        float | None: Non-negative seconds left in the current phase's budget,
-        or ``None`` when the budget window is unlimited or the phase has no
-        allocated fraction.
+        float | None: Non-negative seconds left in the current phase entry's
+        budget, or ``None`` when the budget window is unlimited or the phase has
+        no allocated fraction.
     """
     total = _phase_budget_total_seconds(state, budget_pct=budget_pct, now_unix=now_unix)
     if total is None:
         return None
-    return max(0.0, total - phase_cumulative_seconds(state, now_unix=now_unix))
+    return max(0.0, total - phase_elapsed_seconds(state, now_unix=now_unix))
 
 
 def effective_max_minutes(state: Any) -> float:

--- a/src/hyperloom/orchestrator/state/_shared_state/render.py
+++ b/src/hyperloom/orchestrator/state/_shared_state/render.py
@@ -208,9 +208,8 @@ class _RenderMixin:
 
         phase = (self.phase or "").strip().upper() or "UNSET"
         elapsed = int(phase_elapsed_seconds(self, now_unix=now_unix))
-        # ``remaining`` is charged against every entry of this phase, so showing
-        # only the current entry's elapsed time next to it reads as a
-        # contradiction on a re-entered phase: "elapsed_sec=0 remaining_sec=0".
+        # ``remaining`` paces this entry; the absolute cap reads ``cumulative``.
+        # A re-entered phase needs both to be legible.
         cumulative = int(phase_cumulative_seconds(self, now_unix=now_unix))
         budget = normalize_budget_pct(budget_pct or self.phase_budget_pct)
         budget_pct_for_phase = budget.get(phase, 0.0)


### PR DESCRIPTION

## Problem

`phase_budget_remaining_seconds` subtracted the phase's **cumulative** spend from an
allotment that `_phase_budget_total_seconds` builds **per entry**. Charge-back already
reconstructs that allotment from the clock at the current entry's start, so earlier
entries are priced into it. Subtracting the cumulative total billed them a second time,
which pins a re-entered phase at `0` for the rest of the run.

That reads as the phase being skipped rather than paced:

- `dispatcher._dispatch_paused_for_phase_budget()` stops launching new work at `0` — the
  queue accepts tasks and never drains.
- `exit_normal_optimize` / `exit_normal_kernel` / `exit_normal_sweep` exit on the same
  predicate, so the phase leaves immediately and `cycle_reloop` buys nothing.

## Evidence

An 18h AgentX session (`--no-kernel`, so FRAMEWORK_AGENT held 0.80 after
`redistribute_budget_pct`), replayed from its persisted `state.json` at the cycle-1
re-entry:

| | before | after |
|---|---|---|
| `session_remaining` | 27584s | 27584s |
| entry allotment | 23842s | 23842s |
| cumulative spend (cycle 0) | 27567s | 27567s |
| **budget remaining** | **0s** | **23842s** |
| absolute cap / exceeded | 51840s / no | 51840s / no |
| `exit_normal_optimize` | exits | `None` |

Cycles 1 and 2 lasted 64s and 78s. The run closed `global_converged` at 0.00% gain with
7.5h of an 18h budget unspent.

## Fix

Charge the current entry, matching the allotment's basis:

```python
return max(0.0, total - phase_elapsed_seconds(state, now_unix=now_unix))
```

The lifetime ceiling was never this function's job. `phase_cap_exceeded` compares
`phase_cumulative_seconds` against `phase_cap_seconds`, and every exit predicate that
reads the budget checks that cap in the same breath, so spend across re-entries stays
bounded. That cap is also what cumulative accounting was originally added for — a 24h
session that entered KERNEL_AGENT three times and finished at 288% of a cap that never
fired — and it still reads cumulative time.

Side effect: `phases/kernel.py` sizes the GEAK subprocess timeout from this value. It
previously got `0` on a re-entered phase and killed the subprocess on arrival.

Also corrects three places that still described the budget as cumulative
(`phase_cumulative_seconds`, the phase-block renderer, and the test module).

## Tests

- `test_a_macro_cycle_reentry_gets_budget_while_the_session_has_time_left` — models the
  session above; fails on `assert 0.0 > 21600.0` without the fix.
- `test_phase_budget_remaining_charges_only_the_current_entry` — replaces the assertion
  that pinned the old contract.
- `test_the_absolute_cap_stops_a_phase_that_outspent_its_share` — an over-spent phase
  still exits, now via the cap.

394 tests pass across the phase-budget surface (13 files plus robustness signals).
