### PR TITLE
fix(attribution): carry the phase into the two children that spawn without one

### DIFF
--- a/src/hyperloom/agents/robustness/runtime/cli.py
+++ b/src/hyperloom/agents/robustness/runtime/cli.py
@@ -55,6 +55,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from hyperloom.common.llm_attribution import set_current_phase
 from hyperloom.common.subprocess_bridge import RuntimeAdapterError, emit_json, read_json
 
 from ..config import Config
@@ -175,6 +176,15 @@ async def _run_tick(request: dict[str, Any]) -> dict[str, Any]:
         tick_index=tick_index,
         now_unix=now_unix,
     )
+
+    # This runs one process below the orchestrator, where the published phase is
+    # empty, so the RCA calls this tick makes would reach the gateway with no
+    # phase on them. The Coordinator prompt carries the phase for exactly this
+    # tick, which makes it the only honest value here -- and the reactor is
+    # re-entered per tick, so re-publishing tracks a run that moves on. An
+    # absent block parses to "", which suppresses the field rather than pinning
+    # a stale one.
+    set_current_phase(reactor_ctx.phase)
 
     bundle = build_reactor_components(config, session_id=session_id)
     try:

--- a/src/hyperloom/agents/robustness/tests/test_runtime_cli.py
+++ b/src/hyperloom/agents/robustness/tests/test_runtime_cli.py
@@ -88,6 +88,55 @@ async def test_run_tick_emits_alert_on_high_crash_count(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "phase_block, expected",
+    [
+        ("=== Phase ===\nphase     : FRAMEWORK_AGENT\n", "FRAMEWORK_AGENT"),
+        # No block is the honest absence of a phase, not a reason to keep the
+        # last one: this process is re-entered per tick and a run moves on.
+        ("", ""),
+    ],
+)
+async def test_run_tick_publishes_the_phase_the_prompt_carries(tmp_path: Path, phase_block: str, expected: str):
+    """RCA spends from a process one below the orchestrator.
+
+    The published phase is a module global, so this interpreter starts with
+    none and every RCA call would reach the gateway unplaceable in the run.
+    The Coordinator prompt is the only transport that knows the phase here.
+    """
+    from hyperloom.common.llm_attribution import current_phase, set_current_phase
+    from hyperloom.agents.robustness.runtime.cli import _coerce_request, _run_tick
+
+    set_current_phase("STALE_PHASE")
+    try:
+        request = _coerce_request(
+            {
+                "kind": "coordinator_inbox",
+                "session_id": "sess-phase",
+                "raw_prompt": (
+                    f"{phase_block}"
+                    "=== Shared session state ===\n"
+                    "session_id=sess-phase\n"
+                    "crash_count=0\n"
+                    "=== Inbox for robustness ===\n"
+                    "(no new messages)\n"
+                ),
+                "context": {"tick_index": 0, "now_unix": 1700000000.0},
+                "options": {
+                    "session_dir": str(tmp_path),
+                    "auto_probe_inference_server": False,
+                    "ray_probe_enabled": False,
+                    "external_deps_enabled": False,
+                },
+            }
+        )
+        await _run_tick(request)
+        assert current_phase() == expected
+    finally:
+        set_current_phase("")
+
+
+@pytest.mark.asyncio
 async def test_run_tick_hands_the_parsed_snapshot_to_the_reactor(tmp_path: Path, monkeypatch):
     """Every parsed shared-state field must survive the trip into the reactor."""
     captured: dict[str, object] = {}

--- a/src/hyperloom/inference_optimizer/tests/test_llm_stability_and_subprocess_kill.py
+++ b/src/hyperloom/inference_optimizer/tests/test_llm_stability_and_subprocess_kill.py
@@ -14,6 +14,7 @@ import time
 
 import pytest
 
