### PR TITLE
docs(agentx): correct the warmup-grace CHANGELOG to what shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,17 +185,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   construction, while `AGENTX_WARMUP_GRACE_PERIOD` is one flat number — a grace
   measured at one concurrency under-budgets every higher one (measured on
   Kimi-K3: conc=8 → 87 warmup requests ~3000s; conc=16 → 177 requests ~5000s).
-  The grace is now scaled by `CONC / AGENTX_WARMUP_GRACE_CONC`, and the scaling
-  lives in one function that both consumers call: this process derives the
-  subprocess cap from it, and `apply_agentx_switch` exports its result into the
-  benchmark env so the client's `--warmup-grace-period` — the thing that
+  The grace can now be scaled by `CONC / AGENTX_WARMUP_GRACE_CONC`, and the
+  scaling lives in one function that both consumers call: this process derives
+  the subprocess cap from it, and `apply_agentx_switch` exports its result into
+  the benchmark env so the client's `--warmup-grace-period` — the thing that
   actually stops the warmup — cannot disagree with the cap.<br/>
-  **Operator note**: `AGENTX_WARMUP_GRACE_CONC` declares the concurrency the
-  grace was measured at and defaults to 8, so every existing configuration
-  derives exactly what it derived before. Declare it when you measured
-  elsewhere — the scaling is a ratio, and a 14400s grace measured at conc=16
-  passed in without the anchor is read as an 8-anchored number and doubled.
-  The floor only ever raises a bound.
+  **Operator note**: the scaling is **opt-in**. `AGENTX_WARMUP_GRACE_CONC`
+  declares the concurrency the grace was measured at, and with no anchor
+  declared the grace is used flat — a ratio needs two numbers, and assuming the
+  second one made the same value mean different things depending on whether it
+  was typed (an explicit `AGENTX_WARMUP_GRACE_PERIOD=1800` yielded a 23400s cap
+  at CONC=64 while leaving it unset yielded 10800s, and the conc sweep then
+  priced every rung against the inflated number). So declare the anchor whenever
+  you run above the concurrency you measured at: without it, a 3600s grace
+  measured at conc=8 stays 3600s at CONC=32, where the warmup needs roughly
+  three times that — and the round does not fail, it reports a prefix-reuse
+  figure taken before the cache filled. When the anchor is declared the scaling
+  only ever raises the bound, and stays identity at or below the anchor.<br/>
+  A conc sweep bounds each rung by **its own** concurrency, not the session's:
+  the grace, the inner Magpie cap and the variant subprocess cap all derive from
+  the rung's `CONC`, and the budget gates that admit a rung price it at the same
+  number, so admission and grant cannot disagree. Raising only the client's
+  grace would be strictly worse than leaving all three alone — the round would
+  wait inside a bound its own caps do not cover and be killed mid-warmup.
 
 - **Budget admission prices a variant at the cap it will actually be granted.**
   Four gates (`_skip_rest_for_budget` and three in the conc sweep) plus the


### PR DESCRIPTION
## Summary

The #1309 CHANGELOG entry describing `AGENTX_WARMUP_GRACE_CONC` is wrong in one place and silent in another. That entry is the **only** human-facing documentation of this knob — the `AGENTX_*` family does not appear in `docs/` at all, and the client header does not carry it because it is consumed orchestrator-side.

### 1. "defaults to 8" — false

The entry says the anchor "defaults to 8, so every existing configuration derives exactly what it derived before". It is **opt-in**:

```python
# baseline.py, agentx_warmup_grace_sec()
if not _agentx_positive_int(src, "AGENTX_WARMUP_GRACE_CONC"):
    return grace
```

With no anchor declared the grace is returned flat and never scales. The conclusion happens to still hold, but for the opposite reason — and an operator who reads it as "CONC scaling is automatic" gets an under-budgeted warmup at every concurrency above the one they measured at. Silently: that branch logs nothing.

The failure that leads to is the one #1309 set out to fix. A warmup cut short does not fail the round; it reports a prefix-reuse figure taken before the cache filled.

### 2. Per-rung bounding — shipped, undocumented

The paragraph used to claim a sweep variant re-derived from its own `CONC`, which was false at the time. `b00f9829` **made it true** and deleted the sentence without replacing it, so the behaviour now ships with no description anywhere in the CHANGELOG.

One sentence adds it back. Verified against the code, not the commit message:

| claim | where |
|---|---|
| grace + inner Magpie cap take the rung's `CONC` | `_grid_runner.py:632` → `apply_agentx_switch(conc=variant_conc(variant))` |
| variant subprocess cap likewise | `_grid_runner.py:1452` → `agentx_baseline_timeout_sec(agentx_env_for_conc(conc))` |
| budget gates price admission at the same number | `_grid_runner.py:1738`, `:1911`, `conc_sweep.py:781`, `:950` |

## Scope note (rebased 2026-09-03)

This branch originally corrected two sentences and added a "**Not covered**" clause. Rebasing onto current `main` changed what is still true:

| originally | now |
|---|---|
| "a sweep variant re-derives from its own `CONC`" was false | `b00f9829` made it true — so this PR now **documents** it rather than correcting it |
| a "**Not covered**" clause explaining why sweep variants deliberately did **not** re-derive | would now be false itself — **dropped**, not rebased in |
| "defaults to 8" was false | still false on `main` — corrected |

The merge conflict was in this same paragraph (not, as first read, in an unrelated entry `main` had added). Resolved by keeping `main`'s text and replacing only the operator note; every other entry `main` added is preserved.

## Changes

CHANGELOG only — **no code change**. One file, +22/−10.

## Test plan

- [x] `git diff origin/main..HEAD` is `CHANGELOG.md` only; every other entry `main` added is intact
- [x] Every surviving claim re-verified against `main`'s code: the opt-in early return, the identity-at-or-below-anchor behaviour (`if conc <= anchor: return grace`), the 23400s-vs-10800s example (quoted from the code comment that documents it), and the four call sites in the table above
- N/A — no code paths touched, so no tests to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

