### PR TITLE
Remove HYPERLOOM_CODEX_EXTERNAL_SANDBOX double opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- **Codex sandbox bypass uses a single env var.** Set
+  `HYPERLOOM_CODEX_SANDBOX_MODE=bypass` when an external sandbox already
+  enforces isolation. `HYPERLOOM_CODEX_EXTERNAL_SANDBOX` is removed from
+  Hyperloom and KernelForge.
+
 - **PR Monitor now shares the KB Store endpoint.** Hyperloom derives REST
   `${KB_STORE_URL}/pr-monitor/v1` and MCP
   `${KB_STORE_URL}/pr-monitor/mcp/` URLs for Framework discovery,

--- a/docs/kernelforge/reference/cli.md
+++ b/docs/kernelforge/reference/cli.md
@@ -237,7 +237,7 @@ when no fusion is found.
 | `--author` / `--no-author` | on | Author the fused kernel via the LLM. Non-dry-run only. |
 | `--fuse-all-confirmed` | off | Author ALL source-confirmed patterns together rather than only the top one, and A/B all their flags. A compile-pass candidate cannot be authored with them, so it is claimed alone and the rest wait for a later round. |
 | `--agent-backend <name>` | `auto` | `auto`, `claude` or `codex`, for discovery and authoring. |
-| `--agent-sandbox-mode <v>` | `workspace-write` | `workspace-write`, `read-only` or `bypass`. Bypass additionally requires `HYPERLOOM_CODEX_EXTERNAL_SANDBOX=1`. |
+| `--agent-sandbox-mode <v>` | `workspace-write` | `workspace-write`, `read-only` or `bypass`. Use `bypass` only when an external sandbox already enforces isolation. |
 | `--model <name>` | provider default | Agent model. An explicit value wins; otherwise `$CODEX_MODEL` / `$CLAUDE_MODEL`, then the registered provider default. |
 | `--max-turns <n>` | `100` | Max authoring turns. |
 | `--gpu <id>` | `0` | HIP device id for authoring and A/B. |

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -396,20 +396,17 @@ container prevents it from establishing the sandbox, `workspace-write` and
 `read-only` fail closed before the app-server starts. There is no automatic
 fallback to `bypass`.
 
-`bypass` is a deliberate double opt-in. Set both
-`HYPERLOOM_CODEX_SANDBOX_MODE=bypass` and
-`HYPERLOOM_CODEX_EXTERNAL_SANDBOX=1`; the second variable confirms that an
-external container or sandbox already enforces the required isolation. It does
-not create that boundary. A confirmed bypass maps to Codex full access even
-when no writable roots are declared, because the external sandbox is
-authoritative. Under the contained modes, no writable roots remains
-`read-only`. Unknown modes and incomplete bypass configuration fail
+`bypass` is an explicit operator opt-in. Set
+`HYPERLOOM_CODEX_SANDBOX_MODE=bypass` when an external container or sandbox
+already enforces the required isolation. Hyperloom does not create that
+boundary. A confirmed bypass maps to Codex full access even when no writable
+roots are declared, because the external sandbox is authoritative. Under the
+contained modes, no writable roots remains `read-only`. Unknown modes fail
 immediately.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `HYPERLOOM_`<br>`CODEX_SANDBOX_MODE` | `workspace-write` | `workspace-write` restricts writes to the session directory plus declared output roots; `read-only` forbids writes; `bypass` selects Codex full access only when the external-sandbox confirmation below is also set. |
-| `HYPERLOOM_`<br>`CODEX_EXTERNAL_`<br>`SANDBOX` | Unset | Set exactly to `1` only when an external isolation boundary is already active and `HYPERLOOM_CODEX_SANDBOX_MODE=bypass`. Setting this alone has no effect and never weakens the default sandbox. |
+| `HYPERLOOM_`<br>`CODEX_SANDBOX_MODE` | `workspace-write` | `workspace-write` restricts writes to the session directory plus declared output roots; `read-only` forbids writes; `bypass` selects Codex full access when an external sandbox already enforces isolation. |
 
 ---
 

--- a/src/hyperloom/agents/kernel/tests/test_codex_session.py
+++ b/src/hyperloom/agents/kernel/tests/test_codex_session.py
@@ -35,7 +35,6 @@ _CODEX_ENV = (
     "LLM_GATEWAY_KEY",
     "CODEX_HOME",
     "HYPERLOOM_CODEX_SANDBOX_MODE",
-    "HYPERLOOM_CODEX_EXTERNAL_SANDBOX",
     "HYPERLOOM_RUNTIME_DIR",
 )
 
@@ -45,7 +44,6 @@ _SECRET = "sk-do-not-leak-this-value"
 # rename of the variable or of an accepted value is a breaking change for every
 # deployment that set it, so it has to fail here.
 _SANDBOX_MODE_ENV = "HYPERLOOM_CODEX_SANDBOX_MODE"