+from hyperloom.common import llm_attribution
 from hyperloom.orchestrator.roles._llm_stability_env import (
     DEFAULT_API_TIMEOUT_MS,
     apply_llm_stability_env,
@@ -22,6 +23,13 @@ from hyperloom.orchestrator.kernel.request_handlers import _run_subprocess, _too
 from hyperloom.orchestrator.trace.task_progress import progress_scope
 
 from .conftest import chatty_child, suppression_window_s
+
+
+@pytest.fixture(autouse=True)
+def _reset_published_phase():
+    """The phase is a module global; leaving one set would label later tests."""
+    yield
+    llm_attribution.set_current_phase("")
 
 
 def test_apply_llm_stability_env_sets_defaults():
@@ -75,6 +83,46 @@ async def test_run_subprocess_leaves_an_operator_chosen_buffering_alone(monkeypa
     rc, stdout, _stderr = await _run_subprocess(_ECHO_UNBUFFERED, timeout_sec=30)
     assert rc == 0
     assert stdout.strip() == "0"
+
+
+_ECHO_TAGS = [
+    "python3",
+    "-c",
+    "import os; print(os.environ.get('ANTHROPIC_CUSTOM_HEADERS', '(unset)'))",
+]
+
+
+async def test_run_subprocess_carries_the_phase_into_its_child(monkeypatch):
+    """The kernel tools spend a phase's money and cannot name the phase.
+
+    It is a module global of the orchestrator, so the child interpreter starts
+    with none; without this the tools that do name themselves still reach the
+    gateway unplaceable in the run.
+    """
+    monkeypatch.setenv(llm_attribution.ATTRIBUTION_ENV, "litellm")
+    monkeypatch.setenv(llm_attribution.CLAW_SESSION_ID_ENV, "claw-abc")
+    monkeypatch.setenv(llm_attribution.ANTHROPIC_CUSTOM_HEADERS_ENV, "Ocp-Apim-Subscription-Key: secret")
+    llm_attribution.set_current_phase("KERNEL_AGENT")
+
+    rc, stdout, _stderr = await _run_subprocess(_ECHO_TAGS, timeout_sec=30)
+
+    assert rc == 0
+    assert "phase=KERNEL_AGENT" in stdout
+    assert "session=claw-abc" in stdout
+    # The operator's own header has to survive being joined, not be replaced.
+    assert "Ocp-Apim-Subscription-Key" in stdout
+
+
+async def test_run_subprocess_leaves_an_unconfigured_deployment_alone(monkeypatch):
+    """No gateway selected means the child sees the env it always did."""
+    monkeypatch.delenv(llm_attribution.ATTRIBUTION_ENV, raising=False)
+    monkeypatch.delenv(llm_attribution.ANTHROPIC_CUSTOM_HEADERS_ENV, raising=False)
+    llm_attribution.set_current_phase("KERNEL_AGENT")
+
+    rc, stdout, _stderr = await _run_subprocess(_ECHO_TAGS, timeout_sec=30)
+
+    assert rc == 0
+    assert stdout.strip() == "(unset)"
 
 
 async def test_run_subprocess_counts_the_lines_its_child_emits(monkeypatch):

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -1644,12 +1644,25 @@ async def _run_subprocess(
             subprocess.TimeoutExpired: When the command exceeds ``timeout_sec``.
         """
         env = os.environ.copy()
+        from hyperloom.common.llm_attribution import inject_env
+
         from ..actions.executors._multi_node_env import (
             is_multi_node,
             ray_gcs_address_from_state,
             infera_ssh_env_from_state,
         )
         from ..actions.executors._subprocess_kill import run_with_session_kill
+
+        # Every kernel tool spends through this one spawn, and the phase it
+        # spends in lives only in this process: a new interpreter starts with
+        # none and cannot restate it. Without the tag the tools that do name
+        # themselves -- tracelens, the candidate reviewer -- still arrive at the
+        # gateway with no phase, so their spend cannot be placed in the run.
+        #
+        # The component stands for whichever calls the child does not name
+        # itself, and these tools are the kernel agent's; the ones that do name
+        # themselves refine it. What only this side can supply is the phase.
+        inject_env(env, component="kernel_agent", operation=_tool_label(cmd))
 
         if is_multi_node():
             # Infera backend: route GEAK GPU work to a pod over SSH (no Ray).


### PR DESCRIPTION
## Why

#1346 taught a child to inherit the ambient fields from its parent's tag, but two spawn sites never wrote a tag at all, so there was nothing to inherit. Both run an interpreter below the orchestrator, where the published phase is a module global that starts empty and cannot be restated from inside.

Measured on a live run (`42005977-54dc-41ab-b492-dd0c96baf8a8`): 285 gateway calls arrived with no phase and could not be placed anywhere in the run's timeline. They come from `tracelens/analyze_trace`, `kernel_agent/review_candidates` and the robustness RCA.

## What

- `_run_subprocess` (kernel tools): inject the tag on the child env. Every kernel tool spawns through this one helper. The tools that name themselves keep their own `component`/`operation`; the phase is the part only the parent knows. The `component` given here stands for whichever calls the child does not name itself, and those are the kernel agent's.
- Robustness runtime tick: publish the phase the Coordinator prompt carries. The reactor is re-entered per tick and the prompt is the only transport that knows the phase at this depth, so re-publishing tracks a run that moves on. An absent block parses to `""`, which suppresses the field rather than pinning a stale one.

No new component vocabulary: both reuse existing labels, so no rollup splits.

## Test plan

- [x] Three new tests, each verified to fail without the fix and pass with it:
  - `_run_subprocess` carries `phase=` and `session=` into the real child, and joins rather than replaces an operator's existing header
  - an unconfigured deployment (no gateway selected) hands its child exactly the env it always did
  - the robustness tick publishes the prompt's phase, and clears a stale one when the prompt carries none
- [x] `ruff check` / `ruff format --check` clean on the changed files
- [x] 1392 passed across `agents/robustness`, `common`, the kernel request-handler suites, and the attribution coverage guard

Made with [Cursor](https://cursor.com)