### PR TITLE
Parse Claude Code __unparsedToolInput emit_intent envelopes

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_claude_backend.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_backend.py
@@ -136,6 +136,15 @@ async def test_cancellation_is_not_marked_as_an_llm_failure():
             },
             id="review_verdict_full",
         ),
+        pytest.param(
+            {
+                "__unparsedToolInput": {
+                    "raw": '{"intent_type": "send_message", "payload": {"topic": "heartbeat"}}',
+                    "len": 62,
+                }
+            },
+            id="unparsed_wrapper_fallback",
+        ),
     ],
 )
 def test_validate_emit_intent_input_accepts_well_formed(payload):
@@ -493,18 +502,19 @@ async def test_run_invalid_tool_use_input_drops_block_silently():
     assert len(res.intents) == 1
 
 
+@pytest.mark.parametrize("tool_name", [EMIT_INTENT_TOOL_QUALIFIED, EMIT_INTENT_TOOL_NAME])
 @pytest.mark.asyncio
-async def test_unparsed_tool_wrapper_retries_dedupe_to_one_intent():
+async def test_unparsed_tool_wrapper_retries_dedupe_to_one_intent(tool_name):
     """Claude Code retries the same wrapped JSON; keep one validated intent."""
     raw = '{"intent_type": "send_message", "payload": {"topic": "heartbeat", "body_md": "ok"}}'
     wrapped = {"__unparsedToolInput": {"raw": raw, "len": len(raw)}}
     other = '{"intent_type": "send_message", "payload": {"topic": "status", "body_md": "next"}}'
     msg = FakeAssistantMessage(
         content=[
-            ToolUseBlock(name=EMIT_INTENT_TOOL_QUALIFIED, input=dict(wrapped)),
-            ToolUseBlock(name=EMIT_INTENT_TOOL_QUALIFIED, input=dict(wrapped)),
+            ToolUseBlock(name=tool_name, input=dict(wrapped)),
+            ToolUseBlock(name=tool_name, input=dict(wrapped)),
             ToolUseBlock(
-                name=EMIT_INTENT_TOOL_QUALIFIED,
+                name=tool_name,
                 input={"__unparsedToolInput": {"raw": other, "len": len(other)}},
             ),
         ]
@@ -520,14 +530,38 @@ async def test_unparsed_tool_wrapper_retries_dedupe_to_one_intent():
     assert [intent.payload["topic"] for intent in res.intents] == ["heartbeat", "status"]
 
 
+@pytest.mark.parametrize("tool_name", [EMIT_INTENT_TOOL_QUALIFIED, EMIT_INTENT_TOOL_NAME])
 @pytest.mark.asyncio
-async def test_identical_native_tool_inputs_are_not_deduped():
+async def test_identical_native_tool_inputs_are_not_deduped(tool_name):
     """Native Claude objects keep every emit_intent call, even duplicates."""
     native = {"intent_type": "send_message", "payload": {"topic": "heartbeat"}}
     msg = FakeAssistantMessage(
         content=[
-            ToolUseBlock(name=EMIT_INTENT_TOOL_QUALIFIED, input=dict(native)),
-            ToolUseBlock(name=EMIT_INTENT_TOOL_QUALIFIED, input=dict(native)),
+            ToolUseBlock(name=tool_name, input=dict(native)),
+            ToolUseBlock(name=tool_name, input=dict(native)),
+        ]
+    )
+    backend = ClaudeBackend(
+        sdk_query_factory=_make_query_factory([msg]),
+        sdk_options_cls=FakeOptions,
+        enable_mcp_emit_intent=False,
+    )
+    res = await backend.run("p")
+    assert res.metadata["tool_blocks"] == 2
+    assert len(res.intents) == 2
+
+
+@pytest.mark.parametrize("tool_name", [EMIT_INTENT_TOOL_QUALIFIED, EMIT_INTENT_TOOL_NAME])
+@pytest.mark.asyncio
+async def test_wrapper_then_native_same_intent_keeps_both(tool_name):
+    """Wrapper fallback then a native retry of the same intent both land."""
+    raw = '{"intent_type": "send_message", "payload": {"topic": "heartbeat"}}'
+    wrapped = {"__unparsedToolInput": {"raw": raw, "len": len(raw)}}
+    native = {"intent_type": "send_message", "payload": {"topic": "heartbeat"}}
+    msg = FakeAssistantMessage(
+        content=[
+            ToolUseBlock(name=tool_name, input=dict(wrapped)),
+            ToolUseBlock(name=tool_name, input=dict(native)),
         ]
     )
     backend = ClaudeBackend(

--- a/src/hyperloom/inference_optimizer/tests/test_claude_backend.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_backend.py
@@ -523,11 +523,13 @@ async def test_unparsed_tool_wrapper_retries_dedupe_to_one_intent(tool_name):
         sdk_query_factory=_make_query_factory([msg]),
         sdk_options_cls=FakeOptions,
         enable_mcp_emit_intent=False,
+        capture_turn_diagnostics=True,
     )
     res = await backend.run("p")
     assert res.metadata["tool_blocks"] == 3
     assert len(res.intents) == 2
     assert [intent.payload["topic"] for intent in res.intents] == ["heartbeat", "status"]
+    assert backend.get_turn_diagnostic()["deduped_fallback_intents"] == 1
 
 
 @pytest.mark.parametrize("tool_name", [EMIT_INTENT_TOOL_QUALIFIED, EMIT_INTENT_TOOL_NAME])

--- a/src/hyperloom/inference_optimizer/tests/test_claude_backend.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_backend.py
@@ -494,6 +494,53 @@ async def test_run_invalid_tool_use_input_drops_block_silently():
 
 
 @pytest.mark.asyncio
+async def test_unparsed_tool_wrapper_retries_dedupe_to_one_intent():
+    """Claude Code retries the same wrapped JSON; keep one validated intent."""
+    raw = '{"intent_type": "send_message", "payload": {"topic": "heartbeat", "body_md": "ok"}}'
+    wrapped = {"__unparsedToolInput": {"raw": raw, "len": len(raw)}}
+    other = '{"intent_type": "send_message", "payload": {"topic": "status", "body_md": "next"}}'
+    msg = FakeAssistantMessage(
+        content=[
+            ToolUseBlock(name=EMIT_INTENT_TOOL_QUALIFIED, input=dict(wrapped)),
+            ToolUseBlock(name=EMIT_INTENT_TOOL_QUALIFIED, input=dict(wrapped)),
+            ToolUseBlock(
+                name=EMIT_INTENT_TOOL_QUALIFIED,
+                input={"__unparsedToolInput": {"raw": other, "len": len(other)}},
+            ),
+        ]
+    )
+    backend = ClaudeBackend(
+        sdk_query_factory=_make_query_factory([msg]),
+        sdk_options_cls=FakeOptions,
+        enable_mcp_emit_intent=False,
+    )
+    res = await backend.run("p")
+    assert res.metadata["tool_blocks"] == 3
+    assert len(res.intents) == 2
+    assert [intent.payload["topic"] for intent in res.intents] == ["heartbeat", "status"]
+
+
+@pytest.mark.asyncio
+async def test_identical_native_tool_inputs_are_not_deduped():
+    """Native Claude objects keep every emit_intent call, even duplicates."""
+    native = {"intent_type": "send_message", "payload": {"topic": "heartbeat"}}
+    msg = FakeAssistantMessage(
+        content=[
+            ToolUseBlock(name=EMIT_INTENT_TOOL_QUALIFIED, input=dict(native)),
+            ToolUseBlock(name=EMIT_INTENT_TOOL_QUALIFIED, input=dict(native)),
+        ]
+    )
+    backend = ClaudeBackend(
+        sdk_query_factory=_make_query_factory([msg]),
+        sdk_options_cls=FakeOptions,
+        enable_mcp_emit_intent=False,
+    )
+    res = await backend.run("p")
+    assert res.metadata["tool_blocks"] == 2
+    assert len(res.intents) == 2
+
+
+@pytest.mark.asyncio
 async def test_raw_completion_returns_raw_text_without_intent():
     """raw_completion mode: a text-only reply yields raw_text and does NOT raise NoIntentEmitted."""
     action = '{"tool": "read_source", "args": {"path": "/x"}}'

--- a/src/hyperloom/inference_optimizer/tests/test_claude_backend.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_backend.py
@@ -554,7 +554,13 @@ async def test_identical_native_tool_inputs_are_not_deduped(tool_name):
 @pytest.mark.parametrize("tool_name", [EMIT_INTENT_TOOL_QUALIFIED, EMIT_INTENT_TOOL_NAME])
 @pytest.mark.asyncio
 async def test_wrapper_then_native_same_intent_keeps_both(tool_name):
-    """Wrapper fallback then a native retry of the same intent both land."""
+    """A wrapper block and a native block are two tool_use events.
+
+    The coordinator executes every intent with no merge. After the MCP
+    handler acks the wrapper, the model should not retry; if both still
+    appear in one query they are kept rather than dropping a real second
+    emit.
+    """
     raw = '{"intent_type": "send_message", "payload": {"topic": "heartbeat"}}'
     wrapped = {"__unparsedToolInput": {"raw": raw, "len": len(raw)}}
     native = {"intent_type": "send_message", "payload": {"topic": "heartbeat"}}

--- a/src/hyperloom/inference_optimizer/tests/test_claude_backend_branches_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_backend_branches_unit.py
@@ -446,6 +446,14 @@ async def test_emit_intent_handler_ok():
 
 
 @pytest.mark.asyncio
+async def test_emit_intent_handler_accepts_unparsed_wrapper():
+    raw = '{"intent_type": "send_message", "payload": {"topic": "heartbeat"}}'
+    res = await mei._emit_intent_handler({"__unparsedToolInput": {"raw": raw, "len": len(raw)}})
+    assert res["content"][0]["text"] == "ok"
+    assert "is_error" not in res
+
+
+@pytest.mark.asyncio
 async def test_emit_intent_handler_validation_error_returns_is_error():
     res = await mei._emit_intent_handler({"intent_type": "bogus", "payload": {}})
     assert res["is_error"] is True

--- a/src/hyperloom/inference_optimizer/tests/test_claude_backend_helpers_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_backend_helpers_coverage_unit.py
@@ -7,7 +7,6 @@ extraction, and conversation-session accessors."""
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -224,57 +223,6 @@ def test_parse_tool_use_block_unparsed_malformed_json_returns_none() -> None:
         input={"__unparsedToolInput": {"raw": "{not-json", "len": 9}},
     )
     assert b._parse_tool_use_block(bad) is None
-
-
-def _query_messages(messages: list[Any]):
-    async def _q(*, prompt, options):
-        for message in messages:
-            yield message
-
-    return _q
-
-
-def test_unparsed_wrapper_retries_dedupe_to_one_intent() -> None:
-    raw = '{"intent_type": "send_message", "payload": {"topic": "heartbeat", "body_md": "ok"}}'
-    wrapped = {"__unparsedToolInput": {"raw": raw, "len": len(raw)}}
-    other = '{"intent_type": "send_message", "payload": {"topic": "status", "body_md": "next"}}'
-    msg = _Msg(
-        content=[
-            ToolUseBlock(name=EMIT_INTENT_TOOL_NAME, input=dict(wrapped)),
-            ToolUseBlock(name=EMIT_INTENT_TOOL_NAME, input=dict(wrapped)),
-            ToolUseBlock(
-                name=EMIT_INTENT_TOOL_NAME,
-                input={"__unparsedToolInput": {"raw": other, "len": len(other)}},
-            ),
-        ]
-    )
-    b = _backend(sdk_query_factory=_query_messages([msg]), enable_mcp_emit_intent=False)
-
-    async def _run():
-        return await b.run("p")
-
-    res = asyncio.run(_run())
-    assert res.metadata["tool_blocks"] == 3
-    assert len(res.intents) == 2
-    assert [intent.payload["topic"] for intent in res.intents] == ["heartbeat", "status"]
-
-
-def test_identical_native_tool_inputs_are_not_deduped() -> None:
-    native = {"intent_type": "send_message", "payload": {"topic": "heartbeat"}}
-    msg = _Msg(
-        content=[
-            ToolUseBlock(name=EMIT_INTENT_TOOL_NAME, input=dict(native)),
-            ToolUseBlock(name=EMIT_INTENT_TOOL_NAME, input=dict(native)),
-        ]
-    )
-    b = _backend(sdk_query_factory=_query_messages([msg]), enable_mcp_emit_intent=False)
-
-    async def _run():
-        return await b.run("p")
-
-    res = asyncio.run(_run())
-    assert res.metadata["tool_blocks"] == 2
-    assert len(res.intents) == 2
 
 
 def test_extract_text_shapes() -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_claude_backend_helpers_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_backend_helpers_coverage_unit.py
@@ -7,6 +7,7 @@ extraction, and conversation-session accessors."""
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -182,6 +183,98 @@ def test_parse_tool_use_block_valid_and_invalid() -> None:
     # invalid envelope -> None (validation failure swallowed)
     bad = ToolUseBlock(name=EMIT_INTENT_TOOL_NAME, input={"intent_type": "not_a_real_type"})
     assert b._parse_tool_use_block(bad) is None
+
+
+def test_parse_tool_use_block_prefers_native_intent_type() -> None:
+    b = _backend()
+    block = ToolUseBlock(
+        name=EMIT_INTENT_TOOL_NAME,
+        input={
+            "intent_type": "send_message",
+            "payload": {"topic": "heartbeat", "body_md": "native"},
+            "__unparsedToolInput": {
+                "raw": '{"intent_type": "alert", "payload": {"severity": "high", "summary": "x"}}',
+                "len": 1,
+            },
+        },
+    )
+    intent = b._parse_tool_use_block(block)
+    assert intent is not None
+    assert intent.type.value == "send_message"
+    assert intent.payload["body_md"] == "native"
+
+
+def test_parse_tool_use_block_unwraps_claude_code_wrapper() -> None:
+    b = _backend()
+    raw = '{"intent_type": "send_message", "payload": {"topic": "heartbeat", "body_md": "ok"}}'
+    wrapped = ToolUseBlock(
+        name=EMIT_INTENT_TOOL_NAME,
+        input={"__unparsedToolInput": {"raw": raw, "len": len(raw)}},
+    )
+    intent = b._parse_tool_use_block(wrapped)
+    assert intent is not None
+    assert intent.type.value == "send_message"
+    assert intent.payload["topic"] == "heartbeat"
+
+
+def test_parse_tool_use_block_unparsed_malformed_json_returns_none() -> None:
+    b = _backend()
+    bad = ToolUseBlock(
+        name=EMIT_INTENT_TOOL_NAME,
+        input={"__unparsedToolInput": {"raw": "{not-json", "len": 9}},
+    )
+    assert b._parse_tool_use_block(bad) is None
+
+
+def _query_messages(messages: list[Any]):
+    async def _q(*, prompt, options):
+        for message in messages:
+            yield message
+
+    return _q
+
+
+def test_unparsed_wrapper_retries_dedupe_to_one_intent() -> None:
+    raw = '{"intent_type": "send_message", "payload": {"topic": "heartbeat", "body_md": "ok"}}'
+    wrapped = {"__unparsedToolInput": {"raw": raw, "len": len(raw)}}
+    other = '{"intent_type": "send_message", "payload": {"topic": "status", "body_md": "next"}}'
+    msg = _Msg(
+        content=[
+            ToolUseBlock(name=EMIT_INTENT_TOOL_NAME, input=dict(wrapped)),
+            ToolUseBlock(name=EMIT_INTENT_TOOL_NAME, input=dict(wrapped)),
+            ToolUseBlock(
+                name=EMIT_INTENT_TOOL_NAME,
+                input={"__unparsedToolInput": {"raw": other, "len": len(other)}},
+            ),
+        ]
+    )
+    b = _backend(sdk_query_factory=_query_messages([msg]), enable_mcp_emit_intent=False)
+
+    async def _run():
+        return await b.run("p")
+
+    res = asyncio.run(_run())
+    assert res.metadata["tool_blocks"] == 3
+    assert len(res.intents) == 2
+    assert [intent.payload["topic"] for intent in res.intents] == ["heartbeat", "status"]
+
+
+def test_identical_native_tool_inputs_are_not_deduped() -> None:
+    native = {"intent_type": "send_message", "payload": {"topic": "heartbeat"}}
+    msg = _Msg(
+        content=[
+            ToolUseBlock(name=EMIT_INTENT_TOOL_NAME, input=dict(native)),
+            ToolUseBlock(name=EMIT_INTENT_TOOL_NAME, input=dict(native)),
+        ]
+    )
+    b = _backend(sdk_query_factory=_query_messages([msg]), enable_mcp_emit_intent=False)
+
+    async def _run():
+        return await b.run("p")
+
+    res = asyncio.run(_run())
+    assert res.metadata["tool_blocks"] == 2
+    assert len(res.intents) == 2
 
 
 def test_extract_text_shapes() -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for Claude Code ``__unparsedToolInput`` emit_intent fallback."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
+from hyperloom.orchestrator.roles.claude import (
+    ClaudeBackend,
+    _coerce_emit_intent_input,
+    _intent_fingerprint,
+    _is_unparsed_tool_wrapper,
+)
+
+
+@dataclass
+class _FakeToolUse:
+    name: str
+    input: dict[str, Any]
+
+
+class ToolUseBlock(_FakeToolUse):
+    pass
+
+
+def _backend() -> ClaudeBackend:
+    async def _q(*, prompt, options):  # pragma: no cover
+        if False:
+            yield None
+
+    class _Opts:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    return ClaudeBackend(
+        sdk_query_factory=_q,
+        sdk_options_cls=_Opts,
+        api_key_env="UNSET_KEY_ENV_FOR_TEST",
+        enable_mcp_emit_intent=False,
+    )
+
+
+def test_is_unparsed_wrapper_false_for_native_and_junk() -> None:
+    assert _is_unparsed_tool_wrapper(None) is False
+    assert _is_unparsed_tool_wrapper({"intent_type": "send_message"}) is False
+    assert _is_unparsed_tool_wrapper({"__unparsedToolInput": "raw"}) is False
+    assert _is_unparsed_tool_wrapper({"__unparsedToolInput": {"raw": 1}}) is False
+    assert (
+        _is_unparsed_tool_wrapper({"__unparsedToolInput": {"raw": '{"intent_type": "send_message"}'}})
+        is True
+    )
+
+
+def test_coerce_returns_empty_for_non_dict() -> None:
+    assert _coerce_emit_intent_input(None) == {}
+    assert _coerce_emit_intent_input("x") == {}
+
+
+def test_coerce_keeps_native_when_intent_type_present() -> None:
+    native = {
+        "intent_type": "send_message",
+        "payload": {"topic": "heartbeat"},
+        "__unparsedToolInput": {"raw": '{"intent_type": "alert"}'},
+    }
+    assert _coerce_emit_intent_input(native) is native
+
+
+def test_coerce_decodes_wrapper_object() -> None:
+    raw = '{"intent_type": "send_message", "payload": {"topic": "heartbeat"}}'
+    out = _coerce_emit_intent_input({"__unparsedToolInput": {"raw": raw, "len": len(raw)}})
+    assert out["intent_type"] == "send_message"
+    assert out["payload"]["topic"] == "heartbeat"
+
+
+def test_coerce_leaves_wrapper_when_raw_is_not_object_json() -> None:
+    wrapped = {"__unparsedToolInput": {"raw": "[1, 2]", "len": 6}}
+    assert _coerce_emit_intent_input(wrapped) is wrapped
+    empty = {"__unparsedToolInput": {"raw": "   "}}
+    assert _coerce_emit_intent_input(empty) is empty
+    missing = {"__unparsedToolInput": {}}
+    assert _coerce_emit_intent_input(missing) is missing
+
+
+def test_coerce_leaves_wrapper_when_raw_is_malformed() -> None:
+    wrapped = {"__unparsedToolInput": {"raw": "{not-json"}}
+    assert _coerce_emit_intent_input(wrapped) is wrapped
+
+
+def test_parse_unparsed_wrapper_missing_required_payload_returns_none() -> None:
+    b = _backend()
+    raw = '{"intent_type": "propose_action", "payload": {"action_name": "baseline"}}'
+    block = ToolUseBlock(
+        name="emit_intent",
+        input={"__unparsedToolInput": {"raw": raw, "len": len(raw)}},
+    )
+    assert b._parse_tool_use_block(block) is None
+
+
+def test_diagnostic_records_unwrapped_intent_type() -> None:
+    b = _backend()
+    b._active_turn_diagnostic = {"tool_blocks": []}
+    raw = '{"intent_type": "send_message", "payload": {"topic": "heartbeat"}}'
+    block = ToolUseBlock(
+        name="emit_intent",
+        input={"__unparsedToolInput": {"raw": raw, "len": len(raw)}},
+    )
+    b._record_tool_block_diagnostic(block)
+    summary = b._active_turn_diagnostic["tool_blocks"][0]
+    assert summary["input_keys"] == ["__unparsedToolInput"]
+    assert summary["intent_type"] == "send_message"
+
+
+def test_intent_fingerprint_is_stable() -> None:
+    a = Intent(type=IntentType.SEND_MESSAGE, payload={"topic": "heartbeat", "body_md": "ok"})
+    b = Intent(type=IntentType.SEND_MESSAGE, payload={"body_md": "ok", "topic": "heartbeat"})
+    assert _intent_fingerprint(a) == _intent_fingerprint(b)

--- a/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
@@ -100,6 +100,34 @@ def test_parse_unparsed_wrapper_missing_required_payload_returns_none() -> None:
     assert b._parse_tool_use_block(block) is None
 
 
+def test_parse_tool_use_block_ignores_extra_native_keys() -> None:
+    """Stream ingest stays lenient: extra native keys are not a reason to drop."""
+    b = _backend()
+    block = ToolUseBlock(
+        name="emit_intent",
+        input={
+            "intent_type": "send_message",
+            "payload": {"topic": "heartbeat"},
+            "reasoning": "why this emit exists",
+        },
+    )
+    intent = b._parse_tool_use_block(block)
+    assert intent is not None
+    assert intent.type is IntentType.SEND_MESSAGE
+    assert intent.payload["topic"] == "heartbeat"
+
+
+def test_parse_tool_use_block_records_malformed_wrapper_decode_error() -> None:
+    b = _backend()
+    b._active_turn_diagnostic = {"parse_errors": []}
+    block = ToolUseBlock(
+        name="emit_intent",
+        input={"__unparsedToolInput": {"raw": "{not-json"}},
+    )
+    assert b._parse_tool_use_block(block) is None
+    assert any("__unparsedToolInput.raw is not valid JSON" in err for err in b._active_turn_diagnostic["parse_errors"])
+
+
 def test_parse_tool_use_block_prefers_native_intent_type() -> None:
     """Canonical input remains authoritative when a fallback is also present."""
     b = _backend()

--- a/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
@@ -125,52 +125,56 @@ _WRAPPER_RAW = '{"intent_type": "send_message", "payload": {"topic": "heartbeat"
 _WRAPPER_EMIT = {"__unparsedToolInput": {"raw": _WRAPPER_RAW, "len": len(_WRAPPER_RAW)}}
 
 
-def _emit_intent_server() -> Any:
-    """The in-process MCP server, or a skip when the SDK is not installed."""
-    pytest.importorskip("claude_agent_sdk")
-    pytest.importorskip("mcp")
-    cfg = build_emit_intent_server()
-    if cfg is None:
-        pytest.skip("in-process MCP helpers unavailable")
-    return cfg["instance"]
+def _registered_emit_intent_tool() -> Any:
+    """The emit_intent tool as the real SDK decorator registers it.
+
+    Captured off the ``server_factory`` seam so the ``tool`` decorator, the
+    schema and the handler are all the production ones, without depending on
+    where a given ``mcp`` release keeps its server internals.
+    """
+    sdk = pytest.importorskip("claude_agent_sdk")
+    captured: list[Any] = []
+
+    def capture(name: str, version: str, tools: list[Any]) -> None:
+        captured.extend(tools)
+
+    build_emit_intent_server(sdk_module=sdk, server_factory=capture)
+    tool = next((t for t in captured if getattr(t, "name", None) == EMIT_INTENT_TOOL_NAME), None)
+    if tool is None:
+        pytest.skip("SDK did not register the emit_intent tool")
+    return tool
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "arguments,expect_error,text_substr",
-    [
-        (_NATIVE_EMIT, False, "ok"),
-        (_WRAPPER_EMIT, False, "ok"),
-        ({"nonsense": 1}, True, "Additional properties"),
-    ],
+    "arguments,schema_ok",
+    [(_NATIVE_EMIT, True), (_WRAPPER_EMIT, True), ({"nonsense": 1}, False)],
     ids=["native", "wrapper", "junk"],
 )
