### PR TITLE
fix(kernel): name the reason when kernel_opt is never dispatched

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_kernel_attempt_summary.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_attempt_summary.py
@@ -435,6 +435,38 @@ def test_dispatch_skip_reason_empty_by_default(tmp_path: Path) -> None:
     assert out["dispatch_skip_reason"] == {}
 
 
+def test_takeaway_names_the_dispatch_skip_instead_of_guessing(tmp_path: Path) -> None:
+    """With nothing attempted, the takeaway must state the recorded reason.
+
+    The old sentence offered two guesses -- disabled, or nothing qualified --
+    and so could not express the case that actually happened: the candidate
+    table was never produced, so kernel_opt was never asked for. A reader
+    holding six zero buckets and that sentence concluded the workload had no
+    headroom.
+    """
+    state = _make_state(top15=[])
+    state.last_kernel_opt_dispatch_skip = {
+        "reason": "no_candidate_table",
+        "trace_analyze_empty": True,
+        "roofline_failure_streak": 3,
+        "ts": "2026-09-01T00:00:00+00:00",
+    }
+    out = build_kernel_optimization_summary(state, tmp_path)
+    joined = " ".join(out["top_takeaways"])
+    assert "no_candidate_table" in joined
+    assert "never dispatched" in joined
+    assert "no candidates qualified" not in joined
+
+
+def test_takeaway_keeps_the_generic_line_without_a_recorded_reason(tmp_path: Path) -> None:
+    """No breadcrumb => the original wording stays (nothing to name)."""
+    state = _make_state(top15=[])
+    out = build_kernel_optimization_summary(state, tmp_path)
+    joined = " ".join(out["top_takeaways"])
+    assert "No kernels were attempted" in joined
+    assert "no candidates qualified" in joined
+
+
 def test_zero_attempts_session_does_not_crash(tmp_path: Path) -> None:
     state = _make_state(top15=[])
     out = build_kernel_optimization_summary(state, tmp_path)

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_attempt_summary.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_attempt_summary.py
@@ -454,8 +454,28 @@ def test_takeaway_names_the_dispatch_skip_instead_of_guessing(tmp_path: Path) ->
     out = build_kernel_optimization_summary(state, tmp_path)
     joined = " ".join(out["top_takeaways"])
     assert "no_candidate_table" in joined
-    assert "never dispatched" in joined
     assert "no candidates qualified" not in joined
+
+
+def test_takeaway_does_not_claim_a_dispatch_never_happened(tmp_path: Path) -> None:
+    """``no_eligible_kernels`` is written by a dispatch that did happen.
+
+    The two writers of this field disagree about what the skip was: the phase
+    records declining to ask, while this reason records a dispatch whose queue
+    came back empty. A sentence built around "never dispatched" is false for
+    the second, and a confident false statement is worse than the hedge it
+    replaced.
+    """
+    state = _make_state(top15=[])
+    state.last_kernel_opt_dispatch_skip = {
+        "reason": "no_eligible_kernels",
+        "kernels_considered": 7,
+        "ts": "2026-09-01T00:00:00+00:00",
+    }
+    out = build_kernel_optimization_summary(state, tmp_path)
+    joined = " ".join(out["top_takeaways"])
+    assert "no_eligible_kernels" in joined
+    assert "never dispatched" not in joined
 
 
 def test_takeaway_keeps_the_generic_line_without_a_recorded_reason(tmp_path: Path) -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_prelude_roofline.py
