### PR TITLE
refactor(kernel): catch what the fusion manifest read can actually raise

### DIFF
--- a/src/hyperloom/agents/kernel/tools/forge_fusion.py
+++ b/src/hyperloom/agents/kernel/tools/forge_fusion.py
@@ -280,7 +280,7 @@ def _normalize_manifest(output_dir: str, rc: int) -> dict[str, Any]:
         return result
     try:
         m = json.loads(manifest_path.read_text(encoding="utf-8", errors="replace"))
-    except Exception as exc:  # noqa: BLE001
+    except (OSError, json.JSONDecodeError) as exc:
         result["error"] = f"fusion_manifest.json parse error: {exc!r}"
         return result
 


### PR DESCRIPTION
- **Description: what and why**

  The `fusion_manifest.json` read caught `Exception` behind a `# noqa: BLE001`
  waiver, so *any* unexpected error was reshaped into a
  `"fusion_manifest.json parse error: ..."` string and returned as an ordinary
  failed result. That makes a genuine bug indistinguishable from malformed JSON,
  and the reported cause is actively misleading.

  The two calls guarded here raise exactly two things: `read_text` raises
  `OSError` (the `is_file()` guard is already above it, and `errors="replace"`
  rules out `UnicodeDecodeError`), `json.loads` raises `json.JSONDecodeError`.
  Naming them keeps the error message honest and lets anything else surface.

  **Where an escaping exception lands**, since that is what makes this safe
  rather than merely tidier: `_normalize_manifest`'s only production caller is
  `forge_fusion.main()`, and that call is not inside a `try`, so an unexpected
  error now propagates, `_emit` never runs, and no
  `FORGE_FUSION_RESULT_BEGIN` block is printed. The consumer handles exactly
  that: `request_handlers._parse_forge_fusion_sentinel` returns `None`, and
  `_shape_tool_result` then returns
  `status: failed` / `error_class: tool_output_unparseable` with the traceback in
  `stderr_tail`. It explicitly refuses to infer success from `rc == 0` (the
  comment there records a roofline leg that once reported success over an empty
  analysis). So the failure arrives as a structured failure with a real cause,
  not as a silent wrong answer.

  Scope note: this is deliberately one handler, not a sweep. The Forge
  integration layer has 32 broad handlers and most are load-bearing (structured
  failure reporting, lock release before re-raise). This one is not — it sits on
  a pure read-and-parse with a known, small exception surface.

- **Linked issue(s):** none

- **Tests: added/updated? commands run?**

  No new test: the existing `_normalize_manifest` coverage in
  `test_forge_fusion.py` exercises the malformed-manifest path with `"{not-json"`
  (a `JSONDecodeError`, still caught), and the change narrows which exceptions
  are caught rather than altering the result contract for the errors that were
  genuinely being handled.

  `test_forge_fusion.py` transitively imports `forge_submit`, which imports
  `fcntl` (Unix-only, pre-existing), so it cannot be collected on Windows
  unmodified. Run with a no-op `fcntl` shim on `PYTHONPATH`,
  `test_forge_fusion.py` + `test_invocation_spec.py` give **87 passed** on this
  branch. `ruff check` + `ruff format --check` pass.

  **Correcting an earlier version of this description:** removing the
  `# noqa: BLE001` buys no lint protection. This repo's ruff config is
  `select = ["E", "F", "W"]` (`pyproject.toml`) and CI runs a plain
  `ruff check .`, so `BLE001` has never been enforced here — the `noqa` was
  decorative, and `RUF100` is not on either, so it would not have been reported
  as unused. Nothing would flag a future re-broadening of this handler. Making
  that ratchet real means enabling `BLE001`, which lights up the backlog above
  and is its own change.

- **Breaking changes:** no, unless something was relying on an unrelated
  exception being silently reported as a parse error — which is the behaviour
  this removes on purpose.

- **Known rough edge left alone:** an `OSError` is still labelled
  `"fusion_manifest.json parse error"`, which is the wrong noun for a read
  failure. Renaming it to `read/parse error` is a one-word fix, but it changes a
  user-visible string, so it is left out of a PR whose point is the handler.