-async def test_sdk_tools_call_schema_accepts_native_and_wrapper(
-    arguments: dict[str, Any],
-    expect_error: bool,
-    text_substr: str,
-) -> None:
-    """The tool schema is validated before the handler runs, so a shape the
-    handler accepts but the schema rejects never reaches it. Driven through a
-    real client session rather than the handler directly, which is the only
-    way that ordering is exercised."""
-    memory = pytest.importorskip("mcp.shared.memory")
-    server = _emit_intent_server()
-    async with memory.create_connected_server_and_client_session(server) as session:
-        result = await session.call_tool(EMIT_INTENT_TOOL_NAME, arguments)
-    assert result.isError is expect_error
-    assert text_substr in result.content[0].text
+async def test_registered_schema_and_handler_agree(arguments: dict[str, Any], schema_ok: bool) -> None:
+    """The declared schema gates the call before the handler ever runs, so a
+    shape the handler accepts but the schema rejects can never land. Both are
+    checked here against the same tool the SDK registers, because they used to
+    disagree: the handler decoded the wrapper the schema had already refused.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    tool = _registered_emit_intent_tool()
+
+    if not schema_ok:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=arguments, schema=tool.input_schema)
+        return
+
+    jsonschema.validate(instance=arguments, schema=tool.input_schema)
+    result = await tool.handler(arguments)
+    assert result["content"][0]["text"] == "ok"
+    assert "is_error" not in result
 
 
-@pytest.mark.asyncio
-async def test_broadcast_schema_offers_both_shapes() -> None:
-    """tools/list is what the model reads, so the wrapper alternative has to
-    survive into the advertised schema and say it is internal."""
-    memory = pytest.importorskip("mcp.shared.memory")
-    server = _emit_intent_server()
-    async with memory.create_connected_server_and_client_session(server) as session:
-        tools = await session.list_tools()
-    schema = next(t.inputSchema for t in tools.tools if t.name == EMIT_INTENT_TOOL_NAME)
+def test_registered_schema_offers_both_shapes() -> None:
+    """The declared schema is what the model reads, so the wrapper alternative
+    has to survive into it and say it is internal."""
+    schema = _registered_emit_intent_tool().input_schema
     assert {"required": ["intent_type", "payload"]} in schema["anyOf"]
     assert {"required": ["__unparsedToolInput"]} in schema["anyOf"]
     assert "Never emit this deliberately" in schema["properties"]["__unparsedToolInput"]["description"]

--- a/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
@@ -134,14 +134,22 @@ async def _sdk_tools_call(arguments: dict[str, Any]) -> Any:
     cfg = build_emit_intent_server()
     if cfg is None:
         pytest.skip("in-process MCP helpers unavailable")
-    handler = cfg["instance"].request_handlers[CallToolRequest]
+    # mcp.Server renamed the public dict to `_request_handlers` in some
+    # versions; both spellings reach the same jsonschema-then-handler path.
+    server = cfg["instance"]
+    handlers = getattr(server, "request_handlers", None) or getattr(
+        server, "_request_handlers", None
+    )
+    if not handlers:
+        pytest.skip("MCP server has no CallToolRequest handler map")
+    handler = handlers[CallToolRequest]
     result = await handler(
         CallToolRequest(
             method="tools/call",
             params=CallToolRequestParams(name=EMIT_INTENT_TOOL_NAME, arguments=arguments),
         )
     )
-    return result.root
+    return getattr(result, "root", result)
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
@@ -8,12 +8,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+import pytest
+
 from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
-from hyperloom.orchestrator.roles.claude import (
-    ClaudeBackend,
-    _coerce_emit_intent_input,
-    _intent_fingerprint,
-    _is_unparsed_tool_wrapper,
+from hyperloom.orchestrator.roles.claude import ClaudeBackend, _intent_fingerprint
+from hyperloom.orchestrator.roles.mcp_emit_intent import (
+    EMIT_INTENT_TOOL_NAME,
+    build_emit_intent_server,
+    coerce_emit_intent_input,
+    is_unparsed_tool_wrapper,
 )
 
 
@@ -45,19 +48,16 @@ def _backend() -> ClaudeBackend:
 
 
 def test_is_unparsed_wrapper_false_for_native_and_junk() -> None:
-    assert _is_unparsed_tool_wrapper(None) is False
-    assert _is_unparsed_tool_wrapper({"intent_type": "send_message"}) is False
-    assert _is_unparsed_tool_wrapper({"__unparsedToolInput": "raw"}) is False
-    assert _is_unparsed_tool_wrapper({"__unparsedToolInput": {"raw": 1}}) is False
-    assert (
-        _is_unparsed_tool_wrapper({"__unparsedToolInput": {"raw": '{"intent_type": "send_message"}'}})
-        is True
-    )
+    assert is_unparsed_tool_wrapper(None) is False
+    assert is_unparsed_tool_wrapper({"intent_type": "send_message"}) is False
+    assert is_unparsed_tool_wrapper({"__unparsedToolInput": "raw"}) is False
+    assert is_unparsed_tool_wrapper({"__unparsedToolInput": {"raw": 1}}) is False
+    assert is_unparsed_tool_wrapper({"__unparsedToolInput": {"raw": '{"intent_type": "send_message"}'}}) is True
 
 
 def test_coerce_returns_empty_for_non_dict() -> None:
-    assert _coerce_emit_intent_input(None) == {}
-    assert _coerce_emit_intent_input("x") == {}
+    assert coerce_emit_intent_input(None) == {}
+    assert coerce_emit_intent_input("x") == {}
 
 
 def test_coerce_keeps_native_when_intent_type_present() -> None:
@@ -66,28 +66,28 @@ def test_coerce_keeps_native_when_intent_type_present() -> None:
         "payload": {"topic": "heartbeat"},
         "__unparsedToolInput": {"raw": '{"intent_type": "alert"}'},
     }
-    assert _coerce_emit_intent_input(native) is native
+    assert coerce_emit_intent_input(native) is native
 
 
 def test_coerce_decodes_wrapper_object() -> None:
     raw = '{"intent_type": "send_message", "payload": {"topic": "heartbeat"}}'
-    out = _coerce_emit_intent_input({"__unparsedToolInput": {"raw": raw, "len": len(raw)}})
+    out = coerce_emit_intent_input({"__unparsedToolInput": {"raw": raw, "len": len(raw)}})
     assert out["intent_type"] == "send_message"
     assert out["payload"]["topic"] == "heartbeat"
 
 
 def test_coerce_leaves_wrapper_when_raw_is_not_object_json() -> None:
     wrapped = {"__unparsedToolInput": {"raw": "[1, 2]", "len": 6}}
-    assert _coerce_emit_intent_input(wrapped) is wrapped
+    assert coerce_emit_intent_input(wrapped) is wrapped
     empty = {"__unparsedToolInput": {"raw": "   "}}
-    assert _coerce_emit_intent_input(empty) is empty
+    assert coerce_emit_intent_input(empty) is empty
     missing = {"__unparsedToolInput": {}}
-    assert _coerce_emit_intent_input(missing) is missing
+    assert coerce_emit_intent_input(missing) is missing
 
 
 def test_coerce_leaves_wrapper_when_raw_is_malformed() -> None:
     wrapped = {"__unparsedToolInput": {"raw": "{not-json"}}
-    assert _coerce_emit_intent_input(wrapped) is wrapped
+    assert coerce_emit_intent_input(wrapped) is wrapped
 
 
 def test_parse_unparsed_wrapper_missing_required_payload_returns_none() -> None:
@@ -118,3 +118,48 @@ def test_intent_fingerprint_is_stable() -> None:
     a = Intent(type=IntentType.SEND_MESSAGE, payload={"topic": "heartbeat", "body_md": "ok"})
     b = Intent(type=IntentType.SEND_MESSAGE, payload={"body_md": "ok", "topic": "heartbeat"})
     assert _intent_fingerprint(a) == _intent_fingerprint(b)
+
+
+_NATIVE_EMIT = {"intent_type": "send_message", "payload": {"topic": "heartbeat"}}
+_WRAPPER_RAW = '{"intent_type": "send_message", "payload": {"topic": "heartbeat"}}'
+_WRAPPER_EMIT = {"__unparsedToolInput": {"raw": _WRAPPER_RAW, "len": len(_WRAPPER_RAW)}}
+
+
+async def _sdk_tools_call(arguments: dict[str, Any]) -> Any:
+    """Call emit_intent through the real SDK MCP server, including schema checks."""
+    pytest.importorskip("claude_agent_sdk")
+    pytest.importorskip("mcp")
+    from mcp.types import CallToolRequest, CallToolRequestParams
+
+    cfg = build_emit_intent_server()
+    if cfg is None:
+        pytest.skip("in-process MCP helpers unavailable")
+    handler = cfg["instance"].request_handlers[CallToolRequest]
+    result = await handler(
+        CallToolRequest(
+            method="tools/call",
+            params=CallToolRequestParams(name=EMIT_INTENT_TOOL_NAME, arguments=arguments),
+        )
+    )
+    return result.root
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "arguments,expect_error,text_substr",
+    [
+        (_NATIVE_EMIT, False, "ok"),
+        (_WRAPPER_EMIT, False, "ok"),
+        ({"nonsense": 1}, True, "Additional properties"),
+    ],
+    ids=["native", "wrapper", "junk"],
+)
+async def test_sdk_tools_call_schema_accepts_native_and_wrapper(
+    arguments: dict[str, Any],
+    expect_error: bool,
+    text_substr: str,
+) -> None:
+    """jsonschema on tools/call runs before the handler; both legal shapes must pass it."""
+    result = await _sdk_tools_call(arguments)
+    assert result.isError is expect_error
+    assert text_substr in result.content[0].text

--- a/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
@@ -125,29 +125,14 @@ _WRAPPER_RAW = '{"intent_type": "send_message", "payload": {"topic": "heartbeat"
 _WRAPPER_EMIT = {"__unparsedToolInput": {"raw": _WRAPPER_RAW, "len": len(_WRAPPER_RAW)}}
 
 
-async def _sdk_tools_call(arguments: dict[str, Any]) -> Any:
-    """Call emit_intent through the real SDK MCP server, including schema checks."""
+def _emit_intent_server() -> Any:
+    """The in-process MCP server, or a skip when the SDK is not installed."""
     pytest.importorskip("claude_agent_sdk")
     pytest.importorskip("mcp")
-    from mcp.types import CallToolRequest, CallToolRequestParams
-
     cfg = build_emit_intent_server()
     if cfg is None:
         pytest.skip("in-process MCP helpers unavailable")
-    # mcp.Server renamed the public dict to `_request_handlers` in some
-    # versions; both spellings reach the same jsonschema-then-handler path.
-    server = cfg["instance"]
-    handlers = getattr(server, "request_handlers", None) or getattr(server, "_request_handlers", None)
-    if not handlers:
-        pytest.skip("MCP server has no CallToolRequest handler map")
-    handler = handlers[CallToolRequest]
-    result = await handler(
-        CallToolRequest(
-            method="tools/call",
-            params=CallToolRequestParams(name=EMIT_INTENT_TOOL_NAME, arguments=arguments),
-        )
-    )
-    return getattr(result, "root", result)
+    return cfg["instance"]
 
 
 @pytest.mark.asyncio
@@ -165,7 +150,27 @@ async def test_sdk_tools_call_schema_accepts_native_and_wrapper(
     expect_error: bool,
     text_substr: str,
 ) -> None:
-    """jsonschema on tools/call runs before the handler; both legal shapes must pass it."""
-    result = await _sdk_tools_call(arguments)
+    """The tool schema is validated before the handler runs, so a shape the
+    handler accepts but the schema rejects never reaches it. Driven through a
+    real client session rather than the handler directly, which is the only
+    way that ordering is exercised."""
+    memory = pytest.importorskip("mcp.shared.memory")
+    server = _emit_intent_server()
+    async with memory.create_connected_server_and_client_session(server) as session:
+        result = await session.call_tool(EMIT_INTENT_TOOL_NAME, arguments)
     assert result.isError is expect_error
     assert text_substr in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_broadcast_schema_offers_both_shapes() -> None:
+    """tools/list is what the model reads, so the wrapper alternative has to
+    survive into the advertised schema and say it is internal."""
+    memory = pytest.importorskip("mcp.shared.memory")
+    server = _emit_intent_server()
+    async with memory.create_connected_server_and_client_session(server) as session:
+        tools = await session.list_tools()
+    schema = next(t.inputSchema for t in tools.tools if t.name == EMIT_INTENT_TOOL_NAME)
+    assert {"required": ["intent_type", "payload"]} in schema["anyOf"]
+    assert {"required": ["__unparsedToolInput"]} in schema["anyOf"]
+    assert "Never emit this deliberately" in schema["properties"]["__unparsedToolInput"]["description"]

--- a/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
@@ -100,6 +100,22 @@ def test_parse_unparsed_wrapper_missing_required_payload_returns_none() -> None:
     assert b._parse_tool_use_block(block) is None
 
 
+def test_parse_tool_use_block_prefers_native_intent_type() -> None:
+    """Canonical input remains authoritative when a fallback is also present."""
+    b = _backend()
+    block = ToolUseBlock(
+        name="emit_intent",
+        input={
+            "intent_type": "send_message",
+            "payload": {"topic": "native"},
+            "__unparsedToolInput": {"raw": '{"intent_type": "send_message", "payload": {"topic": "fallback"}}'},
+        },
+    )
+    intent = b._parse_tool_use_block(block)
+    assert intent is not None
+    assert intent.payload["topic"] == "native"
+
+
 def test_diagnostic_records_unwrapped_intent_type() -> None:
     b = _backend()
     b._active_turn_diagnostic = {"tool_blocks": []}
@@ -123,6 +139,8 @@ def test_intent_fingerprint_is_stable() -> None:
 _NATIVE_EMIT = {"intent_type": "send_message", "payload": {"topic": "heartbeat"}}
 _WRAPPER_RAW = '{"intent_type": "send_message", "payload": {"topic": "heartbeat"}}'
 _WRAPPER_EMIT = {"__unparsedToolInput": {"raw": _WRAPPER_RAW, "len": len(_WRAPPER_RAW)}}
+_MIXED_EMIT = {**_NATIVE_EMIT, **_WRAPPER_EMIT}
+_WRAPPER_WITH_JUNK = {**_WRAPPER_EMIT, "junk": 1}
 
 
 def _registered_emit_intent_tool() -> Any:
@@ -147,11 +165,17 @@ def _registered_emit_intent_tool() -> Any:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "arguments,schema_ok",
-    [(_NATIVE_EMIT, True), (_WRAPPER_EMIT, True), ({"nonsense": 1}, False)],
-    ids=["native", "wrapper", "junk"],
+    "arguments,accepted",
+    [
+        (_NATIVE_EMIT, True),
+        (_WRAPPER_EMIT, True),
+        (_MIXED_EMIT, True),
+        ({"nonsense": 1}, False),
+        (_WRAPPER_WITH_JUNK, False),
+    ],
+    ids=["native", "wrapper", "native-with-wrapper", "junk", "wrapper-with-junk"],
 )
-async def test_registered_schema_and_handler_agree(arguments: dict[str, Any], schema_ok: bool) -> None:
+async def test_registered_schema_and_handler_agree(arguments: dict[str, Any], accepted: bool) -> None:
     """The declared schema gates the call before the handler ever runs, so a
     shape the handler accepts but the schema rejects can never land. Both are
     checked here against the same tool the SDK registers, because they used to
