### PR TITLE
chore(kernel): drop parameters the forge submit path never reads

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_invocation_spec.py
+++ b/src/hyperloom/agents/kernel/tests/test_invocation_spec.py
@@ -305,7 +305,6 @@ def test_forge_invoke_persists_and_passes_operator_spec(tmp_path, monkeypatch):
         return {"returncode": 0, "stdout": "ok", "stdout_tail": "ok", "stderr_tail": ""}
 
     monkeypatch.setattr(kernel_optimization, "_forge_output_dir", lambda *_args: out_dir)
-    monkeypatch.setattr(kernel_optimization, "ray_available", lambda: False)
     monkeypatch.setattr(
         kernel_optimization,
         "_import_backend",

--- a/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
+++ b/src/hyperloom/agents/kernel/tools/backends/forge_submit.py
@@ -1751,9 +1751,7 @@ def _export_best_artifacts(
     return str(primary), changed
 
 
-def _normalized(
-    returncode: int, stdout: str, stderr: str, elapsed_s: float, gpu_ids: str = "", skipped: bool = False
-) -> dict:
+def _normalized(returncode: int, stdout: str, stderr: str, elapsed_s: float, skipped: bool = False) -> dict:
     """Shape the kernel-backend result dict (``returncode`` / ``skipped`` /
     ``stdout_tail`` / ``stderr_tail`` / ``stdout`` / ``gpu_ids`` / ``elapsed_s``
     / ``cmd``).
@@ -1771,7 +1769,7 @@ def _normalized(
         "stdout_tail": (stdout or "")[-4000:],
         "stderr_tail": (stderr or "")[-4000:],
         "stdout": stdout or "",
-        "gpu_ids": gpu_ids or (os.environ.get("HIP_VISIBLE_DEVICES") or os.environ.get("CUDA_VISIBLE_DEVICES") or ""),
+        "gpu_ids": os.environ.get("HIP_VISIBLE_DEVICES") or os.environ.get("CUDA_VISIBLE_DEVICES") or "",
         "elapsed_s": round(elapsed_s, 2),
         "cmd": ["forge_submit.submit"],
     }
@@ -4508,9 +4506,7 @@ def submit(
     output_dir: Path,
     source_type: str = "unknown",
     candidate: dict | None = None,
-    num_gpus: int = 1,
     timeout_s: int = 1800,
-    prefer_ray: bool = True,
     kernel_repo: str = "",
     invocation_spec_file: str = "",
 ) -> dict:

--- a/src/hyperloom/agents/kernel/tools/kernel_optimization.py
+++ b/src/hyperloom/agents/kernel/tools/kernel_optimization.py
@@ -1961,20 +1961,6 @@ def build_prompt(
     )
 
 
-def ray_available() -> bool:
-    """Report whether the optional ``ray`` dependency can be imported.
-
-    Returns:
-        bool: True when ``import ray`` succeeds; False on any import error.
-    """
-    try:
-        import ray  # noqa: F401
-
-        return True
-    except Exception:
-        return False
-
-
 def _backends_module_dir() -> Path:
     """Return the directory holding the per-backend submitter modules.
 
@@ -2094,11 +2080,8 @@ def invoke_backend(
     """
     budget_min = float(getattr(args, "budget_minutes", 60) or 60)
     timeout_s = max(60, int(budget_min * 60))
-    prefer_ray = ray_available()
     candidate = candidate or {}
     kernel_repo = str(candidate.get("kernel_repo") or "")
-    # GPU count: CLI override, then candidate hint, then 1.
-    num_gpus = max(1, int(getattr(args, "num_gpus", 0) or 0) or int(candidate.get("num_gpus_recommended") or 1))
 
     try:
         if backend == "forge":
@@ -2126,9 +2109,7 @@ def invoke_backend(
                 output_dir=out_dir,
                 source_type=str((candidate or {}).get("source_type") or "unknown"),
                 candidate=candidate or {},
-                num_gpus=num_gpus,
                 timeout_s=timeout_s,
-                prefer_ray=prefer_ray,
                 kernel_repo=kernel_repo,
                 invocation_spec_file=(str(invocation_spec_path) if invocation_spec_path.is_file() else ""),
             )


### PR DESCRIPTION
- **Description: what and why**

  `submit()` accepted `num_gpus` and `prefer_ray` and read neither. Everything
  upstream that computed them was therefore work thrown away:

  - `invoke_backend()` derived both values for the sole purpose of passing them on.
  - `ray_available()` existed only to produce `prefer_ray`. Its import probe was
    also one of the file's bare `except Exception` handlers, so deleting the
    function retires a broad catch along with the dead value.

  `_normalized()` had the same shape: no call site passed `gpu_ids` (checked with
  ast across every call site — all 19 pass exactly 4 positional args, and
  `gpu_ids` is the 5th), so `gpu_ids or <env chain>` always took the env side.
  Reading the env directly says what the function actually does.

  No behaviour change: none of these values ever reached a decision.

  Nothing is orphaned by the deletion: `args.num_gpus` and
  `candidate["num_gpus_recommended"]` are still read at
  `kernel_optimization.py:1578` for the multi-GPU prompt text, so `--num-gpus`
  keeps a consumer; and `ray_runtime.py` stays live via
  `orchestrator/actions/executors/_ray_backend.py`, which imports
  `ensure_ray_cluster` / `quiet_ray_init` on the production path.

  Found while auditing Forge for dead code. Worth recording that the audit came
  back mostly empty — module-level reachability analysis over `src/kernelforge/`
  (232 non-test modules) found **zero** dead modules, and symbol-level analysis
  over the Hyperloom-side Forge integration (148 top-level symbols) found
  **zero** unreferenced symbols. This dead parameter chain was the one genuine
  find. Symbol-level analysis is also the wrong instrument for the rest of it:
  dead *values* and dead fallback branches live inside functions that are very
  much alive, which is why this find is a parameter chain rather than a symbol.

- **Linked issue(s):** none

- **Tests: added/updated? commands run?**

  No new tests: this is a pure deletion of values that never reached a decision,
  and the existing suite already covers the call path. One line dropped from
  `test_invocation_spec.py` — it monkeypatched `ray_available`, which no longer
  exists, and `monkeypatch.setattr` on a removed attribute raises
  `AttributeError`, so that line had to go rather than merely being tidied.

  Ran: `ruff check` + `ruff format --check` (pass), `py_compile` on all changed
  files (pass).

  `forge_submit.py` imports `fcntl` (Unix-only, pre-existing), so these tests
  cannot be collected on Windows unmodified. Run with a no-op `fcntl` shim on
  `PYTHONPATH`, `test_invocation_spec.py` + `test_forge_fusion.py` +
  `test_forge_long_horizon_cli.py` + `test_kernel_optimization_verification.py`
  give **5 failed / 289 passed both before and after this change, with an
  identical set of failing test ids** (pre-existing Windows path-separator and
  signal-handling failures). Locking is a no-op under that shim, so CI on Linux
  remains the authority for anything lock-dependent — but the regression signal
  here is real.

- **Breaking changes:** no. `submit()` is called from exactly one place
  (`kernel_optimization.invoke_backend`, updated here); it is not part of any
  external contract, and `forge_collective.py`'s cross-module import list does
  not include `submit` or `_normalized`. Nothing outside `src/` (docs, scripts,
  `.github/`) passes either parameter.

- **Follow-up, deliberately not in this PR:** the `gpu_ids` *output* key now
  looks like the deeper dead value. `_normalized` computes it from
  `HIP_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES`, `invoke_backend` emits
  `"gpu_ids": ""` on its unknown-backend shape, and both docstrings document it,
  but no reader of `result["gpu_ids"]` exists in this repo for this contract (the
  other `gpu_ids` hits belong to separate subsystems: gemm_tune's `ctx.gpu_ids`,
  the orchestrator's `GpuLease.gpu_ids`, rebench's own result dict). Dropping a
  key from a result contract that gets persisted needs an artifact-consumer
  check first, so it belongs in its own change.
