### PR TITLE
fix: baseline pre-start cleanup no longer relies on port-health probing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -409,7 +409,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   whose timed-out rounds most often leave one of these orphans -- now also
   reap any lingering server once they themselves finish, shrinking the
   window an orphan can sit on the GPU before the next baseline attempt.
-  (AMD-AGI/Hyperloom#1354)
+  `_kill_stale_servers()` itself is now scoped to our own GPU allocation
+  when one is known (`ROCR_VISIBLE_DEVICES` et al set by an operator that
+  carved us a subset of the machine's cards): a matching process is only
+  reaped when its own visible-GPU mask overlaps ours, and a candidate whose
+  mask cannot be read or declares none at all is left alone rather than
+  reaped, so it can no longer touch a co-tenant's server parked on a
+  different subset of the same machine. (AMD-AGI/Hyperloom#1354)
 - **GEMM tuning no longer discards the MoE dispatch key.** `gemm-tune run`
   derived its demand file only when the serving log carried dense tuned-config
   misses, so a MoE-only model -- or one whose dense tables all hit while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -389,6 +389,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **A baseline round no longer OOMs against a server a prior sweep/explore
+  round's timeout left orphaned.** `BaselineExecutor`'s pre-start cleanup
+  ran only on the double-run path, and only when the reuse port answered
+  `/health` with no matching pid/json metadata (a "zombie" heuristic). That
+  heuristic was unreliable either way: an eligible `server_lifecycle` port
+  is a freshly OS-assigned ephemeral port confirmed free at assignment time,
+  so it always reported unhealthy and the cleanup never fired even when a
+  same-port zombie was in fact present; an ineligible port fell back to a
+  fixed default that could coincide with an unrelated co-tenant's server,
+  risking the opposite failure. Pre-start cleanup now runs unconditionally
+  before every baseline round (double-run and single-round alike -- the
+  latter being the common way the kernel phase re-establishes its
+  baseline), reaping any lingering server via the same `_kill_stale_servers()`
+  `/proc` scan already used elsewhere: Hyperloom's own scheduling
+  (`gpu_research_lane`, capacity 1) guarantees at most one server-holding
+  task runs at a time, so nothing matching should be alive at this point
+  regardless of port health. (AMD-AGI/Hyperloom#1354)
 - **GEMM tuning no longer discards the MoE dispatch key.** `gemm-tune run`
   derived its demand file only when the serving log carried dense tuned-config
   misses, so a MoE-only model -- or one whose dense tables all hit while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,7 +405,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   `/proc` scan already used elsewhere: Hyperloom's own scheduling
   (`gpu_research_lane`, capacity 1) guarantees at most one server-holding
   task runs at a time, so nothing matching should be alive at this point
-  regardless of port health. (AMD-AGI/Hyperloom#1354)
+  regardless of port health. `conc_sweep` and `explore` -- the two actions
+  whose timed-out rounds most often leave one of these orphans -- now also
+  reap any lingering server once they themselves finish, shrinking the
+  window an orphan can sit on the GPU before the next baseline attempt.
+  (AMD-AGI/Hyperloom#1354)
 - **GEMM tuning no longer discards the MoE dispatch key.** `gemm-tune run`
   derived its demand file only when the serving log carried dense tuned-config
   misses, so a MoE-only model -- or one whose dense tables all hit while

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
@@ -2271,181 +2271,18 @@ def test_double_run_runtime_anchor_is_full_warmup_round(tmp_path, monkeypatch):
     assert result["measure_round_runtime_sec"] < result["subprocess_runtime_sec"]
 
 
-def test_double_run_pre_start_cleanup_kills_zombie_and_clears_stale_meta(
-    tmp_path,
-    monkeypatch,
-):
-    """When the reuse port is occupied by a zombie (healthy but no metadata),
-    pre-start cleanup must (a) unlink stale pid/json without sending signals to
-    potentially-recycled PIDs, and (b) invoke _kill_stale_servers() to reap the
-    zombie listener."""
-    base = tmp_path / "base.yaml"
-    _write_yaml(base, framework="vllm")
-    output_dir = tmp_path / "ws"
-    output_dir.mkdir(parents=True)
-    (output_dir / "vllm_8888.pid").write_text("2147483646")
-    monkeypatch.setattr(
-        "hyperloom.orchestrator.actions.executors._server_lifecycle._pick_free_port",
-        lambda: 8888,
-    )
+def test_pre_start_cleanup_unlinks_meta_and_kills_unconditionally(tmp_path, monkeypatch):
+    """Pre-start cleanup no longer probes port health: it unconditionally
+    (a) unlinks stale pid/json without sending signals to potentially-recycled
+    PIDs, and (b) invokes _kill_stale_servers() -- Hyperloom's own scheduling
+    (gpu_research_lane, capacity 1) guarantees nothing matching should be
+    alive at this point, so no extra evidence is required before reaping.
 
-    kill_calls = {"n": 0}
-
-    def fake_kill():
-        kill_calls["n"] += 1
-
-    captured: list = []
-    fake_run, state = _cold_then_hot_fake_run(captured)
-    executor = _executor(base, tmp_path, baseline_double_run=True)
-    ctx = _make_ctx(
-        {
-            "output_dir": str(output_dir),
-            "timeout_sec": 10,
-            "gpu_type": "mi300x",
-        }
-    )
-
-    with (
-        patch.object(
-            type(executor),
-            "_port_healthy",
-            return_value=True,
-        ),
-        patch(
-            "hyperloom.orchestrator.actions.executors.baseline._kill_stale_servers",
-            side_effect=fake_kill,
-        ),
-        patch(
-            "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
-            side_effect=fake_run,
-        ),
-    ):
-        result = _run(executor(ctx))
-
-    assert result["status"] == "succeeded"
-    assert kill_calls["n"] == 1
-    assert not (output_dir / "vllm_8888.pid").exists()
-    assert state["calls"] == 2
-    assert result["output_throughput"] == pytest.approx(_HOT_TPUT)
-    warmup_lc = captured[0]["benchmark"]["server_lifecycle"]
-    measure_lc = captured[1]["benchmark"]["server_lifecycle"]
-    assert warmup_lc["cleanup"] is False
-    assert measure_lc["cleanup"] is True
-    assert warmup_lc["pid_dir"] == measure_lc["pid_dir"] == str(output_dir)
-
-
-def test_pre_start_cleanup_no_kill_when_port_free(tmp_path, monkeypatch):
-    """When the port is NOT occupied (no zombie), _kill_stale_servers must
-    NOT fire — avoids killing unrelated servers sharing the pod."""
-    base = tmp_path / "base.yaml"
-    _write_yaml(base, framework="vllm")
-    output_dir = tmp_path / "ws"
-    output_dir.mkdir(parents=True)
-    (output_dir / "vllm_8888.pid").write_text("2147483646")
-    monkeypatch.setattr(
-        "hyperloom.orchestrator.actions.executors._server_lifecycle._pick_free_port",
-        lambda: 8888,
-    )
-
-    kill_calls = {"n": 0}
-
-    def fake_kill():
-        kill_calls["n"] += 1
-
-    captured: list = []
-    fake_run, state = _cold_then_hot_fake_run(captured)
-    executor = _executor(base, tmp_path, baseline_double_run=True)
-    ctx = _make_ctx(
-        {
-            "output_dir": str(output_dir),
-            "timeout_sec": 10,
-            "gpu_type": "mi300x",
-        }
-    )
-
-    with (
-        patch.object(
-            type(executor),
-            "_port_healthy",
-            return_value=False,
-        ),
-        patch(
-            "hyperloom.orchestrator.actions.executors.baseline._kill_stale_servers",
-            side_effect=fake_kill,
-        ),
-        patch(
-            "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
-            side_effect=fake_run,
-        ),
-    ):
-        result = _run(executor(ctx))
-
-    assert result["status"] == "succeeded"
-    assert kill_calls["n"] == 0
-    assert not (output_dir / "vllm_8888.pid").exists()
-    assert state["calls"] == 2
-
-
-def test_pre_start_cleanup_no_kill_when_metadata_existed(tmp_path, monkeypatch):
-    """A healthy port with matching metadata is not a zombie signal.
-
-    The global stale-server reaper must not fire for a likely legitimate
-    server. File preservation is covered by the direct pre-start test below;
-    this full double-run path later removes files in final teardown.
+    Calls the method directly (not through the full executor) so clearing
+    ``PYTEST_CURRENT_TEST`` for this one call can't leak into unrelated code
+    paths (e.g. Ray) that also branch on it.
     """
-    base = tmp_path / "base.yaml"
-    _write_yaml(base, framework="vllm")
-    output_dir = tmp_path / "ws"
-    output_dir.mkdir(parents=True)
-    (output_dir / "vllm_8888.pid").write_text("2147483646")
-    monkeypatch.setattr(
-        "hyperloom.orchestrator.actions.executors._server_lifecycle._pick_free_port",
-        lambda: 8888,
-    )
-    (output_dir / "vllm_8888.json").write_text("{}")
-
-    kill_calls = {"n": 0}
-
-    def fake_kill():
-        kill_calls["n"] += 1
-
-    captured: list = []
-    fake_run, state = _cold_then_hot_fake_run(captured)
-    executor = _executor(base, tmp_path, baseline_double_run=True)
-    ctx = _make_ctx(
-        {
-            "output_dir": str(output_dir),
-            "timeout_sec": 10,
-            "gpu_type": "mi300x",
-        }
-    )
-
-    with (
-        patch.object(
-            type(executor),
-            "_port_healthy",
-            return_value=True,
-        ),
-        patch(
-            "hyperloom.orchestrator.actions.executors.baseline._kill_stale_servers",
-            side_effect=fake_kill,
-        ),
-        patch(
-            "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
-            side_effect=fake_run,
-        ),
-    ):
-        result = _run(executor(ctx))
-
-    assert result["status"] == "succeeded"
-    assert kill_calls["n"] == 0
-    assert state["calls"] == 2
-
-
-def test_pre_start_cleanup_preserves_metadata_when_reuse_target_healthy(
-    tmp_path,
-):
-    """Direct guard: do not create port-occupied/no-metadata state."""
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     output_dir = tmp_path / "ws"
     output_dir.mkdir(parents=True)
     pid_file = output_dir / "vllm_8888.pid"
@@ -2459,99 +2296,124 @@ def test_pre_start_cleanup_preserves_metadata_when_reuse_target_healthy(
     def fake_kill():
         kill_calls["n"] += 1
 
-    with (
-        patch.object(
-            type(executor),
-            "_port_healthy",
-            return_value=True,
-        ),
-        patch(
-            "hyperloom.orchestrator.actions.executors.baseline._kill_stale_servers",
-            side_effect=fake_kill,
-        ),
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline._kill_stale_servers",
+        side_effect=fake_kill,
     ):
-        executor._pre_start_cleanup(
-            pid_dir=output_dir,
-            framework="vllm",
-            port=8888,
+        _run(
+            executor._pre_start_cleanup(
+                pid_dir=output_dir,
+                framework="vllm",
+                port=8888,
+            )
         )
 
-    assert kill_calls["n"] == 0
-    assert pid_file.exists()
-    assert meta_file.exists()
+    assert kill_calls["n"] == 1
+    assert not pid_file.exists()
+    assert not meta_file.exists()
 
 
-def test_pre_start_cleanup_failure_does_not_break_double_run(tmp_path, monkeypatch):
-    """The pre-start cleanup is best-effort: a raising _kill_stale_servers()
-    must not abort the run — the double-run proceeds and still succeeds."""
-    base = tmp_path / "base.yaml"
-    _write_yaml(base, framework="vllm")
+def test_pre_start_cleanup_skipped_under_pytest(tmp_path):
+    """Direct guard: _kill_stale_servers must NOT fire while
+    ``PYTEST_CURRENT_TEST`` is set (pytest always sets it for a running
+    test), mirroring the same guard on the per-launch preclean in
+    ``_grid_runner.py``. Stale pid/meta files are still unlinked regardless.
+    """
     output_dir = tmp_path / "ws"
+    output_dir.mkdir(parents=True)
+    pid_file = output_dir / "vllm_8888.pid"
+    meta_file = output_dir / "vllm_8888.json"
+    pid_file.write_text("2147483646")
+    meta_file.write_text("{}")
 
-    def boom():
-        raise RuntimeError("proc scan blew up")
-
-    captured: list = []
-    fake_run, state = _cold_then_hot_fake_run(captured)
-    executor = _executor(base, tmp_path, baseline_double_run=True)
-    ctx = _make_ctx(
-        {
-            "output_dir": str(output_dir),
-            "timeout_sec": 10,
-            "gpu_type": "mi300x",
-        }
-    )
-
-    with (
-        patch.object(
-            type(executor),
-            "_port_healthy",
-            return_value=True,
-        ),
-        patch(
-            "hyperloom.orchestrator.actions.executors.baseline._kill_stale_servers",
-            side_effect=boom,
-        ),
-        patch(
-            "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
-            side_effect=fake_run,
-        ),
-    ):
-        result = _run(executor(ctx))
-
-    assert result["status"] == "succeeded"
-    assert state["calls"] == 2
-
-
-def test_pre_start_cleanup_skipped_when_single_round(tmp_path, monkeypatch):
-    """Single-round (double-run disabled) keeps legacy behaviour: the
-    pre-start deep clean is a double-run-only concern and must not fire."""
-    base = tmp_path / "base.yaml"
-    _write_yaml(base, framework="vllm")
-    output_dir = tmp_path / "ws"
-
+    executor = _executor(tmp_path / "base.yaml", tmp_path)
     kill_calls = {"n": 0}
 
     def fake_kill():
         kill_calls["n"] += 1
 
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline._kill_stale_servers",
+        side_effect=fake_kill,
+    ):
+        _run(
+            executor._pre_start_cleanup(
+                pid_dir=output_dir,
+                framework="vllm",
+                port=8888,
+            )
+        )
+
+    assert kill_calls["n"] == 0, "must be a no-op while PYTEST_CURRENT_TEST is set"
+    assert not pid_file.exists()
+    assert not meta_file.exists()
+
+
+def test_pre_start_cleanup_failure_does_not_break_double_run(tmp_path, monkeypatch):
+    """The pre-start cleanup is best-effort: a raising _kill_stale_servers()
+    must not propagate out of _pre_start_cleanup() itself.
+
+    Calls the method directly (see the "unconditionally" test above for why),
+    with ``_kill_stale_servers`` -- the one piece of real work it does beyond
+    unlinking files -- swapped for a function that raises.
+    """
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    output_dir = tmp_path / "ws"
+    output_dir.mkdir(parents=True)
+
+    def boom():
+        raise RuntimeError("proc scan blew up")
+
+    executor = _executor(tmp_path / "base.yaml", tmp_path)
+
+    with patch(
+        "hyperloom.orchestrator.actions.executors.baseline._kill_stale_servers",
+        side_effect=boom,
+    ):
+        _run(
+            executor._pre_start_cleanup(
+                pid_dir=output_dir,
+                framework="vllm",
+                port=8888,
+            )
+        )
+    # No exception propagated past _pre_start_cleanup: that's the assertion.
+
+
+@pytest.mark.parametrize("baseline_double_run", [True, False])
+def test_pre_start_cleanup_called_once_regardless_of_double_run(tmp_path, baseline_double_run):
+    """The pre-start deep clean must run exactly once before the round(s)
+    boot, whether this is a double-run or a single round.
+
+    This is the kernel-phase re-baseline path: single-round baselines are
+    the common way the kernel phase re-establishes its baseline, and without
+    this an orphan a prior sweep/explore round's timeout left behind would
+    survive into the baseline attempt and OOM the new server
+    (AMD-AGI/Hyperloom#1354).
+    """
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, framework="vllm")
+    output_dir = tmp_path / "ws"
+
+    cleanup_calls: list[dict] = []
+
+    async def fake_cleanup(**kwargs):
+        cleanup_calls.append(kwargs)
+
     captured: list = []
     fake_run, state = _cold_then_hot_fake_run(captured)
-    executor = _executor(base, tmp_path)
+    executor = _executor(base, tmp_path, baseline_double_run=baseline_double_run)
     ctx = _make_ctx(
         {
             "output_dir": str(output_dir),
             "timeout_sec": 10,
             "gpu_type": "mi300x",
-            "baseline_double_run": False,
+            "baseline_double_run": baseline_double_run,
         }
     )
 
     with (
-        patch(
-            "hyperloom.orchestrator.actions.executors.baseline._kill_stale_servers",
-            side_effect=fake_kill,
-        ),
+        patch.object(type(executor), "_pre_start_cleanup", side_effect=fake_cleanup),
         patch(
             "hyperloom.orchestrator.actions.executors.baseline.run_with_session_kill",
             side_effect=fake_run,
@@ -2560,8 +2422,8 @@ def test_pre_start_cleanup_skipped_when_single_round(tmp_path, monkeypatch):
         result = _run(executor(ctx))
 
     assert result["status"] == "succeeded"
-    assert state["calls"] == 1
-    assert kill_calls["n"] == 0
+    assert len(cleanup_calls) == 1
+    assert state["calls"] == (2 if baseline_double_run else 1)
 
 
 def test_teardown_lifecycle_server_removes_state_files(tmp_path):

--- a/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
+++ b/src/hyperloom/inference_optimizer/tests/test_baseline_warmup_double_run.py
@@ -2380,6 +2380,44 @@ def test_pre_start_cleanup_failure_does_not_break_double_run(tmp_path, monkeypat
     # No exception propagated past _pre_start_cleanup: that's the assertion.
 
 
+def test_pre_start_cleanup_skipped_when_round_is_not_affordable(tmp_path):
+    """The pre-start cleanup must not pay its cost for a round the budget
+    gate is about to refuse: it now runs right before the round actually
+    boots (after the affordability check and the Ray lease construction),
+    not up front where an unaffordable round would still have paid for a
+    scan it gets no benefit from (review on AMD-AGI/Hyperloom#1354)."""
+    base = tmp_path / "base.yaml"
+    _write_yaml(base, framework="vllm")
+    output_dir = tmp_path / "ws"
+
+    cleanup_calls: list[dict] = []
+
+    async def fake_cleanup(**kwargs):
+        cleanup_calls.append(kwargs)
+
+    executor = _executor(base, tmp_path)
+    ctx = _make_ctx(
+        {
+            "output_dir": str(output_dir),
+            "timeout_sec": 10,
+            "gpu_type": "mi300x",
+        }
+    )
+
+    with (
+        patch.object(type(executor), "_pre_start_cleanup", side_effect=fake_cleanup),
+        patch.object(
+            type(executor),
+            "_round_affordable_before_ignition",
+            return_value=(False, {"expected_cost_sec": 999.0, "affordable_sec": 0.0, "bound": "session"}),
+        ),
+    ):
+        result = _run(executor(ctx))
+
+    assert result["error_class"] == SESSION_TIME_EXHAUSTED_CLASS
+    assert cleanup_calls == []
+
+
 @pytest.mark.parametrize("baseline_double_run", [True, False])
 def test_pre_start_cleanup_called_once_regardless_of_double_run(tmp_path, baseline_double_run):
     """The pre-start deep clean must run exactly once before the round(s)

--- a/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
+++ b/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
@@ -1915,3 +1915,100 @@ def test_the_admission_price_never_lowers_an_operator_raised_cap(
     """An operator who asked for longer than AgentX derives keeps what they asked for."""
     monkeypatch.setenv("HYPERLOOM_AGENTX", "1")
     assert _granted_cap_sec(99_999) == 99_999.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Post-run orphan reap (AMD-AGI/Hyperloom#1354)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_run_conc_sweep_reaps_stale_servers_after_both_arms(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """After both arms finish (happy path), run_conc_sweep must reap any
+    lingering server via the same broad /proc scan used elsewhere: a
+    per-variant timeout that fires before a server_lifecycle pidfile is
+    written leaves nothing for that pidfile-based teardown to find, so this
+    is the safety net that catches it (AMD-AGI/Hyperloom#1354)."""
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **_kw):
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    kill_calls = {"n": 0}
+
+    def _fake_kill():
+        kill_calls["n"] += 1
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+        patch("hyperloom.orchestrator.kernel.conc_sweep._kill_stale_servers", side_effect=_fake_kill),
+    ):
+        payload = asyncio.run(run_conc_sweep(state, session_dir, concs=[4, 16]))
+
+    assert payload["status"] == "succeeded"
+    assert kill_calls["n"] == 1
+
+
+def test_run_conc_sweep_reaps_stale_servers_even_when_an_arm_raises(
+    session_dir: Path,
+    baseline_yaml: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The reap must fire from a ``finally`` -- even when an arm blows up
+    with an exception that escapes its own internal handling, not just on
+    the happy path. ``_sweep_one_arm_single_server`` itself is mocked out
+    (rather than the ``run_grid`` it calls) so its own per-variant error
+    handling can't swallow the exception before it reaches run_conc_sweep."""
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+
+    async def _boom(*_a, **_kw):
+        raise RuntimeError("arm blew up")
+
+    kill_calls = {"n": 0}
+
+    def _fake_kill():
+        kill_calls["n"] += 1
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep._sweep_one_arm_single_server", side_effect=_boom),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+        patch("hyperloom.orchestrator.kernel.conc_sweep._kill_stale_servers", side_effect=_fake_kill),
+    ):
+        with pytest.raises(RuntimeError):
+            asyncio.run(run_conc_sweep(state, session_dir, concs=[4, 16]))
+
+    assert kill_calls["n"] == 1
+
+
+def test_run_conc_sweep_skips_reap_under_pytest(
+    session_dir: Path,
+    baseline_yaml: Path,
+):
+    """Direct guard: the reap must NOT fire while ``PYTEST_CURRENT_TEST`` is
+    set (pytest always sets it for a running test), mirroring the guard on
+    the per-launch preclean in ``_grid_runner.py``."""
+    state = _make_state(baseline_config_path=str(baseline_yaml))
+
+    async def _fake_run_grid(*, grid: list[GridVariant], **_kw):
+        return [_fake_variant(v.name, throughput=100.0, envs=v.extra_envs) for v in grid]
+
+    kill_calls = {"n": 0}
+
+    def _fake_kill():
+        kill_calls["n"] += 1
+
+    with (
+        patch("hyperloom.orchestrator.kernel.conc_sweep.run_grid", side_effect=_fake_run_grid),
+        patch("hyperloom.orchestrator.kernel.conc_sweep.materialize_config_with_envs", side_effect=_fake_materialize),
+        patch("hyperloom.orchestrator.kernel.conc_sweep._kill_stale_servers", side_effect=_fake_kill),
+    ):
+        payload = asyncio.run(run_conc_sweep(state, session_dir, concs=[4, 16]))
+
+    assert payload["status"] == "succeeded"
+    assert kill_calls["n"] == 0, "must be a no-op while PYTEST_CURRENT_TEST is set"

--- a/src/hyperloom/inference_optimizer/tests/test_explore_executor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_explore_executor.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -2275,3 +2276,71 @@ async def test_explore_executor_historical_failed_and_accepted_rerun(sub_agent_r
     assert fp_failed in tested
     # The latest result for fp_failed overwrites the FAILED entry.
     assert tested[fp_failed]["outcome"] in ("KEEP", "REVERT", "FAILED", "KILLED_OVERTIME")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Post-run orphan reap (AMD-AGI/Hyperloom#1354)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _missing_config_ctx(tmp_path: Path) -> SimpleNamespace:
+    """A ctx that makes __call__ take its earliest ``return`` (missing_config),
+    exercising the wrapper without needing to drive a full benchmark round."""
+    return SimpleNamespace(
+        task=SimpleNamespace(
+            task_id="t-explore-reap",
+            params={"config_path": str(tmp_path / "does_not_exist.yaml")},
+        ),
+        extra={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_explore_call_reaps_stale_servers_even_on_early_return(tmp_path, monkeypatch):
+    """__call__ must reap any lingering server after _run_explore returns,
+    even on its earliest failure path (missing_config) -- not just after a
+    full benchmark round. A magpie_timeout that fires before a
+    server_lifecycle variant's pidfile is ever written leaves nothing for
+    that pidfile-based teardown to find, orphaning its server
+    (AMD-AGI/Hyperloom#1354)."""
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    executor = ExploreExecutor(session_dir=tmp_path)
+    ctx = _missing_config_ctx(tmp_path)
+
+    kill_calls = {"n": 0}
+
+    def fake_kill():
+        kill_calls["n"] += 1
+
+    with patch(
+        "hyperloom.orchestrator.actions.executors.explore._kill_stale_servers",
+        side_effect=fake_kill,
+    ):
+        result = await executor(ctx)
+
+    assert result["status"] == "failed"
+    assert result["error_class"] == "missing_config"
+    assert kill_calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_explore_call_skips_reap_under_pytest(tmp_path):
+    """Direct guard: the reap must NOT fire while ``PYTEST_CURRENT_TEST`` is
+    set (pytest always sets it for a running test), mirroring the guard on
+    the per-launch preclean in ``_grid_runner.py``."""
+    executor = ExploreExecutor(session_dir=tmp_path)
+    ctx = _missing_config_ctx(tmp_path)
+
+    kill_calls = {"n": 0}
+
+    def fake_kill():
+        kill_calls["n"] += 1
+
+    with patch(
+        "hyperloom.orchestrator.actions.executors.explore._kill_stale_servers",
+        side_effect=fake_kill,
+    ):
+        result = await executor(ctx)
+
+    assert result["status"] == "failed"
+    assert kill_calls["n"] == 0, "must be a no-op while PYTEST_CURRENT_TEST is set"

--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner_kill_and_branches_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner_kill_and_branches_unit.py
@@ -271,6 +271,29 @@ def test_kill_stale_servers_reaps_everything_when_we_have_no_mask(monkeypatch):
     assert kill_calls == [1]
 
 
+def test_kill_stale_servers_skips_sleep_when_nothing_was_killed(monkeypatch):
+    """The KFD-release pause must not be paid on the common case where the
+    /proc scan finds nothing to reap. This function now runs at 4 call sites
+    (was 1) instead of just before every Magpie launch, so paying an
+    unconditional sleep here on the "GPU was already clean" case adds up
+    fast (e.g. conc_sweep's own reap immediately followed by baseline's),
+    per review on AMD-AGI/Hyperloom#1354."""
+    _clear_gpu_mask_envs(monkeypatch)
+    slept: list[int] = []
+
+    monkeypatch.setattr(os, "getpid", lambda: 999)
+    monkeypatch.setattr(os, "getpgrp", lambda: 100)
+    monkeypatch.setattr(os, "listdir", lambda _p: ["1"])
+    cmdlines = {"/proc/1/cmdline": b"python\x00-m\x00something_unrelated\x00"}
+    monkeypatch.setattr("builtins.open", _proc_open_factory(cmdlines, {}, {}))
+    monkeypatch.setattr("glob.glob", lambda pat: [])
+    monkeypatch.setattr("time.sleep", lambda s: slept.append(s))
+
+    gr._kill_stale_servers()
+
+    assert slept == []
+
+
 def test_kill_stale_servers_swallows_proc_errors(monkeypatch):
     slept: list[int] = []
 

--- a/src/hyperloom/inference_optimizer/tests/test_grid_runner_kill_and_branches_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_grid_runner_kill_and_branches_unit.py
@@ -42,9 +42,14 @@ def test_kill_stale_servers_noop_in_multi_node(monkeypatch):
     assert slept == []
 
 
-def _proc_open_factory(cmdlines: dict[str, bytes], maps: dict[str, str]):
-    """Build a fake ``open`` that serves /proc cmdline + maps from dicts."""
+def _proc_open_factory(
+    cmdlines: dict[str, bytes],
+    maps: dict[str, str],
+    environs: dict[str, bytes] | None = None,
+):
+    """Build a fake ``open`` that serves /proc cmdline + maps + environ from dicts."""
     real_open = open
+    environs = environs or {}
 
     def _fake_open(path, mode="r", *args, **kwargs):
         p = str(path)
@@ -58,6 +63,11 @@ def _proc_open_factory(cmdlines: dict[str, bytes], maps: dict[str, str]):
             if data is None:
                 raise OSError("no maps")
             return io.StringIO(data)
+        if p.endswith("/environ"):
+            data = environs.get(p)
+            if data is None:
+                raise OSError("no environ")
+            return io.BytesIO(data)
         return real_open(path, mode, *args, **kwargs)
 
     return _fake_open
@@ -93,6 +103,172 @@ def test_kill_stale_servers_kills_pattern_and_orphan_atom(monkeypatch):
     assert set(kill_calls) == {1, 2}
     assert removed  # /dev/shm segments cleared
     assert slept == [8]
+
+
+def _clear_gpu_mask_envs(monkeypatch) -> None:
+    for name in ("ROCR_VISIBLE_DEVICES", "HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"):
+        monkeypatch.delenv(name, raising=False)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GPU-scoped reaping (AMD-AGI/Hyperloom#1354)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_kill_stale_servers_skips_candidate_outside_our_gpu_mask(monkeypatch):
+    """When we have our own visible-GPU mask (an operator carved us a subset
+    of the machine), a matching candidate whose own mask is disjoint from
+    ours must be left alone -- it belongs to someone else's GPU allocation."""
+    _clear_gpu_mask_envs(monkeypatch)
+    monkeypatch.setenv("ROCR_VISIBLE_DEVICES", "4,5,6,7")
+
+    killpg_calls: list[int] = []
+    kill_calls: list[int] = []
+
+    monkeypatch.setattr(os, "getpid", lambda: 999)
+    monkeypatch.setattr(os, "getpgrp", lambda: 100)
+    monkeypatch.setattr(os, "listdir", lambda _p: ["1"])
+    cmdlines = {"/proc/1/cmdline": b"vllm serve\x00--model\x00m\x00"}
+    environs = {"/proc/1/environ": b"ROCR_VISIBLE_DEVICES=0,1\x00PATH=/bin\x00"}
+    monkeypatch.setattr("builtins.open", _proc_open_factory(cmdlines, {}, environs))
+    monkeypatch.setattr(os, "getpgid", lambda pid: 50)
+    monkeypatch.setattr(os, "killpg", lambda pgid, sig: killpg_calls.append(pgid))
+    monkeypatch.setattr(os, "kill", lambda pid, sig: kill_calls.append(pid))
+    monkeypatch.setattr("glob.glob", lambda pat: [])
+    monkeypatch.setattr("time.sleep", lambda s: None)
+
+    gr._kill_stale_servers()
+
+    assert killpg_calls == []
+    assert kill_calls == []
+
+
+def test_kill_stale_servers_kills_candidate_overlapping_our_gpu_mask(monkeypatch):
+    """A matching candidate whose mask overlaps ours (same GPU allocation)
+    is reaped, same as with no mask at all."""
+    _clear_gpu_mask_envs(monkeypatch)
+    monkeypatch.setenv("ROCR_VISIBLE_DEVICES", "4,5,6,7")
+
+    killpg_calls: list[int] = []
+    kill_calls: list[int] = []
+
+    monkeypatch.setattr(os, "getpid", lambda: 999)
+    monkeypatch.setattr(os, "getpgrp", lambda: 100)
+    monkeypatch.setattr(os, "listdir", lambda _p: ["1"])
+    cmdlines = {"/proc/1/cmdline": b"vllm serve\x00--model\x00m\x00"}
+    environs = {"/proc/1/environ": b"ROCR_VISIBLE_DEVICES=6,7\x00PATH=/bin\x00"}
+    monkeypatch.setattr("builtins.open", _proc_open_factory(cmdlines, {}, environs))
+    monkeypatch.setattr(os, "getpgid", lambda pid: 50)
+    monkeypatch.setattr(os, "killpg", lambda pgid, sig: killpg_calls.append(pgid))
+    monkeypatch.setattr(os, "kill", lambda pid, sig: kill_calls.append(pid))
+    monkeypatch.setattr("glob.glob", lambda pat: [])
+    monkeypatch.setattr("time.sleep", lambda s: None)
+
+    gr._kill_stale_servers()
+
+    assert killpg_calls == [50]
+    assert kill_calls == [1]
+
+
+def test_kill_stale_servers_skips_candidate_with_unreadable_environ(monkeypatch):
+    """A candidate whose /proc/<pid>/environ cannot be read (permission,
+    already exited) is skipped, not reaped -- unknown scope is never treated
+    as safe to kill."""
+    _clear_gpu_mask_envs(monkeypatch)
+    monkeypatch.setenv("ROCR_VISIBLE_DEVICES", "4,5,6,7")
+
+    kill_calls: list[int] = []
+
+    monkeypatch.setattr(os, "getpid", lambda: 999)
+    monkeypatch.setattr(os, "getpgrp", lambda: 100)
+    monkeypatch.setattr(os, "listdir", lambda _p: ["1"])
+    cmdlines = {"/proc/1/cmdline": b"vllm serve\x00--model\x00m\x00"}
+    # No environ entry for pid 1 -> _proc_open_factory raises OSError on read.
+    monkeypatch.setattr("builtins.open", _proc_open_factory(cmdlines, {}, {}))
+    monkeypatch.setattr(os, "getpgid", lambda pid: 50)
+    monkeypatch.setattr(os, "killpg", lambda pgid, sig: None)
+    monkeypatch.setattr(os, "kill", lambda pid, sig: kill_calls.append(pid))
+    monkeypatch.setattr("glob.glob", lambda pat: [])
+    monkeypatch.setattr("time.sleep", lambda s: None)
+
+    gr._kill_stale_servers()
+
+    assert kill_calls == []
+
+
+def test_kill_stale_servers_skips_candidate_declaring_no_mask(monkeypatch):
+    """A candidate with a readable but empty environ (no GPU-mask var set at
+    all) is skipped -- its GPU scope is unknown, not "the whole machine"."""
+    _clear_gpu_mask_envs(monkeypatch)
+    monkeypatch.setenv("ROCR_VISIBLE_DEVICES", "4,5,6,7")
+
+    kill_calls: list[int] = []
+
+    monkeypatch.setattr(os, "getpid", lambda: 999)
+    monkeypatch.setattr(os, "getpgrp", lambda: 100)
+    monkeypatch.setattr(os, "listdir", lambda _p: ["1"])
+    cmdlines = {"/proc/1/cmdline": b"vllm serve\x00--model\x00m\x00"}
+    environs = {"/proc/1/environ": b"PATH=/bin\x00HOME=/root\x00"}
+    monkeypatch.setattr("builtins.open", _proc_open_factory(cmdlines, {}, environs))
+    monkeypatch.setattr(os, "getpgid", lambda pid: 50)
+    monkeypatch.setattr(os, "killpg", lambda pgid, sig: None)
+    monkeypatch.setattr(os, "kill", lambda pid, sig: kill_calls.append(pid))
+    monkeypatch.setattr("glob.glob", lambda pat: [])
+    monkeypatch.setattr("time.sleep", lambda s: None)
+
+    gr._kill_stale_servers()
+
+    assert kill_calls == []
+
+
+def test_kill_stale_servers_skips_shm_wipe_when_we_have_a_gpu_mask(monkeypatch):
+    """The /dev/shm wipe carries no GPU/owner tag to scope by, so with a mask
+    of our own it must not run at all: it could otherwise crash a correctly
+    spared co-tenant's server by pulling its shared-memory segments out from
+    under it, even though the per-pid reap above left it alone."""
+    _clear_gpu_mask_envs(monkeypatch)
+    monkeypatch.setenv("ROCR_VISIBLE_DEVICES", "4,5,6,7")
+
+    glob_calls: list[str] = []
+    removed: list[str] = []
+
+    monkeypatch.setattr(os, "getpid", lambda: 999)
+    monkeypatch.setattr(os, "getpgrp", lambda: 100)
+    monkeypatch.setattr(os, "listdir", lambda _p: [])  # no candidates to reap
+    monkeypatch.setattr("builtins.open", _proc_open_factory({}, {}, {}))
+    monkeypatch.setattr("glob.glob", lambda pat: (glob_calls.append(pat), [f"{pat}_seg"])[1])
+    monkeypatch.setattr(os, "remove", lambda f: removed.append(f))
+    monkeypatch.setattr("time.sleep", lambda s: None)
+
+    gr._kill_stale_servers()
+
+    assert glob_calls == [], "the /dev/shm wipe must not even glob when we have a GPU mask"
+    assert removed == []
+
+
+def test_kill_stale_servers_reaps_everything_when_we_have_no_mask(monkeypatch):
+    """With no mask on our own side (whole machine is ours, or nothing is
+    scoping either side), every match is reaped regardless of the
+    candidate's own mask -- this is the pre-existing, unscoped behavior."""
+    _clear_gpu_mask_envs(monkeypatch)
+
+    kill_calls: list[int] = []
+
+    monkeypatch.setattr(os, "getpid", lambda: 999)
+    monkeypatch.setattr(os, "getpgrp", lambda: 100)
+    monkeypatch.setattr(os, "listdir", lambda _p: ["1"])
+    cmdlines = {"/proc/1/cmdline": b"vllm serve\x00--model\x00m\x00"}
+    # No environ served at all; must not matter since we have no mask.
+    monkeypatch.setattr("builtins.open", _proc_open_factory(cmdlines, {}, {}))
+    monkeypatch.setattr(os, "getpgid", lambda pid: 50)
+    monkeypatch.setattr(os, "killpg", lambda pgid, sig: None)
+    monkeypatch.setattr(os, "kill", lambda pid, sig: kill_calls.append(pid))
+    monkeypatch.setattr("glob.glob", lambda pat: [])
+    monkeypatch.setattr("time.sleep", lambda s: None)
+
+    gr._kill_stale_servers()
+
+    assert kill_calls == [1]
 
 
 def test_kill_stale_servers_swallows_proc_errors(monkeypatch):

--- a/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
@@ -834,6 +834,42 @@ def _run_grid_warmup_enabled() -> bool:
     return (raw if raw is not None else "1").strip().lower() not in {"0", "false", "no", "off", ""}
 
 
+def _read_pid_gpu_mask(pid: int) -> tuple[list[int], bool] | None:
+    """Resolve ``pid``'s visible-GPU mask from its own environment.
+
+    Mirrors :func:`hyperloom.orchestrator.bus.gpu_pool._visible_device_mask`
+    (``ROCR_VISIBLE_DEVICES``, then ``HIP``/``CUDA``), but reads a foreign
+    process's ``/proc/<pid>/environ`` instead of our own ``os.environ`` --
+    used to scope :func:`_kill_stale_servers` to our own GPU allocation
+    (AMD-AGI/Hyperloom#1354).
+
+    Args:
+        pid: Candidate process id to inspect.
+
+    Returns:
+        ``(ids, present)`` as in ``_visible_device_mask``, or ``None`` when
+        ``/proc/<pid>/environ`` cannot be read (permission, already exited,
+        etc.) -- callers must treat that as "unknown", not "no mask".
+    """
+    from ...bus.gpu_pool import _parse_gpu_list
+
+    try:
+        with open(f"/proc/{pid}/environ", "rb") as fh:
+            raw = fh.read()
+    except (OSError, PermissionError):
+        return None
+    env = {}
+    for entry in raw.split(b"\0"):
+        if b"=" not in entry:
+            continue
+        key, _, value = entry.partition(b"=")
+        env[key.decode("utf-8", "replace")] = value.decode("utf-8", "replace")
+    for env_name in ("ROCR_VISIBLE_DEVICES", "HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"):
+        if env_name in env:
+            return _parse_gpu_list(env[env_name]), True
+    return [], False
+
+
 def _kill_stale_servers() -> None:
     """Deep-clean any lingering inference server processes + shared memory.
 
@@ -842,12 +878,24 @@ def _kill_stale_servers() -> None:
     pgrep) to avoid clashing with test subprocess mocks. No-op in multi-node
     mode (servers live in RayJob pods).
 
+    Scoped to our own GPU allocation when one is known: if our own process
+    has a visible-GPU mask (``ROCR_VISIBLE_DEVICES`` et al, set whenever an
+    operator carved us a subset of the machine's cards rather than handing us
+    the whole box), a candidate process is only reaped when its own mask
+    overlaps ours. A candidate whose mask cannot be read (permission,
+    already exited) or that declares no mask at all is skipped rather than
+    reaped -- unknown scope is treated as "not ours", never as "safe to
+    kill" (AMD-AGI/Hyperloom#1354). With no mask on our own side (the whole
+    machine is ours, or nothing is scoping either side), every match is
+    reaped as before.
+
     Note:
         Side-effecting and best-effort: it sends signals to matching processes
         and unlinks stale shared-memory segments, swallowing errors. Returns
         nothing.
     """
     from ._multi_node_env import is_multi_node
+    from ...bus.gpu_pool import _visible_device_mask
 
     if is_multi_node():
         return
@@ -878,6 +926,25 @@ def _kill_stale_servers() -> None:
         my_pgid = os.getpgrp()
     except OSError:
         my_pgid = -1
+    my_gpu_ids, my_gpu_mask_present = _visible_device_mask()
+    my_gpu_id_set = frozenset(my_gpu_ids)
+
+    def _in_our_gpu_scope(pid: int) -> bool:
+        """Whether ``pid`` overlaps our own visible-GPU mask.
+
+        No-op (always True) when we have no mask ourselves -- nothing to
+        scope against. Otherwise conservative: an unreadable or absent mask
+        on the candidate's side is out of scope, not in it.
+        """
+        if not my_gpu_mask_present:
+            return True
+        candidate = _read_pid_gpu_mask(pid)
+        if candidate is None:
+            return False
+        candidate_ids, candidate_present = candidate
+        if not candidate_present:
+            return False
+        return not my_gpu_id_set.isdisjoint(candidate_ids)
 
     def _is_orphaned_atom_worker(pid: int, cmdline: bytes) -> bool:
         """Detect an orphaned atom ModelRunner worker by its memory maps.
@@ -925,36 +992,45 @@ def _kill_stale_servers() -> None:
             continue
         text = cmdline.replace(b"\0", b" ").decode("utf-8", "replace")
         is_atom_server = "atom.entrypoints" in text
-        if any(pat in text for pat in _KILL_PATTERNS) or _is_orphaned_atom_worker(pid, cmdline):
-            killed_atom = killed_atom or is_atom_server or b"--multiprocessing-fork" in cmdline
-            # Kill the whole pgrp so atom children die with the leader.
-            try:
-                pgid = os.getpgid(pid)
-                if pgid not in (my_pgid, 0):
-                    os.killpg(pgid, signal.SIGKILL)
-            except (ProcessLookupError, PermissionError, OSError):
-                # Group gone or not ours; fall through to per-pid kill.
-                pass
-            try:
-                os.kill(pid, signal.SIGKILL)
-            except (ProcessLookupError, PermissionError):
-                # Already exited or owned by another user.
-                pass
+        if not (any(pat in text for pat in _KILL_PATTERNS) or _is_orphaned_atom_worker(pid, cmdline)):
+            continue
+        if not _in_our_gpu_scope(pid):
+            continue
+        killed_atom = killed_atom or is_atom_server or b"--multiprocessing-fork" in cmdline
+        # Kill the whole pgrp so atom children die with the leader.
+        try:
+            pgid = os.getpgid(pid)
+            if pgid not in (my_pgid, 0):
+                os.killpg(pgid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            # Group gone or not ours; fall through to per-pid kill.
+            pass
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            # Already exited or owned by another user.
+            pass
 
-    # Clear GPU runtime shared-memory segments that prevent re-binding.
-    for pattern in (  # nosec B108 - intentionally targets known /dev/shm runtime prefixes.
-        "/dev/shm/vllm*",
-        "/dev/shm/nccl*",
-        "/dev/shm/cuda*",
-        "/dev/shm/torch*",
-        "/dev/shm/atom*",
-    ):
-        for f in glob.glob(pattern):
-            try:
-                os.remove(f)
-            except OSError:
-                # Already removed or held by another process.
-                pass
+    # Clear GPU runtime shared-memory segments that prevent re-binding. These
+    # files carry no GPU/owner tag we can scope by, so -- unlike the per-pid
+    # reap above -- they are only touched when we have no GPU mask of our own
+    # (whole machine is ours): with a mask set, a co-tenant's otherwise-spared
+    # server could still crash from having its shared-memory segments pulled
+    # out from under it (AMD-AGI/Hyperloom#1354).
+    if not my_gpu_mask_present:
+        for pattern in (  # nosec B108 - intentionally targets known /dev/shm runtime prefixes.
+            "/dev/shm/vllm*",
+            "/dev/shm/nccl*",
+            "/dev/shm/cuda*",
+            "/dev/shm/torch*",
+            "/dev/shm/atom*",
+        ):
+            for f in glob.glob(pattern):
+                try:
+                    os.remove(f)
+                except OSError:
+                    # Already removed or held by another process.
+                    pass
 
     # Pause for KFD async VRAM release; atom teardown lags past 2s.
     time.sleep(8 if killed_atom else 2)

--- a/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
+++ b/src/hyperloom/orchestrator/actions/executors/_grid_runner.py
@@ -979,6 +979,7 @@ def _kill_stale_servers() -> None:
         return any(sig in maps for sig in _ATOM_MAP_SIGNATURES)
 
     killed_atom = False
+    killed_any = False
     for entry in os.listdir("/proc"):
         if not entry.isdigit():
             continue
@@ -996,6 +997,7 @@ def _kill_stale_servers() -> None:
             continue
         if not _in_our_gpu_scope(pid):
             continue
+        killed_any = True
         killed_atom = killed_atom or is_atom_server or b"--multiprocessing-fork" in cmdline
         # Kill the whole pgrp so atom children die with the leader.
         try:
@@ -1032,8 +1034,13 @@ def _kill_stale_servers() -> None:
                     # Already removed or held by another process.
                     pass
 
-    # Pause for KFD async VRAM release; atom teardown lags past 2s.
-    time.sleep(8 if killed_atom else 2)
+    # Pause for KFD async VRAM release; atom teardown lags past 2s. Skipped
+    # entirely when nothing was actually killed this call -- this function now
+    # runs at 4 call sites (was 1), so paying it unconditionally on the common
+    # "GPU was already clean" case adds up fast (e.g. conc_sweep's own reap
+    # immediately followed by baseline's).
+    if killed_any:
+        time.sleep(8 if killed_atom else 2)
 
 
 def _prepend_magpie_pythonpath(magpie_dir: str, current_pythonpath: str) -> str:

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -3397,6 +3397,19 @@ class BaselineExecutor:
             ctx_extra=extra,
         )
         double_run = double_run_requested and lifecycle["eligible"]
+        # Deep-clean any lingering server BEFORE any round boots. Unconditional
+        # (not just double-run): a single-round baseline is the common path
+        # for kernel-phase re-baselining, and it is exactly the server-start
+        # attempt that must not silently OOM against a server a prior
+        # sweep/explore round's timeout left running (setsid'd server
+        # processes escape that round's process-group teardown; see
+        # _grid_runner._kill_stale_servers). Best-effort and idempotent, so
+        # calling it once here up front is safe for both paths.
+        await self._pre_start_cleanup(
+            pid_dir=output_dir,
+            framework=lifecycle["framework"],
+            port=lifecycle["port"],
+        )
         if defer_accuracy_until_after_measure and double_run:
             # Only the lifecycle path can reuse the hot server for a staged
             # accuracy round. A single-round fallback must retain the original
@@ -3647,13 +3660,6 @@ class BaselineExecutor:
         # server; task root keeps it per-task isolated.
         pid_dir = output_dir
         try:
-            # Deep-clean zombie listeners + stale pid/meta BEFORE round 1 boots.
-            # Runs once here so round 1's server survives for round 2's re-attach.
-            self._pre_start_cleanup(
-                pid_dir=pid_dir,
-                framework=framework,
-                port=port,
-            )
             # Round 1 (warmup): boot + run, leave running so round 2 can
             # re-attach. Throughput discarded (cold-contaminated).
             warmup_dir = output_dir / "warmup_round"
@@ -4235,44 +4241,39 @@ class BaselineExecutor:
             yaml.safe_dump(cfg, f, sort_keys=False)
         return out
 
-    @staticmethod
-    def _port_healthy(port: int, timeout: float = 3.0) -> bool:
-        """Return True when localhost:{port}/health responds HTTP 200.
-
-        Args:
-            port: Local server port to probe.
-            timeout: Per-request timeout in seconds.
-
-        Returns:
-            ``True`` when the health endpoint responds HTTP 200, else
-            ``False``.
-        """
-        import urllib.request
-
-        try:
-            r = urllib.request.urlopen(
-                f"http://127.0.0.1:{port}/health",
-                timeout=timeout,
-            )  # nosec B310 - fixed loopback health check.
-            return r.status == 200
-        except Exception:  # noqa: BLE001
-            return False
-
-    def _pre_start_cleanup(
+    async def _pre_start_cleanup(
         self,
         *,
         pid_dir: Path,
         framework: str,
         port: int,
     ) -> None:
-        """Best-effort startup pre-clean for the double-run path.
+        """Best-effort startup pre-clean, run once before every baseline round.
 
-        Only acts when there is concrete evidence of a zombie: the reuse
-        port responds to /health but the matching metadata file is absent
-        (the exact "Reuse metadata mismatch" trigger). In that case it
-        calls _kill_stale_servers() to reap the orphan listener. Stale
-        pid/json files are always unlinked (without sending signals to
-        potentially-recycled PIDs). Never raises.
+        Unconditionally reaps any lingering vLLM/SGLang/atom server via
+        _kill_stale_servers(). Hyperloom's own scheduling (``gpu_research_lane``,
+        capacity 1) guarantees at most one server-holding task runs at a time,
+        so nothing matching should still be alive at this point, before this
+        task's own server has even booted. A prior sweep/explore round's
+        timeout can leave one running anyway — its setsid'd server process
+        escapes that round's process-group teardown — and this is the safety
+        net that catches it before the new server OOMs against it
+        (AMD-AGI/Hyperloom#1354).
+
+        This used to gate the scan on a "zombie" heuristic: only fire when the
+        reuse port answered /health but had no matching pid/json metadata.
+        That signal was unreliable in both directions and has been dropped:
+        an eligible server_lifecycle port is a freshly OS-assigned ephemeral
+        port (confirmed free at assignment time), so it always reports
+        unhealthy and the scan would never fire; an ineligible port falls
+        back to a fixed default that can coincide with an unrelated
+        co-tenant's server, so the heuristic could also fire on the wrong
+        target.
+
+        Stale pid/json metadata files are always unlinked first (no signal
+        sent to potentially-recycled PIDs). Skipped under pytest, matching
+        the same guard on the per-launch preclean in ``_grid_runner.py``:
+        real ``/proc`` scanning is unsafe there. Never raises.
 
         Args:
             pid_dir: Directory holding the server pid/metadata files.
@@ -4281,34 +4282,16 @@ class BaselineExecutor:
         """
         base = Path(pid_dir)
         tag = f"{framework}_{port}"
-        pid_file = base / f"{tag}.pid"
-        meta_file = base / f"{tag}.json"
-        meta_exists = meta_file.exists()
-        try:
-            port_healthy = self._port_healthy(port)
-        except Exception as exc:  # noqa: BLE001 — best-effort pre-clean
-            log.warning(
-                "baseline_executor: pre-start port probe failed (%s); proceeding.",
-                exc,
-            )
-            port_healthy = False
-        if meta_exists and port_healthy:
-            # A healthy reuse target with metadata is not a zombie; keep the
-            # files so Magpie can reattach.
-            return
-        # Unlink stale metadata/pid files only (no signal to possibly-recycled
-        # PIDs).
-        for p in (pid_file, meta_file):
+        for p in (base / f"{tag}.pid", base / f"{tag}.json"):
             try:
                 if p.exists():
                     p.unlink()
             except OSError:
                 pass
-        # Only deep-clean when the port is occupied by a zombie (healthy
-        # endpoint, no metadata), to avoid killing unrelated servers.
+        if os.environ.get("PYTEST_CURRENT_TEST"):
+            return
         try:
-            if not meta_exists and port_healthy:
-                _kill_stale_servers()
+            await asyncio.to_thread(_kill_stale_servers)
         except Exception as exc:  # noqa: BLE001 — best-effort pre-clean
             log.warning(
                 "baseline_executor: pre-start _kill_stale_servers failed (%s); proceeding.",

--- a/src/hyperloom/orchestrator/actions/executors/baseline.py
+++ b/src/hyperloom/orchestrator/actions/executors/baseline.py
@@ -3397,19 +3397,6 @@ class BaselineExecutor:
             ctx_extra=extra,
         )
         double_run = double_run_requested and lifecycle["eligible"]
-        # Deep-clean any lingering server BEFORE any round boots. Unconditional
-        # (not just double-run): a single-round baseline is the common path
-        # for kernel-phase re-baselining, and it is exactly the server-start
-        # attempt that must not silently OOM against a server a prior
-        # sweep/explore round's timeout left running (setsid'd server
-        # processes escape that round's process-group teardown; see
-        # _grid_runner._kill_stale_servers). Best-effort and idempotent, so
-        # calling it once here up front is safe for both paths.
-        await self._pre_start_cleanup(
-            pid_dir=output_dir,
-            framework=lifecycle["framework"],
-            port=lifecycle["port"],
-        )
         if defer_accuracy_until_after_measure and double_run:
             # Only the lifecycle path can reuse the hot server for a staged
             # accuracy round. A single-round fallback must retain the original
@@ -3612,6 +3599,22 @@ class BaselineExecutor:
         from ._ray_serving import maybe_serving_lease
 
         bench_lease = maybe_serving_lease(num_gpus=_num_gpus_for_config(materialized_config_path))
+
+        # Deep-clean any lingering server right before this round actually
+        # boots -- after every earlier gate that can still bail out without
+        # starting a server (budget, warm-patch failure), so a round that
+        # will not run does not pay for a scan it gets no benefit from.
+        # Unconditional (not just double-run): a single-round baseline is the
+        # common path for kernel-phase re-baselining, and it is exactly the
+        # server-start attempt that must not silently OOM against a server a
+        # prior sweep/explore round's timeout left running (setsid'd server
+        # processes escape that round's process-group teardown; see
+        # _grid_runner._kill_stale_servers). Best-effort and idempotent.
+        await self._pre_start_cleanup(
+            pid_dir=output_dir,
+            framework=lifecycle["framework"],
+            port=lifecycle["port"],
+        )
 
         common = {
             "timeout_sec": timeout_sec,

--- a/src/hyperloom/orchestrator/actions/executors/explore.py
+++ b/src/hyperloom/orchestrator/actions/executors/explore.py
@@ -24,6 +24,7 @@ the ``return`` at the end of ``__call__`` for the authoritative field set.
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import logging
 import os
@@ -63,6 +64,7 @@ from ._grid_runner import (
     _MN_BACKENDS_PRIORITY,
     _MN_PARAMS_PRIORITY,
     GridVariant,
+    _kill_stale_servers,
     _num_gpus_for_config,
     _resolve_session_dir,
     apply_aiter_moe_pin_filter,
@@ -674,9 +676,16 @@ class ExploreExecutor:
     async def __call__(self, ctx) -> dict[str, Any]:
         """Run the merged ``explore`` action for one task.
 
-        Resolves the benchmark config and output workspace, builds the
-        candidate grid (programmatic seed and/or LLM/specialist variants),
-        and benchmarks each variant with per-variant KEEP/REVERT gating.
+        Thin wrapper around :meth:`_run_explore` that guarantees a
+        post-round GPU sweep regardless of how the task ends (success,
+        failure, or an early ``return``): every variant this task started is
+        expected to be torn down by its own per-variant finally by the time
+        this returns, but a magpie_timeout that fires before a
+        server_lifecycle variant's pidfile is ever written leaves nothing
+        for that pidfile-based teardown to find, orphaning its server
+        (AMD-AGI/Hyperloom#1354). Skipped under pytest (unsafe there),
+        matching the guard on the per-launch preclean in ``_grid_runner.py``.
+        Best-effort; never raises.
 
         Args:
             ctx: The action runner context carrying the task and params.
@@ -686,6 +695,20 @@ class ExploreExecutor:
             accepted/rejected variants and ledger updates), or a failure
             dict on error.
         """
+        try:
+            return await self._run_explore(ctx)
+        finally:
+            if not os.environ.get("PYTEST_CURRENT_TEST"):
+                try:
+                    await asyncio.to_thread(_kill_stale_servers)
+                except Exception:  # noqa: BLE001 - best-effort safety net
+                    log.warning(
+                        "explore: post-run _kill_stale_servers failed",
+                        exc_info=True,
+                    )
+
+    async def _run_explore(self, ctx) -> dict[str, Any]:
+        """Run body for :meth:`__call__`; see its docstring for the wrapper."""
         params = dict(ctx.task.params or {})
         # ----- Config / output workspace -----------------------------------
         config_path = Path(params.get("config_path") or self.default_config_path or default_baseline_config())

--- a/src/hyperloom/orchestrator/kernel/conc_sweep.py
+++ b/src/hyperloom/orchestrator/kernel/conc_sweep.py
@@ -1402,7 +1402,11 @@ async def run_conc_sweep(
                 for v in skip_grid_fn():
                     results.append(_budget_skip_result(v))
                 continue
-            if has_budget and _arm_remaining is not None and _arm_remaining < _granted_cap_sec(variant_timeout_sec, state):
+            if (
+                has_budget
+                and _arm_remaining is not None
+                and _arm_remaining < _granted_cap_sec(variant_timeout_sec, state)
+            ):
                 _budget_state["budget_exhausted"] = True
                 _budget_state["budget_skip_reason"] = "insufficient_remaining_for_variant"
                 _budget_state["budget_remaining_sec"] = max(0.0, float(_arm_remaining))

--- a/src/hyperloom/orchestrator/kernel/conc_sweep.py
+++ b/src/hyperloom/orchestrator/kernel/conc_sweep.py
@@ -11,6 +11,7 @@ LLM-proposable.
 
 from __future__ import annotations
 
+import asyncio
 import csv
 import json
 import logging
@@ -27,6 +28,7 @@ from hyperloom.inference_optimizer.session.session_paths import reports_dir, run
 from ..actions.executors._grid_runner import (
     GridVariant,
     VariantResult,
+    _kill_stale_servers,
     agentx_variant_timeout_sec,
     run_grid,
 )
@@ -1379,69 +1381,89 @@ async def run_conc_sweep(
         ("optimized", opt_args, dict(opt_envs)),
         ("baseline", "", {}),
     ]
-    for arm_name, arm_args, arm_envs in arms_order:
-        skip_grid_fn = lambda _an=arm_name, _aa=arm_args, _ae=arm_envs: _build_arm_grid(  # noqa: E731
-            _an,
-            concs_desc,
-            isl=isl,
-            osl=osl,
-            num_prompts_factor=num_prompts_factor,
-            arm_args=_aa,
-            arm_envs=_ae,
-        )
+    try:
+        for arm_name, arm_args, arm_envs in arms_order:
+            skip_grid_fn = lambda _an=arm_name, _aa=arm_args, _ae=arm_envs: _build_arm_grid(  # noqa: E731
+                _an,
+                concs_desc,
+                isl=isl,
+                osl=osl,
+                num_prompts_factor=num_prompts_factor,
+                arm_args=_aa,
+                arm_envs=_ae,
+            )
 
-        # Check overall budget before starting each arm.
-        _arm_remaining = (deadline - time.time()) if has_budget and deadline is not None else None
-        if has_budget and _arm_remaining is not None and _arm_remaining <= 0:
-            _budget_state["budget_exhausted"] = True
-            _budget_state["budget_skip_reason"] = "total_budget_exhausted"
-            _budget_state["budget_remaining_sec"] = max(0.0, float(_arm_remaining))
-            for v in skip_grid_fn():
-                results.append(_budget_skip_result(v))
-            continue
-        if has_budget and _arm_remaining is not None and _arm_remaining < _granted_cap_sec(variant_timeout_sec, state):
-            _budget_state["budget_exhausted"] = True
-            _budget_state["budget_skip_reason"] = "insufficient_remaining_for_variant"
-            _budget_state["budget_remaining_sec"] = max(0.0, float(_arm_remaining))
-            for v in skip_grid_fn():
-                results.append(_budget_skip_result(v))
-            continue
-        if getattr(state, "closing_phase", False) or getattr(state, "stop_reason", ""):
-            _budget_state["budget_exhausted"] = True
-            _budget_state["budget_skip_reason"] = "session_deadline_reserve"
-            _budget_state["budget_remaining_sec"] = 0.0
-            for v in skip_grid_fn():
-                results.append(_budget_skip_result(v))
-            continue
+            # Check overall budget before starting each arm.
+            _arm_remaining = (deadline - time.time()) if has_budget and deadline is not None else None
+            if has_budget and _arm_remaining is not None and _arm_remaining <= 0:
+                _budget_state["budget_exhausted"] = True
+                _budget_state["budget_skip_reason"] = "total_budget_exhausted"
+                _budget_state["budget_remaining_sec"] = max(0.0, float(_arm_remaining))
+                for v in skip_grid_fn():
+                    results.append(_budget_skip_result(v))
+                continue
+            if has_budget and _arm_remaining is not None and _arm_remaining < _granted_cap_sec(variant_timeout_sec, state):
+                _budget_state["budget_exhausted"] = True
+                _budget_state["budget_skip_reason"] = "insufficient_remaining_for_variant"
+                _budget_state["budget_remaining_sec"] = max(0.0, float(_arm_remaining))
+                for v in skip_grid_fn():
+                    results.append(_budget_skip_result(v))
+                continue
+            if getattr(state, "closing_phase", False) or getattr(state, "stop_reason", ""):
+                _budget_state["budget_exhausted"] = True
+                _budget_state["budget_skip_reason"] = "session_deadline_reserve"
+                _budget_state["budget_remaining_sec"] = 0.0
+                for v in skip_grid_fn():
+                    results.append(_budget_skip_result(v))
+                continue
 
-        await _sweep_one_arm_single_server(
-            arm_name,
-            concs_desc,
-            isl=isl,
-            osl=osl,
-            num_prompts_factor=num_prompts_factor,
-            arm_args=arm_args,
-            arm_envs=arm_envs,
-            base_yaml_path=base_yaml_path,
-            workspace=workspace,
-            model_path=resolved_model,
-            gpu_type=resolved_gpu,
-            variant_timeout_sec=variant_timeout_sec,
-            soft_deadline_sec=_session_soft_dl,
-            deadline=deadline,
-            state=state,
-            session_dir=session_dir,
-            json_path=json_path,
-            csv_path=csv_path,
-            started_at=started_at,
-            total_budget_sec=total_budget_sec,
-            has_budget=has_budget,
-            opt_args=opt_args,
-            opt_envs=opt_envs,
-            _all_results_ref=results,
-            _budget_state=_budget_state,
-        )
-        # Results are added to `results` in place by _all_results_ref.
+            await _sweep_one_arm_single_server(
+                arm_name,
+                concs_desc,
+                isl=isl,
+                osl=osl,
+                num_prompts_factor=num_prompts_factor,
+                arm_args=arm_args,
+                arm_envs=arm_envs,
+                base_yaml_path=base_yaml_path,
+                workspace=workspace,
+                model_path=resolved_model,
+                gpu_type=resolved_gpu,
+                variant_timeout_sec=variant_timeout_sec,
+                soft_deadline_sec=_session_soft_dl,
+                deadline=deadline,
+                state=state,
+                session_dir=session_dir,
+                json_path=json_path,
+                csv_path=csv_path,
+                started_at=started_at,
+                total_budget_sec=total_budget_sec,
+                has_budget=has_budget,
+                opt_args=opt_args,
+                opt_envs=opt_envs,
+                _all_results_ref=results,
+                _budget_state=_budget_state,
+            )
+            # Results are added to `results` in place by _all_results_ref.
+    finally:
+        # Safety net, independent of each arm's own per-variant teardown: by
+        # the time both arms have run (or one raised/was cut short), nothing
+        # this conc_sweep started should still be alive -- each arm's own
+        # server is only ever kept warm *between* its own CONC-ladder rounds,
+        # never past the arm itself. A round that timed out before its
+        # server_lifecycle pidfile was ever written leaves that pidfile-based
+        # teardown nothing to find, so this falls back to the broad /proc
+        # scan (AMD-AGI/Hyperloom#1354). Skipped under pytest (unsafe there),
+        # matching the same guard on the per-launch preclean in
+        # _grid_runner.py. Best-effort; never raises.
+        if not os.environ.get("PYTEST_CURRENT_TEST"):
+            try:
+                await asyncio.to_thread(_kill_stale_servers)
+            except Exception:  # noqa: BLE001 - best-effort safety net
+                log.warning(
+                    "conc_sweep: post-run _kill_stale_servers failed",
+                    exc_info=True,
+                )
 
     budget_exhausted = _budget_state["budget_exhausted"]
     budget_skip_reason = _budget_state["budget_skip_reason"]


### PR DESCRIPTION
## Problem

`BaselineExecutor`'s pre-start zombie cleanup only ran on the double-run path, and only fired when the reuse port answered `/health` with no matching pid/json metadata (a "zombie" heuristic). That heuristic is unreliable either way:

- An eligible `server_lifecycle` port is a freshly OS-assigned ephemeral port, confirmed free by the kernel at assignment time, so it always reports unhealthy — the cleanup never fires even when a same-port orphan is present elsewhere.
- An ineligible port falls back to a fixed default (`8888`) that can coincide with an unrelated co-tenant's server, risking a false positive.
- The single-round path (the common way the kernel phase re-establishes its baseline) never ran this check at all.

Separately, an orphan produced by a timed-out `conc_sweep`/`explore` round (a `magpie_timeout` that fires before a `server_lifecycle` variant's pidfile is ever written leaves nothing for the caller's pidfile-based `teardown_lifecycle_server` to find) would sit on the GPU for the entire gap between when that action finished and the next baseline attempt started.

Together this let an orphaned inference server left behind by a timed-out sweep/explore round OOM the kernel phase's baseline evaluation.

Separately: the broad `/proc` scan these fixes rely on (`_kill_stale_servers()`) matches purely on cmdline text with no awareness of which GPUs a candidate process actually uses. On a bare-metal host where an operator has carved a subset of the machine's cards to this Hyperloom session, a matching server running on a *different* subset — an unrelated co-tenant's server — would be reaped right along with our own orphans; its `/dev/shm` segments could be wiped too, crashing it even where the per-pid reap itself left it alone.

Fixes #1354.

## Fix

- `baseline.py`: `_pre_start_cleanup()` drops the port-health probe entirely; it unconditionally unlinks stale pid/json metadata and invokes `_kill_stale_servers()` (skipped under pytest, matching the same guard on the per-launch preclean in `_grid_runner.py`; run via `asyncio.to_thread` so its internal wait doesn't block the event loop). The call site now runs right before the round actually boots — after the budget-affordability gate and the Ray lease construction — so a round the budget gate is about to refuse (or whose warm-patch application fails) no longer pays for a scan it gets no benefit from. This is safe unconditionally: Hyperloom's own scheduling (`gpu_research_lane`, capacity 1) guarantees at most one server-holding task runs at a time, so nothing matching should be alive at this point.
- `conc_sweep.py` / `explore.py`: both now also reap any lingering server via the same `_kill_stale_servers()` scan once they themselves finish (success, failure, or an exception alike), shrinking the window an orphan can occupy GPU memory instead of waiting for the next baseline attempt to catch it. Safe unconditionally for the same reason: each arm's/variant's own server is only ever kept warm *between* its own reuse rounds, never past the action itself.
- `_grid_runner.py`: `_kill_stale_servers()` now resolves its own visible-GPU mask (`ROCR_VISIBLE_DEVICES`, then `HIP`/`CUDA`) and, when one is set, only reaps a matching candidate whose own mask (read from `/proc/<pid>/environ`) overlaps ours; a candidate whose mask can't be read or declares none at all is left alone rather than reaped, since unknown scope is never treated as safe to kill. The trailing `/dev/shm` wipe carries no per-GPU tag to scope by, so it now only runs when we have no mask of our own (whole machine is ours) — with a mask set it is skipped entirely, so it can no longer pull a correctly-spared co-tenant's shared-memory segments out from under it. Container-isolated deployments (private PID namespace per session) are unaffected either way, since a co-located session's processes never show up in our `/proc` scan to begin with. The KFD-release pause (2-8s) that used to run unconditionally is now skipped when the scan found nothing to reap — this function runs at 4 call sites now (was 1), so paying it on the common no-orphan case adds up (e.g. `conc_sweep`'s own reap immediately followed by `baseline`'s).
- Regression tests cover: unconditional cleanup at all three call sites (no more port-health gating), the `PYTEST_CURRENT_TEST` skip on all of them, best-effort tolerance of a raising `_kill_stale_servers()`, each cleanup point firing exactly once regardless of success/failure/early-return, the cleanup being skipped for a round the budget gate refuses, the GPU-mask scoping (overlapping mask reaped, disjoint/unreadable/absent mask left alone, unscoped behavior unchanged when we have no mask ourselves), the `/dev/shm` wipe being skipped entirely when a GPU mask is set, and the KFD pause being skipped when nothing was killed.