@@ -160,15 +184,33 @@ async def test_registered_schema_and_handler_agree(arguments: dict[str, Any], sc
     jsonschema = pytest.importorskip("jsonschema")
     tool = _registered_emit_intent_tool()
 
-    if not schema_ok:
+    if accepted:
+        jsonschema.validate(instance=arguments, schema=tool.input_schema)
+    else:
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=arguments, schema=tool.input_schema)
-        return
 
-    jsonschema.validate(instance=arguments, schema=tool.input_schema)
     result = await tool.handler(arguments)
-    assert result["content"][0]["text"] == "ok"
-    assert "is_error" not in result
+    assert ("is_error" not in result) is accepted
+
+
+@pytest.mark.asyncio
+async def test_handler_rejects_extra_key_inside_wrapped_raw() -> None:
+    """Decoded fallback JSON observes the canonical top-level key contract."""
+    tool = _registered_emit_intent_tool()
+    raw = '{"intent_type": "send_message", "payload": {"topic": "heartbeat"}, "junk": 1}'
+    result = await tool.handler({"__unparsedToolInput": {"raw": raw, "len": len(raw)}})
+    assert result["is_error"] is True
+    assert "unexpected keys: ['junk']" in result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_handler_reports_malformed_wrapped_raw() -> None:
+    """A parser fallback reports its malformed JSON instead of blaming its key."""
+    tool = _registered_emit_intent_tool()
+    result = await tool.handler({"__unparsedToolInput": {"raw": "{not-json"}})
+    assert result["is_error"] is True
+    assert "__unparsedToolInput.raw is not valid JSON" in result["content"][0]["text"]
 
 
 def test_registered_schema_offers_both_shapes() -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py