+++ b/src/hyperloom/inference_optimizer/tests/test_prelude_roofline.py
@@ -431,6 +431,81 @@ async def test_kernel_entry_does_not_dispatch_without_untried_candidates(coord: 
     assert dispatched == 0
 
 
+@pytest.mark.asyncio
+async def test_kernel_entry_records_why_it_dispatched_nothing(coord: Coordinator, monkeypatch):
+    """A wholesale dispatch skip has to name itself.
+
+    ``untried_hot_reusable_kernels`` reads the candidate table, so a session
+    whose trace_analyze never landed one takes this path -- and left no trace of
+    having done so. The summary's unattempted buckets only count kernels the
+    table listed, so all six stayed at zero and a 28-hour run with no candidate
+    table read exactly like a workload with no headroom.
+    """
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_SKIP_GEMM_TUNING", "1")
+    monkeypatch.setattr(coord.phase_machine, "_kernel_enabled", lambda: True)
+    monkeypatch.setattr(coord.phase_kernel, "_geak_enabled", lambda: False)
+    monkeypatch.setattr(coord.phase_kernel, "_fusion_required_before_kernel_opt", lambda: False)
+
+    async def _skip_reprofile() -> None:
+        return None
+
+    monkeypatch.setattr(coord.phase_kernel, "_maybe_reprofile_for_kernel", _skip_reprofile)
+    coord.shared_state.last_trace_analyze = {}
+    coord.shared_state.roofline_failure_streak = 3
+
+    await coord._on_enter_kernel(from_phase="FRAMEWORK_AGENT")
+
+    skip = coord.shared_state.last_kernel_opt_dispatch_skip
+    assert skip.get("reason") == "no_candidate_table", (
+        "an absent candidate table must be named; without it the summary "
+        "reports six zero buckets and reads as 'nothing worth optimising'"
+    )
+    assert skip.get("trace_analyze_empty") is True
+    assert skip.get("roofline_failure_streak") == 3
+    assert skip.get("ts")
+
+
+@pytest.mark.asyncio
+async def test_kernel_entry_separates_an_empty_table_from_a_spent_one(coord: Coordinator, monkeypatch):
+    """A table whose kernels were all tried is not the same as no table."""
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_SKIP_GEMM_TUNING", "1")
+    monkeypatch.setattr(coord.phase_machine, "_kernel_enabled", lambda: True)
+    monkeypatch.setattr(coord.phase_kernel, "_geak_enabled", lambda: False)
+    monkeypatch.setattr(coord.phase_kernel, "_fusion_required_before_kernel_opt", lambda: False)
+
+    async def _skip_reprofile() -> None:
+        return None
+
+    monkeypatch.setattr(coord.phase_kernel, "_maybe_reprofile_for_kernel", _skip_reprofile)
+    # A snapshot exists; the dispatch floor is what declines it.
+    coord.shared_state.last_trace_analyze = {
+        "candidates_path": "/tmp/kernel_candidates.json",
+        "kernel_roofline_top15": [],
+    }
+
+    await coord._on_enter_kernel(from_phase="FRAMEWORK_AGENT")
+
+    assert coord.shared_state.last_kernel_opt_dispatch_skip.get("reason") == "no_untried_hot_kernels"
+
+
+@pytest.mark.asyncio
+async def test_kernel_entry_records_a_snapshot_without_a_candidates_artifact(
+    coord: Coordinator,
+    monkeypatch,
+):
+    """The batch's own guard is a third distinct state worth naming."""
+    monkeypatch.setattr(
+        coord.phase_kernel.shared_state,
+        "last_trace_analyze",
+        {"kernel_roofline_top15": [{"kernel_id": "k001"}]},
+        raising=False,
+    )
+
+    await coord.phase_kernel._run_kernel_opt_entry_batch()
+
+    assert coord.shared_state.last_kernel_opt_dispatch_skip.get("reason") == "no_candidates_path"
+
+
 def test_a_trace_recorded_with_task_params_is_not_stale(coord: Coordinator):
     """The two writers of ``last_profile_workload`` disagree by construction.
 

--- a/src/hyperloom/inference_optimizer/tests/test_prelude_roofline.py
+++ b/src/hyperloom/inference_optimizer/tests/test_prelude_roofline.py
@@ -467,7 +467,13 @@ async def test_kernel_entry_records_why_it_dispatched_nothing(coord: Coordinator
 
 @pytest.mark.asyncio
 async def test_kernel_entry_separates_an_empty_table_from_a_spent_one(coord: Coordinator, monkeypatch):
-    """A table whose kernels were all tried is not the same as no table."""
+    """A table whose kernels were all tried is not the same as no table.
+
+    The fixture has to satisfy the gate's own admission test, so the hot kernel
+    is reusable and above the floor, and the ledger records an attempt against
+    it. Anything less leaves the queue empty for want of a table, which is the
+    other reason entirely.
+    """
     monkeypatch.setenv("INFERENCE_OPTIMIZER_SKIP_GEMM_TUNING", "1")
     monkeypatch.setattr(coord.phase_machine, "_kernel_enabled", lambda: True)
     monkeypatch.setattr(coord.phase_kernel, "_geak_enabled", lambda: False)
@@ -477,15 +483,88 @@ async def test_kernel_entry_separates_an_empty_table_from_a_spent_one(coord: Coo
         return None
 
     monkeypatch.setattr(coord.phase_kernel, "_maybe_reprofile_for_kernel", _skip_reprofile)
-    # A snapshot exists; the dispatch floor is what declines it.
     coord.shared_state.last_trace_analyze = {
         "candidates_path": "/tmp/kernel_candidates.json",
-        "kernel_roofline_top15": [],
+        "hot_kernels_top15": [
+            {
+                "kernel_id": "k001",
+                "name": "hot_gemm",
+                "source_file": "/p/a.py",
+                "gpu_pct": 40.0,
+                "reusable_native_kernel": True,
+            }
+        ],
     }
+    coord.shared_state.kernel_opt_task_attempts = {
+        "task-1": {
+            "kernel_id": "k001",
+            "current_kernel_id": "k001",
+            "last_source_file": "/p/a.py",
+            "attempts": 1,
+        }
+    }
+    assert coord.shared_state.untried_hot_reusable_kernels() == [], "fixture must exercise the spent-table state"
 
     await coord._on_enter_kernel(from_phase="FRAMEWORK_AGENT")
 
     assert coord.shared_state.last_kernel_opt_dispatch_skip.get("reason") == "no_untried_hot_kernels"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_trace_analyze_is_not_a_spent_table(coord: Coordinator, monkeypatch):
+    """A non-empty snapshot is not evidence of a table.
+
+    trace_analyze that ran and crashed leaves a status/error dict behind. Judged
+    on the dict being non-empty, that reads as "the table listed kernels and
+    they were all tried" -- the same false conclusion this breadcrumb exists to
+    prevent, relocated from the buckets into the reason.
+    """
+    monkeypatch.setenv("INFERENCE_OPTIMIZER_SKIP_GEMM_TUNING", "1")
+    monkeypatch.setattr(coord.phase_machine, "_kernel_enabled", lambda: True)
+    monkeypatch.setattr(coord.phase_kernel, "_geak_enabled", lambda: False)
+    monkeypatch.setattr(coord.phase_kernel, "_fusion_required_before_kernel_opt", lambda: False)
+
+    async def _skip_reprofile() -> None:
+        return None
+
+    monkeypatch.setattr(coord.phase_kernel, "_maybe_reprofile_for_kernel", _skip_reprofile)
+    coord.shared_state.last_trace_analyze = {"status": "failed", "error": "roofline crashed"}
+
+    await coord._on_enter_kernel(from_phase="FRAMEWORK_AGENT")
+
+    assert coord.shared_state.last_kernel_opt_dispatch_skip.get("reason") == "no_candidate_table"
+
+
+@pytest.mark.asyncio
+async def test_a_dispatch_retires_an_earlier_skip_breadcrumb(coord: Coordinator, monkeypatch):
+    """A batch dispatch names no kernel_id, so nothing else clears the field.
+
+    Left standing, a breadcrumb from an earlier entry outlives the dispatch and
+    the report asserts "never dispatched" for a round that dispatched and had
+    its candidates filtered by the handler's own floor.
+    """
+    coord.shared_state.last_kernel_opt_dispatch_skip = {"reason": "no_candidate_table"}
+    coord.shared_state.last_trace_analyze = {"candidates_path": "/tmp/kernel_candidates.json"}
+
+    async def _handler(_payload, **_kwargs):
+        return {"status": "ok", "batch_mode": True, "dispatched": 2}
+
+    import hyperloom.orchestrator.kernel.request_handlers as krh
+
+    monkeypatch.setattr(krh, "run_optimization_handler", _handler)
+
+    sent: list[Any] = []
+
+    class _Bus:
+        async def append_and_seq(self, message: Any) -> None:
+            sent.append(message)
+
+    coord.phase_kernel.bus = _Bus()
+
+    await coord.phase_kernel._run_kernel_opt_entry_batch()
+
+    assert coord.shared_state.last_kernel_opt_dispatch_skip == {}
+    assert sent, "the batch result is still reported on the bus"
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/orchestrator/kernel/attempt_summary.py
+++ b/src/hyperloom/orchestrator/kernel/attempt_summary.py
@@ -1054,11 +1054,13 @@ def build_kernel_optimization_summary(
         by_kernel.append(_render_collective_attempt_row(collective_attempt, category))
 
     failure_reason_breakdown = _aggregate_failure_reasons(by_kernel)
+    dispatch_skip = dict(getattr(state, "last_kernel_opt_dispatch_skip", {}) or {})
     top_takeaways = _build_top_takeaways(
         counts=counts,
         by_kernel=by_kernel,
         rejection_breakdown=rejection_breakdown,
         failure_reason_breakdown=failure_reason_breakdown,
+        dispatch_skip=dispatch_skip,
     )
 
     return {
@@ -1072,7 +1074,7 @@ def build_kernel_optimization_summary(
         "unattempted_reason_breakdown": unattempted_breakdown,
         "failure_reason_breakdown": failure_reason_breakdown,
         # Non-failure breadcrumb for a wholesale dispatch skip; {} otherwise.
-        "dispatch_skip_reason": dict(getattr(state, "last_kernel_opt_dispatch_skip", {}) or {}),
+        "dispatch_skip_reason": dispatch_skip,
         "field_glossary": FIELD_GLOSSARY,
         "by_kernel": by_kernel,
         "top_takeaways": top_takeaways,
@@ -1302,6 +1304,7 @@ def _build_top_takeaways(
     by_kernel: list[dict[str, Any]],
     rejection_breakdown: dict[str, int],
     failure_reason_breakdown: dict[str, int],
+    dispatch_skip: dict[str, Any] | None = None,
 ) -> list[str]:
     """Deterministic 2-4 sentence summary, no LLM.
 
@@ -1310,6 +1313,8 @@ def _build_top_takeaways(
         by_kernel: The per-kernel summary rows.
         rejection_breakdown: Counts of rejection reasons.
         failure_reason_breakdown: Counts of failure modes.
+        dispatch_skip: The recorded wholesale dispatch-skip breadcrumb, used to
+            name the reason instead of guessing at it.
 
     Returns:
         A list of takeaway sentences.
@@ -1325,9 +1330,19 @@ def _build_top_takeaways(
             f"{integrated} of {attempted} attempted kernels reached KEEP and integrated; {rejected} were rejected."
         )
     else:
-        out.append(
-            "No kernels were attempted in this session (check if kernel_opt was disabled or no candidates qualified)."
-        )
+        # The reason is recorded, so state it. Guessing between "disabled" and
+        # "nothing qualified" left the third case -- the candidate table was
+        # never produced, so nothing was ever asked -- unrepresented, and a
+        # reader with every bucket at zero concluded the workload had no
+        # headroom.
+        skip_reason = str((dispatch_skip or {}).get("reason") or "")
+        if skip_reason:
+            out.append(f"No kernels were attempted in this session: kernel_opt was never dispatched ({skip_reason}).")
+        else:
+            out.append(
+                "No kernels were attempted in this session "
+                "(check if kernel_opt was disabled or no candidates qualified)."
+            )
 
     ladder_all = failure_reason_breakdown.get("ladder_all_failed", 0)
     if ladder_all >= 1:

--- a/src/hyperloom/orchestrator/kernel/attempt_summary.py
+++ b/src/hyperloom/orchestrator/kernel/attempt_summary.py
@@ -1335,9 +1335,14 @@ def _build_top_takeaways(
         # never produced, so nothing was ever asked -- unrepresented, and a
         # reader with every bucket at zero concluded the workload had no
         # headroom.
+        #
+        # Worded around the skip, not around "never dispatched": the reasons
+        # come from two writers with different meanings. The phase records why
+        # it declined to ask at all, while ``no_eligible_kernels`` comes from a
+        # dispatch that did happen and found nothing eligible.
         skip_reason = str((dispatch_skip or {}).get("reason") or "")
         if skip_reason:
-            out.append(f"No kernels were attempted in this session: kernel_opt was never dispatched ({skip_reason}).")
+            out.append(f"No kernels were attempted in this session (kernel_opt dispatch skip: {skip_reason}).")
         else:
             out.append(
                 "No kernels were attempted in this session "

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -67,6 +67,17 @@ _GEAK_RESIDUAL_MIN_RATIO = 1.001
 # a transient cause plus the original attempt.
 MAX_FUSION_INFRA_RETRIES = 2
 
+# Why KERNEL entry dispatched no kernel_opt at all, recorded on
+# ``last_kernel_opt_dispatch_skip`` and surfaced by the summary as
+# ``dispatch_skip_reason``. A wholesale skip is invisible in the summary's
+# unattempted buckets, which only ever count kernels the candidate table
+# listed: an absent table leaves every bucket at zero, which reads as "this
+# workload had nothing worth optimising" rather than "nothing was ever asked".
+KERNEL_OPT_SKIP_DISABLED = "auto_kernel_opt_disabled"
+KERNEL_OPT_SKIP_NO_CANDIDATE_TABLE = "no_candidate_table"
+KERNEL_OPT_SKIP_NO_UNTRIED_KERNELS = "no_untried_hot_kernels"
+KERNEL_OPT_SKIP_NO_CANDIDATES_PATH = "no_candidates_path"
+
 
 def _as_int(value: object) -> int:
     """Read a counter that round-tripped through JSON, defaulting to 0."""
@@ -3553,6 +3564,66 @@ class KernelPhase(PhaseHandler):
         await self._maybe_run_collective_before_kernel_opt()
         if self._kernel_opt_work_remains():
             await self._run_kernel_opt_entry_batch()
+        else:
+            self._record_kernel_opt_dispatch_skip(self._kernel_opt_dispatch_skip_reason())
+
+    def _kernel_opt_dispatch_skip_reason(self) -> str:
+        """Name why the phase is declining to dispatch kernel_opt itself.
+
+        Separates the three states :meth:`_kernel_opt_work_remains` collapses
+        into one ``False``: the feature is off, no candidate table was ever
+        produced, or the table's hot kernels have all been tried.
+
+        Returns:
+            str: One of ``auto_kernel_opt_disabled`` /
+                ``no_candidate_table`` / ``no_untried_hot_kernels``.
+        """
+        state = self.shared_state
+        if not bool(getattr(state, "auto_kernel_opt_enabled", True)):
+            return KERNEL_OPT_SKIP_DISABLED
+        cached = getattr(state, "last_trace_analyze", None)
+        if not isinstance(cached, dict) or not cached:
+            return KERNEL_OPT_SKIP_NO_CANDIDATE_TABLE
+        return KERNEL_OPT_SKIP_NO_UNTRIED_KERNELS
+
+    def _record_kernel_opt_dispatch_skip(self, reason: str) -> None:
+        """Record why KERNEL entry skipped the whole kernel_opt batch.
+
+        The summary's unattempted buckets each mean "the candidate table listed
+        this kernel and nobody tried it", so a run whose table never
+        materialised counts zero in every bucket and reads as "nothing here was
+        worth optimising". Both skip paths return before ``run_optimization``
+        is called, so ``record_kernel_opt`` -- this field's other writer --
+        never runs to say otherwise.
+
+        The evidence fields carry the state the decision was made on, so the
+        report answers "why was the table empty" without a state.json dig.
+
+        Args:
+            reason: One of the ``KERNEL_OPT_SKIP_*`` reason codes.
+        """
+        state = self.shared_state
+        cached = getattr(state, "last_trace_analyze", None)
+        cached = cached if isinstance(cached, dict) else {}
+        try:
+            streak = int(getattr(state, "roofline_failure_streak", 0) or 0)
+        except (TypeError, ValueError):
+            streak = 0
+        state.last_kernel_opt_dispatch_skip = {
+            "reason": reason,
+            "candidates_path": str(cached.get("candidates_path") or ""),
+            "trace_analyze_empty": not cached,
+            "profile_trace": str(getattr(state, "last_profile_trace", "") or ""),
+            "profile_status": str(getattr(state, "last_profile_status", "") or ""),
+            "roofline_failure_streak": streak,
+            "ts": datetime.now(timezone.utc).isoformat(),
+        }
+        log.info(
+            "KERNEL entry: no kernel_opt dispatch (reason=%s, trace_analyze_empty=%s, roofline_failure_streak=%d)",
+            reason,
+            not cached,
+            streak,
+        )
 
     def _kernel_opt_work_remains(self) -> bool:
         """Whether KERNEL entry should dispatch source-level kernel_opt itself.
@@ -3581,6 +3652,7 @@ class KernelPhase(PhaseHandler):
         candidates_path = str(cached.get("candidates_path") or "")
         if not candidates_path:
             log.info("KERNEL entry: skip kernel_opt; no candidates_path")
+            self._record_kernel_opt_dispatch_skip(KERNEL_OPT_SKIP_NO_CANDIDATES_PATH)
             return
         log.info(
             "KERNEL entry: dispatching the source-level kernel_opt batch",

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -3574,6 +3574,12 @@ class KernelPhase(PhaseHandler):
         into one ``False``: the feature is off, no candidate table was ever
         produced, or the table's hot kernels have all been tried.
 
+        Reads the same field the gate reads. ``last_trace_analyze`` being a
+        non-empty dict does not mean it carries a table -- a trace_analyze that
+        ran and failed leaves ``{"status": "failed", ...}`` behind -- and
+        calling that "the kernels were all tried" states the very conclusion
+        this breadcrumb exists to prevent.
+
         Returns:
             str: One of ``auto_kernel_opt_disabled`` /
                 ``no_candidate_table`` / ``no_untried_hot_kernels``.
@@ -3582,7 +3588,9 @@ class KernelPhase(PhaseHandler):
         if not bool(getattr(state, "auto_kernel_opt_enabled", True)):
             return KERNEL_OPT_SKIP_DISABLED
         cached = getattr(state, "last_trace_analyze", None)
-        if not isinstance(cached, dict) or not cached:
+        cached = cached if isinstance(cached, dict) else {}
+        hot = cached.get("hot_kernels_top15") or cached.get("hot_kernels") or []
+        if not isinstance(hot, list) or not hot:
             return KERNEL_OPT_SKIP_NO_CANDIDATE_TABLE
         return KERNEL_OPT_SKIP_NO_UNTRIED_KERNELS
 
@@ -3624,6 +3632,15 @@ class KernelPhase(PhaseHandler):
             not cached,
             streak,
         )
+        # Persisted here rather than left to whichever later turn happens to
+        # save: the run this breadcrumb is for is the one that spends hours in
+        # the phase and is then killed or wedged, which is exactly when an
+        # unsaved breadcrumb is lost and the report falls back to reading as
+        # "nothing worth optimising".
+        try:
+            state.save(self.session_dir)
+        except Exception:  # noqa: BLE001 — a breadcrumb must never fail the phase
+            log.debug("KERNEL entry: saving the dispatch-skip breadcrumb failed", exc_info=True)
 
     def _kernel_opt_work_remains(self) -> bool:
         """Whether KERNEL entry should dispatch source-level kernel_opt itself.
@@ -3657,6 +3674,12 @@ class KernelPhase(PhaseHandler):
         log.info(
             "KERNEL entry: dispatching the source-level kernel_opt batch",
         )
+        # A dispatch retires any earlier skip breadcrumb. ``record_kernel_opt``
+        # clears it too, but only for a result naming a ``kernel_id``, and this
+        # batch names none by design -- so an earlier "never dispatched" would
+        # outlive the dispatch and the report would assert it as fact for a
+        # round whose candidates were merely filtered by the handler's floor.
+        self.shared_state.last_kernel_opt_dispatch_skip = {}
         try:
             from ..kernel.request_handlers import run_optimization_handler
 


### PR DESCRIPTION
## Problem

A session that reached `KERNEL_AGENT` without a candidate table dispatched no `kernel_opt` at all and left nothing on record saying so.

The summary's six `unattempted_reason_breakdown` buckets each mean "the candidate table listed this kernel and nobody tried it", so an absent table counts zero in every one of them. The zero-attempt takeaway then offered two guesses — `kernel_opt` disabled, or no candidate qualified — and neither is what happened: nothing was ever asked for, because `untried_hot_reusable_kernels()` reads `last_trace_analyze` and that snapshot was empty.

Seven forge sessions (2026-08-29..31) spent ~28 GPU-hours in the phase with `attempted=0`, `top_candidates=0` and all six buckets at 0, and read as workloads with no headroom. Telling "the lane died for want of input" apart from "candidates arrived and were all filtered" required reading `state.json` by hand.

## Fix

The field that should carry this already exists: `record_kernel_opt` writes `last_kernel_opt_dispatch_skip` for an empty dispatch queue and the summary surfaces it as `dispatch_skip_reason`. Both wholesale-skip paths return before `run_optimization` is called, so that writer never runs for them.

- `phases/kernel.py`: KERNEL entry records the breadcrumb on both skip paths, separating the states `_kernel_opt_work_remains()` collapses into a single `False` — `auto_kernel_opt_disabled`, `no_candidate_table`, `no_untried_hot_kernels` — plus `no_candidates_path` for a snapshot that carries no candidates artifact. The reason is derived from the field the gate itself admits on (`hot_kernels_top15` / `hot_kernels`), not from the snapshot dict being non-empty: a trace_analyze that ran and crashed leaves `{"status": "failed", ...}` behind, and calling that "the kernels were all tried" would assert the very conclusion this breadcrumb exists to prevent. The evidence fields (`trace_analyze_empty`, `candidates_path`, `profile_trace`, `profile_status`, `roofline_failure_streak`) answer "why was the table empty" without a `state.json` dig, and are persisted where they are written — the run this serves is the one that spends hours in the phase and is then killed.
- `phases/kernel.py`: the entry batch clears the field before dispatching. It names no `kernel_id`, so `record_kernel_opt` — which retires the breadcrumb only for a result that names one — never cleared it, and a later entry that dispatched and had its candidates filtered by the handler's own floor still reported "never dispatched" as fact.
- `kernel/attempt_summary.py`: with nothing attempted, `_build_top_takeaways` states the recorded reason instead of guessing; the original wording is kept when no breadcrumb exists. Worded around the skip rather than around "never dispatched", because the field has two writers with different meanings — the phase records declining to ask, while `no_eligible_kernels` records a dispatch that did happen and found nothing eligible.

No schema change: both the report key and its state field predate this, and `unattempted_reason_breakdown` / `totals` are untouched.

## Tests

Seven tests, each verified red on the tree it targets:

- `test_prelude_roofline.py`: an empty snapshot records `no_candidate_table` with its evidence; a failed trace_analyze records `no_candidate_table` rather than `no_untried_hot_kernels`; a spent table (a reusable hot kernel above the floor with an attempt recorded against it, asserted to leave the gate empty) records `no_untried_hot_kernels`; a snapshot without a candidates artifact records `no_candidates_path`; a `batch_mode` dispatch retires an earlier breadcrumb.
- `test_kernel_attempt_summary.py`: the takeaway names the recorded reason; it does not claim a dispatch never happened for `no_eligible_kernels`; it keeps the generic line when nothing was recorded.