-_EXTERNAL_SANDBOX_ENV = "HYPERLOOM_CODEX_EXTERNAL_SANDBOX"
 _WRITABLE_ROOTS = (Path("/tmp/out"),)
 
 
@@ -495,32 +493,15 @@ def test_resolve_codex_sandbox_mode_reads_the_operator_variable():
     assert cs.resolve_codex_sandbox_mode(env={_SANDBOX_MODE_ENV: " Read-Only "}) == "read-only"
 
 
-def test_resolve_codex_sandbox_mode_requires_external_isolation_for_bypass():
-    """The mode opt-in alone cannot disable Codex's filesystem containment."""
-    with pytest.raises(cs.CodexSessionUnavailableError, match=_EXTERNAL_SANDBOX_ENV):
-        cs.resolve_codex_sandbox_mode(env={_SANDBOX_MODE_ENV: "bypass"})
+def test_resolve_codex_sandbox_mode_allows_bypass_with_mode_opt_in():
+    """Explicit bypass in the deployment environment permits full access."""
+    assert cs.resolve_codex_sandbox_mode(env={_SANDBOX_MODE_ENV: "bypass"}) == "bypass"
 
 
 def test_resolve_codex_sandbox_mode_requires_the_environment_mode_opt_in_for_bypass():
     """A caller argument cannot replace the operator-owned mode opt-in."""
     with pytest.raises(cs.CodexSessionUnavailableError, match=_SANDBOX_MODE_ENV):
-        cs.resolve_codex_sandbox_mode(
-            sandbox_mode="bypass",
-            env={_EXTERNAL_SANDBOX_ENV: "1"},
-        )
-
-
-def test_resolve_codex_sandbox_mode_allows_bypass_with_both_opt_ins():
-    """Explicit mode plus confirmed external isolation permits full access."""
-    assert (
-        cs.resolve_codex_sandbox_mode(
-            env={
-                _SANDBOX_MODE_ENV: "bypass",
-                _EXTERNAL_SANDBOX_ENV: "1",
-            }
-        )
-        == "bypass"
-    )
+        cs.resolve_codex_sandbox_mode(sandbox_mode="bypass", env={})
 
 
 def test_resolve_codex_sandbox_mode_reads_the_process_environment(monkeypatch):
@@ -681,7 +662,7 @@ def test_run_codex_turn_honors_an_explicit_sandbox_mode(tmp_path, monkeypatch):
     assert record["turn_options"]["sandbox"] == _FakeSandbox.read_only
 
 
-def test_run_codex_turn_uses_full_access_for_confirmed_bypass_without_write_roots(tmp_path, monkeypatch):
+def test_run_codex_turn_uses_full_access_for_bypass_without_write_roots(tmp_path, monkeypatch):
     """External isolation remains authoritative when no roots are declared."""
     record = _install_fake_sdk(monkeypatch)
 
@@ -692,12 +673,7 @@ def test_run_codex_turn_uses_full_access_for_confirmed_bypass_without_write_root
             cwd=tmp_path,
             model="m",
             timeout_sec=5.0,
-            env=_gateway_env(
-                **{
-                    _SANDBOX_MODE_ENV: "bypass",
-                    _EXTERNAL_SANDBOX_ENV: "1",
-                }
-            ),
+            env=_gateway_env(**{_SANDBOX_MODE_ENV: "bypass"}),
         )
     )
 
@@ -705,11 +681,11 @@ def test_run_codex_turn_uses_full_access_for_confirmed_bypass_without_write_root
     assert record["turn_options"]["sandbox"] == _FakeSandbox.full_access
 
 
-def test_run_codex_turn_rejects_unconfirmed_bypass_before_starting(tmp_path, monkeypatch):
-    """An unsafe bypass setting fails before the app-server is constructed."""
+def test_run_codex_turn_rejects_bypass_without_operator_mode_opt_in(tmp_path, monkeypatch):
+    """A caller argument cannot replace the operator-owned bypass opt-in."""
     record = _install_fake_sdk(monkeypatch)
 
