### PR TITLE
fix: a retired API key must not satisfy a credential check

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_forge_collective.py
+++ b/src/hyperloom/agents/kernel/tests/test_forge_collective.py
@@ -515,7 +515,7 @@ def test_gateway_env_is_derived_from_openai_settings(monkeypatch):
     """Missing author settings are derived without leaking process state."""
     _clear_author_env(monkeypatch)
     monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example/v1")
-    monkeypatch.setenv("SAFE_API_KEY", "token-1")
+    monkeypatch.setenv("OPENAI_API_KEY", "token-1")
 
     def _root_euid() -> int:
         """Simulate execution as root."""
@@ -542,7 +542,7 @@ def test_gateway_env_preserves_operator_settings(monkeypatch):
     _clear_author_env(monkeypatch)
     values = {
         "OPENAI_BASE_URL": "https://gateway.example/v1",
-        "SAFE_API_KEY": "derived-token",
+        "OPENAI_API_KEY": "derived-token",
         "ANTHROPIC_BASE_URL": "https://anthropic.example",
         "ANTHROPIC_API_KEY": "api-token",
         "ANTHROPIC_AUTH_TOKEN": "auth-token",
@@ -566,6 +566,37 @@ def test_gateway_env_preserves_operator_settings(monkeypatch):
     fc._inject_author_gateway_env()
 
     assert {key: fc.os.environ[key] for key in values} == values
+
+
+def test_a_legacy_key_does_not_outrank_the_openai_key(monkeypatch):
+    """The configured key wins over ``SAFE_API_KEY``, which the installers purge."""
+    _clear_author_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example/v1")
+    monkeypatch.setenv("SAFE_API_KEY", "stale-legacy-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "live-key")
+
+    fc._inject_author_gateway_env()
+
+    assert fc.os.environ["ANTHROPIC_API_KEY"] == "live-key"
+    assert fc.os.environ["ANTHROPIC_AUTH_TOKEN"] == "live-key"
+
+
+def test_a_legacy_key_alone_authenticates_nothing(monkeypatch):
+    """``SAFE_API_KEY`` alone derives no credential.
+
+    The Git identity assertions pin that the rest of the seeding still runs, so
+    this cannot pass by the function doing nothing at all.
+    """
+    _clear_author_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example/v1")
+    monkeypatch.setenv("SAFE_API_KEY", "stale-legacy-key")
+
+    fc._inject_author_gateway_env()
+
+    assert fc.os.environ.get("ANTHROPIC_API_KEY") is None
+    assert fc.os.environ.get("ANTHROPIC_AUTH_TOKEN") is None
+    assert fc.os.environ["ANTHROPIC_BASE_URL"] == "https://gateway.example"
+    assert fc.os.environ["GIT_AUTHOR_NAME"] == "forge-bot"
 
 
 def test_load_input_json_requires_path():

--- a/src/hyperloom/agents/kernel/tools/forge_collective.py
+++ b/src/hyperloom/agents/kernel/tools/forge_collective.py
@@ -75,10 +75,10 @@ FORGE_SHUTDOWN_GRACE_SEC = 30
 
 def _inject_author_gateway_env() -> None:
     """Seed missing Forge author credentials and Git identity."""
-    openai_base = str(os.environ.get("OPENAI_BASE_URL") or "").strip()
+    openai_base = os.environ.get("OPENAI_BASE_URL", "").strip()
     if openai_base and not os.environ.get("ANTHROPIC_BASE_URL"):
         os.environ["ANTHROPIC_BASE_URL"] = openai_base[:-3] if openai_base.endswith("/v1") else openai_base
-    token = str(os.environ.get("SAFE_API_KEY") or os.environ.get("OPENAI_API_KEY") or "").strip()
+    token = os.environ.get("OPENAI_API_KEY", "").strip()
     if token:
         os.environ.setdefault("ANTHROPIC_API_KEY", token)
         os.environ.setdefault("ANTHROPIC_AUTH_TOKEN", token)

--- a/src/kernelforge/fusion/command.py
+++ b/src/kernelforge/fusion/command.py
@@ -96,8 +96,15 @@ _EXTERNAL_SANDBOX_CONFIRMATION = "HYPERLOOM_CODEX_EXTERNAL_SANDBOX"
 
 
 def _credential_shape() -> tuple[bool, bool]:
-    """Return whether OpenAI-side and Anthropic-side credentials are configured."""
-    openai = any(os.environ.get(name, "").strip() for name in ("OPENAI_API_KEY", "SAFE_API_KEY", "FORGE_API_KEY"))
+    """Return whether OpenAI-side and Anthropic-side credentials are configured.
+
+    Only keys the gateway actually authenticates with count. ``SAFE_API_KEY`` and
+    ``FORGE_API_KEY`` used to be accepted here; they no longer authenticate
+    anything (``resolve_openai_gateway`` ignores them), so counting them meant a
+    stale value routed ``auto`` to codex and failed downstream instead of raising
+    the "no credentials" error below.
+    """
+    openai = bool(os.environ.get("OPENAI_API_KEY", "").strip())
     anthropic = any(os.environ.get(name, "").strip() for name in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")) or any(
         os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
         for name in ("CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX")

--- a/src/kernelforge/tests/fusion/test_resolve_and_cli.py
+++ b/src/kernelforge/tests/fusion/test_resolve_and_cli.py
@@ -109,6 +109,21 @@ def test_auto_agent_backend_rejects_unconfigured_environment(clean_agent_env):
         _resolve_agent_choice("auto", None)
 
 
+@pytest.mark.parametrize("retired", ["SAFE_API_KEY", "FORGE_API_KEY"])
+def test_a_retired_key_does_not_configure_a_provider(clean_agent_env, monkeypatch, retired):
+    """A key the gateway rejects must not satisfy ``auto``.
+
+    ``resolve_openai_gateway`` stopped accepting these, so treating one as an
+    OpenAI credential picked codex and failed later at the call, hiding the
+    real problem: nothing is configured.
+    """
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://openai.example/v1")
+    monkeypatch.setenv(retired, "retired-value")
+
+    with pytest.raises(click.UsageError, match="no OpenAI or Anthropic credentials"):
+        _resolve_agent_choice("auto", None)
+
+
 def test_explicit_agent_backend_wins_over_credential_shape(clean_agent_env, monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
     provider, model = _resolve_agent_choice("codex", None)


### PR DESCRIPTION
- **Description: what and why**

  One concern, on both sides of the Forge boundary: **a retired credential must
  not satisfy a credential check.** `SAFE_API_KEY` / `FORGE_API_KEY` are legacy
  gateway vars — both installers `remove_dotenv_var` them and the setup tests
  assert the legacy key "is never read, exported or persisted" — yet two live
  code paths still counted them.

  **KernelForge side — `fusion/command.py::_credential_shape()`.** It counted
  both retired names as OpenAI credentials, but `resolve_openai_gateway()`
  stopped accepting them (already pinned by `test_retired_keys_are_not_credentials`
  and `test_supervisor_backend.py`). The two disagreed, and the disagreement was
  load-bearing. Measured directly:

  | environment | `_credential_shape()` says | gateway actually |
  |---|---|---|
  | `OPENAI_BASE_URL` + `SAFE_API_KEY` | configured | **unusable** |
  | `OPENAI_BASE_URL` + `OPENAI_API_KEY` | configured | usable |

  A stale value was therefore **worse than no value at all**:

  - Nothing set → `--agent-backend auto` raises
    `no OpenAI or Anthropic credentials` and names the variable to set.
  - Only the retired key set → that error is skipped, `auto` resolves to
    `('codex', 'gpt-5.6')`, and the run fails later at the call — pointing the
    operator at codex instead of at the unset credential. "Later" matters:
    `require_agent_backend()` is lazy and first runs after `diagnose_trace`, and
    is also handed to the campaign as `agent_factory`, so a stale key survives
    startup and dies mid-run.

  **Hyperloom side — `forge_collective.py::_inject_author_gateway_env()`.** The
  same retired name, in the same shape, one repo over:
  `SAFE_API_KEY or OPENAI_API_KEY` — read *first*, so a stale value outranked
  the key the operator did configure and became the authoring run's
  `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`. Deriving the Anthropic pair from
  the OpenAI pair is deliberate here (one LiteLLM gateway serving both
  protocols, mirroring `_resolve_llm_endpoints()`); what was wrong is *which*
  variable fed it.

  Since `FORGE_` is on env_safety's dotenv prefix allowlist, a stale
  `FORGE_API_KEY` in an operator's `.env` is still forwarded into the run, so
  both paths are reachable in practice rather than theoretical.

- **Linked issue(s):** none

- **Tests: added/updated? commands run?**

  KernelForge side: added `test_a_retired_key_does_not_configure_a_provider`,
  parametrized over both retired names, asserting `auto` still raises rather
  than resolving a provider. Ran `pytest src/kernelforge/tests/fusion/` before
  and after: baseline `50 failed, 549 passed, 2 skipped` → `50 failed, 551
  passed, 2 skipped`, identical failure set (pre-existing Windows
  `PermissionError` / environment limits).

  Hyperloom side: added `test_a_legacy_key_does_not_outrank_the_openai_key`
  (stale legacy var *and* a live `OPENAI_API_KEY` set → the live one must win,
  asserted by exact equality) and `test_a_legacy_key_alone_authenticates_nothing`
  (legacy var alone derives no credential; it also asserts the Git identity
  seeding still happens, so it cannot pass by the function doing nothing). Two
  existing tests switched from supplying the value via `SAFE_API_KEY` to
  `OPENAI_API_KEY`.

  Both new tests were run against the unfixed code first and fail there
  (`assert 'stale-legacy-key' == 'live-key'`). After the fix, the four
  gateway-env tests pass. The full `test_forge_collective.py` reports `22
  failed, 141 passed`; a clean `git worktree` at the parent commit reports `22
  failed, 139 passed` with a **byte-identical failure list** (Windows
  `WinError 32` on `workspace.lock` and friends), the two extra passes being the
  new tests. `ruff check` + `ruff format --check` clean on all changed files.

- **Breaking changes:** behavioural, and deliberately so.

  - An operator who set only `SAFE_API_KEY` / `FORGE_API_KEY` previously got an
    implicit codex selection that could not authenticate; they now get the
    explicit "no credentials" error naming `OPENAI_API_KEY`.
  - A collective authoring run that was picking up a stale `SAFE_API_KEY` now
    uses the configured `OPENAI_API_KEY`, or fails at the missing credential
    instead of at the gateway.

  No configuration that previously *worked* stops working: the retired names
  could not authenticate anything on either side.

- **Not in this PR, on purpose:** `_credential_shape()` still reports the OpenAI
  line as configured when `OPENAI_API_KEY` is set but `OPENAI_BASE_URL` is not,
  which is the same disagreement with a different missing half (the gateway
  requires both). Fixing it structurally means delegating to
  `resolve_openai_gateway().is_complete()` rather than re-deriving the
  credential rules here — a different change, and it wants the error message to
  name `OPENAI_BASE_URL` too. Also untouched:
  `_inject_author_gateway_env()` seeds Claude-only variables unconditionally
  without consulting `agent_backend`, which `forge_fusion.py` already handles by
  returning early for codex. Neither is a retired-credential problem.