@@ -137,9 +137,7 @@ async def _sdk_tools_call(arguments: dict[str, Any]) -> Any:
     # mcp.Server renamed the public dict to `_request_handlers` in some
     # versions; both spellings reach the same jsonschema-then-handler path.
     server = cfg["instance"]
-    handlers = getattr(server, "request_handlers", None) or getattr(
-        server, "_request_handlers", None
-    )
+    handlers = getattr(server, "request_handlers", None) or getattr(server, "_request_handlers", None)
     if not handlers:
         pytest.skip("MCP server has no CallToolRequest handler map")
     handler = handlers[CallToolRequest]

--- a/src/hyperloom/orchestrator/roles/__init__.py
+++ b/src/hyperloom/orchestrator/roles/__init__.py
@@ -18,6 +18,8 @@ from .mcp_emit_intent import (
     EMIT_INTENT_TOOL_QUALIFIED,
     MCP_SERVER_NAME,
     build_emit_intent_server,
+    coerce_emit_intent_input,
+    is_unparsed_tool_wrapper,
     validate_emit_intent_input,
 )
 from .mock_backend import (
@@ -60,5 +62,7 @@ __all__ = [
     "auto_approve_critic",
     "build_context_tools_server",
     "build_emit_intent_server",
+    "coerce_emit_intent_input",
+    "is_unparsed_tool_wrapper",
     "validate_emit_intent_input",
 ]

--- a/src/hyperloom/orchestrator/roles/claude.py
+++ b/src/hyperloom/orchestrator/roles/claude.py
@@ -52,10 +52,10 @@ from .mcp_emit_intent import (
     EMIT_INTENT_TOOL_QUALIFIED,
     EMIT_INTENT_TOOL_INPUT_SCHEMA,
     MCP_SERVER_NAME,
-    _coerce_emit_intent_input,
-    _is_unparsed_tool_wrapper,
     build_emit_intent_server,
+    coerce_emit_intent_input,
     constraints_sentence,
+    is_unparsed_tool_wrapper,
     payload_contract,
 )
 
@@ -898,8 +898,8 @@ class ClaudeBackend:
         text_chunks: list[str] = []
         result_chunks: list[str] = []
         tool_block_count = 0
-        # Claude Code may retry the same wrapped tool JSON many times in one
-        # query; keep the first decoded fallback envelope only.
+        # Defense in depth: identical wrapper envelopes in one query are the
+        # parser retry storm. Native duplicates still count separately.
         seen_fallback_intents: set[str] = set()
         # Every usage dict the stream reports, in order: the last is cumulative
         # over the call, the ones before it describe single requests.
@@ -931,7 +931,7 @@ class ClaudeBackend:
                         tool_block_count += 1
                         intent = self._parse_tool_use_block(block)
                         if intent is not None:
-                            if _is_unparsed_tool_wrapper(getattr(block, "input", None)):
+                            if is_unparsed_tool_wrapper(getattr(block, "input", None)):
                                 fingerprint = _intent_fingerprint(intent)
                                 if fingerprint in seen_fallback_intents:
                                     continue
@@ -1049,7 +1049,7 @@ class ClaudeBackend:
             Intent | None: The validated intent, or ``None`` if validation
             fails (the failure is logged, not raised).
         """
-        raw_input = _coerce_emit_intent_input(getattr(block, "input", None) or {})
+        raw_input = coerce_emit_intent_input(getattr(block, "input", None) or {})
         try:
             envelope = {
                 "intents": [
@@ -1094,7 +1094,7 @@ class ClaudeBackend:
         raw_input = getattr(block, "input", None)
         if isinstance(raw_input, dict):
             summary["input_keys"] = sorted(str(key) for key in raw_input)
-            coerced = _coerce_emit_intent_input(raw_input)
+            coerced = coerce_emit_intent_input(raw_input)
             intent_type = coerced.get("intent_type")
             if isinstance(intent_type, str):
                 summary["intent_type"] = intent_type

--- a/src/hyperloom/orchestrator/roles/claude.py
+++ b/src/hyperloom/orchestrator/roles/claude.py
@@ -57,6 +57,7 @@ from .mcp_emit_intent import (
     constraints_sentence,
     is_unparsed_tool_wrapper,
     payload_contract,
+    validate_emit_intent_input,
 )
 
 
@@ -674,6 +675,7 @@ class ClaudeBackend:
             "raw_text": "",
             "tool_blocks": [],
             "parse_errors": [],
+            "deduped_fallback_intents": 0,
             "usage": {},
             "stderr_tail": [],
         }
@@ -934,6 +936,12 @@ class ClaudeBackend:
                             if is_unparsed_tool_wrapper(getattr(block, "input", None)):
                                 fingerprint = _intent_fingerprint(intent)
                                 if fingerprint in seen_fallback_intents:
+                                    if self._active_turn_diagnostic is not None:
+                                        self._active_turn_diagnostic["deduped_fallback_intents"] += 1
+                                    log.info(
+                                        "claude fallback intent deduped (fingerprint=%s)",
+                                        hashlib.sha256(fingerprint.encode("utf-8")).hexdigest()[:12],
+                                    )
                                     continue
                                 seen_fallback_intents.add(fingerprint)
                             intents.append(intent)
@@ -1049,8 +1057,10 @@ class ClaudeBackend:
             Intent | None: The validated intent, or ``None`` if validation
             fails (the failure is logged, not raised).
         """
-        raw_input = coerce_emit_intent_input(getattr(block, "input", None) or {})
+        block_input = getattr(block, "input", None) or {}
         try:
+            validate_emit_intent_input(block_input)
+            raw_input = coerce_emit_intent_input(block_input)
             envelope = {
                 "intents": [
                     {
@@ -1094,8 +1104,9 @@ class ClaudeBackend:
         raw_input = getattr(block, "input", None)
         if isinstance(raw_input, dict):
             summary["input_keys"] = sorted(str(key) for key in raw_input)
-            coerced = coerce_emit_intent_input(raw_input)
-            intent_type = coerced.get("intent_type")
+            intent_type = raw_input.get("intent_type")
+            if not isinstance(intent_type, str) and is_unparsed_tool_wrapper(raw_input):
+                intent_type = coerce_emit_intent_input(raw_input).get("intent_type")
             if isinstance(intent_type, str):
                 summary["intent_type"] = intent_type
         diag["tool_blocks"].append(summary)

--- a/src/hyperloom/orchestrator/roles/claude.py
+++ b/src/hyperloom/orchestrator/roles/claude.py
@@ -136,6 +136,55 @@ _RAW_COMPLETION_MIN_MAX_TURNS: int = 8
 # gateway is not re-killed at the same wall.
 _RETRY_IDLE_TIMEOUT_MULTIPLIER: float = 2.0
 
+# Claude Code stores a tool JSON string the streaming parser did not promote
+# to an object. Native Claude input already has ``intent_type`` at the top
+# level and is left unchanged.
+_UNPARSED_TOOL_INPUT_KEY = "__unparsedToolInput"
+
+
+def _is_unparsed_tool_wrapper(raw_input: Any) -> bool:
+    """Whether ``input`` is Claude Code's wrapped unparsed tool JSON object."""
+    if not isinstance(raw_input, dict):
+        return False
+    if "intent_type" in raw_input:
+        return False
+    wrapped = raw_input.get(_UNPARSED_TOOL_INPUT_KEY)
+    return isinstance(wrapped, dict) and isinstance(wrapped.get("raw"), str)
+
+
+def _coerce_emit_intent_input(raw_input: Any) -> dict[str, Any]:
+    """Return native emit_intent input, decoding Claude Code's wrapper when needed.
+
+    A dict that already carries ``intent_type`` is returned as-is. Only the
+    ``__unparsedToolInput.raw`` shape is decoded; malformed JSON leaves the
+    original dict so existing validation still fails.
+    """
+    if not isinstance(raw_input, dict):
+        return {}
+    if "intent_type" in raw_input:
+        return raw_input
+    wrapped = raw_input.get(_UNPARSED_TOOL_INPUT_KEY)
+    if not isinstance(wrapped, dict):
+        return raw_input
+    raw = wrapped.get("raw")
+    if not isinstance(raw, str) or not raw.strip():
+        return raw_input
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return raw_input
+    return parsed if isinstance(parsed, dict) else raw_input
+
+
+def _intent_fingerprint(intent: Intent) -> str:
+    """Stable key for one validated intent used to drop fallback retries."""
+    return json.dumps(
+        {"intent_type": intent.type.value, "payload": intent.payload},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+
 
 # Built-in tools disallowed in raw_completion mode so the model produces
 # exactly one text turn (no agentic tool loop).
@@ -886,6 +935,9 @@ class ClaudeBackend:
         text_chunks: list[str] = []
         result_chunks: list[str] = []
         tool_block_count = 0
+        # Claude Code may retry the same wrapped tool JSON many times in one
+        # bounded turn; keep the first decoded fallback envelope only.
+        seen_fallback_intents: set[str] = set()
         # Every usage dict the stream reports, in order: the last is cumulative
         # over the call, the ones before it describe single requests.
         usages: list[dict[str, Any]] = []
@@ -916,6 +968,11 @@ class ClaudeBackend:
                         tool_block_count += 1
                         intent = self._parse_tool_use_block(block)
                         if intent is not None:
+                            if _is_unparsed_tool_wrapper(getattr(block, "input", None)):
+                                fingerprint = _intent_fingerprint(intent)
+                                if fingerprint in seen_fallback_intents:
+                                    continue
+                                seen_fallback_intents.add(fingerprint)
                             intents.append(intent)
                     else:
                         txt = self._extract_text(block)
@@ -1022,13 +1079,14 @@ class ClaudeBackend:
 
         Args:
             block (Any): A tool-use block whose ``input`` carries
-                ``intent_type`` and ``payload``.
+                ``intent_type`` and ``payload``, or Claude Code's
+                ``__unparsedToolInput.raw`` wrapper around that JSON.
 
         Returns:
             Intent | None: The validated intent, or ``None`` if validation
             fails (the failure is logged, not raised).
         """
-        raw_input = getattr(block, "input", None) or {}
+        raw_input = _coerce_emit_intent_input(getattr(block, "input", None) or {})
         try:
             envelope = {
                 "intents": [
@@ -1073,7 +1131,8 @@ class ClaudeBackend:
         raw_input = getattr(block, "input", None)
         if isinstance(raw_input, dict):
             summary["input_keys"] = sorted(str(key) for key in raw_input)
-            intent_type = raw_input.get("intent_type")
+            coerced = _coerce_emit_intent_input(raw_input)
+            intent_type = coerced.get("intent_type")
             if isinstance(intent_type, str):
                 summary["intent_type"] = intent_type
         diag["tool_blocks"].append(summary)

--- a/src/hyperloom/orchestrator/roles/claude.py
+++ b/src/hyperloom/orchestrator/roles/claude.py
@@ -52,6 +52,8 @@ from .mcp_emit_intent import (
     EMIT_INTENT_TOOL_QUALIFIED,
     EMIT_INTENT_TOOL_INPUT_SCHEMA,
     MCP_SERVER_NAME,
+    _coerce_emit_intent_input,
+    _is_unparsed_tool_wrapper,
     build_emit_intent_server,
     constraints_sentence,
     payload_contract,
@@ -135,45 +137,6 @@ _RAW_COMPLETION_MIN_MAX_TURNS: int = 8
 # Retried timeouts get a progressively larger idle budget so a genuinely slow
 # gateway is not re-killed at the same wall.
 _RETRY_IDLE_TIMEOUT_MULTIPLIER: float = 2.0
-
-# Claude Code stores a tool JSON string the streaming parser did not promote
-# to an object. Native Claude input already has ``intent_type`` at the top
-# level and is left unchanged.
-_UNPARSED_TOOL_INPUT_KEY = "__unparsedToolInput"
-
-
-def _is_unparsed_tool_wrapper(raw_input: Any) -> bool:
-    """Whether ``input`` is Claude Code's wrapped unparsed tool JSON object."""
-    if not isinstance(raw_input, dict):
-        return False
-    if "intent_type" in raw_input:
-        return False
-    wrapped = raw_input.get(_UNPARSED_TOOL_INPUT_KEY)
-    return isinstance(wrapped, dict) and isinstance(wrapped.get("raw"), str)
-
-
-def _coerce_emit_intent_input(raw_input: Any) -> dict[str, Any]:
-    """Return native emit_intent input, decoding Claude Code's wrapper when needed.
-
-    A dict that already carries ``intent_type`` is returned as-is. Only the
-    ``__unparsedToolInput.raw`` shape is decoded; malformed JSON leaves the
-    original dict so existing validation still fails.
-    """
-    if not isinstance(raw_input, dict):
-        return {}
-    if "intent_type" in raw_input:
-        return raw_input
-    wrapped = raw_input.get(_UNPARSED_TOOL_INPUT_KEY)
-    if not isinstance(wrapped, dict):
-        return raw_input
-    raw = wrapped.get("raw")
-    if not isinstance(raw, str) or not raw.strip():
-        return raw_input
-    try:
-        parsed = json.loads(raw)
-    except (TypeError, ValueError):
-        return raw_input
-    return parsed if isinstance(parsed, dict) else raw_input
 
 
 def _intent_fingerprint(intent: Intent) -> str:
@@ -936,7 +899,7 @@ class ClaudeBackend:
         result_chunks: list[str] = []
         tool_block_count = 0
         # Claude Code may retry the same wrapped tool JSON many times in one
-        # bounded turn; keep the first decoded fallback envelope only.
+        # query; keep the first decoded fallback envelope only.
         seen_fallback_intents: set[str] = set()
         # Every usage dict the stream reports, in order: the last is cumulative
         # over the call, the ones before it describe single requests.

--- a/src/hyperloom/orchestrator/roles/claude.py
+++ b/src/hyperloom/orchestrator/roles/claude.py
@@ -55,9 +55,9 @@ from .mcp_emit_intent import (
     build_emit_intent_server,
     coerce_emit_intent_input,
     constraints_sentence,
+    decode_emit_intent_input,
     is_unparsed_tool_wrapper,
     payload_contract,
-    validate_emit_intent_input,
 )
 
 
@@ -1058,9 +1058,15 @@ class ClaudeBackend:
             fails (the failure is logged, not raised).
         """
         block_input = getattr(block, "input", None) or {}
+        if not isinstance(block_input, dict):
+            block_input = {}
+        raw_input, decode_error = decode_emit_intent_input(block_input)
+        if decode_error is not None:
+            log.info("claude tool_use decode failed: %s", decode_error)
+            if self._active_turn_diagnostic is not None:
+                self._active_turn_diagnostic["parse_errors"].append(decode_error)
+            return None
         try:
-            validate_emit_intent_input(block_input)
-            raw_input = coerce_emit_intent_input(block_input)
             envelope = {
                 "intents": [
                     {

--- a/src/hyperloom/orchestrator/roles/mcp_emit_intent.py
+++ b/src/hyperloom/orchestrator/roles/mcp_emit_intent.py
@@ -199,8 +199,17 @@ EMIT_INTENT_TOOL_INPUT_SCHEMA: dict[str, Any] = {
                 f"{constraints_sentence(IntentType)}"
             ),
         },
+        "__unparsedToolInput": {
+            "type": "object",
+            "description": (
+                "Internal fallback produced by the Claude Code streaming parser. Never emit this deliberately."
+            ),
+        },
     },
-    "required": ["intent_type", "payload"],
+    "anyOf": [
+        {"required": ["intent_type", "payload"]},
+        {"required": ["__unparsedToolInput"]},
+    ],
     "additionalProperties": False,
 }
 
@@ -218,7 +227,7 @@ EMIT_INTENT_TOOL_DESCRIPTION = (
 _UNPARSED_TOOL_INPUT_KEY = "__unparsedToolInput"
 
 
-def _is_unparsed_tool_wrapper(raw_input: Any) -> bool:
+def is_unparsed_tool_wrapper(raw_input: Any) -> bool:
     """Whether ``input`` is Claude Code's wrapped unparsed tool JSON object."""
     if not isinstance(raw_input, dict):
         return False
@@ -228,7 +237,7 @@ def _is_unparsed_tool_wrapper(raw_input: Any) -> bool:
     return isinstance(wrapped, dict) and isinstance(wrapped.get("raw"), str)
 
 
-def _coerce_emit_intent_input(raw_input: Any) -> dict[str, Any]:
+def coerce_emit_intent_input(raw_input: Any) -> dict[str, Any]:
     """Return native emit_intent input, decoding the wrapper only as fallback.
 
     Canonical ``{intent_type, payload}`` is returned unchanged. The
@@ -272,7 +281,7 @@ def validate_emit_intent_input(payload: dict[str, Any]) -> None:
     """
     if not isinstance(payload, dict):
         raise IntentValidationError(f"emit_intent input must be an object, got {type(payload).__name__}")
-    coerced = _coerce_emit_intent_input(payload)
+    coerced = coerce_emit_intent_input(payload)
     extra = set(coerced.keys()) - {"intent_type", "payload"}
     if extra:
         raise IntentValidationError(f"emit_intent input has unexpected keys: {sorted(extra)!r}")
@@ -372,6 +381,8 @@ __all__ = [
     "MCP_SERVER_NAME",
     "build_emit_intent_server",
     "build_intent_envelope_schema",
+    "coerce_emit_intent_input",
+    "is_unparsed_tool_wrapper",
     "payload_contract",
     "validate_emit_intent_input",
 ]

--- a/src/hyperloom/orchestrator/roles/mcp_emit_intent.py
+++ b/src/hyperloom/orchestrator/roles/mcp_emit_intent.py
@@ -231,7 +231,7 @@ _UNPARSED_TOOL_INPUT_KEY = "__unparsedToolInput"
 _EMIT_INTENT_TOP_LEVEL_KEYS = {"intent_type", "payload", _UNPARSED_TOOL_INPUT_KEY}
 
 
-def _decode_emit_intent_input(raw_input: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+def decode_emit_intent_input(raw_input: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
     """Decode a parser fallback and report why decoding failed.
 
     Canonical input always wins when ``intent_type`` is present. The fallback
@@ -274,7 +274,7 @@ def coerce_emit_intent_input(raw_input: Any) -> dict[str, Any]:
     """
     if not isinstance(raw_input, dict):
         return {}
-    coerced, _ = _decode_emit_intent_input(raw_input)
+    coerced, _ = decode_emit_intent_input(raw_input)
     return coerced
 
 
@@ -300,7 +300,7 @@ def validate_emit_intent_input(payload: dict[str, Any]) -> None:
     original_extra = set(payload) - _EMIT_INTENT_TOP_LEVEL_KEYS
     if original_extra:
         raise IntentValidationError(f"emit_intent input has unexpected keys: {sorted(original_extra)!r}")
-    coerced, decode_error = _decode_emit_intent_input(payload)
+    coerced, decode_error = decode_emit_intent_input(payload)
     if decode_error is not None:
         raise IntentValidationError(f"emit_intent: {decode_error}")
     extra = set(coerced) - _EMIT_INTENT_TOP_LEVEL_KEYS
@@ -403,6 +403,7 @@ __all__ = [
     "build_emit_intent_server",
     "build_intent_envelope_schema",
     "coerce_emit_intent_input",
+    "decode_emit_intent_input",
     "is_unparsed_tool_wrapper",
     "payload_contract",
     "validate_emit_intent_input",

--- a/src/hyperloom/orchestrator/roles/mcp_emit_intent.py
+++ b/src/hyperloom/orchestrator/roles/mcp_emit_intent.py
@@ -22,6 +22,7 @@ factory overrides for tests. The SDK rewrites the tool name to
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, Callable, Iterable
 
@@ -211,13 +212,54 @@ EMIT_INTENT_TOOL_DESCRIPTION = (
     "intents in a single turn, call this tool multiple times."
 )
 
+# Exception-only: Claude Code stores a tool JSON string the streaming parser
+# did not promote to an object. Canonical input remains ``intent_type`` +
+# ``payload`` and is never rewritten when that shape is already present.
+_UNPARSED_TOOL_INPUT_KEY = "__unparsedToolInput"
+
+
+def _is_unparsed_tool_wrapper(raw_input: Any) -> bool:
+    """Whether ``input`` is Claude Code's wrapped unparsed tool JSON object."""
+    if not isinstance(raw_input, dict):
+        return False
+    if "intent_type" in raw_input:
+        return False
+    wrapped = raw_input.get(_UNPARSED_TOOL_INPUT_KEY)
+    return isinstance(wrapped, dict) and isinstance(wrapped.get("raw"), str)
+
+
+def _coerce_emit_intent_input(raw_input: Any) -> dict[str, Any]:
+    """Return native emit_intent input, decoding the wrapper only as fallback.
+
+    Canonical ``{intent_type, payload}`` is returned unchanged. The
+    ``__unparsedToolInput.raw`` object is decoded only when that native shape
+    is absent. Malformed JSON leaves the original dict so validation still
+    fails.
+    """
+    if not isinstance(raw_input, dict):
+        return {}
+    if "intent_type" in raw_input:
+        return raw_input
+    wrapped = raw_input.get(_UNPARSED_TOOL_INPUT_KEY)
+    if not isinstance(wrapped, dict):
+        return raw_input
+    raw = wrapped.get("raw")
+    if not isinstance(raw, str) or not raw.strip():
+        return raw_input
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return raw_input
+    return parsed if isinstance(parsed, dict) else raw_input
+
 
 def validate_emit_intent_input(payload: dict[str, Any]) -> None:
     """Eager single-intent validation (mirrors :func:`validate_envelope`).
 
-    Checks the tool-input shape (only ``intent_type`` and ``payload`` keys,
-    both present), that ``intent_type`` is a known :class:`IntentType`, and
-    that the inner payload carries every required field for that type.
+    Canonical input is ``intent_type`` + ``payload``. A Claude Code
+    ``__unparsedToolInput`` wrapper is decoded first only when that native
+    shape is missing, then the same checks apply: only those two top-level
+    keys, a known :class:`IntentType`, and every required payload field.
 
     Args:
         payload (dict[str, Any]): The raw ``emit_intent`` tool input to
@@ -230,16 +272,17 @@ def validate_emit_intent_input(payload: dict[str, Any]) -> None:
     """
     if not isinstance(payload, dict):
         raise IntentValidationError(f"emit_intent input must be an object, got {type(payload).__name__}")
-    extra = set(payload.keys()) - {"intent_type", "payload"}
+    coerced = _coerce_emit_intent_input(payload)
+    extra = set(coerced.keys()) - {"intent_type", "payload"}
     if extra:
         raise IntentValidationError(f"emit_intent input has unexpected keys: {sorted(extra)!r}")
-    if "intent_type" not in payload or "payload" not in payload:
+    if "intent_type" not in coerced or "payload" not in coerced:
         raise IntentValidationError("emit_intent input requires both 'intent_type' and 'payload'")
     try:
-        intent_type = IntentType(payload["intent_type"])
+        intent_type = IntentType(coerced["intent_type"])
     except ValueError as exc:
-        raise IntentValidationError(f"emit_intent: unknown intent_type {payload['intent_type']!r}") from exc
-    inner = payload["payload"]
+        raise IntentValidationError(f"emit_intent: unknown intent_type {coerced['intent_type']!r}") from exc
+    inner = coerced["payload"]
     if not isinstance(inner, dict):
         raise IntentValidationError(f"emit_intent: 'payload' must be an object, got {type(inner).__name__}")
     required = _PAYLOAD_REQUIRED.get(intent_type, ())

--- a/src/hyperloom/orchestrator/roles/mcp_emit_intent.py
+++ b/src/hyperloom/orchestrator/roles/mcp_emit_intent.py
@@ -213,6 +213,9 @@ EMIT_INTENT_TOOL_INPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
+# The fallback branch lets the MCP handler acknowledge parser-generated
+# wrappers instead of returning an error the model cannot repair. Native
+# ``intent_type`` + ``payload`` remains the canonical and preferred contract.
 
 EMIT_INTENT_TOOL_DESCRIPTION = (
     "Emit ONE structured intent into the inference_optimizer system. This "
@@ -225,6 +228,30 @@ EMIT_INTENT_TOOL_DESCRIPTION = (
 # did not promote to an object. Canonical input remains ``intent_type`` +
 # ``payload`` and is never rewritten when that shape is already present.
 _UNPARSED_TOOL_INPUT_KEY = "__unparsedToolInput"
+_EMIT_INTENT_TOP_LEVEL_KEYS = {"intent_type", "payload", _UNPARSED_TOOL_INPUT_KEY}
+
+
+def _decode_emit_intent_input(raw_input: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    """Decode a parser fallback and report why decoding failed.
+
+    Canonical input always wins when ``intent_type`` is present. The fallback
+    is inspected only when canonical input is absent.
+    """
+    if "intent_type" in raw_input or _UNPARSED_TOOL_INPUT_KEY not in raw_input:
+        return raw_input, None
+    wrapped = raw_input.get(_UNPARSED_TOOL_INPUT_KEY)
+    if not isinstance(wrapped, dict):
+        return raw_input, f"{_UNPARSED_TOOL_INPUT_KEY} must be an object"
+    raw = wrapped.get("raw")
+    if not isinstance(raw, str) or not raw.strip():
+        return raw_input, f"{_UNPARSED_TOOL_INPUT_KEY}.raw must be a non-empty JSON object string"
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return raw_input, f"{_UNPARSED_TOOL_INPUT_KEY}.raw is not valid JSON"
+    if not isinstance(parsed, dict):
+        return raw_input, f"{_UNPARSED_TOOL_INPUT_KEY}.raw must decode to a JSON object"
+    return parsed, None
 
 
 def is_unparsed_tool_wrapper(raw_input: Any) -> bool:
@@ -247,19 +274,8 @@ def coerce_emit_intent_input(raw_input: Any) -> dict[str, Any]:
     """
     if not isinstance(raw_input, dict):
         return {}
-    if "intent_type" in raw_input:
-        return raw_input
-    wrapped = raw_input.get(_UNPARSED_TOOL_INPUT_KEY)
-    if not isinstance(wrapped, dict):
-        return raw_input
-    raw = wrapped.get("raw")
-    if not isinstance(raw, str) or not raw.strip():
-        return raw_input
-    try:
-        parsed = json.loads(raw)
-    except (TypeError, ValueError):
-        return raw_input
-    return parsed if isinstance(parsed, dict) else raw_input
+    coerced, _ = _decode_emit_intent_input(raw_input)
+    return coerced
 
 
 def validate_emit_intent_input(payload: dict[str, Any]) -> None:
@@ -281,8 +297,13 @@ def validate_emit_intent_input(payload: dict[str, Any]) -> None:
     """
     if not isinstance(payload, dict):
         raise IntentValidationError(f"emit_intent input must be an object, got {type(payload).__name__}")
-    coerced = coerce_emit_intent_input(payload)
-    extra = set(coerced.keys()) - {"intent_type", "payload"}
+    original_extra = set(payload) - _EMIT_INTENT_TOP_LEVEL_KEYS
+    if original_extra:
+        raise IntentValidationError(f"emit_intent input has unexpected keys: {sorted(original_extra)!r}")
+    coerced, decode_error = _decode_emit_intent_input(payload)
+    if decode_error is not None:
+        raise IntentValidationError(f"emit_intent: {decode_error}")
+    extra = set(coerced) - _EMIT_INTENT_TOP_LEVEL_KEYS
     if extra:
         raise IntentValidationError(f"emit_intent input has unexpected keys: {sorted(extra)!r}")
     if "intent_type" not in coerced or "payload" not in coerced:


### PR DESCRIPTION
## Summary
- Decode Claude Code `__unparsedToolInput.raw` into native `emit_intent` input when `intent_type` is absent.
- Leave native Claude tool objects unchanged; drop identical fallback retries in one turn.
- Add unit tests for unwrap, malformed JSON, native preference, and native vs fallback dedupe.

## Test plan
- [ ] `python3 -m pytest -n auto src/hyperloom/inference_optimizer/tests/test_claude_unparsed_tool_input_unit.py src/hyperloom/inference_optimizer/tests/test_claude_backend_helpers_coverage_unit.py src/hyperloom/inference_optimizer/tests/test_claude_backend.py`

Made with [Cursor](https://cursor.com)