### PR TITLE
ci: scope Forge E2E to loop changes

### DIFF
--- a/.github/scripts/forge_e2e_gate.py
+++ b/.github/scripts/forge_e2e_gate.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Return success when changed paths require the Forge end-to-end check."""
+"""Return success when changed paths require the Forge loop end-to-end check."""
 
 from __future__ import annotations
 
@@ -10,9 +10,9 @@ import sys
 from collections.abc import Iterable
 
 
-# This smoke exercises the vendored ``kernelforge`` package directly. Keep the
-# gate narrower than Hyperloom's full kernel-optimization integration surface:
-# changes outside these paths are covered by the normal Hyperloom E2E workflow.
+# This smoke exercises ``kernelforge forge-loop``. Keep shared package surfaces
+# in scope because the loop imports them, but do not spend a GPU run on changes
+# confined to the independent fusion or GEMM-tuning products.
 FORGE_E2E_PATHS = (
     "src/kernelforge/**",
     "pyproject.toml",
@@ -23,13 +23,23 @@ FORGE_E2E_PATHS = (
     ".github/scripts/forge_e2e_report.py",
 )
 
+FORGE_E2E_EXCLUDED_PATHS = (
+    "src/kernelforge/fusion/**",
+    "src/kernelforge/gemm_tune/**",
+    "src/kernelforge/tests/fusion/**",
+)
+
 
 def requires_forge_e2e(paths: Iterable[str]) -> bool:
-    """Whether any normalized repository path affects the Forge smoke test."""
+    """Whether any normalized repository path affects the Forge loop smoke."""
 
     for path in paths:
         normalized = path.strip().replace("\\", "/")
-        if normalized and any(fnmatch.fnmatchcase(normalized, pattern) for pattern in FORGE_E2E_PATHS):
+        if not normalized:
+            continue
+        if any(fnmatch.fnmatchcase(normalized, pattern) for pattern in FORGE_E2E_EXCLUDED_PATHS):
+            continue
+        if any(fnmatch.fnmatchcase(normalized, pattern) for pattern in FORGE_E2E_PATHS):
             return True
     return False
 

--- a/.github/workflows/forge-e2e.yml
+++ b/.github/workflows/forge-e2e.yml
@@ -2,8 +2,10 @@ name: Forge E2E (single-GPU forge-loop smoke)
 
 # Run the same Triton-softmax ``kernelforge forge-loop`` smoke that guarded the
 # standalone KernelForge repository, now against the exact Hyperloom PR commit
-# containing the vendored package. The GPU job is path-gated; the cheap resolve
-# job still handles labels, comments, renames, and manual dispatch consistently.
+# containing the vendored package. The GPU job is path-gated to loop-affecting
+# code; standalone Fusion/GEMM changes use their focused checks instead. The
+# cheap resolve job still handles labels, comments, renames, and manual dispatch
+# consistently.
 
 on:
   pull_request:
@@ -174,7 +176,7 @@ jobs:
               page=$((page + 1))
             done
             if [ "$forge_changed" != true ]; then
-              echo "no Forge package or Forge E2E paths changed; skipping GPU smoke"
+              echo "no Forge loop or Forge E2E paths changed; skipping GPU smoke"
               run=false; path_skipped=true; emit; exit 0
             fi
           fi
@@ -205,7 +207,7 @@ jobs:
           if [ "$OPTED_OUT" = true ]; then
             description="skipped via skip-e2e-test label"
           else
-            description="skipped: no Forge-related files changed"
+            description="skipped: no Forge loop-related files changed"
           fi
           # Fork pull_request jobs get a read-only GITHUB_TOKEN even with
           # permissions.statuses: write, so this POST 403s and used to fail

--- a/scripts/tests/test_forge_e2e_gate.py
+++ b/scripts/tests/test_forge_e2e_gate.py
@@ -36,6 +36,26 @@ def test_vendored_forge_changes_trigger() -> None:
         assert gate.requires_forge_e2e([path]), path
 
 
+def test_fusion_and_gemm_only_changes_do_not_trigger() -> None:
+    assert not gate.requires_forge_e2e(
+        [
+            "src/kernelforge/fusion/loop.py",
+            "src/kernelforge/tests/fusion/test_loop.py",
+            "src/kernelforge/gemm_tune/router.py",
+            "src/kernelforge/gemm_tune/tests/test_router.py",
+        ]
+    )
+
+
+def test_shared_or_loop_change_still_triggers_alongside_excluded_changes() -> None:
+    assert gate.requires_forge_e2e(
+        [
+            "src/kernelforge/gemm_tune/router.py",
+            "src/kernelforge/agent_backends/codex.py",
+        ]
+    )
+
+
 def test_forge_e2e_contract_changes_trigger() -> None:
     for path in (
         ".github/workflows/forge-e2e.yml",
@@ -63,7 +83,16 @@ def test_previous_filename_can_trigger_a_rename_out_of_forge() -> None:
     assert gate.requires_forge_e2e(
         [
             "src/hyperloom/unrelated/new_home.py",
-            "src/kernelforge/old_home.py",
+            "src/kernelforge/loop/old_home.py",
+        ]
+    )
+
+
+def test_rename_confined_to_excluded_products_does_not_trigger() -> None:
+    assert not gate.requires_forge_e2e(
+        [
+            "src/kernelforge/fusion/new_home.py",
+            "src/kernelforge/gemm_tune/old_home.py",
         ]
     )
 
@@ -93,7 +122,7 @@ def test_workflow_gates_all_pr_backed_retries_but_not_manual_runs() -> None:
     assert "files?per_page=100&page=$page" in workflow
     assert '[.labels[].name] | index("skip-e2e-test")' in workflow
     assert "path_skipped=true" in workflow
-    assert 'description="skipped: no Forge-related files changed"' in workflow
+    assert 'description="skipped: no Forge loop-related files changed"' in workflow
 
 
 def test_only_resolved_events_can_cancel_an_in_flight_forge_run() -> None:


### PR DESCRIPTION
## Summary

- scope the single-GPU Forge E2E path gate to changes that can affect `kernelforge forge-loop`
- skip PRs confined to `src/kernelforge/fusion/**`, `src/kernelforge/tests/fusion/**`, or `src/kernelforge/gemm_tune/**`
- keep shared Forge code, packaging, the smoke example, and E2E workflow/scripts in scope
- clarify the skipped status as "no Forge loop-related files changed"

The smoke runs the Triton softmax `forge-loop` flow, so dedicated Fusion/GEMM-only changes do not exercise its contract and should not consume a GPU slot. This deliberately does not narrow the gate to only `src/kernelforge/loop/**`: CLI, agent backends, orchestration, knowledge, and packaging are shared dependencies of the loop.

Manual workflow dispatch remains unconditional. A mixed PR containing any loop/shared change still runs the smoke.

## Testing

- `python -m pytest scripts/tests/test_forge_e2e_gate.py -q` (`11 passed`)
- `python -m ruff check .github/scripts/forge_e2e_gate.py scripts/tests/test_forge_e2e_gate.py`
- direct gate probes: Fusion/GEMM exit 1 (skip), loop/shared CLI exit 0 (run)