-    with pytest.raises(cs.CodexSessionUnavailableError, match=_EXTERNAL_SANDBOX_ENV):
+    with pytest.raises(cs.CodexSessionUnavailableError, match=_SANDBOX_MODE_ENV):
         asyncio.run(
             cs.run_codex_turn(
                 prompt="inspect",
@@ -717,7 +693,8 @@ def test_run_codex_turn_rejects_unconfirmed_bypass_before_starting(tmp_path, mon
                 cwd=tmp_path,
                 model="m",
                 timeout_sec=5.0,
-                env=_gateway_env(**{_SANDBOX_MODE_ENV: "bypass"}),
+                sandbox_mode="bypass",
+                env=_gateway_env(),
             )
         )
 

--- a/src/hyperloom/agents/kernel/tests/test_codex_session.py
+++ b/src/hyperloom/agents/kernel/tests/test_codex_session.py
@@ -44,6 +44,7 @@ _SECRET = "sk-do-not-leak-this-value"
 # rename of the variable or of an accepted value is a breaking change for every
 # deployment that set it, so it has to fail here.
 _SANDBOX_MODE_ENV = "HYPERLOOM_CODEX_SANDBOX_MODE"
+_LEGACY_EXTERNAL_SANDBOX_ENV = "HYPERLOOM_CODEX_EXTERNAL_SANDBOX"
 _WRITABLE_ROOTS = (Path("/tmp/out"),)
 
 
@@ -496,6 +497,24 @@ def test_resolve_codex_sandbox_mode_reads_the_operator_variable():
 def test_resolve_codex_sandbox_mode_allows_bypass_with_mode_opt_in():
     """Explicit bypass in the deployment environment permits full access."""
     assert cs.resolve_codex_sandbox_mode(env={_SANDBOX_MODE_ENV: "bypass"}) == "bypass"
+
+
+def test_resolve_codex_sandbox_mode_ignores_retired_external_sandbox_env():
+    """The removed confirmation env must not influence sandbox policy."""
+    assert cs.resolve_codex_sandbox_mode(env={_LEGACY_EXTERNAL_SANDBOX_ENV: "1"}) == "workspace-write"
+
+
+def test_resolve_codex_sandbox_mode_bypass_without_retired_external_sandbox_env():
+    """Bypass succeeds with only the operator mode opt-in after EXTERNAL_SANDBOX removal."""
+    assert (
+        cs.resolve_codex_sandbox_mode(
+            env={
+                _SANDBOX_MODE_ENV: "bypass",
+                _LEGACY_EXTERNAL_SANDBOX_ENV: "",
+            }
+        )
+        == "bypass"
+    )
 
 
 def test_resolve_codex_sandbox_mode_requires_the_environment_mode_opt_in_for_bypass():

--- a/src/hyperloom/agents/kernel/tests/test_forge_fusion.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_fusion.py
@@ -189,6 +189,19 @@ def test_build_cmd_forwards_bypass_agent_sandbox(tmp_path, monkeypatch):
     assert cmd[cmd.index("--agent-sandbox-mode") + 1] == "bypass"
 
 
+def test_build_cmd_forwards_bypass_without_retired_external_sandbox_env(tmp_path, monkeypatch):
+    """forge-fusion bypass must not require HYPERLOOM_CODEX_EXTERNAL_SANDBOX."""
+    monkeypatch.setenv(CODEX_SANDBOX_MODE_ENV, "bypass")
+    monkeypatch.delenv("HYPERLOOM_CODEX_EXTERNAL_SANDBOX", raising=False)
+    payload = _payload(tmp_path)
+    payload["agent_backend"] = "codex"
+    payload["agent_sandbox_mode"] = "bypass"
+
+    cmd = forge_fusion._build_cmd(payload)
+
+    assert cmd[cmd.index("--agent-sandbox-mode") + 1] == "bypass"
+
+
 def test_build_cmd_rejects_invalid_agent_sandbox_mode(tmp_path):
     payload = _payload(tmp_path)
     payload["agent_sandbox_mode"] = "unconfined"

--- a/src/hyperloom/agents/kernel/tests/test_forge_fusion.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_fusion.py
@@ -15,7 +15,6 @@ from pathlib import Path
 import pytest
 
 from hyperloom.common.codex_session import (
-    CODEX_EXTERNAL_SANDBOX_ENV,
     CODEX_SANDBOX_MODE_ENV,
 )
 
@@ -179,9 +178,8 @@ def test_build_cmd_forwards_read_only_agent_sandbox(tmp_path):
     assert cmd[cmd.index("--agent-sandbox-mode") + 1] == "read-only"
 
 
-def test_build_cmd_forwards_confirmed_bypass_agent_sandbox(tmp_path, monkeypatch):
+def test_build_cmd_forwards_bypass_agent_sandbox(tmp_path, monkeypatch):
     monkeypatch.setenv(CODEX_SANDBOX_MODE_ENV, "bypass")
-    monkeypatch.setenv(CODEX_EXTERNAL_SANDBOX_ENV, "1")
     payload = _payload(tmp_path)
     payload["agent_backend"] = "codex"
     payload["agent_sandbox_mode"] = "bypass"
@@ -189,17 +187,6 @@ def test_build_cmd_forwards_confirmed_bypass_agent_sandbox(tmp_path, monkeypatch
     cmd = forge_fusion._build_cmd(payload)
 
     assert cmd[cmd.index("--agent-sandbox-mode") + 1] == "bypass"
-
-
-def test_build_cmd_rejects_unconfirmed_bypass_agent_sandbox(tmp_path, monkeypatch):
-    monkeypatch.setenv(CODEX_SANDBOX_MODE_ENV, "bypass")
-    monkeypatch.delenv(CODEX_EXTERNAL_SANDBOX_ENV, raising=False)
-    payload = _payload(tmp_path)
-    payload["agent_backend"] = "codex"
-    payload["agent_sandbox_mode"] = "bypass"
-
-    with pytest.raises(RuntimeError, match=CODEX_EXTERNAL_SANDBOX_ENV):
-        forge_fusion._build_cmd(payload)
 
 
 def test_build_cmd_rejects_invalid_agent_sandbox_mode(tmp_path):

--- a/src/hyperloom/common/codex_session.py
+++ b/src/hyperloom/common/codex_session.py
@@ -21,9 +21,8 @@ Codex's ``read-only`` and ``workspace-write`` presets rely on bubblewrap.
 Hyperloom defaults to ``workspace-write`` and performs a real bubblewrap
 capability probe before starting the SDK, so a binary that exists but cannot
 create the required namespace fails closed. ``bypass`` is available only when
-the operator selects it with :data:`CODEX_SANDBOX_MODE_ENV` *and* confirms that
-an external sandbox is already enforcing isolation with
-:data:`CODEX_EXTERNAL_SANDBOX_ENV`.
+the operator selects it with :data:`CODEX_SANDBOX_MODE_ENV`, delegating
+containment to an external sandbox boundary.
 
 Provider credentials and headers remain environment-backed. Config overrides
 contain variable names only, because the SDK forwards every override through
@@ -72,10 +71,9 @@ _TOML_BARE_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 _EXACT_ENV_REF_RE = re.compile(r"^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$")
 _PRIVATE_HEADER_ENV_PREFIX = "HYPERLOOM_CODEX_HTTP_HEADER_"
 
-# Sandbox preset selector. Full access is a double opt-in because it delegates
-# all containment to an external boundary.
+# Sandbox preset selector. ``bypass`` delegates all containment to an external
+# boundary and must be set explicitly by the operator.
 CODEX_SANDBOX_MODE_ENV = "HYPERLOOM_CODEX_SANDBOX_MODE"
-CODEX_EXTERNAL_SANDBOX_ENV = "HYPERLOOM_CODEX_EXTERNAL_SANDBOX"
 DEFAULT_CODEX_SANDBOX_MODE = "workspace-write"
 # Ordered so the error raised for an unknown mode lists them predictably.
 CODEX_SANDBOX_MODES: tuple[str, ...] = ("bypass", "workspace-write", "read-only")
@@ -417,9 +415,9 @@ def resolve_codex_sandbox_mode(*, sandbox_mode: str = "", env: dict[str, str] | 
     """Resolve which Codex sandbox preset family a session may use.
 
     ``bypass`` is deliberately different from the contained modes: the
-    deployment must set both ``HYPERLOOM_CODEX_SANDBOX_MODE=bypass`` and
-    ``HYPERLOOM_CODEX_EXTERNAL_SANDBOX=1``. A caller argument may narrow the
-    deployment policy but cannot replace either operator-owned bypass opt-in.
+    deployment must set ``HYPERLOOM_CODEX_SANDBOX_MODE=bypass``. A caller
+    argument may narrow the deployment policy but cannot replace the
+    operator-owned bypass opt-in.
 
     Args:
         sandbox_mode (str): Mode stated by the caller; outranks the
@@ -432,7 +430,7 @@ def resolve_codex_sandbox_mode(*, sandbox_mode: str = "", env: dict[str, str] | 
 
     Raises:
         CodexSessionUnavailableError: If the resolved value names no known mode
-            or ``bypass`` lacks either required opt-in.
+            or ``bypass`` lacks the operator mode opt-in.
     """
     return _resolve_codex_sandbox_mode(
         sandbox_mode=sandbox_mode,
@@ -450,10 +448,6 @@ def _resolve_codex_sandbox_mode(*, sandbox_mode: str, source: Mapping[str, str])
     if configured != "bypass":
         raise CodexSessionUnavailableError(
             f"Codex sandbox bypass requires {CODEX_SANDBOX_MODE_ENV}=bypass in the effective environment"
-        )
-    if (source.get(CODEX_EXTERNAL_SANDBOX_ENV) or "").strip() != "1":
-        raise CodexSessionUnavailableError(
-            f"Codex sandbox bypass requires {CODEX_EXTERNAL_SANDBOX_ENV}=1 to confirm external isolation"
         )
     return resolved
 
@@ -1233,7 +1227,6 @@ async def run_codex_turn(
 
 
 __all__ = [
-    "CODEX_EXTERNAL_SANDBOX_ENV",
     "CODEX_PROVIDER_NAME",
     "CODEX_SANDBOX_MODES",
     "CODEX_SANDBOX_MODE_ENV",

--- a/src/hyperloom/inference_optimizer/tests/test_codex_intent_transport.py
+++ b/src/hyperloom/inference_optimizer/tests/test_codex_intent_transport.py
@@ -390,7 +390,6 @@ def test_run_codex_turn_forwards_the_output_schema_to_the_sdk(
                 "OPENAI_API_KEY": "key",
                 "OPENAI_BASE_URL": "https://gateway.invalid/v1",
                 "HYPERLOOM_CODEX_SANDBOX_MODE": "bypass",
-                "HYPERLOOM_CODEX_EXTERNAL_SANDBOX": "1",
                 "HYPERLOOM_RUNTIME_DIR": str(tmp_path / "runtime"),
             },
         )
@@ -420,7 +419,6 @@ def test_run_codex_turn_defaults_to_no_output_schema(
                 "OPENAI_API_KEY": "key",
                 "OPENAI_BASE_URL": "https://gateway.invalid/v1",
                 "HYPERLOOM_CODEX_SANDBOX_MODE": "bypass",
-                "HYPERLOOM_CODEX_EXTERNAL_SANDBOX": "1",
                 "HYPERLOOM_RUNTIME_DIR": str(tmp_path / "runtime"),
             },
         )

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -966,6 +966,18 @@ class TestForgeGemmHelperCoverage:
             == "bypass"
         )
 
+    def test_resolve_forge_fusion_ignores_retired_external_sandbox_env(self, monkeypatch):
+        _pin_fusion_provider_env(monkeypatch, _OPENAI_ONLY_ENV)
+        monkeypatch.setenv("HYPERLOOM_CODEX_EXTERNAL_SANDBOX", "1")
+
+        assert (
+            krh._resolve_forge_fusion_sandbox_mode(
+                {},
+                agent_backend="codex",
+            )
+            == DEFAULT_CODEX_SANDBOX_MODE
+        )
+
     def test_resolve_forge_fusion_claude_sandbox_uses_audit_default_or_override(self, monkeypatch):
         _pin_fusion_provider_env(monkeypatch, _ANTHROPIC_ONLY_ENV)
         # Claude's audit default is stable even if the Codex operator default is narrower.

--- a/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kernel_request_handlers_units.py
@@ -16,7 +16,6 @@ from pathlib import Path
 import pytest
 
 from hyperloom.common.codex_session import (
-    CODEX_EXTERNAL_SANDBOX_ENV,
     CODEX_SANDBOX_MODE_ENV,
     DEFAULT_CODEX_SANDBOX_MODE,
 )
@@ -41,7 +40,6 @@ _FUSION_PROVIDER_ENV_KEYS = (
     "FORGE_CLAUDE_MODEL",
     "FORGE_CODEX_MODEL",
     CODEX_SANDBOX_MODE_ENV,
-    CODEX_EXTERNAL_SANDBOX_ENV,
 )
 _OPENAI_ONLY_ENV = {
     "OPENAI_BASE_URL": "https://gateway.invalid/Unified/v1",
@@ -956,10 +954,9 @@ class TestForgeGemmHelperCoverage:
             == DEFAULT_CODEX_SANDBOX_MODE
         )
 
-    def test_resolve_forge_fusion_codex_sandbox_accepts_confirmed_bypass(self, monkeypatch):
+    def test_resolve_forge_fusion_codex_sandbox_accepts_bypass(self, monkeypatch):
         _pin_fusion_provider_env(monkeypatch, _OPENAI_ONLY_ENV)
         monkeypatch.setenv(CODEX_SANDBOX_MODE_ENV, "bypass")
-        monkeypatch.setenv(CODEX_EXTERNAL_SANDBOX_ENV, "1")
 
         assert (
             krh._resolve_forge_fusion_sandbox_mode(
@@ -1132,40 +1129,6 @@ class TestForgeGemmHelperCoverage:
 
         assert result["status"] == "failed"
         assert result["error_class"] == "llm_provider_unconfigured"
-        assert result["decision"] == "REVERT"
-        assert result["kept"] is False
-
-    @pytest.mark.asyncio
-    async def test_run_forge_fusion_rejects_unconfirmed_codex_bypass_before_subprocess(
-        self,
-        tmp_path,
-        monkeypatch,
-    ):
-        trace = tmp_path / "decode.trace.json.gz"
-        trace.write_text("{}", encoding="utf-8")
-        SharedState(
-            framework="sglang",
-            model_path="/models/zaya",
-            last_profile_trace=str(trace),
-        ).save(tmp_path)
-        _pin_fusion_provider_env(monkeypatch, _OPENAI_ONLY_ENV)
-        monkeypatch.setenv(CODEX_SANDBOX_MODE_ENV, "bypass")
-        monkeypatch.delenv(CODEX_EXTERNAL_SANDBOX_ENV, raising=False)
-        monkeypatch.setattr(krh, "_forge_fusion_available", lambda: True)
-
-        async def _should_not_run(*_args, **_kwargs):
-            raise AssertionError("forge-fusion must not run with unconfirmed bypass")
-
-        monkeypatch.setattr(krh, "_run_subprocess", _should_not_run)
-
-        result = await krh._run_forge_fusion(
-            {"agent_sandbox_mode": "bypass"},
-            session_dir=tmp_path,
-        )
-
-        assert result["status"] == "failed"
-        assert result["error_class"] == "invalid_agent_sandbox_mode"
-        assert CODEX_EXTERNAL_SANDBOX_ENV in result["error"]
         assert result["decision"] == "REVERT"
         assert result["kept"] is False
 

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_codex_backend.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_codex_backend.py
@@ -55,7 +55,6 @@ _PROVIDER_ENV_KEYS: tuple[str, ...] = (
     "OPENAI_API_KEY",
     "OPENAI_BASE_URL",
     "OPENAI_CUSTOM_HEADERS",
-    "HYPERLOOM_CODEX_EXTERNAL_SANDBOX",
     "HYPERLOOM_CODEX_SANDBOX_MODE",
 )
 
@@ -168,7 +167,6 @@ async def test_openai_only_deployment_runs_the_specialist_on_the_codex_cli(
     """
     _pin_provider_env(monkeypatch, _OPENAI_ONLY_ENV)
     monkeypatch.setenv("HYPERLOOM_CODEX_SANDBOX_MODE", "bypass")
-    monkeypatch.setenv("HYPERLOOM_CODEX_EXTERNAL_SANDBOX", "1")
     bin_dir = _fake_agent_bin_dir(tmp_path)
     monkeypatch.setenv("PATH", f"{bin_dir}:/usr/bin:/bin")
 
@@ -225,7 +223,6 @@ async def test_codex_home_is_per_task_and_outside_any_temp_dir(
     """
     _pin_provider_env(monkeypatch, _OPENAI_ONLY_ENV)
     monkeypatch.setenv("HYPERLOOM_CODEX_SANDBOX_MODE", "bypass")
-    monkeypatch.setenv("HYPERLOOM_CODEX_EXTERNAL_SANDBOX", "1")
     bin_dir = tmp_path / "bin"
     _write_executable(
         bin_dir / "codex",
@@ -399,17 +396,13 @@ def test_codex_argv_uses_workspace_write_sandbox_by_default(
     assert "--dangerously-bypass-approvals-and-sandbox" not in default_cmd
 
 
-def test_codex_argv_bypass_requires_both_operator_opt_ins(
+def test_codex_argv_bypass_requires_mode_opt_in(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Full access is available only under the canonical double opt-in."""
+    """Full access is available only when the operator selects bypass."""
     _pin_provider_env(monkeypatch, _OPENAI_ONLY_ENV)
     monkeypatch.setenv("HYPERLOOM_CODEX_SANDBOX_MODE", "bypass")
-    with pytest.raises(SpecialistAgentUnavailableError, match="EXTERNAL_SANDBOX"):
-        _build_cmd(tmp_path, codex_executable="/usr/bin/codex")
-
-    monkeypatch.setenv("HYPERLOOM_CODEX_EXTERNAL_SANDBOX", "1")
     bypass_cmd = _build_cmd(tmp_path, codex_executable="/usr/bin/codex")
     assert "--dangerously-bypass-approvals-and-sandbox" in bypass_cmd
     assert "--sandbox" not in bypass_cmd
@@ -544,7 +537,6 @@ async def test_missing_codex_runtime_fails_the_task_instead_of_spawning_claude(
     """
     _pin_provider_env(monkeypatch, _OPENAI_ONLY_ENV)
     monkeypatch.setenv("HYPERLOOM_CODEX_SANDBOX_MODE", "bypass")
-    monkeypatch.setenv("HYPERLOOM_CODEX_EXTERNAL_SANDBOX", "1")
     monkeypatch.setattr(
         "hyperloom.orchestrator.specialists.subprocess_.resolve_codex_executable",
         lambda explicit="": "",
@@ -586,7 +578,6 @@ async def test_unconfigured_codex_gateway_fails_the_task(
     """
     _pin_provider_env(monkeypatch, {"OPENAI_API_KEY": "openai-side-key"})
     monkeypatch.setenv("HYPERLOOM_CODEX_SANDBOX_MODE", "bypass")
-    monkeypatch.setenv("HYPERLOOM_CODEX_EXTERNAL_SANDBOX", "1")
     dispatcher = SpecialistSubprocessDispatcher(
         SpecialistSubprocessConfig(codex_executable="/usr/bin/codex", poll_interval_seconds=0.05)
     )
@@ -816,8 +807,6 @@ def test_codex_usage_returns_none_when_no_counters_are_reported(tmp_path: Path) 
 def _enable_codex_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
     """Select canonical bypass with both required operator opt-ins."""
     monkeypatch.setenv("HYPERLOOM_CODEX_SANDBOX_MODE", "bypass")
-    monkeypatch.setenv("HYPERLOOM_CODEX_EXTERNAL_SANDBOX", "1")
-
 
 def _successful_codex_script(path: Path) -> Path:
     """Write a fake Codex CLI that consumes stdin and completes the contract."""

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_codex_backend.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_codex_backend.py
@@ -805,8 +805,9 @@ def test_codex_usage_returns_none_when_no_counters_are_reported(tmp_path: Path) 
 
 
 def _enable_codex_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Select canonical bypass with both required operator opt-ins."""
+    """Select Codex sandbox bypass for unattended specialist runs."""
     monkeypatch.setenv("HYPERLOOM_CODEX_SANDBOX_MODE", "bypass")
+
 
 def _successful_codex_script(path: Path) -> Path:
     """Write a fake Codex CLI that consumes stdin and completes the contract."""

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_codex_backend.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_codex_backend.py
@@ -408,6 +408,18 @@ def test_codex_argv_bypass_requires_mode_opt_in(
     assert "--sandbox" not in bypass_cmd
 
 
+def test_codex_argv_retired_external_sandbox_env_alone_does_not_enable_bypass(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy HYPERLOOM_CODEX_EXTERNAL_SANDBOX=1 must not replace the mode opt-in."""
+    _pin_provider_env(monkeypatch, _OPENAI_ONLY_ENV)
+    monkeypatch.setenv("HYPERLOOM_CODEX_EXTERNAL_SANDBOX", "1")
+    cmd = _build_cmd(tmp_path, codex_executable="/usr/bin/codex")
+    assert cmd[cmd.index("--sandbox") + 1] == "workspace-write"
+    assert "--dangerously-bypass-approvals-and-sandbox" not in cmd
+
+
 def test_codex_specialist_rejects_read_only_sandbox(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/src/hyperloom/orchestrator/kernel/request_handlers.py
+++ b/src/hyperloom/orchestrator/kernel/request_handlers.py
@@ -4784,7 +4784,7 @@ def _resolve_forge_fusion_sandbox_mode(
     """Resolve and validate the sandbox policy recorded for forge-fusion.
 
     Codex delegates both defaults and validation to the canonical Hyperloom
-    resolver, including its double opt-in for ``bypass``. Claude records
+    resolver, including its operator opt-in for ``bypass``. Claude records
     ``workspace-write`` as the stable audit default; an explicit override is
     validated by that same resolver so both backends share one policy vocabulary
     and unsafe bypass cannot reach the subprocess.
@@ -4800,7 +4800,7 @@ def _resolve_forge_fusion_sandbox_mode(
 
     Raises:
         CodexSessionUnavailableError: If the mode is unknown or bypass lacks
-            either operator confirmation.
+            the operator mode confirmation.
     """
     explicit = str(payload.get("agent_sandbox_mode") or "").strip()
     if agent_backend == "claude" and not explicit:

--- a/src/kernelforge/fusion/command.py
+++ b/src/kernelforge/fusion/command.py
@@ -92,7 +92,6 @@ EXIT_LLM_UNAVAILABLE = 3
 # setup/environment problem from a genuine "nothing to fuse" answer.
 EXIT_INFRASTRUCTURE_FAILURE = 4
 _AGENT_SANDBOX_MODES = frozenset({"workspace-write", "read-only", "bypass"})
-_EXTERNAL_SANDBOX_CONFIRMATION = "HYPERLOOM_CODEX_EXTERNAL_SANDBOX"
 
 
 def _credential_shape() -> tuple[bool, bool]:
@@ -147,10 +146,6 @@ def _resolve_agent_sandbox_mode(explicit: Optional[str]) -> str:
     if mode not in _AGENT_SANDBOX_MODES:
         choices = ", ".join(sorted(_AGENT_SANDBOX_MODES))
         raise click.UsageError(f"unsupported agent sandbox mode {mode!r}; choose one of: {choices}")
-    if mode == "bypass" and os.environ.get(_EXTERNAL_SANDBOX_CONFIRMATION, "").strip() != "1":
-        raise click.UsageError(
-            f"--agent-sandbox-mode bypass requires {_EXTERNAL_SANDBOX_CONFIRMATION}=1 to confirm an external sandbox"
-        )
     return mode
 
 
@@ -523,7 +518,7 @@ def _setup_logging(output_dir: Path, verbose: bool = False) -> None:
     envvar="FORGE_AGENT_SANDBOX_MODE",
     default="workspace-write",
     show_default=True,
-    help="Agent runtime sandbox. Bypass additionally requires HYPERLOOM_CODEX_EXTERNAL_SANDBOX=1.",
+    help="Agent runtime sandbox. Use bypass only when an external boundary already enforces isolation.",
 )
 @click.option(
     "--model",

--- a/src/kernelforge/tests/fusion/test_resolve_and_cli.py
+++ b/src/kernelforge/tests/fusion/test_resolve_and_cli.py
@@ -51,7 +51,6 @@ _AGENT_ENV = (
     "CODEX_MODEL",
     "FORGE_API_KEY",
     "FORGE_AGENT_SANDBOX_MODE",
-    "HYPERLOOM_CODEX_EXTERNAL_SANDBOX",
     "OPENAI_API_KEY",
     "OPENAI_BASE_URL",
     "SAFE_API_KEY",
@@ -177,23 +176,7 @@ def test_explicit_secure_sandbox_mode_is_wired(
     assert captured["sandbox_mode"] == mode
 
 
-def test_unconfirmed_bypass_is_rejected_before_backend_construction(
-    clean_agent_env,
-    monkeypatch,
-):
-    monkeypatch.setattr(
-        cli_module,
-        "resolve_agent_runtime",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("runtime must not be resolved before bypass confirmation")
-        ),
-    )
-    with pytest.raises(click.UsageError, match="HYPERLOOM_CODEX_EXTERNAL_SANDBOX=1"):
-        _create_agent_backend("codex", "gpt-explicit", "bypass")
-
-
-def test_confirmed_bypass_is_wired(clean_agent_env, monkeypatch):
-    monkeypatch.setenv("HYPERLOOM_CODEX_EXTERNAL_SANDBOX", "1")
+def test_bypass_is_wired(clean_agent_env, monkeypatch):
     captured = {}
 
     def fake_resolve(provider, **kwargs):

--- a/src/kernelforge/tests/fusion/test_resolve_and_cli.py
+++ b/src/kernelforge/tests/fusion/test_resolve_and_cli.py
@@ -194,6 +194,32 @@ def test_bypass_is_wired(clean_agent_env, monkeypatch):
     assert captured["sandbox_mode"] == "bypass"
 
 
+def test_bypass_is_wired_without_retired_external_sandbox_env(clean_agent_env, monkeypatch):
+    """forge-fuse bypass no longer gates on HYPERLOOM_CODEX_EXTERNAL_SANDBOX."""
+    monkeypatch.delenv("HYPERLOOM_CODEX_EXTERNAL_SANDBOX", raising=False)
+    captured = {}
+
+    def fake_resolve(provider, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(provider=provider, model=kwargs["model"], sandbox_mode="bypass")
+
+    backend = SimpleNamespace(
+        name="codex",
+        runtime=SimpleNamespace(provider="codex", model="gpt-explicit", sandbox_mode="bypass"),
+    )
+    monkeypatch.setattr(cli_module, "resolve_agent_runtime", fake_resolve)
+    monkeypatch.setattr(cli_module, "create_registered_backend", lambda runtime: backend)
+
+    assert _create_agent_backend("codex", "gpt-explicit", "bypass") is backend
+    assert captured["sandbox_mode"] == "bypass"
+
+
+def test_retired_external_sandbox_env_does_not_confirm_bypass(clean_agent_env, monkeypatch):
+    """Legacy HYPERLOOM_CODEX_EXTERNAL_SANDBOX=1 must not substitute bypass mode."""
+    monkeypatch.setenv("HYPERLOOM_CODEX_EXTERNAL_SANDBOX", "1")
+    assert cli_module._resolve_agent_sandbox_mode(None) == "workspace-write"
+
+
 def test_sandbox_mode_explicit_value_wins_over_environment(clean_agent_env, monkeypatch):
     monkeypatch.setenv("FORGE_AGENT_SANDBOX_MODE", "read-only")
     assert cli_module._resolve_agent_sandbox_mode(None) == "read-only"


### PR DESCRIPTION
## Summary
- Remove `HYPERLOOM_CODEX_EXTERNAL_SANDBOX`; Codex sandbox bypass now requires only `HYPERLOOM_CODEX_SANDBOX_MODE=bypass`.
- Keep the operator env guard so callers cannot enable bypass without the deployment-level mode opt-in.
- Update docs and tests to match the single-variable contract.

## Test plan
- [x] `pytest src/hyperloom/agents/kernel/tests/test_codex_session.py`
- [x] `pytest src/hyperloom/agents/kernel/tests/test_forge_fusion.py`
- [x] `pytest src/hyperloom/inference_optimizer/tests/test_specialist_codex_backend.py::test_codex_argv_bypass_requires_mode_opt_in`


Made with [Cursor](https://cursor.com)