### PR TITLE
Stop reporting a GEAK run that found nothing as a fault

### DIFF
--- a/src/hyperloom/inference_optimizer/breakdown/collectors/v6_stages.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/v6_stages.py
@@ -132,10 +132,17 @@ _GEAK_REVALIDATION_OUTCOMES = {
 # the orchestrator's own rebench, so the outcome ladder below leaves a
 # ``no_gain`` run at ``NEEDS_REVIEW`` unless a writeback or a linked rebench
 # settles it. GEAK's self-report is the claim, not the verdict.
+# ``baseline_reproduction_failed`` is the runner reporting that its baseline
+# reference did not reproduce the orchestrator's, which makes the whole run's
+# gain non-comparable -- ``phases/kernel.py`` reads it as a guard and refuses to
+# promote a phantom-baseline gain. ``failed`` is where the unknown-status
+# default already put it, so this changes no classification; it is listed so a
+# status the runtime declares terminal stops being reported as drift.
 _GEAK_STATUS_ALIASES = {
     "missing": "failed",
     "no_result_recovered_from_disk": "failed",
     "no_gain": "succeeded",
+    "baseline_reproduction_failed": "failed",
 }
 # ``missing`` is the one GEAK status that is not a record of work: it is what
 # ``collect_geak`` returns when ``kernel_optimizer=geak`` was selected, nothing

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/v6_stages.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/v6_stages.py
@@ -111,10 +111,32 @@ _GEAK_REVALIDATION_OUTCOMES = {
     "failed": "FAILED",
     "fallback_failed": "FAILED",
 }
-# ``collect_geak``'s own words for a run whose result it could not read back.
-# Both carry ``error_class: no_result``; recognizing them here keeps the shared
-# status normalizer from reporting an ordinary GEAK miss as vocabulary drift.
-_GEAK_STATUS_ALIASES = {"missing": "failed", "no_result_recovered_from_disk": "failed"}
+# GEAK's own status words, which are not the shared lane vocabulary.
+#
+# ``missing`` / ``no_result_recovered_from_disk`` are ``collect_geak``'s words
+# for a run whose result it could not read back; both carry
+# ``error_class: no_result``.
+#
+# ``no_gain`` is a *completed* run that found nothing, and is the third most
+# common GEAK status in production -- 212 sessions against 115 ``ok`` over the
+# corpus, roughly 9% of every session that engaged GEAK. The runtime treats it
+# as terminal beside ``ok`` in three places: ``machine_state`` lists it among
+# the statuses that end the kernel phase, ``collect_geak`` pairs it with ``ok``
+# when backfilling accepted kernels, and ``kernel_work_pending`` reads it as
+# "nothing left to try". Falling through to :func:`_lane_status` mapped it to
+# ``failed``, which reported every GEAK run that honestly found no improvement
+# as a GEAK fault -- the exact conflation this lane was built to remove.
+#
+# It maps to ``succeeded`` and no further: ``status`` says the runner finished,
+# which is a fact about the runner. Whether the candidate is adopted stays with
+# the orchestrator's own rebench, so the outcome ladder below leaves a
+# ``no_gain`` run at ``NEEDS_REVIEW`` unless a writeback or a linked rebench
+# settles it. GEAK's self-report is the claim, not the verdict.
+_GEAK_STATUS_ALIASES = {
+    "missing": "failed",
+    "no_result_recovered_from_disk": "failed",
+    "no_gain": "succeeded",
+}
 # ``missing`` is the one GEAK status that is not a record of work: it is what
 # ``collect_geak`` returns when ``kernel_optimizer=geak`` was selected, nothing
 # was recorded, and nothing was on disk either — the launch config echoed back.

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_v6_stages.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_v6_stages.py
@@ -2329,6 +2329,44 @@ def test_the_geak_echo_is_still_reported_inside_a_real_visit(tmp_path):
     assert (run["status"], run["outcome"]) == ("failed", "FAILED")
 
 
+@pytest.mark.parametrize(
+    ("geak_status", "expected_status", "expected_outcome"),
+    [
+        # The whole vocabulary GEAK writes, measured over the 2404 production
+        # sessions that carry a geak block: missing 1503, no_gain 212, ok 115,
+        # timeout 95, skipped 67, error 11.
+        ("ok", "succeeded", "NEEDS_REVIEW"),
+        # A completed run that found nothing. Reported as a GEAK fault until
+        # the alias existed, which is 212 sessions of the corpus.
+        ("no_gain", "succeeded", "NEEDS_REVIEW"),
+        ("missing", "failed", "FAILED"),
+        ("no_result_recovered_from_disk", "failed", "FAILED"),
+        ("timeout", "failed", "FAILED"),
+        ("error", "failed", "FAILED"),
+        ("skipped", "skipped", "SKIPPED"),
+    ],
+)
+def test_every_geak_status_maps_without_drift(tmp_path, geak_status, expected_status, expected_outcome):
+    """No GEAK status the runtime writes may reach the normalizer as drift.
+
+    A word this table does not know maps to ``failed``, which is the right
+    default for something genuinely unrecognized and the wrong answer for a
+    status the runtime treats as terminal. Pinning the whole vocabulary makes a
+    new spelling fail here rather than in a report.
+    """
+    warnings: list[str] = []
+    timeline = collect_v6_timeline(
+        tmp_path,
+        warnings,
+        state=_kernel_state() | {"kernel_optimizer": "geak"},
+        geak={"engaged": True, "status": geak_status, "accepted_kernels": []},
+    )
+
+    run = _events(timeline, "kernel")[0]["ext"]["geak_runs"][0]
+    assert (run["status"], run["outcome"]) == (expected_status, expected_outcome)
+    assert not [w for w in warnings if "unrecognized geak_runs status" in w]
+
+
 def test_a_skipped_geak_spelling_does_not_contradict_itself(tmp_path):
     """``not_run`` used to emit ``status: failed`` beside ``outcome: SKIPPED``."""
     warnings: list[str] = []

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_v6_stages.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_v6_stages.py
@@ -25,6 +25,7 @@ from hyperloom.inference_optimizer.breakdown.collectors import v6 as v6_collecto
 from hyperloom.inference_optimizer.breakdown.collectors.v6 import collect_v6_timeline
 from hyperloom.inference_optimizer.breakdown.collectors.v6_close import collect_v6_close
 from hyperloom.inference_optimizer.session.sbd_v6 import write_timeline_event
+from hyperloom.orchestrator.phases.machine_state import GEAK_TERMINAL_STATUSES
 
 
 def _write_json(path: Path, payload: dict) -> None:
@@ -2329,31 +2330,7 @@ def test_the_geak_echo_is_still_reported_inside_a_real_visit(tmp_path):
     assert (run["status"], run["outcome"]) == ("failed", "FAILED")
 
 
-@pytest.mark.parametrize(
-    ("geak_status", "expected_status", "expected_outcome"),
-    [
-        # The whole vocabulary GEAK writes, measured over the 2404 production
-        # sessions that carry a geak block: missing 1503, no_gain 212, ok 115,
-        # timeout 95, skipped 67, error 11.
-        ("ok", "succeeded", "NEEDS_REVIEW"),
-        # A completed run that found nothing. Reported as a GEAK fault until
-        # the alias existed, which is 212 sessions of the corpus.
-        ("no_gain", "succeeded", "NEEDS_REVIEW"),
-        ("missing", "failed", "FAILED"),
-        ("no_result_recovered_from_disk", "failed", "FAILED"),
-        ("timeout", "failed", "FAILED"),
-        ("error", "failed", "FAILED"),
-        ("skipped", "skipped", "SKIPPED"),
-    ],
-)
-def test_every_geak_status_maps_without_drift(tmp_path, geak_status, expected_status, expected_outcome):
-    """No GEAK status the runtime writes may reach the normalizer as drift.
-
-    A word this table does not know maps to ``failed``, which is the right
-    default for something genuinely unrecognized and the wrong answer for a
-    status the runtime treats as terminal. Pinning the whole vocabulary makes a
-    new spelling fail here rather than in a report.
-    """
+def _geak_run_row(tmp_path, geak_status: str) -> tuple[dict, list[str]]:
     warnings: list[str] = []
     timeline = collect_v6_timeline(
         tmp_path,
@@ -2361,10 +2338,75 @@ def test_every_geak_status_maps_without_drift(tmp_path, geak_status, expected_st
         state=_kernel_state() | {"kernel_optimizer": "geak"},
         geak={"engaged": True, "status": geak_status, "accepted_kernels": []},
     )
+    return _events(timeline, "kernel")[0]["ext"]["geak_runs"][0], warnings
 
-    run = _events(timeline, "kernel")[0]["ext"]["geak_runs"][0]
-    assert (run["status"], run["outcome"]) == (expected_status, expected_outcome)
+
+@pytest.mark.parametrize("geak_status", sorted(GEAK_TERMINAL_STATUSES))
+def test_no_terminal_geak_status_reaches_the_normalizer_as_drift(tmp_path, geak_status):
+    """Every status the runtime declares terminal must already be known here.
+
+    Read off the producer's own set rather than restated, so a status added to
+    ``GEAK_TERMINAL_STATUSES`` and to nothing else fails here instead of
+    surfacing months later as a drift warning on a run that worked. That is how
+    ``no_gain`` and ``baseline_reproduction_failed`` were both missed: the first
+    vocabulary was assembled from what production had already written, which
+    cannot contain a status nothing has hit yet.
+    """
+    run, warnings = _geak_run_row(tmp_path, geak_status)
+
+    assert run["status"] in {"succeeded", "failed", "skipped"}
     assert not [w for w in warnings if "unrecognized geak_runs status" in w]
+
+
+@pytest.mark.parametrize(
+    ("geak_status", "expected_status", "expected_outcome"),
+    [
+        ("ok", "succeeded", "NEEDS_REVIEW"),
+        # A completed run that found nothing, and the third most common status
+        # in production -- 212 sessions against 115 ``ok``. Reported as a GEAK
+        # fault until the alias existed.
+        ("no_gain", "succeeded", "NEEDS_REVIEW"),
+        # The runner's baseline reference did not reproduce the orchestrator's,
+        # so the run's gain is non-comparable and ``phases/kernel.py`` refuses
+        # to promote it. A real failure, and one the runtime names.
+        ("baseline_reproduction_failed", "failed", "FAILED"),
+        ("failed", "failed", "FAILED"),
+        ("error", "failed", "FAILED"),
+        ("missing", "failed", "FAILED"),
+        ("no_result_recovered_from_disk", "failed", "FAILED"),
+        # Reaches the field from the runner without being terminal: 95 sessions.
+        ("timeout", "failed", "FAILED"),
+        ("skipped", "skipped", "SKIPPED"),
+    ],
+)
+def test_every_geak_status_maps_to_its_own_classification(tmp_path, geak_status, expected_status, expected_outcome):
+    """The classification each status lands on, not merely that it is known.
+
+    Union of two sources, because neither is complete on its own:
+    ``GEAK_TERMINAL_STATUSES`` is what the runtime declares, and the corpus of
+    2404 sessions carrying a geak block is what it has actually written --
+    ``missing`` (1503), ``timeout`` (95) and the collector's disk-recovery word
+    appear only in the second.
+    """
+    run, _ = _geak_run_row(tmp_path, geak_status)
+
+    assert (run["status"], run["outcome"]) == (expected_status, expected_outcome)
+
+
+def test_the_pinned_vocabulary_covers_the_producer_set(tmp_path):
+    """The parametrization above must not fall behind the producer's set."""
+    pinned = {
+        "ok",
+        "no_gain",
+        "baseline_reproduction_failed",
+        "failed",
+        "error",
+        "missing",
+        "no_result_recovered_from_disk",
+        "timeout",
+        "skipped",
+    }
+    assert GEAK_TERMINAL_STATUSES <= pinned
 
 
 def test_a_skipped_geak_spelling_does_not_contradict_itself(tmp_path):

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -1721,15 +1721,20 @@ def _kernel_opt_max_failures() -> int:
     return resolve_kernel_opt_max_failures()
 
 
-def _geak_phase_terminal(state: Any) -> bool:
-    """Return true once the GEAK-owned KERNEL phase has produced a terminal result."""
-    if str(getattr(state, "kernel_optimizer", "") or "").strip().lower() != "geak":
-        return False
-    result = getattr(state, "geak_result", None) or {}
-    if not isinstance(result, dict):
-        return False
-    status = str(result.get("status") or "").strip().lower()
-    return status in {
+# The statuses a finished GEAK run writes to ``geak_result.status``. Named
+# rather than inlined because the breakdown layer has to agree with it: its
+# ``geak_runs`` projection maps each of these onto a closed enum and warns about
+# anything it does not know, so a status added here and nowhere else surfaces as
+# vocabulary drift on a run that was working exactly as intended. See
+# ``breakdown/collectors/v6_stages._GEAK_STATUS_ALIASES``, which is pinned
+# against this set by test.
+#
+# Not exhaustive of what can appear in the field: the collector adds its own
+# words for a result it could not read back (``missing``,
+# ``no_result_recovered_from_disk``), and ``timeout`` reaches it from the runner
+# without being terminal here.
+GEAK_TERMINAL_STATUSES = frozenset(
+    {
         "ok",
         "no_gain",
         "error",
@@ -1737,6 +1742,17 @@ def _geak_phase_terminal(state: Any) -> bool:
         "skipped",
         "baseline_reproduction_failed",
     }
+)
+
+
+def _geak_phase_terminal(state: Any) -> bool:
+    """Return true once the GEAK-owned KERNEL phase has produced a terminal result."""
+    if str(getattr(state, "kernel_optimizer", "") or "").strip().lower() != "geak":
+        return False
+    result = getattr(state, "geak_result", None) or {}
+    if not isinstance(result, dict):
+        return False
+    return str(result.get("status") or "").strip().lower() in GEAK_TERMINAL_STATUSES
 
 
 # Ledger subfields that change when a kernel attempt actually advances. Listed


### PR DESCRIPTION
`no_gain` is the **third most common GEAK status in production** — 212 sessions against 115 `ok` over the 2404 that carry a geak block, roughly **9% of every session that engaged GEAK** — and the V6 kernel lane was reporting all of them as `status: failed` / `outcome: FAILED`.

## Why it is not a failure

It is a completed run that found nothing. The runtime treats it as terminal beside `ok` in three places:

- `orchestrator/phases/machine_state.py` lists it among the statuses that end the kernel phase
- `breakdown/collectors/geak.py` pairs it with `ok` when backfilling accepted kernels — `status in ("ok", "no_gain")`
- `kernel_work_pending` reads it as "nothing left to try"

Falling through to `_lane_status` mapped it to `failed`, which is the right default for a genuinely unrecognized word and the wrong answer for one the runtime relies on. It is also the exact conflation this lane was built to remove, one status further in.

## What it maps to now

`succeeded`, and no further. `status` says the runner finished, which is a fact about the runner; whether the candidate is adopted stays with the orchestrator's own rebench, so the outcome ladder leaves a `no_gain` run at `NEEDS_REVIEW` unless a writeback or a linked rebench settles it. GEAK's self-report is the claim, not the verdict.

## How it was found

Not by inspection. The normalizer added in #1350 warns on an unrecognized status, and

```
v6.timeline.kernel: unrecognized geak_runs status 'no_gain'; reported as failed
```

surfaced in `metadata.warnings` on the first two V6 sessions that ran GEAK. The drift channel worked as designed; the vocabulary was incomplete.

## Tests

The new test pins the whole vocabulary the runtime writes — `ok`, `no_gain`, `missing`, `no_result_recovered_from_disk`, `timeout`, `error`, `skipped` — so the next spelling fails there instead of in a report. Verified it fails on the pre-fix tree for `no_gain` alone and passes for the other six.

100 → 107 in `test_sbd_v6_stages.py`. Ruff format + check pass.
