### PR TITLE
Add Strix Halo/GFX1151 Support

### DIFF
--- a/docs/kernelforge/quickstart.md
+++ b/docs/kernelforge/quickstart.md
@@ -99,6 +99,37 @@ export OPENAI_BASE_URL=https://your-gateway.example/api/v1/llm-proxy/v1
 export OPENAI_API_KEY=...
 ```
 
+**Native Codex OAuth.** Keep subscription OAuth separate from gateway mode. Use a dedicated absolute,
+non-symlink `CODEX_HOME` that already contains a successful `codex login`, do not combine it with a
+gateway override, and disable both fallback axes explicitly:
+
+```bash
+kernelforge forge-loop ... \
+  --agent-backend codex \
+  --agent-options-json '{"auth_mode":"native_oauth","home":"/absolute/codex-oauth-home"}' \
+  --agent-fallback-provider none \
+  --agent-fallback-model none
+```
+
+In native-OAuth mode KernelForge strips inherited OpenAI gateway variables and does not force a custom
+model provider; authentication comes only from that `CODEX_HOME`.
+
+**Hermes Agent.** Select Hermes as a peer provider through its existing profile. The profile owns its
+provider/model/tools/authentication; KernelForge still owns validation, benchmarking, and KEEP/REVERT:
+
+```bash
+kernelforge forge-loop ... \
+  --agent-backend hermes \
+  --agent-options-json '{"profile":"hyperloomfaithful","provider":"openai-codex","external_sandbox":true}' \
+  --agent-fallback-provider none \
+  --agent-fallback-model none
+```
+
+Hermes has no native filesystem sandbox. `external_sandbox` is therefore required and must be set only
+when the whole run already executes inside a container with a detectable runtime marker. The backend fails closed otherwise, applies
+the shared WorkspaceGuard, narrows read-only runs to no local tools, and narrows writable runs to the
+terminal/file toolsets. The selected profile should have an empty fallback chain.
+
 That is the whole credential contract. Corporate gateways sometimes demand headers
 on top of it, an APIM subscription key or a caller id. Set those on the line they
 belong to; only that line's headers are sent:

--- a/docs/kernelforge/reference/cli.md
+++ b/docs/kernelforge/reference/cli.md
@@ -117,7 +117,8 @@ and passing one alongside `--resume` is refused rather than silently ignored.
 | `--model <name>` | provider default | Selected provider model. |
 | `--agent-reasoning-effort <v>` | provider default | Provider reasoning effort value. |
 | `--agent-sandbox-mode <v>` | provider default | Provider sandbox mode. |
-| `--agent-fallback-provider <name>` | provider default | Fallback provider name, or `none` to refuse a fallback. |
+| `--agent-fallback-provider <name>` | provider default | Fallback provider name, or `none` to refuse a provider fallback. |
+| `--agent-fallback-model <name>` | provider default | Same-provider fallback model, or `none` to refuse model fallback. |
 | `--agent-precheck` / `--no-agent-precheck` | on | Provider preflight and capability probe. |
 | `--agent-options-json <json>` | none | Provider extension options as a JSON object. |
 | `--permission-mode <v>` | provider default | Provider permission mode, where the provider supports one. |

--- a/examples/hyperloom-custom-advanced/SKILL.md
+++ b/examples/hyperloom-custom-advanced/SKILL.md
@@ -47,6 +47,8 @@ Suggested Docker images:
 - `vllm`: `docker.io/vllm/vllm-openai-rocm:v0.27.1`
 - `sglang` MI300X: `docker.io/lmsysorg/sglang-rocm:v0.5.18-rocm724-mi30x-20260825`
 - `sglang` MI355X: `docker.io/lmsysorg/sglang-rocm:v0.5.18-rocm724-mi35x-20260825`
+- `vllm` Radeon 8060S/gfx1151: `hyperloom-vllm-v027-rocm10:v16-runtime-admission-v1`
+- `sglang` Radeon 8060S/gfx1151: `hyperloom-sglang-v0515-rocm10:v16-async-v7`
 
 In Docker mode, start a long-running container on `HYPERLOOM_DOCKER_TARGET_HOST`
 (or the current host when it is unset) before running setup or optimize:

--- a/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
+++ b/examples/hyperloom-qwen3-14b-fp8-12h/SKILL.md
@@ -37,6 +37,8 @@ Suggested Docker images:
 - `vllm`: `docker.io/vllm/vllm-openai-rocm:v0.27.1`
 - `sglang` MI300X: `docker.io/lmsysorg/sglang-rocm:v0.5.18-rocm724-mi30x-20260825`
 - `sglang` MI355X: `docker.io/lmsysorg/sglang-rocm:v0.5.18-rocm724-mi35x-20260825`
+- `vllm` Radeon 8060S/gfx1151: `hyperloom-vllm-v027-rocm10:v16-runtime-admission-v1`
+- `sglang` Radeon 8060S/gfx1151: `hyperloom-sglang-v0515-rocm10:v16-async-v7`
 
 In Docker mode, start a long-running container on `HYPERLOOM_DOCKER_TARGET_HOST`
 (or the current host when it is unset) before running setup or optimize:

--- a/examples/hyperloom-qwen3-8b-3h/SKILL.md
+++ b/examples/hyperloom-qwen3-8b-3h/SKILL.md
@@ -37,6 +37,8 @@ Suggested Docker images:
 - `vllm`: `docker.io/vllm/vllm-openai-rocm:v0.27.1`
 - `sglang` MI300X: `docker.io/lmsysorg/sglang-rocm:v0.5.18-rocm724-mi30x-20260825`
 - `sglang` MI355X: `docker.io/lmsysorg/sglang-rocm:v0.5.18-rocm724-mi35x-20260825`
+- `vllm` Radeon 8060S/gfx1151: `hyperloom-vllm-v027-rocm10:v16-runtime-admission-v1`
+- `sglang` Radeon 8060S/gfx1151: `hyperloom-sglang-v0515-rocm10:v16-async-v7`
 
 In Docker mode, start a long-running container on `HYPERLOOM_DOCKER_TARGET_HOST`
 (or the current host when it is unset) before running setup or optimize:

--- a/src/hyperloom/agents/quantization/README.md
+++ b/src/hyperloom/agents/quantization/README.md
@@ -5,8 +5,9 @@ natural-language prompt.
 
 ## Scope
 
-**What it is.** A thin Claude-SDK driver. It loads `SKILL.md` as the runtime
-contract and lets the LLM invoke Quark's published skills end-to-end
+**What it is.** A thin agent-runtime driver with selectable Claude, Codex, or
+Hermes transport. Every provider receives the same `SKILL.md` runtime contract
+and invokes Quark's published skills end-to-end
 (`quark-torch-ptq` → `quark-torch-result-validator` → `quark-torch-llm-eval`),
 classifies each attempt's workspace state into a 30-row outcome matrix, and
 exposes one diagnose-fix-retry loop on top.
@@ -22,8 +23,12 @@ All ML work runs inside Quark's skills.
   the same tree).
 - Python deps (`claude-agent-sdk`, `PyYAML`) come from Hyperloom's top-level
   `pyproject.toml` — no separate install script.
-- A working Claude SDK authentication (e.g. `ANTHROPIC_API_KEY` in env, or
-  any auth method the SDK accepts).
+- One selected agent runtime and its authentication: Claude Agent SDK,
+  native Codex CLI/OAuth, or Hermes Agent/profile. Provider fallback is not
+  performed by this package.
+- Hermes terminal/file execution must run inside a verifiable outer container;
+  set `HYPERLOOM_HERMES_EXTERNAL_SANDBOX=1` only inside that boundary. The
+  transport fails closed without it.
 
 ## Usage — prompt is the only input
 
@@ -46,6 +51,7 @@ No human interaction at any point.
 
 ```bash
 python -m hyperloom.agents.quantization.cli \
+    --provider hermes \                         # claude | codex | hermes
     --prompt "$PROMPT" \                       # natural-language request
     --workspace /scratch/run-1/wks \           # per-run scratch dir
     --quark-root /path/to/Quark \              # or $QUARK_ROOT
@@ -78,6 +84,7 @@ async def main():
         interactive=False,
         acceptable_eval_gap=0.05,
         max_requantize_attempts=1,
+        provider="hermes",
     )
     print(result.status)                       # success | partial | failed
     print(result.quantized_model_dir)          # Path | None
@@ -114,7 +121,7 @@ The full 30-outcome enumeration lives in `driver/outcomes.py` (`OutcomeId`,
 The agent writes a small, stable set of files under `--workspace`. Callers
 can read these directly:
 
-- `session_context.json` — handshake payload passed to the SDK at session start.
+- `session_context.json` — handshake payload used by the selected agent runtime.
 - `run_manifest.yaml` — Quark's workflow manifest (inputs, outputs, exec phases).
 - `model_analysis.json`, `quant_plan.json` — intake + plan outputs.
 - `validation_report.md` — validator results (4 steps: auxiliary / md5 /
@@ -136,9 +143,11 @@ can read these directly:
 | ------------------------------------ | ------- | -------------------------------------------------------------------------- |
 | `QUARK_ROOT`                         | —       | Path to amd-quark checkout. Required unless passed as `quark_root=` kwarg. |
 | `HYPERLOOM_QUANT_STRICT_VALIDATION`  | `1`     | When `0`, MUST-validate SKIPPED demotes to `partial` instead of `failed`.  |
+| `HYPERLOOM_CODEX_HOME`               | —       | Dedicated absolute, non-symlink native OAuth home for the Codex CLI. When set, gateway credential variables are stripped from the child. |
 
-Claude SDK auth (`ANTHROPIC_API_KEY` or equivalent) is handled by
-`claude-agent-sdk` and is not read directly by this package.
+Authentication belongs to the selected runtime: Claude Agent SDK credentials,
+Codex OAuth/config, or the selected Hermes profile. Credentials are not passed
+through the prompt or written to workspace artifacts.
 
 ## Tests
 
@@ -146,8 +155,8 @@ Claude SDK auth (`ANTHROPIC_API_KEY` or equivalent) is handled by
 pytest src/hyperloom/agents/quantization/tests/
 ```
 
-All tests run offline — no network, no GPU, no Claude SDK calls (a fake-SDK
-fixture is injected). The classifier suite covers each of the 30 outcome
+All tests run offline — no network, no GPU, no real agent-runtime calls (fake
+SDK/subprocess fixtures are injected). The classifier suite covers each of the 30 outcome
 IDs; the retry-loop suite covers counter persistence, hypothesis-gate,
 operator promotion, and budget exhaustion.
 

--- a/src/hyperloom/agents/quantization/SKILL.md
+++ b/src/hyperloom/agents/quantization/SKILL.md
@@ -116,11 +116,11 @@ There is no JSON sidecar and no built-in source-vs-quantized comparison —
 2. Quantized model: `<workspace>/quantized_eval.md`. Re-run every attempt
    (the quantized model may have changed).
 
-If Docker isn't available, or vLLM/SGLang can't start, or the dataset can't
-be reached: write the reason to `<workspace>/eval_skipped.txt`. Use the
-substrings the classifier recognizes: `oom` (→ #29 eval_oom),
-`vllm` / `sglang` / `quantized_load` (→ #28 quantized_load_failed), or
-anything else (→ #22 eval_env_unavailable).
+If Docker isn't available, no serving backend is installed, or the dataset
+can't be reached: write the reason to `<workspace>/eval_skipped.txt`; that is
+#22 `eval_env_unavailable`. Use `oom` only for #29 `eval_oom`. Use
+`quantized_load` only after a serving backend actually attempted and failed to
+load the exported checkpoint (#28 `quantized_load_failed`).
 
 ### 5.2 Parse the Markdown headlines
 

--- a/src/hyperloom/agents/quantization/cli.py
+++ b/src/hyperloom/agents/quantization/cli.py
@@ -1,9 +1,9 @@
 """Standalone CLI for the quantization-agent.
 
 Lets you drive the Quark PTQ skill chain from a natural-language prompt
-without going through ``inference_optimizer``. The prompt is fed to the
-Claude Agent SDK, which loads ``hyperloom/agents/quantization/SKILL.md`` as the
-runtime contract and invokes the Quark skills end-to-end.
+without going through ``inference_optimizer``. Claude, Codex, and Hermes
+receive the same ``hyperloom/agents/quantization/SKILL.md`` runtime contract
+and invoke the same Quark skills end-to-end.
 
 Example (or use the ``quantization-agent`` console script)::
 
@@ -33,7 +33,7 @@ import sys
 from typing import Any
 
 from .driver.retry import quantize_via_prompt
-from .driver.runner import DEFAULT_MODEL
+from .driver.runner import DEFAULT_MODEL, SUPPORTED_PROVIDERS
 
 
 def _interactive_value(raw: str) -> bool | None:
@@ -110,9 +110,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Upper bound on Python-driven retries for Ask-class outcomes (#3/#6/#16/#26) and #30. Default 1.",
     )
     p.add_argument(
+        "--provider",
+        choices=SUPPORTED_PROVIDERS,
+        default="claude",
+        help="Agent runtime for the unchanged Quark skill workflow (default: claude).",
+    )
+    p.add_argument(
         "--model-id",
         default=None,
-        help=f"Override the Claude model id used by the SDK (default {DEFAULT_MODEL}).",
+        help=f"Override the selected provider model id (Claude default {DEFAULT_MODEL}).",
     )
     p.add_argument(
         "--verbose",
@@ -149,6 +155,7 @@ async def _run(args: argparse.Namespace) -> int:
         interactive=args.interactive,
         acceptable_eval_gap=args.acceptable_eval_gap,
         max_requantize_attempts=args.max_requantize_attempts,
+        provider=args.provider,
         model=args.model_id,
         log=log,
     )

--- a/src/hyperloom/agents/quantization/driver/__init__.py
+++ b/src/hyperloom/agents/quantization/driver/__init__.py
@@ -1,6 +1,6 @@
 """Internal driver package for quantization_agent.
 
-Drives the Claude SDK session per ``SKILL.md``: single-attempt session
+Drives the selected Claude/Codex/Hermes session per ``SKILL.md``: single-attempt session
 runner, multi-attempt retry orchestrator, artifact collection, eval gap
 gating, and outcome classification. Public symbols are re-exported by
 ``quantization_agent.__init__``; do not import from ``driver`` directly

--- a/src/hyperloom/agents/quantization/driver/assessment.py
+++ b/src/hyperloom/agents/quantization/driver/assessment.py
@@ -128,8 +128,11 @@ _EXPORT_PATTERNS = (
 )
 
 _QUANTIZED_LOAD_PATTERNS = (
-    "vllm",
-    "sglang",
+    "quantized_load",
+    "quantized load",
+    "failed to load quantized",
+    "vllm engine.start failed",
+    "sglang engine.start failed",
     "engine.start",
     "engine startup",
 )

--- a/src/hyperloom/agents/quantization/driver/retry.py
+++ b/src/hyperloom/agents/quantization/driver/retry.py
@@ -244,6 +244,7 @@ async def quantize_via_prompt(
     interactive: bool | None = None,
     acceptable_eval_gap: float | None = None,
     max_requantize_attempts: int = 1,
+    provider: str = "claude",
     model: str | None = None,
     runner_fn: RunOneAttemptFn | None = None,
     log: Callable[[str], None] | None = None,
@@ -300,17 +301,31 @@ async def quantize_via_prompt(
 
     attempt_n = 1
     while True:
-        attempt_result = await run_attempt(
-            user_prompt=prompt,
-            workspace=workspace_path,
-            quark_root=quark_root_path,
-            attempt_number=attempt_n,
-            acceptable_eval_gap=acceptable_eval_gap,
-            interactive=interactive_resolved,
-            previous_outcome=last_outcome.value if isinstance(last_outcome, OutcomeId) else None,
-            model=model,
-            log=log,
-        )
+        if provider == "claude":
+            attempt_result = await run_attempt(
+                user_prompt=prompt,
+                workspace=workspace_path,
+                quark_root=quark_root_path,
+                attempt_number=attempt_n,
+                acceptable_eval_gap=acceptable_eval_gap,
+                interactive=interactive_resolved,
+                previous_outcome=last_outcome.value if isinstance(last_outcome, OutcomeId) else None,
+                model=model,
+                log=log,
+            )
+        else:
+            attempt_result = await run_attempt(
+                user_prompt=prompt,
+                workspace=workspace_path,
+                quark_root=quark_root_path,
+                attempt_number=attempt_n,
+                acceptable_eval_gap=acceptable_eval_gap,
+                interactive=interactive_resolved,
+                previous_outcome=last_outcome.value if isinstance(last_outcome, OutcomeId) else None,
+                provider=provider,
+                model=model,
+                log=log,
+            )
 
         artifacts = collect_artifacts(workspace_path)
         outcome = classify_attempt(

--- a/src/hyperloom/agents/quantization/driver/runner.py
+++ b/src/hyperloom/agents/quantization/driver/runner.py
@@ -1,24 +1,32 @@
-"""One-attempt SDK driver for the quantization-agent.
+"""One-attempt agent-runtime driver for the quantization-agent.
 
-Keyword-only public API with injection seams (``sdk_query_factory`` /
-``sdk_options_cls``) so tests don't need the SDK installed. Runs with
-``cwd = quark_root`` (graceful fallback for older SDK builds), stores SDK
-errors on the result rather than raising, and routes output through a single
-``log`` callable. The agent leans on ``SKILL.md`` as the runtime contract;
-this module just plumbs run context into a templated prompt for the SDK.
+Claude retains its SDK injection seams (``sdk_query_factory`` /
+``sdk_options_cls``); Codex and Hermes are CLI transports. Every provider
+receives the same rendered ``SKILL.md`` prompt and stores runtime errors on the
+result rather than raising. Hermes starts from the writable workspace while the
+read-only Quark root remains pinned in the prompt.
 """
 
 from __future__ import annotations
 
+import asyncio
 import os
+import shutil
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterable
 
+from hyperloom.common.env_safety import is_secret_shaped_env_name, redact_secret_values
+from hyperloom.common.hermes_runtime import hermes_external_sandbox_enabled, resolve_hermes_executable
 from hyperloom.common.llm_attribution import sdk_env_overlay
 
 
 DEFAULT_MODEL = "claude-opus-5"
+DEFAULT_CODEX_MODEL = "gpt-5.6-sol"
+DEFAULT_HERMES_MODEL = "gpt-5.6-sol"
+SUPPORTED_PROVIDERS = ("claude", "codex", "hermes")
+CODEX_HOME_ENV = "HYPERLOOM_CODEX_HOME"
 DEFAULT_ALLOWED_TOOLS = ["Read", "Write", "Edit", "Bash"]
 DEFAULT_MAX_TURNS = 240  # Quark workflow has 4 STOPs + validator + eval
 
@@ -119,6 +127,125 @@ def _quark_py310_compat_env(workspace: Path, base_env: dict[str, str] | None = N
     return env
 
 
+async def _run_cli_attempt(
+    *,
+    provider: str,
+    prompt: str,
+    workspace: Path,
+    quark_root: Path,
+    model: str | None,
+    log: Callable[[str], None] | None,
+) -> AttemptResult:
+    """Run the same skill prompt through Codex or Hermes Agent."""
+
+    env = _quark_py310_compat_env(workspace)
+    env.update(sdk_env_overlay(component="quantization", operation="quantize_attempt"))
+    if provider == "codex":
+        executable = shutil.which("codex")
+        selected_model = model or env.get("CODEX_MODEL") or DEFAULT_CODEX_MODEL
+        configured_home = str(env.get(CODEX_HOME_ENV) or "").strip()
+        if configured_home:
+            home_path = Path(configured_home).expanduser()
+            if not home_path.is_absolute():
+                return AttemptResult(workspace=workspace, sdk_error="native OAuth CODEX_HOME must be absolute")
+            if home_path.is_symlink():
+                return AttemptResult(workspace=workspace, sdk_error="native OAuth CODEX_HOME cannot be a symlink")
+            if not home_path.is_dir():
+                return AttemptResult(workspace=workspace, sdk_error="native OAuth CODEX_HOME must already exist")
+            env["CODEX_HOME"] = str(home_path.resolve())
+            for name in (
+                "OPENAI_BASE_URL",
+                "OPENAI_API_KEY",
+                "OPENAI_CUSTOM_HEADERS",
+                "CODEX_API_KEY",
+            ):
+                env.pop(name, None)
+        argv = [
+            executable or "codex",
+            "exec",
+            "--sandbox",
+            "workspace-write",
+            "--ephemeral",
+            "--ignore-rules",
+            "-m",
+            selected_model,
+        ]
+        stdin = prompt
+    else:
+        executable = resolve_hermes_executable()
+        if not hermes_external_sandbox_enabled(env):
+            return AttemptResult(
+                workspace=workspace,
+                sdk_error=(
+                    "Hermes quantization requires a verifiable outer container; "
+                    "set HYPERLOOM_HERMES_EXTERNAL_SANDBOX=1 only inside that boundary"
+                ),
+            )
+        selected_model = model or env.get("HYPERLOOM_HERMES_MODEL") or DEFAULT_HERMES_MODEL
+        profile = env.get("HYPERLOOM_HERMES_PROFILE", "hyperloomfaithful")
+        inference_provider = env.get("HYPERLOOM_HERMES_PROVIDER", "openai-codex")
+        argv = [
+            executable or "hermes",
+            "--profile",
+            profile,
+            "--provider",
+            inference_provider,
+            "--model",
+            selected_model,
+            "--safe-mode",
+            "--toolsets",
+            "terminal,file",
+            "-z",
+            prompt,
+        ]
+        stdin = None
+
+    if executable is None:
+        return AttemptResult(workspace=workspace, sdk_error=f"{provider} executable not found")
+
+    def _invoke() -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            argv,
+            cwd=workspace,
+            env=env,
+            input=stdin,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    if log:
+        log(f"quantization-agent {provider} runner: workspace={workspace} quark_root={quark_root}")
+    try:
+        completed = await asyncio.to_thread(_invoke)
+    except Exception as exc:  # noqa: BLE001
+        return AttemptResult(workspace=workspace, sdk_error=f"{type(exc).__name__}: {exc}")
+
+    def _redact_diagnostic(value: str) -> str:
+        redacted = redact_secret_values(value or "")
+        for key, secret in env.items():
+            if secret and is_secret_shaped_env_name(key):
+                redacted = redacted.replace(secret, "[REDACTED]")
+        return redacted
+
+    raw_text = _redact_diagnostic(completed.stdout or "")
+    stderr_text = _redact_diagnostic(completed.stderr or "")
+    if log:
+        for line in raw_text.splitlines():
+            log(f"[{provider}] {line[:1000]}")
+        for line in stderr_text.splitlines():
+            log(f"[{provider}] {line[:1000]}")
+    sdk_error = ""
+    if completed.returncode != 0:
+        sdk_error = f"{provider} exited rc={completed.returncode}: {stderr_text.strip()[-1000:]}"
+    return AttemptResult(
+        workspace=workspace,
+        sdk_error=sdk_error,
+        raw_text=raw_text,
+        chunks=[raw_text] if raw_text else [],
+    )
+
+
 def build_attempt_prompt(
     *,
     user_prompt: str,
@@ -204,6 +331,7 @@ async def run_one_attempt(
     acceptable_eval_gap: float | None = None,
     interactive: bool | None = None,
     previous_outcome: str | None = None,
+    provider: str = "claude",
     skill_path: Path | None = None,
     model: str | None = None,
     max_turns: int = DEFAULT_MAX_TURNS,
@@ -262,6 +390,19 @@ async def run_one_attempt(
         previous_outcome=previous_outcome,
         fix_hypothesis_path=fix_hypothesis_path,
     )
+
+    provider = provider.strip().lower()
+    if provider not in SUPPORTED_PROVIDERS:
+        raise ValueError(f"unsupported quantization-agent provider: {provider}")
+    if provider != "claude":
+        return await _run_cli_attempt(
+            provider=provider,
+            prompt=prompt,
+            workspace=workspace,
+            quark_root=quark_root,
+            model=model,
+            log=log,
+        )
 
     if sdk_query_factory is None or sdk_options_cls is None:
         query, options_cls = _import_sdk()
@@ -339,6 +480,10 @@ __all__ = [
     "DEFAULT_ALLOWED_TOOLS",
     "DEFAULT_MAX_TURNS",
     "DEFAULT_MODEL",
+    "DEFAULT_CODEX_MODEL",
+    "DEFAULT_HERMES_MODEL",
+    "CODEX_HOME_ENV",
+    "SUPPORTED_PROVIDERS",
     "RunOneAttemptFn",
     "build_attempt_prompt",
     "resolve_skill_path",

--- a/src/hyperloom/agents/quantization/tests/test_assessment.py
+++ b/src/hyperloom/agents/quantization/tests/test_assessment.py
@@ -41,6 +41,14 @@ def test_classify_sdk_phase_error() -> None:
     assert cls("nothing matches", "unknown_phase") is None
 
 
+def test_eval_backend_unavailable_is_not_quantized_load_failure(tmp_path) -> None:
+    art = dataclasses.replace(
+        _base_artifacts(tmp_path),
+        eval_skipped_reason="offline host has no Docker daemon, vllm, or sglang installed",
+    )
+    assert A._classify_eval_outcome(art, acceptable_eval_gap=0.03) == OutcomeId.eval_env_unavailable
+
+
 def test_classify_phase_artifact_gap_pyyaml(tmp_path) -> None:
     art = dataclasses.replace(
         _base_artifacts(tmp_path),

--- a/src/hyperloom/agents/quantization/tests/test_assessment_branches_unit.py
+++ b/src/hyperloom/agents/quantization/tests/test_assessment_branches_unit.py
@@ -41,6 +41,14 @@ def test_classify_sdk_phase_error() -> None:
     assert cls("nothing matches", "unknown_phase") is None
 
 
+def test_eval_backend_unavailable_is_not_quantized_load_failure(tmp_path) -> None:
+    art = dataclasses.replace(
+        _base_artifacts(tmp_path),
+        eval_skipped_reason="offline host has no Docker daemon, vllm, or sglang installed",
+    )
+    assert A._classify_eval_outcome(art, acceptable_eval_gap=0.03) == OutcomeId.eval_env_unavailable
+
+
 def test_classify_phase_artifact_gap_pyyaml(tmp_path) -> None:
     art = dataclasses.replace(
         _base_artifacts(tmp_path),

--- a/src/hyperloom/agents/quantization/tests/test_runner.py
+++ b/src/hyperloom/agents/quantization/tests/test_runner.py
@@ -6,6 +6,7 @@ Uses ``FakeSDK`` / ``FakeOptions`` from conftest to bypass the real SDK.
 from __future__ import annotations
 
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -347,3 +348,151 @@ async def test_run_one_attempt_log_callback_captures_chunks(tmp_path, fake_sdk, 
     )
     assert any("alpha" in line for line in captured)
     assert any("beta" in line for line in captured)
+
+
+@pytest.mark.asyncio
+async def test_codex_and_hermes_receive_the_same_original_skill_prompt(tmp_path, monkeypatch):
+    """Provider selection changes transport only, never the Quark workflow prompt."""
+
+    from hyperloom.agents.quantization.driver import runner
+
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("ORIGINAL_QUARK_SKILL", encoding="utf-8")
+    quark_root = tmp_path / "Quark"
+    quark_root.mkdir()
+    workspace = tmp_path / "workspace"
+    codex_home = tmp_path / "codex-oauth"
+    codex_home.mkdir()
+    calls: list[tuple[list[str], dict]] = []
+
+    monkeypatch.setattr(runner.shutil, "which", lambda name: f"/runtime/{name}")
+    monkeypatch.setattr(runner, "resolve_hermes_executable", lambda: "/runtime/hermes")
+    monkeypatch.setattr(runner, "hermes_external_sandbox_enabled", lambda _env: True)
+    monkeypatch.setenv("HYPERLOOM_HERMES_PROFILE", "hyperloomfaithful")
+    monkeypatch.setenv("HYPERLOOM_HERMES_PROVIDER", "openai-codex")
+    monkeypatch.setenv("HYPERLOOM_HERMES_EXTERNAL_SANDBOX", "1")
+    monkeypatch.setenv("HYPERLOOM_CODEX_HOME", str(codex_home))
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://wrong-gateway.invalid/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-reach-native-codex")
+
+    def _fake_run(argv, **kwargs):
+        calls.append((list(argv), dict(kwargs)))
+        return SimpleNamespace(returncode=0, stdout="provider complete", stderr="")
+
+    monkeypatch.setattr(runner.subprocess, "run", _fake_run)
+
+    codex_result = await run_one_attempt(
+        user_prompt="Quantize SOURCE_MODEL with the original Quark skills",
+        workspace=workspace,
+        quark_root=quark_root,
+        skill_path=skill,
+        model="provider-model",
+        provider="codex",
+    )
+    hermes_result = await run_one_attempt(
+        user_prompt="Quantize SOURCE_MODEL with the original Quark skills",
+        workspace=workspace,
+        quark_root=quark_root,
+        skill_path=skill,
+        model="provider-model",
+        provider="hermes",
+    )
+
+    assert codex_result.sdk_error == hermes_result.sdk_error == ""
+    assert len(calls) == 2
+    codex_argv, codex_kwargs = calls[0]
+    hermes_argv, hermes_kwargs = calls[1]
+    codex_prompt = codex_kwargs["input"]
+    hermes_prompt = hermes_argv[-1]
+    assert codex_prompt == hermes_prompt
+    for marker in (
+        str(skill),
+        str(workspace),
+        str(quark_root),
+        "Quantize SOURCE_MODEL with the original Quark skills",
+    ):
+        assert marker in codex_prompt
+    assert codex_kwargs["cwd"] == hermes_kwargs["cwd"] == workspace
+    assert codex_kwargs["env"]["CODEX_HOME"] == str(codex_home.resolve())
+    assert "OPENAI_BASE_URL" not in codex_kwargs["env"]
+    assert "OPENAI_API_KEY" not in codex_kwargs["env"]
+    assert codex_argv[:7] == [
+        "/runtime/codex",
+        "exec",
+        "--sandbox",
+        "workspace-write",
+        "--ephemeral",
+        "--ignore-rules",
+        "-m",
+    ]
+    assert "--dangerously-bypass-approvals-and-sandbox" not in codex_argv
+    assert codex_argv[-2:] == ["-m", "provider-model"]
+    assert hermes_argv[:7] == [
+        "/runtime/hermes",
+        "--profile",
+        "hyperloomfaithful",
+        "--provider",
+        "openai-codex",
+        "--model",
+        "provider-model",
+    ]
+    assert "--safe-mode" in hermes_argv
+    assert hermes_argv[hermes_argv.index("--toolsets") + 1] == "terminal,file"
+    assert "--yolo" not in hermes_argv
+    assert hermes_argv[-2] == "-z"
+
+
+@pytest.mark.asyncio
+async def test_cli_attempt_redacts_provider_diagnostics(tmp_path, monkeypatch):
+    from hyperloom.agents.quantization.driver import runner
+
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("ORIGINAL_QUARK_SKILL", encoding="utf-8")
+    quark_root = tmp_path / "Quark"
+    quark_root.mkdir()
+    workspace = tmp_path / "workspace"
+    captured: list[str] = []
+    monkeypatch.setattr(runner, "resolve_hermes_executable", lambda: "/runtime/hermes")
+    monkeypatch.setattr(runner, "hermes_external_sandbox_enabled", lambda _env: True)
+    monkeypatch.setenv("PRIVATE_TOKEN", "top-secret-value")
+    monkeypatch.setenv("HYPERLOOM_HERMES_EXTERNAL_SANDBOX", "1")
+
+    def _fake_run(argv, **kwargs):
+        return SimpleNamespace(
+            returncode=2,
+            stdout="",
+            stderr="Authorization: Bearer top-secret-value API_KEY=also-secret",
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", _fake_run)
+
+    result = await run_one_attempt(
+        user_prompt="Quantize SOURCE_MODEL",
+        workspace=workspace,
+        quark_root=quark_root,
+        skill_path=skill,
+        provider="hermes",
+        log=captured.append,
+    )
+
+    combined = "\n".join([*captured, result.sdk_error])
+    assert "top-secret-value" not in combined
+    assert "also-secret" not in combined
+    assert "[REDACTED]" in combined
+
+
+@pytest.mark.asyncio
+async def test_run_one_attempt_rejects_unknown_provider(tmp_path):
+    skill = tmp_path / "SKILL.md"
+    skill.write_text("x", encoding="utf-8")
+    quark_root = tmp_path / "Quark"
+    quark_root.mkdir()
+
+    with pytest.raises(ValueError, match="unsupported quantization-agent provider"):
+        await run_one_attempt(
+            user_prompt="x",
+            workspace=tmp_path / "workspace",
+            quark_root=quark_root,
+            skill_path=skill,
+            provider="invented-provider",
+        )

--- a/src/hyperloom/common/gpu_identity.py
+++ b/src/hyperloom/common/gpu_identity.py
@@ -20,6 +20,7 @@ AMD_GPU_DISPATCH_IDENTITIES: dict[str, tuple[str, int]] = {
     "mi308x": ("gfx942", 304),
     "mi325x": ("gfx942", 304),
     "mi355x": ("gfx950", 256),
+    "radeon8060s": ("gfx1151", 40),
 }
 
 

--- a/src/hyperloom/common/hermes_runtime.py
+++ b/src/hyperloom/common/hermes_runtime.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Resolve the operator-selected Hermes CLI consistently across transports."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from collections.abc import Mapping
+from pathlib import Path
+
+HERMES_EXTERNAL_SANDBOX_ENV = "HYPERLOOM_HERMES_EXTERNAL_SANDBOX"
+
+
+def running_in_container(env: Mapping[str, str] | None = None) -> bool:
+    """Return whether this process has a concrete container-runtime marker."""
+
+    del env
+    if Path("/.dockerenv").exists() or Path("/run/.containerenv").exists():
+        return True
+    try:
+        cgroup = Path("/proc/1/cgroup").read_text(encoding="utf-8", errors="replace").lower()
+    except OSError:
+        return False
+    return any(marker in cgroup for marker in ("docker", "kubepods", "containerd", "podman", "lxc"))
+
+
+def hermes_external_sandbox_enabled(env: Mapping[str, str] | None = None) -> bool:
+    """Return whether a declared and verifiable outer container is active."""
+
+    source = os.environ if env is None else env
+    declared = str(source.get(HERMES_EXTERNAL_SANDBOX_ENV, "")).strip().lower() in {"1", "true", "yes", "on"}
+    return declared and running_in_container(source)
+
+
+def resolve_hermes_executable(override: str = "") -> str:
+    """Return one executable Hermes path, or ``""`` when unavailable.
+
+    ``override`` wins, followed by ``HYPERLOOM_HERMES_BIN`` and finally the
+    normal ``PATH`` lookup. Explicit paths must already exist and be executable;
+    an invalid override fails closed instead of silently selecting another CLI.
+    """
+
+    configured = str(override or os.environ.get("HYPERLOOM_HERMES_BIN", "")).strip()
+    if configured:
+        found = shutil.which(configured)
+        if found:
+            return str(Path(found).resolve())
+        candidate = Path(configured).expanduser()
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate.resolve())
+        return ""
+    found = shutil.which("hermes")
+    return str(Path(found).resolve()) if found else ""
+
+
+__all__ = [
+    "HERMES_EXTERNAL_SANDBOX_ENV",
+    "hermes_external_sandbox_enabled",
+    "resolve_hermes_executable",
+    "running_in_container",
+]

--- a/src/hyperloom/common/tests/test_hermes_runtime.py
+++ b/src/hyperloom/common/tests/test_hermes_runtime.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Hermes executable resolution must be shared by every transport."""
+
+from pathlib import Path
+
+from hyperloom.common import hermes_runtime
+
+
+def test_resolve_hermes_executable_honors_configured_absolute_path(tmp_path: Path, monkeypatch) -> None:
+    binary = tmp_path / "custom-hermes"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    binary.chmod(0o755)
+    monkeypatch.setenv("HYPERLOOM_HERMES_BIN", str(binary))
+
+    assert hermes_runtime.resolve_hermes_executable() == str(binary.resolve())
+
+
+def test_resolve_hermes_executable_rejects_nonexecutable_override(tmp_path: Path, monkeypatch) -> None:
+    binary = tmp_path / "custom-hermes"
+    binary.write_text("not executable", encoding="utf-8")
+    monkeypatch.setenv("HYPERLOOM_HERMES_BIN", str(binary))
+
+    assert hermes_runtime.resolve_hermes_executable() == ""
+
+
+def test_external_sandbox_requires_explicit_truthy_value(monkeypatch) -> None:
+    monkeypatch.setattr(hermes_runtime, "running_in_container", lambda _env=None: True)
+    monkeypatch.delenv(hermes_runtime.HERMES_EXTERNAL_SANDBOX_ENV, raising=False)
+    assert not hermes_runtime.hermes_external_sandbox_enabled()
+    monkeypatch.setenv(hermes_runtime.HERMES_EXTERNAL_SANDBOX_ENV, "1")
+    assert hermes_runtime.hermes_external_sandbox_enabled()
+
+
+def test_external_sandbox_declaration_fails_outside_container(monkeypatch) -> None:
+    monkeypatch.setenv(hermes_runtime.HERMES_EXTERNAL_SANDBOX_ENV, "1")
+    monkeypatch.setattr(hermes_runtime, "running_in_container", lambda _env=None: False)
+    assert not hermes_runtime.hermes_external_sandbox_enabled()

--- a/src/hyperloom/inference_optimizer/SKILL.md
+++ b/src/hyperloom/inference_optimizer/SKILL.md
@@ -41,6 +41,26 @@ The CLI starts a Python Coordinator that coordinates:
     WARNING; pass `--robustness-mock` explicitly to suppress it. See
     `src/hyperloom/inference_optimizer/multi_node/SKILL.md` (Robustness limitation in multi-node mode).
 
+### Orchestration and specialist agent runtime
+
+`HYPERLOOM_AGENT_BACKEND=auto|claude|codex|hermes` selects the agent runtime used by the original
+Coordinator and Arbor/EXPLORE specialist flow. `auto` preserves upstream credential-based
+Claude/Codex selection. `hermes` uses the same role prompts, intent envelope, specialist worktree,
+patch harvesting, and PolicyGate through:
+
+```bash
+export HYPERLOOM_AGENT_BACKEND=hermes
+export HYPERLOOM_HERMES_PROFILE=hyperloomfaithful
+export HYPERLOOM_HERMES_PROVIDER=openai-codex
+export HYPERLOOM_HERMES_MODEL=gpt-5.6-sol
+export HYPERLOOM_HERMES_EXTERNAL_SANDBOX=1  # only inside a verifiable outer container
+```
+
+Writable Hermes specialists fail closed unless that external-sandbox declaration is present. The
+transport supplies an explicit terminal/file toolset and the selected profile must have an empty fallback
+chain. Provider selection never grants correctness, KEEP/REVERT, integration, or
+promotion authority; those remain in the existing Coordinator, evaluator, and PolicyGate paths.
+
 State lives under a **session directory** (per optimization run).
 The **workspace root** is ``$USER_DATA_PATH`` (default
 ``/workspace/hyperloom``) — it holds shared ``runtime/`` and ``logs/``.
@@ -612,7 +632,7 @@ when the file is absent, invalid, or stale.
 python3 -m hyperloom.inference_optimizer.cli optimize \
   --model "$MODEL_PATH" \
   --framework vllm \           # sglang (default) / vllm / atom / xdit / custom
-  --gpu-type MI300X \          # or omit for rocm-smi auto-detect
+  --gpu-type radeon8060s \     # Radeon 8060S / RDNA3.5 / gfx1151
   --model-class moe_mla \      # dense / moe_mla / moe_swa / moe_mla_nsa; categorical key for atom seed grid + framework gap token + recipe key + prompt label
   --isl 512 --osl 512 \        # workload shape — pass whatever the prompt states; omitting them uses defaults ISL=1024/OSL=1024
   --conc 64 \                  # client concurrency — pass the prompt's value; default 64
@@ -672,6 +692,9 @@ python3 -m hyperloom.inference_optimizer.cli optimize \
   export dir — the adapter folds `--model` + a per-model export dir under the
   workspace root (`<workspace_root>/quantization/<model>/quantized`) into the
   prompt automatically.
+- `--quantize-provider claude|codex|hermes` selects the agent transport for this
+  same skill-driven prelude. Resolution is CLI flag, then
+  `$HYPERLOOM_QUANT_PROVIDER`, then `claude`.
 - **Structured path for UI/backends**: instead of free text, pass
   `--quantize-scheme <enum>` (one of `none` / `fp8` / `ptpc_fp8` / `mxfp4` /
   `mxfp4_fp8`); `mxfp4` / `mxfp4_fp8` are **MI355X-only**. It resolves to a
@@ -694,8 +717,9 @@ python3 -m hyperloom.inference_optimizer.cli optimize \
 - Prerequisites (in addition to the normal Setup): `$QUARK_ROOT` must point at
   a Quark checkout containing `.claude/skills/quark-torch-*`, and the installed
   `amd-quark` package version must match that checkout (install editable from
-  `$QUARK_ROOT` to keep them consistent). Claude SDK auth is the same
-  `ANTHROPIC_*` env the rest of the loop uses.
+  `$QUARK_ROOT` to keep them consistent). Select `claude`, `codex`, or `hermes`
+  through the quantization-agent provider option; every provider receives the
+  same Hyperloom `SKILL.md` and Quark skill registry.
 - After it finishes, the `Quantization prelude: model -> <dir>` line on stdout
   shows the quantized model path that the rest of the run will use; include it
   in status reports.
@@ -1041,13 +1065,18 @@ python3 -m hyperloom.inference_optimizer.cli optimize --gpu-type mi355x --model 
 GPU_TYPE=mi300x python3 -m hyperloom.inference_optimizer.cli optimize --model "$MODEL_PATH" --max-hours 2
 ```
 
-Accepted values: `mi300x`, `mi308x`, `mi325x`, `mi355x`. **`mi308x` and
+Accepted values: `mi300x`, `mi308x`, `mi325x`, `mi355x`, `radeon8060s`. **`mi308x` and
 `mi325x` map to `runner_type=mi300x`** with a warning, since the GPUs share the
 same runner family and Magpie has not shipped `sglang_mi308x.sh` /
 `sglang_mi325x.sh` / `vllm_mi308x.sh` / `vllm_mi325x.sh` yet. If you
 need a true MI308X/MI325X-specific script, uncomment the `benchmark_script:`
 template in the relevant YAML and point it at your script under
 `InferenceX/benchmarks/...`.
+
+`radeon8060s` maps to native `gfx1151` and uses the dedicated
+`radeon8060s` Magpie runner plus the retained Strix Halo vLLM/SGLang images.
+Do not apply MI300/MI355 AITER, CK, MFMA, OCP-FP8, or partition-mode assumptions
+to this RDNA3.5 target; use its wave32/WMMA/UMA hardware knowledge instead.
 
 Do not set `HIP_VISIBLE_DEVICES` on the known ROCm stack unless the user asks;
 it can make `torch.cuda.is_available()` return false. Use

--- a/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
+++ b/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
@@ -282,7 +282,7 @@ PY
 }
 
 check_rocm_toolchain_alignment() {
-  local hip_version="$1" hip_major hipcc_path hipcc_root header
+  local hip_version="$1" hip_major hipcc_path hipcc_root hipconfig_path hipcc_version header
   hip_major="${hip_version%%.*}"
   [ -n "$hip_major" ] || return 0
   hipcc_path="$(command -v hipcc 2>/dev/null || true)"
@@ -290,10 +290,21 @@ check_rocm_toolchain_alignment() {
     warn "hipcc not found; AITER/source builds need a ROCm compiler toolchain."
     return 0
   fi
-  hipcc_root="$(cd "$(dirname "$hipcc_path")/.." 2>/dev/null && pwd)" || return 0
-  log "hipcc: ${hipcc_path}"
+  hipconfig_path="$(dirname "$hipcc_path")/hipconfig"
+  [ -x "$hipconfig_path" ] || hipconfig_path="$(command -v hipconfig 2>/dev/null || true)"
+  hipcc_root=""
+  hipcc_version=""
+  if [ -n "$hipconfig_path" ]; then
+    hipcc_root="$($hipconfig_path --path 2>/dev/null || true)"
+    hipcc_version="$($hipconfig_path --version 2>/dev/null || true)"
+  fi
+  [ -d "$hipcc_root" ] || hipcc_root="$(cd "$(dirname "$hipcc_path")/.." 2>/dev/null && pwd)" || return 0
+  log "hipcc: ${hipcc_path} (sdk=${hipcc_root})"
   if [ -n "${ROCM_PATH:-}" ] && [ "$hipcc_root" != "$(cd "$ROCM_PATH" 2>/dev/null && pwd)" ]; then
-    warn "hipcc root ${hipcc_root} differs from ROCM_PATH=${ROCM_PATH}; JIT builds may use the wrong ROCm headers."
+    case "$hipcc_version" in
+      "$hip_version"*) ;;
+      *) warn "hipcc SDK ${hipcc_root} (${hipcc_version:-unknown}) differs from ROCM_PATH=${ROCM_PATH} and torch hip=${hip_version}." ;;
+    esac
   fi
   if [ "$hip_major" -ge 7 ] 2>/dev/null; then
     header="${hipcc_root}/include/hip/hip_runtime_api.h"
@@ -316,6 +327,7 @@ detect_gpu_label() {
   case "$gfx" in
     gfx942) echo "MI300X" ;;
     gfx950) echo "MI355X" ;;
+    gfx1151) echo "Radeon 8060S" ;;
     *) echo "MI300X" ;;
   esac
 }
@@ -344,8 +356,9 @@ base_preflight() {
   case "$gfx" in
     gfx942) log "GPU: ${DETECTED_GPU} (${gfx})" ;;
     gfx950) log "GPU: ${DETECTED_GPU} (${gfx})" ;;
+    gfx1151) log "GPU: ${DETECTED_GPU} (${gfx})" ;;
     "")     warn "GPU arch: not detected via rocminfo" ;;
-    *)      warn "GPU arch ${gfx} untested (supported: gfx942/gfx950)" ;;
+    *)      warn "GPU arch ${gfx} untested (supported: gfx942/gfx950/gfx1151)" ;;
   esac
 
   local py

--- a/src/hyperloom/inference_optimizer/cli/backends.py
+++ b/src/hyperloom/inference_optimizer/cli/backends.py
@@ -22,6 +22,7 @@ from hyperloom.inference_optimizer.session.session_paths import agent_dir
 from hyperloom.orchestrator.roles import (
     ClaudeBackend,
     CodexBackend,
+    HermesBackend,
     CriticAgentBackend,
     MockCriticBackend,
     MockRobustnessBackend,
@@ -231,13 +232,27 @@ def _build_backends(
             options=robustness_options,
         )
 
-    if provider_openai_only:
+    requested_orchestration = os.environ.get("HYPERLOOM_AGENT_BACKEND", "auto").strip().lower() or "auto"
+    if requested_orchestration not in {"auto", "claude", "codex", "hermes"}:
+        raise ValueError("HYPERLOOM_AGENT_BACKEND must be one of: auto, claude, codex, hermes")
+
+    intents = default_role_registry()["orchestration"].allowed_intents
+    if requested_orchestration == "hermes":
+        orchestration_backend: Any = HermesBackend(
+            allowed_intents=intents,
+            model=os.environ.get("HYPERLOOM_HERMES_MODEL", "").strip() or codex_model,
+            profile=os.environ.get("HYPERLOOM_HERMES_PROFILE", "hyperloomfaithful").strip(),
+            inference_provider=os.environ.get("HYPERLOOM_HERMES_PROVIDER", "openai-codex").strip(),
+            hermes_bin=os.environ.get("HYPERLOOM_HERMES_BIN", "").strip(),
+            cwd=agent_dir(session_dir, "orchestration") / "hermes_workspace",
+        )
+    elif requested_orchestration == "codex" or (requested_orchestration == "auto" and provider_openai_only):
         # Official OpenAI has no Claude endpoint; use the Codex backend for
         # Orchestration so an OpenAI-only config can drive the coordinator.
         # The role record supplies the intent set, so the enforced Codex
         # output schema and the Claude emit_intent tool describe one contract.
         orchestration_backend: Any = CodexBackend(
-            allowed_intents=default_role_registry()["orchestration"].allowed_intents,
+            allowed_intents=intents,
             model=codex_model,
             # Scratch only. The session directory itself stays outside the
             # sandbox's writable roots so the agent cannot rewrite session state.
@@ -251,7 +266,7 @@ def _build_backends(
             max_turns_default=4,
             conversational=True,
             capture_turn_diagnostics=True,
-            allowed_intents=default_role_registry()["orchestration"].allowed_intents,
+            allowed_intents=intents,
         )
 
     return {

--- a/src/hyperloom/inference_optimizer/cli/credentials.py
+++ b/src/hyperloom/inference_optimizer/cli/credentials.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from hyperloom.common.hermes_runtime import resolve_hermes_executable
 from hyperloom.common.llm_config import (
     ANTHROPIC_SYNTHESIZABLE_KEY_ENVS,
     CLAUDE_OAUTH_TOKEN_ENV,
@@ -28,6 +29,22 @@ log = logging.getLogger(__name__)
 
 _OFFICIAL_ANTHROPIC_BASE_URL = "https://api.anthropic.com"
 _OFFICIAL_OPENAI_BASE_URL = "https://api.openai.com/v1"
+
+
+def _explicit_hermes_profile_is_configured() -> bool:
+    """Return whether explicit Hermes orchestration has a resolvable profile."""
+
+    if os.environ.get("HYPERLOOM_AGENT_BACKEND", "").strip().lower() != "hermes":
+        return False
+    profile = os.environ.get("HYPERLOOM_HERMES_PROFILE", "").strip()
+    if not profile:
+        return False
+    if not resolve_hermes_executable():
+        return False
+    root = Path(os.environ.get("HERMES_HOME", "").strip() or (Path.home() / ".hermes"))
+    config = root / "config.yaml" if profile == "default" else root / "profiles" / profile / "config.yaml"
+    return config.is_file()
+
 
 # AMD Claude allowlist, ordered best-first: on a catalog miss preflight walks
 # this tuple and takes the first id the gateway actually serves, so the order
@@ -455,6 +472,8 @@ def _validate_credentials() -> None:
     _warn_on_shadowed_oauth_token()
     _warn_on_oauth_against_a_foreign_endpoint()
     _warn_on_oauth_widened_provider_shape()
+    if _explicit_hermes_profile_is_configured():
+        return
     anthropic_url, openai_url = _resolve_llm_endpoints()
     has_anthropic_side = has_anthropic_credential()
     has_key = bool(os.environ.get("OPENAI_API_KEY") or has_anthropic_side)
@@ -500,7 +519,10 @@ def _validate_credentials() -> None:
         "  4. Claude Max/Pro subscription (no API credits; run `claude setup-token`):\n"
         "       export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-xxx\n"
         "       # leave ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN unset: either one\n"
-        "       # switches the Claude CLI off subscription mode.",
+        "       # switches the Claude CLI off subscription mode.\n"
+        "  5. Explicit Hermes profile (profile owns provider/auth):\n"
+        "       export HYPERLOOM_AGENT_BACKEND=hermes\n"
+        "       export HYPERLOOM_HERMES_PROFILE=<profile-name>",
         file=sys.stderr,
     )
     sys.exit(2)

--- a/src/hyperloom/inference_optimizer/cli/executors.py
+++ b/src/hyperloom/inference_optimizer/cli/executors.py
@@ -86,11 +86,13 @@ def _build_specialist_executor(
     """
     import shutil
 
+    from hyperloom.common.hermes_runtime import hermes_external_sandbox_enabled, resolve_hermes_executable
     from hyperloom.orchestrator.specialists.mcp_config import write_specialist_mcp_config
     from hyperloom.orchestrator.specialists.runner import SpecialistRunner
     from hyperloom.orchestrator.specialists.domains import DEFAULT_SPECIALIST_MAX_TURNS
     from hyperloom.orchestrator.specialists.subprocess_ import (
         AGENT_BACKEND_CODEX,
+        AGENT_BACKEND_HERMES,
         SpecialistSubprocessConfig,
         resolve_codex_executable,
         resolve_specialist_agent_backend,
@@ -107,10 +109,15 @@ def _build_specialist_executor(
     agent_backend = resolve_specialist_agent_backend()
     specialist_override = str(getattr(args, "specialist_model", None) or "").strip()
     selected_model = specialist_override or (
-        str(args.codex_model).strip() if agent_backend == AGENT_BACKEND_CODEX else str(args.claude_model).strip()
+        os.environ.get("HYPERLOOM_HERMES_MODEL", "").strip() or str(args.codex_model).strip()
+        if agent_backend == AGENT_BACKEND_HERMES
+        else str(args.codex_model).strip()
+        if agent_backend == AGENT_BACKEND_CODEX
+        else str(args.claude_model).strip()
     )
     codex_bin = ""
     claude_bin = ""
+    hermes_bin = ""
     if agent_backend == AGENT_BACKEND_CODEX:
         codex_bin = resolve_codex_executable()
         if dispatch_mode != "inprocess" and not codex_bin:
@@ -122,6 +129,13 @@ def _build_specialist_executor(
                 "specialist task."
             )
         agent_bin = codex_bin
+    elif agent_backend == AGENT_BACKEND_HERMES:
+        hermes_bin = resolve_hermes_executable()
+        if not hermes_bin:
+            raise RuntimeError("Hermes specialists requested but no hermes runtime was found")
+        if dispatch_mode == "inprocess":
+            raise RuntimeError("Hermes specialists use the original subprocess/worktree contract")
+        agent_bin = hermes_bin
     else:
         claude_bin = shutil.which("claude") or ""
         agent_bin = claude_bin
@@ -155,6 +169,10 @@ def _build_specialist_executor(
             "agent_backend": agent_backend,
             "claude_executable": claude_bin or "claude",
             "codex_executable": codex_bin,
+            "hermes_executable": hermes_bin or "hermes",
+            "hermes_profile": os.environ.get("HYPERLOOM_HERMES_PROFILE", "hyperloomfaithful").strip(),
+            "hermes_provider": os.environ.get("HYPERLOOM_HERMES_PROVIDER", "openai-codex").strip(),
+            "hermes_external_sandbox": hermes_external_sandbox_enabled(),
             "model": selected_model,
             "framework_source_roots": framework_source_roots,
             "mcp_config_path": mcp_config_path,

--- a/src/hyperloom/inference_optimizer/cli/parser.py
+++ b/src/hyperloom/inference_optimizer/cli/parser.py
@@ -257,6 +257,13 @@ def _build_parser() -> argparse.ArgumentParser:
         "quantization. Ignored if --quantize (free text) is also given.",
     )
     opt.add_argument(
+        "--quantize-provider",
+        choices=("claude", "codex", "hermes"),
+        default=None,
+        help="Agent runtime for the original Quark skill prelude. Resolution: "
+        "--quantize-provider > HYPERLOOM_QUANT_PROVIDER > claude.",
+    )
+    opt.add_argument(
         "--gpu-type",
         type=str.lower,
         # Sorted for a stable --help listing, and derived so a board added to
@@ -269,7 +276,8 @@ def _build_parser() -> argparse.ArgumentParser:
         "verbatim only when the probe fails (CPU sandbox / no "
         "rocm-smi). Magpie runner_type is derived separately; "
         "mi308x and mi325x currently run with mi300x runner scripts because "
-        "Magpie does not yet ship MI308X/MI325X-specific SGLang/vLLM scripts.",
+        "Magpie does not yet ship MI308X/MI325X-specific SGLang/vLLM scripts. "
+        "Radeon 8060S uses the dedicated radeon8060s/gfx1151 runner.",
     )
     opt.add_argument(
         "--compute-partition-mode",

--- a/src/hyperloom/inference_optimizer/cli/preflight.py
+++ b/src/hyperloom/inference_optimizer/cli/preflight.py
@@ -514,9 +514,17 @@ def _ensure_python_sdks(python_exe: str, pip_extra: list[str]) -> dict[str, Any]
     # through one of them, and a deployment may be Anthropic-only, OpenAI-only, or
     # both. Omitting openai_codex leaves the TraceLens skill runner and the forge
     # kernel backend unable to start on an OpenAI-only gateway.
+    explicit_hermes = os.environ.get("HYPERLOOM_AGENT_BACKEND", "").strip().lower() == "hermes"
+    agent_candidates = (
+        ()
+        if explicit_hermes
+        else (
+            ("claude_agent_sdk", "claude-agent-sdk>=0.2.110"),
+            ("openai_codex", "openai-codex>=0.144"),
+        )
+    )
     candidates = (
-        ("claude_agent_sdk", "claude-agent-sdk>=0.2.110"),
-        ("openai_codex", "openai-codex>=0.144"),
+        *agent_candidates,
         ("openai", "openai>=1.50"),
         ("httpx", "httpx>=0.27"),
     )
@@ -550,7 +558,13 @@ def _ensure_python_sdks(python_exe: str, pip_extra: list[str]) -> dict[str, Any]
     }
 
 
-_RAY_VERSION = "2.44.1"
+def _ray_version_for_python(version_info: tuple[int, int]) -> str:
+    """Return the pinned Ray line that publishes wheels for this Python."""
+
+    return "2.55.1" if version_info >= (3, 14) else "2.44.1"
+
+
+_RAY_VERSION = _ray_version_for_python((sys.version_info.major, sys.version_info.minor))
 # Ray 2.44.1's CLI currently fails during import with click >= 8.3.0.
 _RAY_CLI_CLICK_MAX_VERSION = "8.3.0"
 _RAY_INSTALL_SPEC = f"ray[default]=={_RAY_VERSION}"
@@ -963,6 +977,9 @@ def _probe_rocm_build(framework: str, python_exe: str) -> _Probe:
             "    from vllm.platforms import current_platform",
             "    ck = getattr(current_platform, 'is_rocm', None)",
             "    ok = bool(ck()) if callable(ck) else 'rocm' in f'{current_platform!r}'.lower()",
+            "    version = str(getattr(vllm, '__version__', '')).lower()",
+            "    unspecified = type(current_platform).__name__ == 'UnspecifiedPlatform'",
+            "    ok = ok or (unspecified and 'rocm' in version)",
             "    return 0 if ok else 1",
         ]
     else:
@@ -1507,13 +1524,29 @@ def _ensure_lm_eval_dep(
 
 
 def _unset_hip_visible_devices() -> None:
-    """Drop ``HIP_VISIBLE_DEVICES`` if ``ROCR_VISIBLE_DEVICES`` is set (SKILL.md §"GPU Runner Type").
+    """Resolve duplicate ROCm visibility variables for the selected runtime epoch.
 
-    ROCm gotcha: both set can make torch.cuda.is_available() false in Magpie; ROCR_VISIBLE_DEVICES is canonical.
+    Older Hyperloom images use ROCR as canonical. Newer Torch/ROCm wheels can
+    instead reject ROCR and require HIP. The launcher opts into that behavior
+    with ``HYPERLOOM_PREFER_HIP_VISIBLE_DEVICES=1``; no implicit global switch
+    is made for existing deployments.
     """
     if "HIP_VISIBLE_DEVICES" not in os.environ:
         return
     if "ROCR_VISIBLE_DEVICES" not in os.environ:
+        return
+    prefer_hip = os.environ.get("HYPERLOOM_PREFER_HIP_VISIBLE_DEVICES", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    if prefer_hip:
+        value = os.environ.pop("ROCR_VISIBLE_DEVICES")
+        print(
+            f"Preflight: WARNING — unset ROCR_VISIBLE_DEVICES={value!r} "
+            "(explicit HIP visibility selected for this Torch/ROCm epoch)"
+        )
         return
     value = os.environ.pop("HIP_VISIBLE_DEVICES")
     print(

--- a/src/hyperloom/inference_optimizer/cli/quantization.py
+++ b/src/hyperloom/inference_optimizer/cli/quantization.py
@@ -130,6 +130,11 @@ async def _run_quantization_prelude(args: argparse.Namespace) -> None:
         prompt=prompt,
         source_model=source_model,
         workspace=workspace,
+        provider=(
+            str(getattr(args, "quantize_provider", None) or "").strip().lower()
+            or os.environ.get("HYPERLOOM_QUANT_PROVIDER", "").strip().lower()
+            or "claude"
+        ),
     )
 
     args.model = Path(quantized_model_dir)

--- a/src/hyperloom/inference_optimizer/gpu_types.py
+++ b/src/hyperloom/inference_optimizer/gpu_types.py
@@ -26,6 +26,7 @@ _GFX_TO_RUNNER: dict[str, str] = {
     # the arch a runner is reached by is a deliberate choice, not an inverse.
     "gfx942": "mi300x",
     "gfx950": "mi355x",
+    "gfx1151": "radeon8060s",
 }
 
 #: Re-exported from ``hyperloom.common`` so provenance and this module cannot
@@ -59,7 +60,7 @@ def _resolve_gpu_type(
 
 
 def _autodetect_gpu_type() -> str | None:
-    """Return mi300x|mi308x|mi325x|mi355x or None if undetectable."""
+    """Return a known AMD board label, or None if undetectable."""
     import subprocess
 
     try:

--- a/src/hyperloom/inference_optimizer/tests/test_cli_workload_envs.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_workload_envs.py
@@ -125,6 +125,21 @@ def test_framework_script_match_ok(tmp_path):
     assert bench["benchmark_script"] == "vllm_mi300x.sh"
 
 
+def test_materializer_emits_explicit_hip_visibility_epoch(tmp_path, monkeypatch):
+    src = tmp_path / "cfg.yaml"
+    _write_yaml_with_envs(src, "vllm", {"ROCR_VISIBLE_DEVICES": "9"})
+    monkeypatch.setenv("HYPERLOOM_PREFER_HIP_VISIBLE_DEVICES", "1")
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "4,5")
+    monkeypatch.setenv("ROCR_VISIBLE_DEVICES", "0")
+    monkeypatch.setenv("TP", "2")
+
+    out = materialize_config_with_envs(src, tmp_path / "out")
+    envs = yaml.safe_load(out.read_text())["benchmark"]["envs"]
+
+    assert envs["HIP_VISIBLE_DEVICES"] == "4,5"
+    assert "ROCR_VISIBLE_DEVICES" not in envs
+
+
 def test_single_node_explicit_tp_overrides_stale_env(monkeypatch):
     """`optimize --tp N` must reach YAML materialization on single-node."""
     monkeypatch.setenv("TP", "8")

--- a/src/hyperloom/inference_optimizer/tests/test_hermes_backend_security.py
+++ b/src/hyperloom/inference_optimizer/tests/test_hermes_backend_security.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Security and executable-resolution contract for Coordinator Hermes transport."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hyperloom.inference_optimizer.cli import backends as cli_backends
+from hyperloom.inference_optimizer.protocol.intent import IntentType
+from hyperloom.orchestrator.roles.hermes import HermesBackend, LLMCallFailed
+
+
+@pytest.mark.asyncio
+async def test_coordinator_hermes_is_tool_confined_without_yolo(tmp_path: Path, monkeypatch) -> None:
+    calls: list[tuple[list[str], dict]] = []
+    binary = tmp_path / "custom-hermes"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    binary.chmod(0o755)
+
+    def fake_run(argv, **kwargs):
+        calls.append((list(argv), dict(kwargs)))
+        return SimpleNamespace(returncode=0, stdout="no intent", stderr="")
+
+    monkeypatch.setattr("hyperloom.orchestrator.roles.hermes.subprocess.run", fake_run)
+    backend = HermesBackend(
+        allowed_intents=frozenset({IntentType.ALERT}),
+        hermes_bin=str(binary),
+        cwd=tmp_path,
+    )
+
+    await backend.run("status", allow_no_intent=True)
+
+    argv, kwargs = calls[0]
+    assert argv[0] == str(binary.resolve())
+    assert "--safe-mode" in argv
+    assert argv[argv.index("--toolsets") + 1] == "todo"
+    assert "--yolo" not in argv
+    assert kwargs["cwd"] == tmp_path.resolve()
+
+
+def test_build_backends_propagates_custom_hermes_binary(tmp_path: Path, monkeypatch) -> None:
+    binary = tmp_path / "custom-hermes"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    binary.chmod(0o755)
+    monkeypatch.setenv("HYPERLOOM_AGENT_BACKEND", "hermes")
+    monkeypatch.setenv("HYPERLOOM_HERMES_BIN", str(binary))
+
+    built = cli_backends._build_backends(
+        claude_model="claude-opus-5",
+        codex_model="gpt-5.6",
+        critic_choice="mock",
+        session_dir=tmp_path,
+        robustness_choice="mock",
+    )
+
+    assert built["orchestration"].hermes_bin == str(binary.resolve())
+
+
+@pytest.mark.asyncio
+async def test_coordinator_hermes_redacts_configured_secret_value(tmp_path: Path, monkeypatch) -> None:
+    binary = tmp_path / "custom-hermes"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    binary.chmod(0o755)
+
+    def fake_run(argv, **kwargs):
+        return SimpleNamespace(returncode=2, stdout="", stderr="provider rejected top-secret-value")
+
+    monkeypatch.setattr("hyperloom.orchestrator.roles.hermes.subprocess.run", fake_run)
+    backend = HermesBackend(
+        allowed_intents=frozenset({IntentType.ALERT}),
+        hermes_bin=str(binary),
+        cwd=tmp_path,
+        env={"PRIVATE_TOKEN": "top-secret-value"},
+    )
+
+    with pytest.raises(LLMCallFailed) as exc_info:
+        await backend.run("status", allow_no_intent=True)
+
+    message = str(exc_info.value)
+    assert "top-secret-value" not in message
+    assert "[REDACTED]" in message

--- a/src/hyperloom/inference_optimizer/tests/test_preflight_auth_override.py
+++ b/src/hyperloom/inference_optimizer/tests/test_preflight_auth_override.py
@@ -811,6 +811,26 @@ def test_ensure_python_sdks_skips_when_all_present(monkeypatch, capsys):
     assert "httpx OK" in captured
 
 
+def test_ensure_python_sdks_explicit_hermes_skips_unused_agent_sdks(monkeypatch, capsys):
+    runner = _RecordingRun([_Completed(returncode=0) for _ in range(2)])
+    monkeypatch.setattr(cli_preflight.subprocess, "run", runner)
+    monkeypatch.setenv("HYPERLOOM_AGENT_BACKEND", "hermes")
+
+    result = cli_preflight._ensure_python_sdks("/opt/venv/bin/python", [])
+
+    assert [call[2] for call in runner.calls] == ["import openai", "import httpx"]
+    assert "claude-agent-sdk" not in result["target"]
+    assert "openai-codex" not in result["target"]
+    captured = capsys.readouterr().out
+    assert "openai OK" in captured and "httpx OK" in captured
+
+
+def test_ray_version_tracks_python_wheel_support():
+    assert cli_preflight._ray_version_for_python((3, 12)) == "2.44.1"
+    assert cli_preflight._ray_version_for_python((3, 13)) == "2.44.1"
+    assert cli_preflight._ray_version_for_python((3, 14)) == "2.55.1"
+
+
 def test_ensure_python_sdks_installs_missing_openai_codex(monkeypatch, capsys):
     """Both agent runtimes are provisioned: a missing codex SDK is installed too.
 
@@ -985,6 +1005,20 @@ def test_unset_hip_visible_devices_keeps_hip_when_rocr_unset(monkeypatch):
     import os as _os
 
     assert _os.environ["HIP_VISIBLE_DEVICES"] == "0,1,2,3"
+
+
+def test_visibility_normalizer_prefers_hip_when_explicit(monkeypatch, capsys):
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "0,1")
+    monkeypatch.setenv("ROCR_VISIBLE_DEVICES", "0,1")
+    monkeypatch.setenv("HYPERLOOM_PREFER_HIP_VISIBLE_DEVICES", "1")
+
+    cli_preflight._unset_hip_visible_devices()
+
+    import os as _os
+
+    assert _os.environ["HIP_VISIBLE_DEVICES"] == "0,1"
+    assert "ROCR_VISIBLE_DEVICES" not in _os.environ
+    assert "explicit HIP visibility" in capsys.readouterr().out
 
 
 def _make_args(**overrides) -> argparse.Namespace:

--- a/src/hyperloom/inference_optimizer/tests/test_preflight_serving_framework.py
+++ b/src/hyperloom/inference_optimizer/tests/test_preflight_serving_framework.py
@@ -386,6 +386,26 @@ def test_probe_rocm_build_reports_tri_state(monkeypatch):
         assert preflight._probe_rocm_build("vllm", "/usr/bin/python3").verdict is None
 
 
+def test_vllm_probe_accepts_only_rocm_marked_unspecified_build(monkeypatch):
+    scripts = []
+
+    class _Proc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def _run(cmd, *_args, **_kwargs):
+        scripts.append(cmd[-1])
+        return _Proc()
+
+    monkeypatch.setattr(preflight.subprocess, "run", _run)
+    assert preflight._probe_rocm_build("vllm", "/usr/bin/python3").verdict is True
+    script = scripts[-1]
+    assert "UnspecifiedPlatform" in script
+    assert "'rocm' in version" in script
+    assert "unspecified and 'rocm' in version" in script
+
+
 def _host_rocm_verdict() -> bool | None:
     """What this host says about its own torch, resolved out of process.
 

--- a/src/hyperloom/inference_optimizer/tests/test_quantization_prelude.py
+++ b/src/hyperloom/inference_optimizer/tests/test_quantization_prelude.py
@@ -256,6 +256,21 @@ def test_adapter_success_returns_quantized_dir(tmp_path, monkeypatch):
     assert "fp8" in calls[0]["prompt"]
     assert calls[0]["interactive"] is False
     assert calls[0]["workspace"] == tmp_path
+    assert calls[0]["provider"] == "claude"
+
+
+def test_adapter_forwards_selected_provider(tmp_path, monkeypatch):
+    calls = _patch_quantize(monkeypatch, _fake_result("success", str(tmp_path / "q")))
+    out = asyncio.run(
+        qrh.run_quantization_prelude_async(
+            prompt="fp8",
+            source_model="/models/src",
+            workspace=tmp_path,
+            provider="hermes",
+        )
+    )
+    assert out == str(tmp_path / "q")
+    assert calls[0]["provider"] == "hermes"
 
 
 def test_adapter_partial_with_model_returns_dir(tmp_path, monkeypatch):
@@ -284,10 +299,11 @@ def test_adapter_failed_exits_3(tmp_path, monkeypatch):
 
 
 class _Args:
-    def __init__(self, *, model, quantize=None, quantize_scheme=None, gpu_type=None):
+    def __init__(self, *, model, quantize=None, quantize_scheme=None, quantize_provider=None, gpu_type=None):
         self.model = Path(model)
         self.quantize = quantize
         self.quantize_scheme = quantize_scheme
+        self.quantize_provider = quantize_provider
         self.gpu_type = gpu_type
 
 
@@ -310,7 +326,7 @@ def test_prelude_rewrites_model_on_success(tmp_path, monkeypatch):
 
     monkeypatch.setattr(paths, "workspace_root", lambda: tmp_path)
 
-    async def _fake_async(*, prompt, source_model, workspace):
+    async def _fake_async(*, prompt, source_model, workspace, provider=None):
         return str(tmp_path / "out" / "quantized")
 
     monkeypatch.setattr(qrh, "run_quantization_prelude_async", _fake_async)
@@ -321,6 +337,23 @@ def test_prelude_rewrites_model_on_success(tmp_path, monkeypatch):
 
     assert str(args.model) == str(tmp_path / "out" / "quantized")
     assert os.environ["MODEL_PATH"] == str(tmp_path / "out" / "quantized")
+
+
+def test_prelude_provider_flag_overrides_env(tmp_path, monkeypatch):
+    import hyperloom.inference_optimizer.session.paths as paths
+
+    monkeypatch.setattr(paths, "workspace_root", lambda: tmp_path)
+    monkeypatch.setenv("HYPERLOOM_QUANT_PROVIDER", "codex")
+    seen = {}
+
+    async def _fake_async(*, prompt, source_model, workspace, provider):
+        seen["provider"] = provider
+        return str(tmp_path / "q")
+
+    monkeypatch.setattr(qrh, "run_quantization_prelude_async", _fake_async)
+    args = _Args(model="/models/src", quantize="fp8", quantize_provider="hermes")
+    asyncio.run(cli_quantization._run_quantization_prelude(args))
+    assert seen["provider"] == "hermes"
 
 
 def test_prelude_noop_when_scheme_none(monkeypatch):
@@ -343,7 +376,7 @@ def test_prelude_uses_scheme_enum_when_no_freetext(tmp_path, monkeypatch):
     monkeypatch.setattr(paths, "workspace_root", lambda: tmp_path)
     seen = {}
 
-    async def _fake_async(*, prompt, source_model, workspace):
+    async def _fake_async(*, prompt, source_model, workspace, provider=None):
         seen["prompt"] = prompt
         return str(tmp_path / "q")
 
@@ -385,7 +418,7 @@ def test_prelude_runs_mxfp4_on_mi355x(tmp_path, monkeypatch):
     monkeypatch.delenv("GPU_TYPE", raising=False)
     seen = {}
 
-    async def _fake_async(*, prompt, source_model, workspace):
+    async def _fake_async(*, prompt, source_model, workspace, provider=None):
         seen["prompt"] = prompt
         return str(tmp_path / "q")
 
@@ -402,7 +435,7 @@ def test_prelude_freetext_takes_priority_over_scheme(tmp_path, monkeypatch):
     monkeypatch.setattr(paths, "workspace_root", lambda: tmp_path)
     seen = {}
 
-    async def _fake_async(*, prompt, source_model, workspace):
+    async def _fake_async(*, prompt, source_model, workspace, provider=None):
         seen["prompt"] = prompt
         return str(tmp_path / "q")
 
@@ -421,7 +454,7 @@ def test_prelude_preserves_source_model_identity(tmp_path, monkeypatch):
 
     monkeypatch.setattr(paths, "workspace_root", lambda: tmp_path)
 
-    async def _fake_async(*, prompt, source_model, workspace):
+    async def _fake_async(*, prompt, source_model, workspace, provider=None):
         # Mirror the real adapter: export dir basename is always "quantized".
         return str(tmp_path / "quantization" / "google-gemma-4-26B-A4B-it" / "quantized")
 

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess_helpers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_subprocess_helpers.py
@@ -152,6 +152,30 @@ def test_build_claude_cmd_injects_leaf_agents_when_task_allowed(tmp_path: Path) 
     assert "Task" not in agents[LEAF_AGENT_NAME]["tools"]
 
 
+# -- _build_hermes_cmd ----------------------------------------------------
+def test_build_hermes_cmd_is_narrowed_and_uses_configured_binary(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(ss, "running_in_container", lambda: True)
+    binary = tmp_path / "custom-hermes"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    binary.chmod(0o755)
+    d = _dispatcher(
+        agent_backend="hermes",
+        hermes_executable=str(binary),
+        hermes_profile="isolated",
+        hermes_provider="openai-codex",
+        model="gpt-5.6-sol",
+        hermes_external_sandbox=True,
+    )
+
+    cmd = d._build_hermes_cmd(system_prompt="SYS", user_prompt="USER")
+
+    assert cmd[0] == str(binary)
+    assert "--safe-mode" in cmd
+    assert cmd[cmd.index("--toolsets") + 1] == "terminal,file"
+    assert "--yolo" not in cmd
+    assert cmd[-2] == "-z"
+
+
 # -- _collect_patches ------------------------------------------------------
 def test_collect_patches(tmp_path: Path) -> None:
     wt = tmp_path / "wt"

--- a/src/hyperloom/inference_optimizer/tests/test_startup_robustness.py
+++ b/src/hyperloom/inference_optimizer/tests/test_startup_robustness.py
@@ -32,6 +32,10 @@ def clean_creds_env(monkeypatch):
         "_".join(("DEEPSEEK", "API", "KEY")),
         "DEEPSEEK_BASE_URL",
         _OAUTH_ENV,
+        "HYPERLOOM_AGENT_BACKEND",
+        "HYPERLOOM_HERMES_PROFILE",
+        "HYPERLOOM_HERMES_BIN",
+        "HERMES_HOME",
     ):
         monkeypatch.delenv(var, raising=False)
     return monkeypatch
@@ -84,6 +88,27 @@ def test_validate_credentials_passes_oauth_token_only(clean_creds_env):
     """A Max/Pro subscription token alone is a complete Anthropic-side setup."""
     clean_creds_env.setenv(_OAUTH_ENV, "sk-ant-oat01-fake")
     cli_credentials._validate_credentials()
+
+
+def test_validate_credentials_passes_explicit_hermes_profile(clean_creds_env, tmp_path, monkeypatch):
+    profile = tmp_path / "profiles" / "faithful"
+    profile.mkdir(parents=True)
+    (profile / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+    clean_creds_env.setenv("HYPERLOOM_AGENT_BACKEND", "hermes")
+    clean_creds_env.setenv("HYPERLOOM_HERMES_PROFILE", "faithful")
+    clean_creds_env.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(cli_credentials, "resolve_hermes_executable", lambda: "/usr/bin/hermes")
+    cli_credentials._validate_credentials()
+
+
+def test_validate_credentials_rejects_missing_hermes_profile(clean_creds_env, tmp_path, monkeypatch):
+    clean_creds_env.setenv("HYPERLOOM_AGENT_BACKEND", "hermes")
+    clean_creds_env.setenv("HYPERLOOM_HERMES_PROFILE", "missing")
+    clean_creds_env.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(cli_credentials, "resolve_hermes_executable", lambda: "/usr/bin/hermes")
+    with pytest.raises(SystemExit) as exc_info:
+        cli_credentials._validate_credentials()
+    assert exc_info.value.code == 2
 
 
 def test_resolve_llm_endpoints_oauth_only_implies_official_anthropic(clean_creds_env):

--- a/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
+++ b/src/hyperloom/orchestrator/actions/executors/_workload_envs.py
@@ -908,8 +908,9 @@ def materialize_config_with_envs(
     (so Magpie doesn't fall through to a native script hardcoding
     ``--result-dir /workspace/``); ``benchmark_script`` (pre-sanitized) re-pins
     after that; ``PRECISION`` → ``precision``; ``CONC/ISL/OSL/MAX_MODEL_LEN/TP/
-    RANDOM_RANGE_RATIO`` → ``benchmark.envs``; ``ROCR_VISIBLE_DEVICES``
-    reconciled against TP; ``RUN_EVAL`` defaulted; ``NUM_PROMPTS`` /
+    RANDOM_RANGE_RATIO`` → ``benchmark.envs``; selected ROCm visibility
+    (ROCR by default, HIP when explicitly opted in) reconciled against TP;
+    ``RUN_EVAL`` defaulted; ``NUM_PROMPTS`` /
     ``NUM_WARMUPS`` computed adaptively. ``inferencex_path`` explicitly pins
     ``benchmark.inferencex_path`` for one task (falling back to
     ``$INFERENCEX_PATH`` for existing callers). ``extra_server_args`` routes
@@ -1027,18 +1028,27 @@ def materialize_config_with_envs(
     r_env = os.environ.get("RANDOM_RANGE_RATIO", "").strip()
     if r_env:
         envs["RANDOM_RANGE_RATIO"] = float(r_env)
-    rocr_env = os.environ.get("ROCR_VISIBLE_DEVICES", "").strip()
-    if rocr_env:
-        envs["ROCR_VISIBLE_DEVICES"] = rocr_env
+    prefer_hip = os.environ.get("HYPERLOOM_PREFER_HIP_VISIBLE_DEVICES", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    visibility_key = "HIP_VISIBLE_DEVICES" if prefer_hip else "ROCR_VISIBLE_DEVICES"
+    stale_visibility_key = "ROCR_VISIBLE_DEVICES" if prefer_hip else "HIP_VISIBLE_DEVICES"
+    envs.pop(stale_visibility_key, None)
+    visibility_env = os.environ.get(visibility_key, "").strip()
+    if visibility_env:
+        envs[visibility_key] = visibility_env
     tp_from_env = os.environ.get("TP", "").strip()
     tp_from_yaml = envs.get("TP")
-    rocr_yaml = str(envs.get("ROCR_VISIBLE_DEVICES") or "").strip()
-    rocr_devices = [d.strip() for d in rocr_yaml.split(",") if d.strip()]
+    visibility_yaml = str(envs.get(visibility_key) or "").strip()
+    visible_devices = [d.strip() for d in visibility_yaml.split(",") if d.strip()]
     if tp_from_env:
         resolved_tp = int(tp_from_env)
-    elif rocr_yaml and not tp_from_yaml:
+    elif visibility_yaml and not tp_from_yaml:
         # Derive TP from the user-pinned GPU list when the YAML doesn't set TP.
-        resolved_tp = len(rocr_devices)
+        resolved_tp = len(visible_devices)
         envs["TP"] = resolved_tp
     else:
         resolved_tp = int(tp_from_yaml or 1)
@@ -1058,19 +1068,21 @@ def materialize_config_with_envs(
             )
             resolved_tp = visible
     envs["TP"] = resolved_tp
-    if not rocr_yaml or len(rocr_devices) < resolved_tp:
+    if not visibility_yaml or len(visible_devices) < resolved_tp:
         derived = ",".join(str(i) for i in range(resolved_tp))
-        if rocr_yaml and rocr_yaml != derived:
+        if visibility_yaml and visibility_yaml != derived:
             log.warning(
-                "ROCR_VISIBLE_DEVICES=%r has %d devices but TP=%d; "
+                "%s=%r has %d devices but TP=%d; "
                 "expanding to %r so SGLang sees enough GPUs. Set "
-                "ROCR_VISIBLE_DEVICES explicitly to override.",
-                rocr_yaml,
-                len(rocr_devices),
+                "%s explicitly to override.",
+                visibility_key,
+                visibility_yaml,
+                len(visible_devices),
                 resolved_tp,
                 derived,
+                visibility_key,
             )
-        envs["ROCR_VISIBLE_DEVICES"] = derived
+        envs[visibility_key] = derived
 
     # Last-resort fallbacks kept in sync with the CLI workload defaults
     # (parser.DEFAULT_ISL/OSL/CONC); normally the CLI has already projected the

--- a/src/hyperloom/orchestrator/enablement/build.py
+++ b/src/hyperloom/orchestrator/enablement/build.py
@@ -30,6 +30,10 @@ def _derive_gpu_arch(gpu_type: str) -> str:
         "mi250x": "gfx90a",
         "mi250": "gfx90a",
         "mi210": "gfx90a",
+        "radeon8060s": "gfx1151",
+        "radeon 8060s": "gfx1151",
+        "strix halo": "gfx1151",
+        "gfx1151": "gfx1151",
     }
     gt = (gpu_type or "").strip().lower()
     for key, arch in _MAP.items():

--- a/src/hyperloom/orchestrator/phases/quantization_request_handlers.py
+++ b/src/hyperloom/orchestrator/phases/quantization_request_handlers.py
@@ -26,6 +26,7 @@ async def run_quantization_prelude_async(
     prompt: str,
     source_model: str,
     workspace: Path,
+    provider: str = "claude",
 ) -> str:
     """Quantize ``source_model`` per ``prompt``; return the exported dir.
 
@@ -66,6 +67,7 @@ async def run_quantization_prelude_async(
         effective_prompt,
         workspace=workspace,
         interactive=False,
+        provider=provider,
     )
 
     final = result.assessment.final

--- a/src/hyperloom/orchestrator/roles/__init__.py
+++ b/src/hyperloom/orchestrator/roles/__init__.py
@@ -6,6 +6,7 @@
 from .base import Backend, BackendError, BackendTurnResult
 from .claude import ClaudeBackend
 from .codex import CodexBackend
+from .hermes import HermesBackend
 from .critic_agent import CriticAgentBackend, RuntimeCall, RuntimeCaller
 from .mcp_context_tools import (
     CONTEXT_TOOL_NAMES,
@@ -43,6 +44,7 @@ __all__ = [
     "CONTEXT_TOOL_QUALIFIED_NAMES",
     "ClaudeBackend",
     "CodexBackend",
+    "HermesBackend",
     "ContextProvider",
     "CriticAgentBackend",
     "EMIT_INTENT_TOOL_NAME",

--- a/src/hyperloom/orchestrator/roles/hermes.py
+++ b/src/hyperloom/orchestrator/roles/hermes.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""HermesBackend — Coordinator intent transport through Hermes Agent."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from hyperloom.common.env_safety import is_secret_shaped_env_name, redact_secret_values
+from hyperloom.common.hermes_runtime import resolve_hermes_executable
+from hyperloom.inference_optimizer.protocol.intent import (
+    IntentType,
+    IntentValidationError,
+    NoIntentEmitted,
+    validate_envelope,
+)
+from ..trace.llm_trace import new_call_id
+from .base import BackendError, BackendTurnResult, LLMCallFailed, parse_call_timeout_env
+from .codex import build_output_instructions, decode_intent_envelope
+
+
+def _json_reply(text: str) -> str:
+    """Return the one JSON object from a Hermes final response."""
+
+    value = (text or "").strip()
+    if value.startswith("```"):
+        lines = value.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        value = "\n".join(lines).strip()
+    try:
+        json.loads(value)
+        return value
+    except ValueError:
+        start, end = value.find("{"), value.rfind("}")
+        if start >= 0 and end > start:
+            candidate = value[start : end + 1]
+            try:
+                json.loads(candidate)
+                return candidate
+            except ValueError:
+                pass
+    raise NoIntentEmitted(f"hermes reply did not contain one JSON object (chars={len(value)})")
+
+
+@dataclass
+class HermesBackend:
+    """Stateless Hermes implementation of the Coordinator Backend protocol."""
+
+    allowed_intents: frozenset[IntentType]
+    model: str = "gpt-5.6-sol"
+    cwd: Path = field(default_factory=Path.cwd)
+    profile: str = "hyperloomfaithful"
+    inference_provider: str = "openai-codex"
+    hermes_bin: str = ""
+    call_timeout_s: float = field(
+        default_factory=lambda: parse_call_timeout_env(
+            "INFERENCE_OPTIMIZER_HERMES_CALL_TIMEOUT_SEC",
+            default=600.0,
+        )
+    )
+    env: dict[str, str] | None = None
+
+    name: str = "hermes"
+    calls: list[dict[str, Any]] = field(default_factory=list)
+    conversational = False
+
+    def __post_init__(self) -> None:
+        if not self.allowed_intents:
+            raise BackendError("HermesBackend requires the emitting role's allowed_intents")
+        self.cwd = Path(self.cwd).expanduser().resolve()
+        self.cwd.mkdir(parents=True, exist_ok=True)
+        executable = resolve_hermes_executable(self.hermes_bin)
+        if not executable:
+            raise BackendError("Hermes executable not found")
+        self.hermes_bin = executable
+
+    @property
+    def needs_seed(self) -> bool:
+        return True
+
+    def needs_seed_for(self, _system_prompt: str | None) -> bool:
+        return True
+
+    def reset_conversation(self) -> None:
+        return None
+
+    async def aclose(self) -> None:
+        return None
+
+    async def run(
+        self,
+        prompt: str,
+        *,
+        system_prompt: str | None = None,
+        tools: list[str] | None = None,
+        max_turns: int = 1,
+        allow_no_intent: bool = False,
+    ) -> BackendTurnResult:
+        del tools, max_turns
+        parts = [(system_prompt or "").strip()]
+        if not allow_no_intent:
+            parts.append(build_output_instructions(self.allowed_intents))
+        parts.append(prompt)
+        full_prompt = "\n\n".join(part for part in parts if part)
+        argv = [
+            self.hermes_bin,
+            "--profile",
+            self.profile,
+            "--provider",
+            self.inference_provider,
+            "--model",
+            self.model,
+            "--safe-mode",
+            "--toolsets",
+            "todo",
+            "-z",
+            full_prompt,
+        ]
+        child_env = dict(os.environ)
+        child_env.update(self.env or {})
+
+        def _invoke() -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                argv,
+                cwd=self.cwd,
+                env=child_env,
+                capture_output=True,
+                text=True,
+                timeout=self.call_timeout_s,
+                check=False,
+            )
+
+        try:
+            completed = await asyncio.to_thread(_invoke)
+        except subprocess.TimeoutExpired as exc:
+            raise LLMCallFailed(f"Hermes turn timed out after {self.call_timeout_s:g}s") from exc
+        except OSError as exc:
+            raise BackendError(f"Hermes turn could not start: {exc}") from exc
+        if completed.returncode != 0:
+            detail = redact_secret_values((completed.stderr or "").strip()[-1000:])
+            for key, secret in child_env.items():
+                if secret and is_secret_shaped_env_name(key):
+                    detail = detail.replace(secret, "[REDACTED]")
+            raise LLMCallFailed(f"Hermes turn exited rc={completed.returncode}: {detail}")
+
+        raw_text = completed.stdout or ""
+        metadata: dict[str, Any] = {
+            "model": self.model,
+            "provider": self.inference_provider,
+            "profile": self.profile,
+            "call_id": new_call_id(),
+            "prompt": prompt,
+            "response": raw_text,
+        }
+        self.calls.append(
+            {
+                "model": self.model,
+                "prompt_chars": len(prompt),
+                "reply_chars": len(raw_text),
+            }
+        )
+        if allow_no_intent:
+            return BackendTurnResult(intents=[], raw_text=raw_text, metadata=metadata)
+        envelope = decode_intent_envelope(_json_reply(raw_text))
+        try:
+            intents = validate_envelope(envelope)
+        except IntentValidationError as exc:
+            raise NoIntentEmitted(f"hermes envelope invalid: {exc}") from exc
+        return BackendTurnResult(intents=intents, raw_text=raw_text, metadata=metadata)
+
+
+__all__ = ["HermesBackend"]

--- a/src/hyperloom/orchestrator/specialists/subprocess_.py
+++ b/src/hyperloom/orchestrator/specialists/subprocess_.py
@@ -44,6 +44,7 @@ from hyperloom.common.codex_session import (
     resolve_codex_sandbox_mode,
 )
 from hyperloom.common.env import is_truthy
+from hyperloom.common.hermes_runtime import running_in_container
 from hyperloom.common.llm_attribution import inject_env as inject_attribution_env
 from hyperloom.common.env_safety import (
     BLOCKED_CHILD_ENV_NAMES,
@@ -79,6 +80,7 @@ class SpecialistAgentUnavailableError(RuntimeError):
 # The two agent CLIs that can drive the specialist contract (module docstring).
 AGENT_BACKEND_CLAUDE = "claude"
 AGENT_BACKEND_CODEX = "codex"
+AGENT_BACKEND_HERMES = "hermes"
 
 
 def resolve_specialist_agent_backend(env: Mapping[str, str] | None = None) -> str:
@@ -102,6 +104,10 @@ def resolve_specialist_agent_backend(env: Mapping[str, str] | None = None) -> st
         :data:`AGENT_BACKEND_CODEX` for an OpenAI-only deployment, else
         :data:`AGENT_BACKEND_CLAUDE`.
     """
+    source = os.environ if env is None else env
+    explicit = str(source.get("HYPERLOOM_AGENT_BACKEND") or "").strip().lower()
+    if explicit in {AGENT_BACKEND_CLAUDE, AGENT_BACKEND_CODEX, AGENT_BACKEND_HERMES}:
+        return explicit
     from hyperloom.common import llm_config  # local import: keep module import-light
 
     return AGENT_BACKEND_CODEX if llm_config.is_openai_only(env) else AGENT_BACKEND_CLAUDE
@@ -511,7 +517,7 @@ class SpecialistSubprocessConfig:
     """
 
     agent_backend: str = ""
-    """Which agent CLI to spawn: ``"claude"``, ``"codex"``, or ``""``.
+    """Which agent CLI to spawn: ``"claude"``, ``"codex"``, ``"hermes"``, or ``""``.
 
     Empty resolves the deployment's credential shape per dispatch via
     :func:`resolve_specialist_agent_backend`. The CLI pins it explicitly at boot
@@ -525,6 +531,18 @@ class SpecialistSubprocessConfig:
     codex_executable: str = ""
     """Path / name of the codex CLI binary. Empty resolves it per
     :func:`resolve_codex_executable`."""
+
+    hermes_executable: str = "hermes"
+    """Path / name of the Hermes Agent CLI."""
+
+    hermes_profile: str = "hyperloomfaithful"
+    """Hermes profile carrying terminal/file tools and no fallback chain."""
+
+    hermes_provider: str = "openai-codex"
+    """Inference provider selected inside Hermes."""
+
+    hermes_external_sandbox: bool = False
+    """Whether a verifiable outer container confines Hermes terminal/file tools."""
 
     model: str = ""
     """Model id for the selected agent CLI. Empty = that CLI's own default."""
@@ -936,6 +954,13 @@ class SpecialistSubprocessDispatcher:
                     probe_sandbox=True,
                 )
                 env.update(launch_env_additions)
+            elif backend == AGENT_BACKEND_HERMES:
+                prompt_file.write_text(user_prompt, encoding="utf-8")
+                prompt_file.chmod(0o600)
+                cmd = self._build_hermes_cmd(
+                    system_prompt=system_prompt,
+                    user_prompt=user_prompt,
+                )
             else:
                 prompt_file.write_text(user_prompt, encoding="utf-8")
                 prompt_file.chmod(0o600)
@@ -1147,6 +1172,11 @@ class SpecialistSubprocessDispatcher:
                 outcome["error"] = (
                     f"{prior_error}; codex: {structured_error}" if prior_error else f"codex: {structured_error}"
                 )
+        elif backend == AGENT_BACKEND_HERMES:
+            usage = None
+            response = process_log.read_text(encoding="utf-8", errors="replace") if process_log.is_file() else None
+            tool_calls = []
+            turn_usages = []
         else:
             usage = parse_claude_stream_json_usage(process_log)
             response = parse_claude_stream_json_response(process_log)
@@ -1186,10 +1216,10 @@ class SpecialistSubprocessDispatcher:
         pinned = (self.config.agent_backend or "").strip().lower()
         if not pinned:
             return resolve_specialist_agent_backend()
-        if pinned not in (AGENT_BACKEND_CLAUDE, AGENT_BACKEND_CODEX):
+        if pinned not in (AGENT_BACKEND_CLAUDE, AGENT_BACKEND_CODEX, AGENT_BACKEND_HERMES):
             raise SpecialistAgentUnavailableError(
                 f"agent_backend={self.config.agent_backend!r} is not one of "
-                f"{AGENT_BACKEND_CLAUDE!r} / {AGENT_BACKEND_CODEX!r}"
+                f"{AGENT_BACKEND_CLAUDE!r} / {AGENT_BACKEND_CODEX!r} / {AGENT_BACKEND_HERMES!r}"
             )
         return pinned
 
@@ -1332,6 +1362,40 @@ class SpecialistSubprocessDispatcher:
             cmd.extend(list(cfg.extra_codex_args))
         cmd.append("-")
         return cmd, env_additions
+
+    def _build_hermes_cmd(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+    ) -> list[str]:
+        """Assemble a Hermes argv for the unchanged specialist contract."""
+
+        cfg = self.config
+        if not cfg.hermes_external_sandbox or not running_in_container():
+            raise SpecialistAgentUnavailableError(
+                "Hermes specialists require a verifiable outer container; set "
+                "HYPERLOOM_HERMES_EXTERNAL_SANDBOX=1 only inside that boundary"
+            )
+        executable = shutil.which(cfg.hermes_executable) or (
+            cfg.hermes_executable if Path(cfg.hermes_executable).is_file() else ""
+        )
+        if not executable:
+            raise SpecialistAgentUnavailableError(
+                "no Hermes CLI found: set SpecialistSubprocessConfig.hermes_executable or install hermes"
+            )
+        prompt = "\n\n".join(part for part in (system_prompt.strip(), user_prompt) if part)
+        cmd = [
+            executable,
+            "--profile",
+            cfg.hermes_profile,
+            "--provider",
+            cfg.hermes_provider,
+        ]
+        if cfg.model:
+            cmd.extend(["--model", cfg.model])
+        cmd.extend(["--safe-mode", "--toolsets", "terminal,file", "-z", prompt])
+        return cmd
 
     def _build_claude_cmd(
         self,

--- a/src/kernelforge/agent_backends/base.py
+++ b/src/kernelforge/agent_backends/base.py
@@ -113,6 +113,10 @@ class AgentRuntimeConfig:
     precheck: bool = True
     fallback_provider: str = ""
     options: dict[str, Any] = field(default_factory=dict)
+    # Distinguish an explicitly disabled same-provider fallback from an
+    # unspecified fallback_model. Empty strings alone cannot carry that state:
+    # the registry historically filled them from provider metadata.
+    model_fallback_enabled: bool = True
 
     def __post_init__(self) -> None:
         """Validate generic runtime values without imposing provider semantics."""

--- a/src/kernelforge/agent_backends/codex.py
+++ b/src/kernelforge/agent_backends/codex.py
@@ -384,6 +384,15 @@ class CodexBackend:
             sandbox_mode=("bypass" if bypass_sandbox is not False else "workspace-write"),
         )
         configured_gateway = self.runtime.options.get("gateway")
+        self.auth_mode = str(self.runtime.options.get("auth_mode", "gateway")).strip().lower()
+        if self.auth_mode not in {"gateway", "native_oauth"}:
+            raise CodexUnavailableError(
+                f"unsupported Codex auth_mode {self.auth_mode!r}; expected 'gateway' or 'native_oauth'"
+            )
+        if self.auth_mode == "native_oauth" and (
+            gateway is not None or (isinstance(configured_gateway, Mapping) and bool(configured_gateway))
+        ):
+            raise CodexUnavailableError("native_oauth Codex mode cannot be combined with a gateway override")
         if gateway is None and isinstance(configured_gateway, Mapping):
             gateway = configured_gateway
         # An empty override is "no override": converting it would yield a
@@ -399,6 +408,18 @@ class CodexBackend:
         self._preflight_done = False
         self._codex_home_owner: Any = None
         self._codex_home = ""
+        if self.auth_mode == "native_oauth":
+            configured_home = str(self.runtime.options.get("home", "")).strip()
+            if not configured_home:
+                raise CodexUnavailableError("native_oauth Codex mode requires a dedicated absolute CODEX_HOME")
+            home_path = Path(configured_home).expanduser()
+            if not home_path.is_absolute():
+                raise CodexUnavailableError("native_oauth CODEX_HOME must be absolute")
+            if home_path.is_symlink():
+                raise CodexUnavailableError("native_oauth CODEX_HOME cannot be a symlink")
+            if not home_path.is_dir():
+                raise CodexUnavailableError("native_oauth CODEX_HOME must already exist as a directory")
+            self._codex_home = str(home_path.resolve())
 
     def _child_environment(
         self,
@@ -425,6 +446,16 @@ class CodexBackend:
         # repository would answer every git command the session runs anywhere.
         env.pop("GIT_DIR", None)
         env.pop("GIT_WORK_TREE", None)
+        if self.auth_mode == "native_oauth":
+            # Native subscription OAuth is owned by CODEX_HOME. Inherited API
+            # gateway variables would silently select a different transport.
+            for name in (
+                "OPENAI_BASE_URL",
+                "OPENAI_API_KEY",
+                "OPENAI_CUSTOM_HEADERS",
+                "CODEX_API_KEY",
+            ):
+                env.pop(name, None)
         return env
 
     def _effective_gateway(self) -> LlmGateway:
@@ -445,7 +476,8 @@ class CodexBackend:
         sdk = _load_codex_sdk()
         if self.codex_bin and (not Path(self.codex_bin).is_file() or not os.access(self.codex_bin, os.X_OK)):
             raise CodexUnavailableError(f"Codex SDK runtime is not executable: {self.codex_bin}")
-        _provider_overrides(self._effective_gateway())
+        if self.auth_mode == "gateway":
+            _provider_overrides(self._effective_gateway())
         if self.codex_bin:
             try:
                 version = subprocess.run(
@@ -585,10 +617,9 @@ class CodexBackend:
 
     def _config_overrides(self, spec: AgentRunSpec | None) -> tuple[str, ...]:
         """Collect process-wide SDK app-server configuration overrides."""
-        overrides = [
-            "features.memories=false",
-            *_provider_overrides(self._effective_gateway()),
-        ]
+        overrides = ["features.memories=false"]
+        if self.auth_mode == "gateway":
+            overrides.extend(_provider_overrides(self._effective_gateway()))
         if spec is not None:
             overrides.extend(self._agent_role_overrides(spec))
             overrides.extend(self._mcp_server_overrides(spec))
@@ -623,14 +654,16 @@ class CodexBackend:
         spec: AgentRunSpec,
     ) -> dict[str, Any]:
         """Build SDK options for one new thread."""
-        return {
+        options = {
             "approval_mode": sdk.ApprovalMode.deny_all,
             "cwd": spec.cwd,
             "developer_instructions": _codex_instructions(spec),
             "model": resolve_codex_model(spec.model),
-            "model_provider": "forge",
             "sandbox": self._sdk_sandbox(sdk, spec),
         }
+        if self.auth_mode == "gateway":
+            options["model_provider"] = "forge"
+        return options
 
     def _turn_options(
         self,

--- a/src/kernelforge/agent_backends/hermes.py
+++ b/src/kernelforge/agent_backends/hermes.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Hermes Agent backend for KernelForge's existing AgentRunSpec."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from kernelforge.agent_backends.base import (
+    AgentCapabilities,
+    AgentProviderUnavailableError,
+    AgentRunResult,
+    AgentRunSpec,
+    AgentRuntimeConfig,
+)
+from kernelforge.agent_backends.workspace_guard import WorkspaceGuard
+from kernelforge.knowledge.experience_reader import sanitize_read_error
+
+
+def _running_in_container() -> bool:
+    """Require a concrete outer-container marker for writable Hermes tools."""
+
+    if Path("/.dockerenv").exists() or Path("/run/.containerenv").exists():
+        return True
+    try:
+        cgroup = Path("/proc/1/cgroup").read_text(encoding="utf-8", errors="replace").lower()
+    except OSError:
+        return False
+    return any(marker in cgroup for marker in ("docker", "kubepods", "containerd", "podman", "lxc"))
+
+
+@dataclass
+class HermesBackend:
+    """Run one KernelForge session through a dedicated Hermes profile."""
+
+    runtime: AgentRuntimeConfig
+    name: str = "hermes"
+    capabilities: AgentCapabilities = AgentCapabilities(
+        writable=True,
+        resumable=False,
+        probe=True,
+        requires_workspace_cwd=True,
+        session_env=True,
+        workspace_guard=True,
+    )
+
+    def _executable(self) -> str:
+        value = self.runtime.executable.strip() or shutil.which("hermes") or ""
+        if not value:
+            raise AgentProviderUnavailableError("Hermes executable not found")
+        return value
+
+    def preflight(self) -> None:
+        self._executable()
+        if self.runtime.sandbox_mode.strip().lower() != "bypass":
+            raise AgentProviderUnavailableError(
+                "Hermes CLI has no native OS sandbox; sandbox_mode must be 'bypass' only when the operator "
+                "already provides an external sandbox"
+            )
+        if self.runtime.options.get("external_sandbox") is not True:
+            raise AgentProviderUnavailableError(
+                "Hermes terminal/file sessions require options.external_sandbox=true inside an outer container"
+            )
+        if not _running_in_container():
+            raise AgentProviderUnavailableError(
+                "Hermes external_sandbox=true requires a verifiable outer container runtime"
+            )
+
+    def probe(self, *, cwd: str = "", usage: Any = None) -> None:
+        del cwd, usage
+        self.preflight()
+
+    async def run(self, spec: AgentRunSpec, usage: Any = None) -> AgentRunResult:
+        del usage
+        resolved = spec.resolved(self.runtime)
+        self.preflight()
+        if resolved.progress_log is not None:
+            resolved.progress_log.append("progress: Hermes CLI returns final output only")
+        profile = str(self.runtime.options.get("profile") or "hyperloomfaithful").strip()
+        provider = str(self.runtime.options.get("provider") or "openai-codex").strip()
+        policy = (
+            "You may use terminal and file tools, but only inside the declared workspace and only for target files."
+            if resolved.writable
+            else "This is a read-only reasoning turn. You have no local filesystem or terminal tools."
+        )
+        prompt = "\n\n".join(part for part in (resolved.system_prompt.strip(), policy, resolved.user_prompt) if part)
+        toolsets = "terminal,file" if resolved.writable else "todo"
+        argv = [
+            self._executable(),
+            "--profile",
+            profile,
+            "--provider",
+            provider,
+            "--model",
+            resolved.model,
+            "--safe-mode",
+            "--toolsets",
+            toolsets,
+            "-z",
+            prompt,
+        ]
+        child_env = dict(os.environ)
+        child_env.update(resolved.env)
+        cwd = Path(resolved.cwd).expanduser().resolve()
+        cwd.mkdir(parents=True, exist_ok=True)
+        guard = WorkspaceGuard(resolved, dirty_baseline_default=True)
+        guard.prepare()
+
+        def _invoke() -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                argv,
+                cwd=cwd,
+                env=child_env,
+                capture_output=True,
+                text=True,
+                timeout=resolved.timeout_sec,
+                check=False,
+            )
+
+        try:
+            completed = await asyncio.to_thread(_invoke)
+        except subprocess.TimeoutExpired as exc:
+            with contextlib.suppress(Exception):
+                guard.rollback()
+            raise AgentProviderUnavailableError(f"Hermes session timed out after {resolved.timeout_sec}s") from exc
+        except OSError as exc:
+            with contextlib.suppress(Exception):
+                guard.rollback()
+            raise AgentProviderUnavailableError(f"Hermes session could not start: {exc}") from exc
+        if completed.returncode != 0:
+            with contextlib.suppress(Exception):
+                guard.rollback()
+            secret_values = tuple(
+                value
+                for key, value in child_env.items()
+                if value
+                and any(
+                    fragment in key.upper() for fragment in ("API_KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL")
+                )
+            )
+            detail = sanitize_read_error(
+                RuntimeError((completed.stderr or "").strip()[-1000:]),
+                secrets=secret_values,
+            )
+            raise AgentProviderUnavailableError(f"Hermes session exited rc={completed.returncode}: {detail}")
+        try:
+            actual_changes = guard.verify()
+        except Exception:
+            with contextlib.suppress(Exception):
+                guard.rollback()
+            raise
+        result = AgentRunResult(
+            text=completed.stdout or "",
+            subtype="success",
+            num_turns=1,
+            end_reason="agent_stopped",
+        )
+        result.file_changes = actual_changes
+        result.target_edit_count = guard.count_target_edits()
+        result.edit_count = result.target_edit_count
+        return result
+
+
+__all__ = ["HermesBackend"]

--- a/src/kernelforge/agent_backends/registry.py
+++ b/src/kernelforge/agent_backends/registry.py
@@ -219,6 +219,7 @@ def resolve_agent_runtime(
     provider: str,
     *,
     model: str = "",
+    fallback_model: str | None = None,
     executable: str = "",
     timeout_sec: int = 1800,
     reasoning_effort: str = "high",
@@ -229,19 +230,30 @@ def resolve_agent_runtime(
 ) -> AgentRuntimeConfig:
     """Resolve provider defaults into one complete runtime configuration."""
     registration = get_agent_provider(provider)
-    fallback = normalize_provider_name(fallback_provider) if fallback_provider else ""
+    raw_provider_fallback = (fallback_provider or "").strip().lower()
+    fallback = "" if raw_provider_fallback in {"", "none", "off"} else normalize_provider_name(raw_provider_fallback)
     if fallback == registration.name:
         fallback = ""
     if fallback:
         get_agent_provider(fallback)
+    selected_model = model.strip() or registration.default_model
+    model_fallback_enabled = fallback_model is None
+    if fallback_model is None:
+        selected_fallback_model = registration.fallback_model if selected_model != registration.fallback_model else ""
+    else:
+        requested_fallback = fallback_model.strip()
+        model_fallback_enabled = requested_fallback.lower() not in {
+            "",
+            "none",
+            "off",
+        }
+        selected_fallback_model = "" if not model_fallback_enabled else requested_fallback
+        if selected_fallback_model == selected_model:
+            selected_fallback_model = ""
     return AgentRuntimeConfig(
         provider=registration.name,
-        model=model.strip() or registration.default_model,
-        fallback_model=(
-            registration.fallback_model
-            if (model.strip() or registration.default_model) != registration.fallback_model
-            else ""
-        ),
+        model=selected_model,
+        fallback_model=selected_fallback_model,
         executable=executable.strip(),
         timeout_sec=timeout_sec,
         reasoning_effort=reasoning_effort.strip() or "high",
@@ -249,6 +261,7 @@ def resolve_agent_runtime(
         precheck=precheck,
         fallback_provider=fallback,
         options=dict(options or {}),
+        model_fallback_enabled=model_fallback_enabled,
     )
 
 
@@ -278,7 +291,7 @@ def create_registered_backend(
             runtime,
             provider=fallback_registration.name,
             model=fallback_registration.default_model,
-            fallback_model=fallback_registration.fallback_model,
+            fallback_model=(fallback_registration.fallback_model if runtime.model_fallback_enabled else ""),
             executable="",
             fallback_provider="",
             options={},
@@ -319,6 +332,8 @@ def _prepare_with_model_fallback(
             usage=usage,
         )
     except AgentProviderUnavailableError as primary_error:
+        if not runtime.model_fallback_enabled:
+            raise
         fallback_model = (runtime.fallback_model or registration.fallback_model).strip()
         if not fallback_model or fallback_model == runtime.model:
             raise
@@ -381,6 +396,13 @@ def _create_codex_backend(runtime: AgentRuntimeConfig) -> AgentBackend:
     return CodexBackend(runtime=runtime)
 
 
+def _create_hermes_backend(runtime: AgentRuntimeConfig) -> AgentBackend:
+    """Construct the built-in Hermes backend lazily."""
+    from kernelforge.agent_backends.hermes import HermesBackend
+
+    return HermesBackend(runtime=runtime)
+
+
 def _claude_available() -> bool:
     """Return whether the optional Claude SDK is installed."""
     return util.find_spec("claude_agent_sdk") is not None
@@ -389,6 +411,13 @@ def _claude_available() -> bool:
 def _codex_available() -> bool:
     """Return whether the optional Codex Python SDK is installed."""
     return util.find_spec("openai_codex") is not None
+
+
+def _hermes_available() -> bool:
+    """Return whether the Hermes Agent CLI is installed."""
+    import shutil
+
+    return shutil.which("hermes") is not None
 
 
 def _claude_owns_model(model: str) -> bool:
@@ -452,6 +481,22 @@ register_agent_provider(
         ),
         availability=_codex_available,
         owns_model=_codex_owns_model,
+    )
+)
+register_agent_provider(
+    AgentProvider(
+        name="hermes",
+        factory=_create_hermes_backend,
+        default_model="gpt-5.6-sol",
+        fallback_model="",
+        capabilities=AgentCapabilities(
+            writable=True,
+            probe=True,
+            requires_workspace_cwd=True,
+            session_env=True,
+            workspace_guard=True,
+        ),
+        availability=_hermes_available,
     )
 )
 

--- a/src/kernelforge/cli.py
+++ b/src/kernelforge/cli.py
@@ -395,6 +395,15 @@ def _validate_fallback_provider(ctx, param, value):
     return _validate_agent_provider(ctx, param, value)
 
 
+def _validate_fallback_model(ctx, param, value):
+    """Preserve an explicit fallback model while accepting disablement."""
+    del ctx, param
+    if value is None:
+        return None
+    selected = value.strip()
+    return "" if selected.lower() in {"", "none", "off"} else selected
+
+
 def _validate_optional_agent_provider(ctx, param, value):
     """Validate an optional provider override, empty meaning "inherit"."""
     if value is None or not value.strip():
@@ -440,6 +449,12 @@ def _agent_runtime_options(func):
             help="Fallback provider name, or 'none'",
         ),
         click.option(
+            "--agent-fallback-model",
+            default=None,
+            callback=_validate_fallback_model,
+            help="Same-provider fallback model, or 'none'",
+        ),
+        click.option(
             "--agent-precheck/--no-agent-precheck",
             default=None,
             help="Enable provider preflight and capability probe",
@@ -466,6 +481,7 @@ def _agent_runtime_overrides(
     agent_fallback_provider: str | None,
     agent_precheck: bool | None,
     agent_options_json: str | None,
+    agent_fallback_model: str | None = None,
 ) -> dict:
     """Convert provider-neutral CLI values into Config overrides."""
     values = {
@@ -476,6 +492,7 @@ def _agent_runtime_overrides(
         "agent_reasoning_effort": agent_reasoning_effort,
         "agent_sandbox_mode": agent_sandbox_mode,
         "agent_fallback_provider": agent_fallback_provider,
+        "agent_fallback_model": agent_fallback_model,
         "agent_precheck": agent_precheck,
     }
     overrides = {key: value for key, value in values.items() if value is not None}
@@ -1025,6 +1042,7 @@ def forge_loop(
     agent_reasoning_effort,
     agent_sandbox_mode,
     agent_fallback_provider,
+    agent_fallback_model,
     agent_precheck,
     agent_options_json,
     permission_mode,
@@ -1233,6 +1251,7 @@ def forge_loop(
             agent_reasoning_effort=agent_reasoning_effort,
             agent_sandbox_mode=agent_sandbox_mode,
             agent_fallback_provider=agent_fallback_provider,
+            agent_fallback_model=agent_fallback_model,
             agent_precheck=agent_precheck,
             agent_options_json=agent_options_json,
         )

--- a/src/kernelforge/config.py
+++ b/src/kernelforge/config.py
@@ -122,6 +122,9 @@ class Config:
     # "not specified" indistinguishable, so __post_init__ would silently
     # overwrite an explicit False with whatever the env var said.
     include_mori_kb: bool | None = field(default=None)
+    # Appended to preserve the positional order of the pre-existing Config
+    # contract. None keeps the provider default; empty/none/off disables it.
+    agent_fallback_model: str | None = None
 
     def __post_init__(self):
         """Derive paths and validate provider-specific runtime settings."""
@@ -134,8 +137,13 @@ class Config:
         self.agent_reasoning_effort = (self.agent_reasoning_effort or "high").strip()
         self.agent_sandbox_mode = (self.agent_sandbox_mode or "bypass").strip().lower()
         self.agent_fallback_provider = (self.agent_fallback_provider or "").strip().lower()
+        if self.agent_fallback_provider == "none":
+            self.agent_fallback_provider = ""
         if self.agent_fallback_provider:
             get_agent_provider(self.agent_fallback_provider)
+        if self.agent_fallback_model is not None:
+            fallback_model = str(self.agent_fallback_model).strip()
+            self.agent_fallback_model = "" if fallback_model.lower() in {"", "none", "off"} else fallback_model
         if self.agent_timeout_sec <= 0:
             raise ValueError("agent_timeout_sec must be greater than zero")
         if self.specialist_probe_max <= 0:
@@ -184,6 +192,7 @@ class Config:
         return resolve_agent_runtime(
             provider,
             model=self.agent_model,
+            fallback_model=self.agent_fallback_model,
             executable=self.agent_cli,
             timeout_sec=self.agent_timeout_sec,
             reasoning_effort=self.agent_reasoning_effort,
@@ -238,6 +247,10 @@ class Config:
             agent_fallback_provider=overrides.get(
                 "agent_fallback_provider",
                 os.getenv("FORGE_AGENT_FALLBACK_PROVIDER", "claude"),
+            ),
+            agent_fallback_model=overrides.get(
+                "agent_fallback_model",
+                os.getenv("FORGE_AGENT_FALLBACK_MODEL") if "FORGE_AGENT_FALLBACK_MODEL" in os.environ else None,
             ),
             agent_options=overrides.get("agent_options")
             if "agent_options" in overrides

--- a/src/kernelforge/data/local_knowledge/hardware/INDEX.md
+++ b/src/kernelforge/data/local_knowledge/hardware/INDEX.md
@@ -1,98 +1,139 @@
 ---
-title: MI350X / MI355X hardware — knowledge map
+title: AMD GPU hardware — knowledge map
+authority: hardware-index
 kind: index
 scope: hardware
-gens: [gfx950]
-updated: 2026-08-28
+gens: [gfx950, gfx1151]
+updated: 2026-09-02
 ---
 
-# MI350X / MI355X hardware — knowledge map
+# AMD GPU hardware — knowledge map
 
-Entry index for `hardware/`. Backend-neutral facts about the metal: what the chip is, what the numbers
-are, and what each subsystem does to a kernel.
+Entry index for `hardware/`. Backend-neutral facts about the metal: architecture, topology,
+execution, memory, numeric formats and measurement constraints.
 
 > **Convention (KernelForge standard):** a knowledge folder that contains an `INDEX.md` is navigated
-> **through this file** — load it whole.
+> **through this file**—load it whole, then open only the cards matching the detected `gfx` target.
 
-## Scope: gfx950 only
+## Supported lanes are separate
 
-Target parts are **MI350X** (air, 1000 W) and **MI355X** (liquid, 1400 W), CDNA4, ISA **gfx950**.
+| Lane | Product | Architecture | Native wave | Memory model |
+|---|---|---|---:|---|
+| `gfx950` | MI350X / MI355X | CDNA4 | 64 | 288 GB HBM3E / chiplet Instinct |
+| `gfx1151` | Radeon 8060S / Strix Halo | RDNA3.5 | 32 | integrated UMA/shared LPDDR |
 
-**Earlier generations are not covered** — no CDNA1 (gfx908), CDNA2 (gfx90a), or **CDNA3 (gfx942 /
-MI300X / MI325X)** cards, and no cross-generation comparison tables. If you are targeting MI300X, the
-numbers here are wrong for you; use AMD's CDNA3 documentation instead. CDNA3 appears only as
-*porting warnings* ("that value is MI300X's — here it is X").
+**Never combine constants across rows.** In particular:
 
-## Layout — one flat folder, one file per subsystem
+- gfx950 MFMA, XCD, HBM, OCP-FP8/MX and partition-mode advice is not gfx1151 advice;
+- gfx1151 WMMA, VOPD, WGP/CU-mode and UMA advice is not gfx950 advice;
+- detect the live GFX target before loading a hardware card;
+- framework support is narrower than ISA availability and must be qualified separately.
 
-There are no subfolders. Each card carries **both** the mental model and the concrete gfx950 numbers
-for its subsystem, so a single Read answers a question end to end.
+## gfx950 layout — MI350X / MI355X
 
 | File | Subsystem |
 |---|---|
-| **`mi350_overview.md`** | **START HERE** — one-screen cheat sheet, peak tables, roofline ridges, topology, the four porting deltas |
-| `mi350_execution.md` | wave64, SIMD/CU hierarchy, VGPR/AGPR file, occupancy formula + worked examples |
-| `mi350_matrix_core.md` | MFMA model, shape/cycle table, per-lane registers, block-scaled MFMA, capability list |
-| `mi350_dtypes.md` | format table, the **OCP** FP8 trap, FP6/FP4, MXFP E8M0 block scaling, accumulation rules |
-| `mi350_lds.md` | 160 KiB / **64 banks**, conflicts, padding vs XOR swizzle, 128-bit direct-to-LDS, read-with-transpose |
-| `mi350_memory.md` | bandwidth ladder, HBM3E, Infinity Cache, per-XCD L2, coalescing, roofline ridge |
-| `mi350_chiplet.md` | 8 XCDs × 32 CU, L2 locality and CTA swizzle, 512 B stride cliff, clock variance, SPX/DPX/CPX × NPS |
-| `mi350_isa.md` | gfx950 target/toolchain, changed instruction families, **the disassembly checklist** |
-| `mi350_clocks.md` | MI350X vs MI355X, sustained clock, and what that does to measurements |
+| **`mi350_overview.md`** | **START HERE**—cheat sheet, peak tables, roofline ridges, topology and porting deltas |
+| `mi350_execution.md` | wave64, SIMD/CU hierarchy, VGPR/AGPR file and occupancy |
+| `mi350_matrix_core.md` | MFMA shapes/cycles, register layout and block-scaled MFMA |
+| `mi350_dtypes.md` | OCP FP8, FP6/FP4, MXFP E8M0 scaling and accumulation |
+| `mi350_lds.md` | 160 KiB, 64 banks, direct-to-LDS and transpose reads |
+| `mi350_memory.md` | HBM3E, per-XCD L2, Infinity Cache and roofline |
+| `mi350_chiplet.md` | 8 XCDs, locality/swizzle, stride cliff and SPX/DPX/CPX × NPS |
+| `mi350_isa.md` | gfx950 target/toolchain, changed families and disassembly checklist |
+| `mi350_clocks.md` | MI350X versus MI355X sustained-clock/measurement behavior |
 
-## Constants you will look up most
+### Common gfx950 constants
 
 | | |
 |---|---|
 | 256 CU (8 XCD × 32) · 4 SIMD/CU · 1024 matrix cores | wave64 · 8 slots/SIMD → 32 waves/CU |
-| 512 regs/SIMD, 16-granule · ≤256 AGPR, unified pool | LDS **160 KiB/CU, 64 banks**, 256 B/clk, 320-DWORD granule |
-| HBM3E **288 GB @ 8 TB/s** · 256 MiB Infinity Cache · **L2 per-XCD** | FP16 **2.5 PF** · FP8 **5 PF** · FP6/FP4 **10 PF** |
-| FP16 ridge ≈ **312 FLOP/byte** | tuned GEMM sustains **~45–55% of peak** |
-| FP8 is **OCP**, not FNUZ | **TF32 removed** |
-| `global_load_lds` up to **128 b/lane** | `mfma_16x16` over `32x32`; ≥1024 WGs; 8-multiple tiles |
+| 512 registers/SIMD, 16-granule · ≤256 AGPR, unified pool | LDS 160 KiB/CU, 64 banks, 256 B/clk |
+| HBM3E 288 GB @ 8 TB/s · 256 MiB Infinity Cache · L2 per-XCD | FP16 2.5 PF · FP8 5 PF · FP6/FP4 10 PF |
+| FP16 ridge ≈312 FLOP/byte | tuned GEMM sustains ~45–55% of peak |
+| FP8 is OCP, not FNUZ | TF32 removed |
+
+Use these only for a detected gfx950 target.
+
+## gfx1151 layout — Radeon 8060S / Strix Halo
+
+| File | Subsystem |
+|---|---|
+| **`gfx1151_overview.md`** | **START HERE**—evidence classes, live constants, UMA roofline and Instinct porting deltas |
+| `gfx1151_topology.md` | 40 live CUs, 80 SIMD32s, WGP/CU hierarchy, one XCC and UMA placement |
+| `gfx1151_execution.md` | native wave32, deliberate wave64, EXEC/VCC, register granules, occupancy and VOPD |
+| `gfx1151_lds.md` | 128 KiB/WGP, two 64 KiB halves, 64 banks, CU/WGP modes and waits |
+| `gfx1151_matrix_core.md` | 16×16×16 F16/BF16/IU8/IU4 WMMA, fragments and scheduling hazards |
+| `gfx1151_dtypes.md` | architectural dtype boundary, integer algebra and software-format claim limits |
+| `gfx1151_isa.md` | native compile target, VOPD/WMMA, waits, FLAT/GLOBAL and disassembly checklist |
+| `gfx1151_memory.md` | UMA accounting, local bandwidth reference, bytes/launch roofline and co-tenancy |
+| `gfx1151_clocks.md` | package DVFS, sysfs telemetry, thermal/power controls and paired measurement |
+
+### Common gfx1151 constants
+
+| | |
+|---|---|
+| native `gfx1151` · Radeon PCI `1002:1586` | wave32 native; wave64 supported deliberately |
+| 40 live CUs · 80 SIMD32 · 2 SIMD/CU | 16 live wave slots/SIMD |
+| 20 two-CU WGPs implied by the live CU count | 4 SIMD32/WGP |
+| LDS 64 KiB/CU half · 128 KiB/WGP · 64 banks | one work-group may request ≤64 KiB |
+| one live XCC / no Instinct XCD topology | integrated UMA/shared system memory |
+| 256 GB/s node-theoretical memory reference | ~241 GB/s read / ~209 GB/s copy local probe |
+| WMMA F16/BF16/IU8/IU4 | VOPD is wave32-only; CDNA MFMA is not the route |
+
+The bandwidth values are local measurements/reference math, not universal architecture peaks.
+There is intentionally no unverified peak-FLOP/ridge table for gfx1151.
 
 ## Portable golden rules
 
-- **wave64 everywhere** — all divergence/shuffle/ballot/reduction math is mod 64, never 32.
-- **`mfma_16x16` beats `mfma_32x32`** at equal peak — 4 C-registers/lane vs 16.
-- **Most inference kernels are HBM-bandwidth-bound** — optimize bytes moved, not FLOPs.
-- **L2 is per-XCD, not global** → 8-multiple tiles, ≥1024 workgroups across 256 CUs.
-- **FP8 is OCP** — re-cast any FNUZ checkpoint, never bit-copy it.
-- **TF32 is gone** — fall back to BF16 or FP32.
-- **LDS is 160 KiB over 64 banks** — re-derive any 32-bank swizzle; VGPR pressure, not LDS, is usually
-  the occupancy limiter now.
-- **Accumulate in FP32/INT32**; never down-convert inside the K-loop.
-- **Quote achieved, never peak** — sustained is ~45–55% of peak.
+### gfx950
+
+- wave64 everywhere;
+- MFMA/SMFMAC/scaled MFMA, not RDNA WMMA;
+- L2 is per-XCD; respect 8-XCD locality;
+- FP8 is OCP and MX block scaling is native;
+- use gfx950's 160 KiB LDS/resource model;
+- quote achieved rather than peak.
+
+### gfx1151
+
+- compile natively for `gfx1151`; do not spoof another architecture;
+- assume wave32 unless a code object proves deliberate wave64;
+- use WMMA/VOP3P and VOPD rules, not CDNA MFMA rules;
+- size grids from 40 live CUs and emitted resource metadata;
+- keep each work-group ≤64 KiB LDS and derive 64-bank mappings;
+- treat GTT/RSS as overlapping views of shared physical memory;
+- separate host/launch, device, prefill, decode and shared-memory effects;
+- do not call software FP8/MX/low-bit routes native ISA formats without proof.
 
 ## Problem → file
 
-| Task / symptom | Read |
-|---|---|
-| Orient me on the chip / one-screen cheat sheet | `mi350_overview.md` |
-| Peak numbers, roofline ridge, FLOP·TOPS math | `mi350_overview.md` |
-| Write / tune a GEMM (MFMA) | `mi350_matrix_core.md` → `mi350_lds.md` → `mi350_execution.md` |
-| Low occupancy / register pressure / few waves/CU | `mi350_execution.md` |
-| LDS bank conflicts / `ds_*` stalls / tile won't fit | `mi350_lds.md` |
-| Memory-bound / low HBM BW / coalescing | `mi350_memory.md` → `mi350_lds.md` |
-| Chiplet locality / L2 reuse / tile swizzle / Tagram cliff | `mi350_chiplet.md` → `mi350_memory.md` |
-| Partitioning: SPX / DPX / CPX × NPS | `mi350_chiplet.md` |
-| Which dtype? FP8 OCP / FP6 vs FP4 / numerics | `mi350_dtypes.md` |
-| Low-bit MXFP4 / FP6 / block scaling | `mi350_dtypes.md` → `mi350_matrix_core.md` |
-| Which opcodes / compile target / **read the ISA dump** | `mi350_isa.md` |
-| Benchmark variance / clock throttling / peak ≠ sustained | `mi350_clocks.md` → `mi350_chiplet.md` |
-| **Porting a kernel written for MI300X** | `mi350_overview.md` (the four deltas) → `mi350_dtypes.md` (FNUZ→OCP) → `mi350_lds.md` (32→64 banks) → `mi350_execution.md` (304→256 CU, 64→160 KiB) |
+| Task / symptom | gfx950 | gfx1151 |
+|---|---|---|
+| Orient on the target | `mi350_overview.md` | `gfx1151_overview.md` |
+| Topology/locality/grid | `mi350_chiplet.md` | `gfx1151_topology.md` |
+| Low occupancy/register pressure | `mi350_execution.md` | `gfx1151_execution.md` |
+| Matrix-kernel authoring | `mi350_matrix_core.md` | `gfx1151_matrix_core.md` |
+| Numeric format/quant route | `mi350_dtypes.md` | `gfx1151_dtypes.md` |
+| LDS conflict/tile capacity | `mi350_lds.md` | `gfx1151_lds.md` |
+| Memory-bound/coalescing | `mi350_memory.md` | `gfx1151_memory.md` |
+| ISA target/opcode/waits | `mi350_isa.md` | `gfx1151_isa.md` |
+| Clock/thermal benchmark variance | `mi350_clocks.md` | `gfx1151_clocks.md` |
+| Port an Instinct kernel to Strix | source card(s) above | start at `gfx1151_overview.md`, then topology/execution/matrix/LDS |
 
 ## Reading depth
 
-- **A single number** (a peak, a cache size, a CU count) — `mi350_overview.md` alone.
-- **Designing or tuning a subsystem** — the one card for that subsystem; each is self-contained.
-- **Porting from MI300X** — `mi350_overview.md`, then the three delta cards it names.
-- **ISA-level authoring** — `mi350_isa.md` + `mi350_matrix_core.md`, and treat
-  `amd_matrix_instruction_calculator --architecture cdna4` as authoritative over any table here.
+- **One identity/number:** open the matching overview and verify its evidence class.
+- **Designing a subsystem:** open overview plus that subsystem card.
+- **Porting across gfx950 ↔ gfx1151:** read both overview cards and every affected subsystem; do not
+  build one synthetic comparison table by copying constants.
+- **ISA-level authoring:** read target ISA + execution + matrix/LDS card and inspect the emitted code.
+- **Framework serving:** hardware cards are necessary but insufficient—also require framework/image,
+  loader, route, correctness, quality and request evidence.
 
 ## Cross-links out of this folder
 
-Hardware facts are the substrate. **How to decide what to change** lives in
-`common_methodology/optimization/` (the `lever_*` cards) and `common_methodology/profiling/` (the
-`measure_*` cards). **How to write it in a given language** lives in
-`languages/{hip,triton,gluon,flydsl,ck,asm}/`. The library control plane is `framework/aiter/`.
+Hardware facts are the substrate. Decision methods live in `common_methodology/optimization/` and
+measurement methods in `common_methodology/profiling/`. Language-specific authoring lives in
+`languages/{hip,triton,gluon,flydsl,ck,asm}/`; apply those cards only where the selected language and
+backend support the detected hardware.

--- a/src/kernelforge/data/local_knowledge/hardware/gfx1151_clocks.md
+++ b/src/kernelforge/data/local_knowledge/hardware/gfx1151_clocks.md
@@ -1,0 +1,154 @@
+---
+title: Radeon 8060S / gfx1151 — clocks, thermals, power and measurement hygiene
+kind: hardware
+topic: clocks
+gens: [gfx1151]
+updated: 2026-09-02
+---
+
+# Clocks, thermals, power and measurement hygiene
+
+Do not encode one fixed Radeon 8060S clock as a performance constant. An integrated GPU shares a
+package power/thermal envelope and memory system with the CPU. DVFS, CPU load, skin/cooling state,
+memory pressure and display/co-tenant activity can move results.
+
+## What can be observed on the qualified node
+
+Relevant read-only sysfs paths include:
+
+```text
+/sys/class/drm/card1/device/gpu_busy_percent
+/sys/class/drm/card1/device/mem_busy_percent            # when exposed
+/sys/class/drm/card1/device/hwmon/hwmon*/temp1_input
+/sys/class/drm/card1/device/hwmon/hwmon*/freq1_input
+/sys/class/drm/card1/device/hwmon/hwmon*/power1_average
+/sys/class/drm/card1/device/hwmon/hwmon*/power1_cap      # when exposed
+```
+
+An **illustrative idle snapshot** at `2026-09-02T02:52:24-05:00` showed:
+
+| Sensor | Value |
+|---|---:|
+| GPU busy | 0% |
+| temperature | 40.0 °C |
+| reported frequency | 600 MHz |
+| reported average power | ~11.0 W |
+
+These are not specification values or benchmark baselines. They only demonstrate that the sensors
+are live and that idle state differs materially from sustained compute state.
+
+## Why clocks move
+
+- GPU and CPU share the package power/thermal budget.
+- DVFS raises frequency after work begins and lowers it after demand drops.
+- Short kernels may complete before frequency stabilizes.
+- Sustained matrix/VALU work can encounter package or thermal limits.
+- Memory-bound kernels may not benefit proportionally from higher engine clock.
+- CPU load can consume package power and shared-memory bandwidth simultaneously.
+- Fan/cooling and ambient state affect sustained behavior.
+
+The PCI-reported link speed is not the model-memory bandwidth clock for this integrated GPU and must
+not be used in roofline calculations.
+
+## Measurement protocol
+
+### Before each A/B pair
+
+Record:
+
+- exact source/object/runtime hashes;
+- GPU busy and KFD owner state;
+- temperature, frequency and power sensors;
+- CPU load/governor and competing memory traffic;
+- `MemAvailable`, swap and PSI;
+- model/request geometry and warm/cold state.
+
+### Warmup
+
+Warm up until:
+
+- JIT/autotune is complete;
+- model pages are resident as intended;
+- frequency/temperature behavior is representative;
+- server route/caches are stable.
+
+Discard cold/JIT/first-request results unless cold-start is the explicit metric.
+
+### Pairing
+
+Use paired/interleaved orders such as ABBA or balanced A→B/B→A blocks. A candidate run hours after a
+baseline is not a controlled clock/thermal comparison.
+
+### Report
+
+For every result include:
+
+```text
+median/geomean as appropriate
+all raw repetitions and spread
+sensor range or sampled trace
+host wall and device timing
+route and dispatch count
+thermal/power anomaly notes
+```
+
+A throughput change within the sensor/order noise band is not an optimization claim.
+
+## Clock versus bottleneck
+
+| Bottleneck | Expected clock sensitivity |
+|---|---|
+| WMMA/VALU compute-bound | engine clock can matter strongly |
+| LDS/dependency-bound | clock may help, but conflicts/waits remain primary |
+| shared-memory bandwidth-bound | memory traffic/channel state dominates |
+| launch/host-bound | GPU frequency may barely matter |
+| mixed small-model decode | fixed launch + per-byte memory effects both matter |
+
+Classify with measurement rather than assuming every higher-clock result is compute-bound.
+
+## Thermal and co-tenant discipline
+
+- Do not run a second iGPU/GTT workload during a hard A/B.
+- A CPU-only memory-intensive process is still a co-tenant on UMA.
+- Account for display/compositor traffic when it changes during the run.
+- Do not reset the GPU, kill GUI processes or change system-wide power controls without explicit approval.
+- If clocks cannot be locked safely, monitor and reject mismatched pairs rather than forcing control.
+
+## What it means for kernels
+
+1. Optimize the real bottleneck; engine clock cannot fix extra bytes or launches.
+2. Warm long enough to leave idle DVFS state.
+3. Compare candidates in one controlled session with balanced order.
+4. Include power/thermal state in reproducibility records.
+5. Separate cold start, steady state and sustained long-run behavior.
+6. Re-run marginal gains across a second thermal/order block.
+
+## Pitfalls
+
+- Publishing the 600 MHz idle sample as a GPU specification.
+- Using a marketing boost clock to compute achieved utilization.
+- Comparing a cold baseline to a warm candidate.
+- Ignoring CPU package power and memory traffic.
+- Interpreting memory-bound throughput as proportional to GPU engine clock.
+- “Fixing” variance by mutating global power settings without authorization.
+- Hiding raw spread behind one average.
+
+## Verify
+
+A lightweight read-only sampler can poll sysfs around each repetition. Verify sensor units from the
+kernel interface (`temp*_input` is typically millidegrees C, `freq*_input` Hz, `power*_average`
+microwatts) rather than assuming a userspace presentation format.
+
+For a decisive gate, require comparable sensor ranges and order controls in addition to benchmark
+correctness and route proof.
+
+## Sources
+
+- Live amdgpu sysfs/hwmon interfaces on the qualified EVO-X2.
+- AMD RDNA3.5 ISA for execution behavior; it does not specify this board's sustained clock.
+- Retained paired gfx1151 benchmark methodology/results.
+
+## Related
+
+`gfx1151_overview.md` · `gfx1151_topology.md` · `gfx1151_memory.md` ·
+`common_methodology/profiling/measure_protocol.md`

--- a/src/kernelforge/data/local_knowledge/hardware/gfx1151_dtypes.md
+++ b/src/kernelforge/data/local_knowledge/hardware/gfx1151_dtypes.md
@@ -1,0 +1,142 @@
+---
+title: gfx1151 — numeric formats, WMMA dtypes and software-route boundaries
+kind: hardware
+topic: dtypes
+gens: [gfx1151]
+updated: 2026-09-02
+---
+
+# Number formats on gfx1151
+
+The RDNA3.5 ISA and the serving software stack answer different questions. The ISA defines
+arithmetic/WMMA forms; a framework defines storage layouts, quantization metadata, loaders and
+routing. Do not turn support at one layer into a claim about another.
+
+## Architecturally relevant forms
+
+| Format/domain | ISA-relevant use | Robust accumulation |
+|---|---|---|
+| F32 | scalar/vector arithmetic; WMMA accumulator for F16/BF16 inputs | F32 |
+| F16 | scalar/vector/packed arithmetic; WMMA input and optional narrow output form | F32 for long reductions |
+| BF16 | scalar/vector/packed arithmetic; WMMA input and optional narrow output form | F32 for long reductions |
+| I32/U32 | scalar/vector integer arithmetic; integer matrix accumulator | I32/U32 as algebra requires |
+| I8/U8 | packed/dot arithmetic; IU8 WMMA input | I32 |
+| I4/U4 codes | packed/dot and IU4 WMMA code domain | I32 |
+
+The `IU` name means per-operand signed/unsigned selection. It does not describe a complete tensor
+format, zero point, group scale, packing order or quantization method.
+
+## Packed arithmetic
+
+- 16-bit packed math places two independent halves in one 32-bit VGPR.
+- 8-/4-bit dot and WMMA forms consume packed codes according to instruction-specific lane layouts.
+- Sub-byte elements are not independently byte-addressable; software must define nibble order and
+  aligned storage.
+- Packed storage savings do not guarantee compute savings if unpack/reorder/scale traffic dominates.
+
+## WMMA dtype boundary
+
+The official RDNA3.5 WMMA list includes:
+
+- F16→F32 and BF16→F32;
+- F16→F16 and BF16→BF16 forms;
+- IU8→I32;
+- IU4→I32.
+
+It does **not** justify importing gfx950's OCP FP8, FP6, FP4, MXFP or scaled-MFMA tables. If a
+framework serves an FP8/MX/low-bit model on gfx1151, identify whether it uses:
+
+- conversion plus F16/BF16 WMMA;
+- integer dot/WMMA;
+- VALU dequantization plus GEMM;
+- Triton software kernels;
+- an external library;
+- a fallback path.
+
+The route—not the model-card label—defines the hardware claim.
+
+## Floating-point behavior
+
+- WMMA floating forms use round-to-nearest-even and generate no ALU exceptions.
+- General VALU rounding/denormal behavior is controlled by MODE fields where the instruction permits.
+- SALU floating support has narrower semantics than general VALU: do not substitute it when denormal,
+  rounding or exception behavior matters.
+- Memory/LDS operations do not magically convert tensor formats unless the selected instruction does.
+- Long reductions should retain F32 accumulation through K and narrow at the output boundary.
+
+## Integer quantization algebra
+
+For an integer matrix path, write the exact recurrence before code. A typical asymmetric dot has
+terms for:
+
+```text
+sum((w_code - w_zero) * (a_code - a_zero))
+```
+
+Expanding that expression introduces row/column sums and zero-point corrections. Whether those sums
+are precomputed, packed or fused is part of the ABI. Dropping a term can yield plausible but wrong
+model output.
+
+For IU4/IU8 WMMA specifically:
+
+- signedness controls must match operand code domains;
+- accumulate in I32;
+- test extreme codes and nonzero zero-points;
+- prove nibble/byte order and any matched-K permutation;
+- apply per-output scale metadata to the correct output coordinate, not merely the current lane.
+
+## Software formats retained on Strix
+
+The retained gfx1151 bridge/framework work contains software routes for formats such as FP8-FNUZ,
+MXFP4, W8A8, W4A8, W4A4 and W4A16. Their existence proves only what their exact tests and serving
+receipts prove. For each route record:
+
+- source artifact format and metadata;
+- loader/quantization scheme name;
+- selected kernel implementation;
+- physical code route;
+- accumulator/conversion semantics;
+- quality and correctness limits;
+- supported framework/image/version.
+
+Do not describe all these formats as native RDNA3.5 matrix dtypes.
+
+## Choosing a route
+
+1. Preserve source/model quality constraints first.
+2. Determine whether the serving framework can load the exact artifact.
+3. Inspect the selected physical kernel and its accumulator.
+4. Include packing/reordering/scaling costs in the metric.
+5. Gate numerical correctness independently of performance.
+6. Gate model quality independently of format validity.
+7. Keep fallback behavior explicit.
+
+## Failure modes
+
+| Symptom | Likely class | Required check |
+|---|---|---|
+| Plausible but shifted output | signedness/zero-point/correction error | exact integer reference |
+| Alternating columns/rows wrong | fragment or nibble permutation | basis matrices/output-coordinate map |
+| Microkernel wins, model loses | packing/scale/dispatch overhead | end-to-end route timing |
+| Model loads but wrong kernel runs | framework fallback | request-owned route proof |
+| FP8/MX label assumed native | cross-architecture claim leak | inspect generated ISA and loader |
+| Small tests pass, long reduction drifts | narrow accumulator | long-K F32/I32 reference |
+
+## Verify
+
+- Round-trip storage packing independently of matrix arithmetic.
+- Test scalar/reference dequantization for extreme and random blocks.
+- Run basis/nonuniform matrix cases through the physical target kernel.
+- Inspect the exact code object and target instruction family.
+- Verify finite outputs and model-level quality against the immutable source model.
+- Treat any unproven fallback as a failure of route qualification.
+
+## Sources
+
+- AMD RDNA3.5 ISA guide, packed VALU, dot and WMMA sections.
+- Retained gfx1151 route evidence is software-specific and must be cited separately per framework.
+
+## Related
+
+`gfx1151_matrix_core.md` · `gfx1151_isa.md` · `gfx1151_memory.md` ·
+`common_methodology/optimization/lever_numerics.md`

--- a/src/kernelforge/data/local_knowledge/hardware/gfx1151_execution.md
+++ b/src/kernelforge/data/local_knowledge/hardware/gfx1151_execution.md
@@ -1,0 +1,173 @@
+---
+title: gfx1151 — wave32/wave64 execution, registers, occupancy and VOPD
+kind: hardware
+topic: execution
+gens: [gfx1151]
+updated: 2026-09-02
+---
+
+# Execution model, registers and occupancy
+
+The qualified Radeon 8060S reports native **wave32**, 80 SIMD32s, 40 CUs and at most
+16 waves/SIMD. RDNA3.5 also supports wave64, but wave64 is a separate compiled execution
+mode—not two independent wave32s hidden behind one source-level name.
+
+## Wave32 and wave64
+
+| Behavior | wave32 | wave64 |
+|---|---|---|
+| Active lanes | 32 | 64 |
+| VALU issue | once | normally low half then high half |
+| VMEM/LDS issue | once | normally low half then high half |
+| SALU/SMEM/branch/message | once | once |
+| VOPD | legal | illegal/skipped |
+| EXEC/VCC bits used | low 32 | all 64 |
+
+For wave64, other waves may interleave between low- and high-half issue. Both halves observe
+wave state from before the instruction; do not model the second half as consuming the first
+half's newly written values.
+
+## Thread geometry
+
+```text
+threads_per_workgroup = waves_per_workgroup × compiled_wave_size
+```
+
+Examples:
+
+| Waves | native wave32 threads | wave64 threads |
+|---:|---:|---:|
+| 1 | 32 | 64 |
+| 2 | 64 | 128 |
+| 4 | 128 | 256 |
+| 8 | 256 | 512 |
+
+This is why copying RDNA wave64 `nwarps` tables to gfx1151 can halve effective thread count.
+A launch that remains functionally valid can still lose occupancy, tile coverage or parallelism.
+
+## Live hierarchy
+
+| Level | Qualified-node value |
+|---|---:|
+| GPU node / XCC | 1 / 1 |
+| CUs | 40 |
+| SIMD32s | 80 |
+| SIMD32s per CU | 2 |
+| SIMD32s per WGP | 4 |
+| Native waves/SIMD ceiling | 16 |
+| Native lanes/wave | 32 |
+
+A work-group remains on one WGP. In CU mode, its waves stay on one CU half; in WGP mode,
+they may occupy all four SIMD32s.
+
+## Wave state
+
+- `EXEC` masks VALU, VMEM, LDS, GDS and export lanes; scalar execution and branches are not
+  lane-masked the same way.
+- Wave32 uses `EXEC[31:0]` and `VCC[31:0]`; upper bits are ignored for execution/summary state.
+- `EXEC==0` does **not** prove every instruction is skipped. WMMA and several memory/state cases
+  have explicit exceptions.
+- `VCC` is an SGPR pair and participates in dependency checks.
+- `M0` is a per-wave scalar register used by LDS/GDS/SMEM and other instructions.
+- `FLAT_SCRATCH` supplies the scratch/private base.
+
+## Register allocation
+
+AMD's ISA defines:
+
+- up to 256 architected VGPRs per shader;
+- VGPR allocation blocks of 16 for wave32 and 8 for wave64;
+- 106 normal SGPRs plus named VCC and trap-temporary SGPRs;
+- 64-bit SGPR operands require even alignment; wider scalar-memory destinations have stricter
+  alignment.
+
+Do not infer occupancy from `vgpr_count` alone. The compiler/code object must also disclose:
+
+- private/scratch bytes and spills;
+- SGPR use;
+- LDS bytes/workgroup;
+- workgroup size and compiled wave size.
+
+Out-of-range register use may read VGPR0, discard writes or otherwise fail silently. No-crash is
+not a correctness gate.
+
+## Occupancy method
+
+The hard live wave-slot ceiling is:
+
+```text
+80 SIMD × 16 waves/SIMD = 1280 native wave slots device-wide
+```
+
+That is only a ceiling. Kernel residency is the minimum of:
+
+```text
+wave slots
+VGPR/SGPR allocation
+LDS allocation
+workgroup size and per-WGP limits
+scratch/private resource limits
+```
+
+Use compiler metadata or profiler occupancy output; do not use MI350's 512-register/SIMD
+formula or its 8-wave/SIMD cap.
+
+## VOPD dual issue
+
+VOPD encodes two independent VALU operations in one 64-bit instruction and executes them in
+parallel. It is a gfx1151-relevant wave32 lever, but its constraints are correctness rules:
+
+- wave32 only;
+- X and Y operations must be independent;
+- strict VGPR source-bank/port limits;
+- limited SGPR/literal sourcing;
+- destination VGPRs must form one even and one odd address;
+- no DPP;
+- an overlapping read sees the old value.
+
+If the rules are violated, AMD states that hardware does not function correctly. Treat manual
+VOPD scheduling as assembly-level work requiring disassembly and asymmetric correctness tests.
+
+## Scheduling and dependencies
+
+- Use `s_waitcnt` for outstanding memory/LDS dependencies.
+- Use `s_delay_alu` to reduce ALU dependency stalls; it is not a memory correctness mechanism.
+- Do not insert NOP padding as a substitute for wait counters.
+- Dependent WMMA has its own overlap hazard described in `gfx1151_matrix_core.md`.
+- Scalar-memory loads can complete out of order; wait before consuming their SGPR destinations.
+
+## What it means for kernels
+
+1. Treat wave32 as the baseline and wave64 as an isolated, code-object-proven choice.
+2. Translate wave counts to threads before borrowing any donor geometry.
+3. Cross VGPR allocation granules deliberately; small source edits within one tier may change nothing.
+4. Prefer zero spills to nominally higher occupancy.
+5. Consider VOPD only after the generated ISA exposes independent pair opportunities.
+6. Distinguish launch/host overhead from device occupancy on tiny decode operations.
+
+## Pitfalls
+
+- Reporting `nwarps=4` without the compiled wave size.
+- Assuming wave64's second half observes writes from the first half.
+- Assuming `EXEC==0` means no WMMA/memory work issues.
+- Reading MI/CDNA occupancy tables as RDNA facts.
+- Calling a VOPD mnemonic hit a win without symbol correlation and correctness proof.
+- Ignoring private/scratch state because the source declares no local array.
+
+## Verify
+
+- `rocminfo` and KFD topology for native wave size/SIMD/CU counts.
+- `llvm-readobj --notes --symbols` for kernel metadata.
+- `llvm-objdump -d --mcpu=gfx1151` for wave-sensitive instructions and VOPD.
+- Compiler resource diagnostics for VGPR/SGPR/LDS/private/spills.
+- A profiler or bounded occupancy probe for actual resident waves.
+
+## Sources
+
+- AMD RDNA3.5 ISA guide, Chapters 2, 3, 5 and 7.
+- Live KFD topology on the qualified EVO-X2.
+
+## Related
+
+`gfx1151_topology.md` · `gfx1151_lds.md` · `gfx1151_matrix_core.md` ·
+`gfx1151_isa.md` · `common_methodology/optimization/lever_occupancy.md`

--- a/src/kernelforge/data/local_knowledge/hardware/gfx1151_isa.md
+++ b/src/kernelforge/data/local_knowledge/hardware/gfx1151_isa.md
@@ -1,0 +1,163 @@
+---
+title: gfx1151 — ISA target, instruction families, waits and disassembly
+kind: hardware
+topic: isa
+gens: [gfx1151]
+updated: 2026-09-02
+---
+
+# gfx1151 ISA and toolchain
+
+Use the final gfx1151 code object—not source intent—as the authority for wave size, instruction
+selection, resource use and target identity.
+
+## Target and current qualified toolchain
+
+| Item | Value |
+|---|---|
+| Native target | **`gfx1151`** |
+| HIP compile selector | `--offload-arch=gfx1151` |
+| Qualified container Torch | `2.13.0+rocm10.0.0` |
+| Qualified HIP runtime/toolchain | `7.15.26333` through modular ROCm SDK |
+| Native wave reported by KFD | 32 |
+| Official ISA family | RDNA 3.5 |
+
+Do not set `HSA_OVERRIDE_GFX_VERSION`. Architecture spoofing may make an application launch while
+selecting wrong instructions, wave assumptions or device libraries.
+
+## Verified compile-time identity
+
+In the qualified HIP headers/toolchain, gfx1151 compilation defines:
+
+- `__GFX11__`;
+- `__gfx1151__`;
+- project-level `RDNA3` and `RDNA3_5` where those macros are derived from the architecture defines;
+- not `RDNA3_0` where it is defined as RDNA3 excluding RDNA3.5.
+
+Verify macros in device compilation, not only host preprocessing. A small kernel that prints or
+materializes the selected branch is more reliable than a generic `clang -dM` invocation lacking the
+HIP device pass.
+
+## High-value instruction families
+
+| Area | What matters on gfx1151 |
+|---|---|
+| Matrix | VOP3P `V_WMMA_*_16X16X16_*` for F16/BF16/IU8/IU4 |
+| Packed dot | IU8/IU4 dot instructions with signedness-select NEG fields |
+| Dual issue | `V_DUAL_*` / VOPD, wave32 only and heavily constrained |
+| Vector ALU | VOP1/VOP2/VOP3/VOP3P, packed 16-bit forms, DPP lane movement |
+| Scalar | SOP* flow/address/uniform math; scalar memory through SMEM |
+| LDS | DS indexed/atomic plus CU-mode direct/parameter load forms |
+| Global | GLOBAL and BUFFER for known-global addresses |
+| Generic address | FLAT, with both global and LDS dependency implications |
+| Private | SCRATCH using `FLAT_SCRATCH` |
+| Scheduling | `S_WAITCNT*`, `S_DELAY_ALU`, clauses, barriers |
+
+## Wait counters
+
+`S_WAITCNT` waits until outstanding counts are at or below the encoded thresholds. Counters count
+instructions, not lanes.
+
+| Counter | Covers |
+|---|---|
+| `VMcnt` | vector loads/samples and atomics that return data |
+| `VScnt` | vector stores and non-returning atomics |
+| `LGKMcnt` | LDS indexed ops, SMEM loads, GDS/GWS, messages and FLAT's LDS side |
+| `EXPcnt` | exports and LDS parameter/direct loads |
+
+Memory groups may complete out of order. Use the narrowest correct wait, but after a FLAT access the
+only generally sensible value can be zero because global and LDS sides may complete independently.
+
+`S_DELAY_ALU` describes recent ALU dependencies to avoid stalls. It is optional for correctness and
+must not replace memory waits.
+
+## GLOBAL versus FLAT
+
+- `GLOBAL` is for addresses known to be global and uses VM/VScnt—not LGKMcnt.
+- `FLAT` can resolve per lane to global, scratch or LDS and therefore increments both dependency
+  domains.
+- A pure tensor-global path emitting FLAT deserves investigation: it can consume extra LDS/dependency
+  machinery.
+- Incorrectly using GLOBAL for an LDS/private address can raise MEMVIOL; make the address-space proof
+  explicit.
+
+## Cache controls
+
+GLC, SLC and DLC fields affect first-level behavior, L2 temporal policy and MALL/Infinity Cache policy
+where implemented. They can also affect atomic return semantics. Do not treat cache bits as generic
+“faster/slower” flags; preserve correctness scope and measure the exact streaming/reuse pattern.
+
+## Build and inspect
+
+Example native compile:
+
+```bash
+hipcc -x hip --offload-arch=gfx1151 -O2 -c kernel.hip -o kernel.o
+```
+
+Inspect the offload bundle and target code object with the ROCm LLVM tools available in the selected
+runtime. Typical flow:
+
+```bash
+roc-obj-ls kernel.o
+roc-obj-extract -o - 'hipv4-amdgcn-amd-amdhsa--gfx1151' kernel.o > kernel-gfx1151.co
+llvm-readobj --notes --symbols kernel-gfx1151.co
+llvm-objdump -d --mcpu=gfx1151 kernel-gfx1151.co
+```
+
+Tool syntax varies by ROCm packaging. Preserve the original input hash before extraction and write to
+a disposable output; do not let objcopy-like tools rewrite the authority in place.
+
+## Disassembly checklist
+
+| Check | Pass condition |
+|---|---|
+| Target | embedded code object is exactly `gfx1151` |
+| Wave | metadata/disassembly matches the intended wave32 or deliberate wave64 |
+| Route instruction | expected WMMA/dot/VALU/Triton-generated sequence exists in the target symbol |
+| Address space | GLOBAL/BUFFER versus FLAT matches the proven pointer domain |
+| Waits | consumers are dominated by correct VM/VScnt/LGKM/EXP waits |
+| VOPD | every pair satisfies wave32 and bank/source/destination restrictions |
+| WMMA hazards | dependent overlap has a valid independent op/NOP spacing |
+| Resources | VGPR/SGPR/LDS/private/spill metadata stays within the declared budget |
+| Scratch traffic | no unexpected hot-loop scratch loads/stores |
+| Code change | candidate ISA differs from baseline in the mechanism claimed |
+
+A whole-object mnemonic count is not symbol-correlated proof. A source intrinsic with no reachable
+instantiation is not route proof.
+
+## What it means for kernels
+
+1. Compile for native gfx1151 with the exact runtime toolchain.
+2. Verify the code object and intended symbol before benchmarking.
+3. Read waits and address-space selection as correctness evidence.
+4. Read resource metadata before interpreting occupancy.
+5. Separate instruction availability from framework dispatch.
+6. Preserve source, compile command, object hash and disassembly together.
+
+## Pitfalls
+
+- Spoofing an older GFX target.
+- Trusting a source macro without a device-side compile check.
+- Using NOPs instead of wait counters for memory dependencies.
+- Missing FLAT's dual counter domains.
+- Calling VOPD safe from mnemonic presence alone.
+- Searching an entire library rather than the reachable specialization.
+- Using a code-object tool in a mode that mutates the input.
+
+## Verify
+
+Run a known-answer kernel, then retain native target identity, exact symbol ISA, resource metadata and
+correctness output. For formal encoding questions, cross-check AMD's machine-readable ISA XML rather
+than inferring fields from disassembler formatting.
+
+## Sources
+
+- AMD RDNA3.5 ISA guide, Chapters 3–16.
+- AMD/GPUOpen machine-readable ISA.
+- Qualified ROCm10 modular SDK preflight on the EVO-X2.
+
+## Related
+
+`gfx1151_execution.md` · `gfx1151_matrix_core.md` · `gfx1151_lds.md` ·
+`gfx1151_memory.md`

--- a/src/kernelforge/data/local_knowledge/hardware/gfx1151_lds.md
+++ b/src/kernelforge/data/local_knowledge/hardware/gfx1151_lds.md
@@ -1,0 +1,155 @@
+---
+title: gfx1151 — LDS capacity, 64 banks, CU/WGP modes and dependencies
+kind: hardware
+topic: lds
+gens: [gfx1151]
+updated: 2026-09-02
+---
+
+# LDS — capacity, banks, modes and synchronization
+
+RDNA3.5 provides **128 KiB LDS per WGP**, split into two **64 KiB CU-affiliated halves**,
+over **64 DWORD-wide banks**. One work-group may request at most **64 KiB**.
+
+## Geometry
+
+| Property | RDNA3.5 / qualified gfx1151 |
+|---|---|
+| WGP LDS | 128 KiB |
+| CU-affiliated halves | 2 × 64 KiB |
+| Live KFD `lds_size_in_kb` | 64 per CU |
+| Banks | 64 total, split 32 + 32 by CU affiliation |
+| Bank storage | 512 × 32-bit, two-port (one read + one write per clock) |
+| Integer atomic units | 64 |
+| Maximum one work-group may request | 64 KiB |
+| Addressing modes | indexed DS, direct/parameter load in CU mode, wave collectives/atomics |
+
+DWORDs map serially across banks. For a simple contiguous 32-bit view, reason from:
+
+```text
+bank = (byte_address / 4) mod 64
+```
+
+Then account for CU/WGP mode and operand width. A mapping proven conflict-free for a 32-bank
+CDNA part is not proof for this 64-bank, two-half layout.
+
+## CU mode versus WGP mode
+
+### CU mode
+
+- The work-group's waves stay on one CU's two SIMD32s.
+- The allocation resides in the associated 64 KiB LDS half.
+- Access may not cross or wrap into the other half.
+- Both halves can operate in parallel for independent work-groups.
+- `LDS_PARAM_LOAD` and `LDS_DIRECT_LOAD` are available.
+
+### WGP mode
+
+- Work-group waves may occupy all four SIMD32s.
+- LDS is one contiguous 128 KiB WGP address space.
+- An allocation may lie in either half or straddle the 64 KiB boundary.
+- `LDS_PARAM_LOAD` and `LDS_DIRECT_LOAD` are **not** available.
+- One work-group still cannot allocate more than 64 KiB.
+
+## Bank conflicts
+
+LDS bandwidth comes from parallel bank access. Indexed loads/stores and atomics serialize when
+lanes request different addresses in the same bank. Same-address requests can broadcast where the
+instruction semantics permit.
+
+For a tiled array, inspect the byte stride:
+
+```text
+bank_stride = (byte_stride / 4) mod 64
+```
+
+A stride that repeatedly maps active lanes to the same bank is a conflict pattern. The exact
+active-lane grouping and CU-half affiliation matter; prove a padding/XOR swizzle against the target
+instruction and compiled wave size.
+
+### Repair options
+
+- **Padding:** move row/column strides away from bank-period multiples while retaining vector alignment.
+- **XOR/swizzle:** permute addresses so the target WMMA fragment reads distribute across banks.
+- **Layout change:** store the producer directly in the consumer's fragment order.
+- **Bypass LDS:** when reuse is insufficient, global→VGPR can beat stage/sync/read overhead.
+
+Do not optimize the bank formula in isolation and accidentally scalarize global accesses or break
+fragment layout.
+
+## Access methods
+
+- Indexed DS operations use per-lane VGPR addresses/data.
+- LDS direct load broadcasts one DWORD into a VGPR and implicitly reads `M0`; initialize it.
+- Parameter loads and direct loads contribute to `EXPcnt` and are CU-mode only.
+- LDS indexed operations contribute to `LGKMcnt`.
+- Some global/buffer loads can target LDS, but their exact supported widths and lowering are
+  toolchain/instruction-specific; prove the emitted form rather than importing gfx950 widths.
+- Storing staged LDS data to global normally passes through VGPRs.
+
+## Synchronization and waits
+
+A work-group barrier waits until all participating waves reach the barrier. It does not replace
+memory dependency waits.
+
+- use `s_waitcnt lgkmcnt(...)` before consuming indexed LDS results;
+- use `s_waitcnt expcnt(...)` for direct/parameter LDS results where applicable;
+- do not use NOPs as a memory-ordering substitute;
+- remember that FLAT may use LDS and global machinery simultaneously and therefore participates
+  in both LGKM and VM/VScnt domains.
+
+## Capacity and occupancy
+
+For staged GEMM/attention operands:
+
+```text
+LDS/workgroup ≈ sum(staged operand bytes × pipeline stages) + scratch/exchange space
+```
+
+Then gate:
+
+```text
+LDS/workgroup <= 64 KiB
+resident workgroups <= floor(available LDS side/mode / allocated bytes)
+```
+
+The true allocation granule and occupancy result come from compiler/code-object metadata. Do not
+assume gfx950's 160 KiB denominator or allocation granule.
+
+## What it means for kernels
+
+1. State CU or WGP mode when the distinction affects layout or direct loads.
+2. Keep every work-group ≤64 KiB LDS.
+3. Re-derive swizzles for 64 banks and the target WMMA fragment.
+4. Preserve vector alignment while padding.
+5. Use fine-grained wait counters and barriers for their separate purposes.
+6. Compare against a no-LDS path when reuse is low.
+7. Inspect generated ISA; source-level shared arrays do not prove wide/conflict-free instructions.
+
+## Pitfalls
+
+- Reading “128 KiB/WGP” as “128 KiB per work-group.”
+- Using direct/parameter LDS loads in WGP mode.
+- Copying a 32-bank MI swizzle unchanged.
+- Forgetting the 64 KiB CU-half boundary in CU mode.
+- Treating a barrier as completion of all memory operations.
+- Assuming gfx950 direct-to-LDS widths exist on gfx1151.
+- Spending LDS to stage data that is consumed only once.
+
+## Verify
+
+- Code-object `.group_segment_fixed_size` / LDS metadata.
+- Disassembly for `ds_*`, direct/parameter-load forms and wait counters.
+- A targeted bank-conflict microbenchmark using the exact dtype, stride, wave size and mode.
+- Correctness A/B with padding/swizzle enabled and disabled.
+- Profiler counters where the installed ROCm stack exposes reliable LDS metrics on gfx1151.
+
+## Sources
+
+- AMD RDNA3.5 ISA guide, Chapters 1–3, 5 and 12.
+- Live KFD `lds_size_in_kb=64` on the qualified EVO-X2.
+
+## Related
+
+`gfx1151_topology.md` · `gfx1151_execution.md` · `gfx1151_matrix_core.md` ·
+`gfx1151_memory.md` · `common_methodology/optimization/lever_lds_banks.md`

--- a/src/kernelforge/data/local_knowledge/hardware/gfx1151_matrix_core.md
+++ b/src/kernelforge/data/local_knowledge/hardware/gfx1151_matrix_core.md
@@ -1,0 +1,143 @@
+---
+title: gfx1151 — WMMA matrix instructions, fragments and scheduling
+kind: hardware
+topic: matrix_core
+gens: [gfx1151]
+updated: 2026-09-02
+---
+
+# Matrix core — RDNA3.5 WMMA, not CDNA MFMA
+
+RDNA3.5 exposes wave-level 16×16×16 WMMA operations through the VOP3P instruction
+format. The entire wave cooperates on `D = A·B + C`. This is the matrix model to use for
+native gfx1151 authoring; CDNA MFMA shape, register and cycle tables do not transfer.
+
+## Architecturally listed forms
+
+| Instruction | A/B elements | Accumulator/output |
+|---|---|---|
+| `V_WMMA_F32_16X16X16_F16` | F16 | F32 |
+| `V_WMMA_F32_16X16X16_BF16` | BF16 | F32 |
+| `V_WMMA_F16_16X16X16_F16` | F16 | F16 |
+| `V_WMMA_BF16_16X16X16_BF16` | BF16 | BF16 |
+| `V_WMMA_I32_16X16X16_IU8` | signed/unsigned 8-bit controls | I32 |
+| `V_WMMA_I32_16X16X16_IU4` | signed/unsigned 4-bit controls | I32 |
+
+The instruction list establishes architectural availability—not compiler intrinsic stability,
+framework reachability, performance, or a particular packed-weight ABI.
+
+## Fragment layout
+
+AMD specifies:
+
+- **A** is column-major in the VGPR fragment view;
+- **B**, **C** and **D** are row-major;
+- A/B fragment data from lanes 0–15 must be replicated into lanes 16–31;
+- wave64 additionally replicates into lanes 32–47 and 48–63;
+- source operands are VGPRs;
+- output-coordinate ownership must be derived from the exact WMMA form/toolchain mapping.
+
+Do not validate layout with all-ones inputs: uniform data is invariant under many wrong
+permutations. Use basis matrices, nonuniform rows/columns, both wave halves when applicable,
+extreme codes and every output coordinate.
+
+## Floating-point behavior
+
+- Float WMMA uses round-to-nearest-even.
+- WMMA generates no ALU exceptions.
+- The ISA's MODE rounding controls do not turn WMMA into arbitrary rounding modes.
+- F32 accumulation is the robust default for F16/BF16 long reductions.
+- F16/BF16 output forms are separate instructions, not permission to narrow an F32 accumulator
+  arbitrarily inside K.
+
+## Integer signedness
+
+For `V_WMMA...IU...` and IU dot-product instructions, NEG fields select **signedness**; they are
+not ordinary arithmetic negation controls. Reserved/unsupported NEG combinations can be undefined.
+
+Before using IU4/IU8:
+
+1. define each operand's signed/unsigned code domain;
+2. derive zero-point and offset corrections algebraically;
+3. accumulate products/corrections in I32;
+4. prove packing order and K permutation;
+5. convert to output scale only after the exact integer recurrence is complete.
+
+An instruction mnemonic does not prove the surrounding quantization algebra.
+
+## Scheduling hazard
+
+Back-to-back dependent WMMA instructions require one `V_NOP` or an independent VALU operation
+when the first D destination overlaps the next A or B source. A/B may overlap C when C is distinct
+from D; the usual accumulator pattern has C and D equal.
+
+Treat this as both a correctness and scheduling check. Inspect the final ISA—source-level intrinsic
+ordering may be transformed by the compiler.
+
+## Wave size
+
+Both wave32 and wave64 can execute WMMA, but their fragment replication and issue behavior differ.
+Native gfx1151 kernels normally use wave32. A deliberate wave64 matrix kernel must prove:
+
+- compiled wave size in the code object;
+- both-half fragment replication;
+- lane/output mapping;
+- resource use and correctness independently of a wave32 baseline.
+
+VOPD and WMMA are distinct mechanisms. VOPD is wave32-only dual VALU issue; WMMA is a VOP3P
+wave-matrix operation. Do not claim a WMMA kernel uses VOPD unless the symbol-correlated ISA does.
+
+## Software-stack mapping
+
+| Surface | Claim allowed without more evidence |
+|---|---|
+| ISA manual lists IU4/IU8 WMMA | architecture supports the instruction forms |
+| HIP/LLVM accepts an intrinsic | toolchain can compile one source form |
+| Code object contains target mnemonic | that symbol contains the instruction |
+| Microkernel matches CPU reference | instruction + fragment/algebra work for tested cases |
+| Framework route selects it | integration reached the kernel for the tested request |
+| Model benchmark improves | end-to-end benefit for that exact model/workload/runtime |
+
+Never skip rungs in this ladder.
+
+## What it means for kernels
+
+1. Start from a 16×16×16 WMMA fragment map, not an MFMA map.
+2. Keep floating accumulators in F32 and integer accumulators in I32 unless a separately proven
+   output-form choice is intentional.
+3. Build operand staging around A-column/B-row fragment ownership.
+4. Design LDS swizzles against the exact lane/register map.
+5. Schedule an independent VALU or required NOP across dependent overlap hazards.
+6. Use asymmetric correctness cases before timing.
+7. Count packing, scaling, LDS and dispatch costs in end-to-end claims.
+
+## Pitfalls
+
+- Calling WMMA “unsupported” because one rocWMMA/framework path failed.
+- Calling it “qualified” because an all-ones spike ran.
+- Using CDNA MFMA names, shapes, AGPR advice or cycle tables.
+- Applying the current lane's scale to every output fragment element.
+- Treating NEG as numeric negation for IU4/IU8.
+- Ignoring wave-half replication in wave64.
+- Quoting register counts without the emitted specialization.
+
+## Verify
+
+- Compile natively for `gfx1151` and extract the exact target code object.
+- Correlate the intended kernel symbol with the WMMA mnemonic.
+- Inspect VGPR/SGPR/LDS/private/spill metadata for every host-selectable specialization.
+- Use basis/nonuniform matrices and a CPU reference over full output-coordinate coverage.
+- Verify the actual framework request reaches the intended route before model timing.
+
+Use AMD's matrix-instruction tooling when it supports the target/form; otherwise derive from the
+official ISA and confirm with a standalone known-answer microkernel.
+
+## Sources
+
+- AMD RDNA3.5 ISA guide, Sections 7.5, 7.9, 7.9.1 and VOP3P instruction catalogue.
+- AMD/GPUOpen machine-readable ISA for exact instruction names/encodings.
+
+## Related
+
+`gfx1151_execution.md` · `gfx1151_dtypes.md` · `gfx1151_lds.md` ·
+`gfx1151_isa.md` · `common_methodology/optimization/lever_numerics.md`

--- a/src/kernelforge/data/local_knowledge/hardware/gfx1151_memory.md
+++ b/src/kernelforge/data/local_knowledge/hardware/gfx1151_memory.md
@@ -1,0 +1,155 @@
+---
+title: Radeon 8060S / gfx1151 — UMA memory hierarchy and bandwidth discipline
+kind: hardware
+topic: memory
+gens: [gfx1151]
+updated: 2026-09-02
+---
+
+# Memory hierarchy — UMA, caches and shared bandwidth
+
+The Radeon 8060S is an integrated GPU. Its global memory ultimately resides in shared system
+LPDDR/DDR rather than dedicated HBM. CPU traffic, GPU weights/KV, display activity and other DMA users
+can contend for the same physical channels and capacity.
+
+## Qualified-node memory facts
+
+| Fact | Qualified EVO-X2 value | Evidence class |
+|---|---:|---|
+| Physical system memory | 132,565,487,616 B (~123.5 GiB) | live Linux memory total |
+| GPU memory model | UMA/shared system memory | platform architecture/live behavior |
+| Theoretical memory interface reference | 256 GB/s | node configuration calculation |
+| STREAM-style HIP read | ~241 GB/s | measured local probe |
+| STREAM-style copy | ~209 GB/s | measured local probe |
+| Dedicated HBM | none | platform fact |
+| KFD memory-bank records | 1 | live KFD topology |
+
+The measured numbers are a ceiling reference for that probe, size, clock/thermal state and software
+stack. They are not guaranteed application bandwidth.
+
+## Architecture ladder
+
+AMD's RDNA3.5 model contains:
+
+```text
+VGPRs
+  ↕
+LDS (128 KiB/WGP, 64 banks; one work-group ≤64 KiB)
+  ↕
+per-WGP/on-chip caches and device cache hierarchy
+  ↕
+L2 channels / memory controllers
+  ↕
+shared system memory on the integrated platform
+```
+
+The ISA describes read-only L1/L0 paths, write-combining/atomic-cache behavior and cache-control bits,
+but cache capacities and platform MALL details are device-specific. Do not copy MI350 Infinity Cache,
+per-XCD L2 or HBM capacities into gfx1151 documentation without direct device evidence.
+
+## UMA accounting
+
+- GTT is an addressable GPU view backed by shared system pages, not a second physical RAM pool.
+- Process RSS, page cache and GPU allocations can overlap in physical accounting.
+- `MemAvailable` is more useful for admission than nominal total RAM.
+- Swap pressure can destabilize latency and consume memory bandwidth.
+- CPU memory-intensive work can lower GPU throughput even without owning `/dev/kfd`.
+- Model weights, KV, activations and runtime/JIT buffers compete with the host OS and co-tenants.
+
+For a large-model admission decision, record at least:
+
+```text
+MemTotal / MemAvailable / swap use
+process RSS and cgroup limits
+KFD/GTT ownership
+model weights + KV + runtime estimate
+memory-pressure and I/O-PSI state
+```
+
+Never report `RSS + GTT` as independent physical consumption without reconciling overlap.
+
+## Bandwidth and roofline
+
+For a memory-bound kernel:
+
+```text
+time_floor ≈ bytes transferred / achievable bandwidth
+```
+
+Use the measured ~241 GB/s read ceiling only as a node-specific comparison point. Compute implied
+bandwidth from actual tensor/model bytes, then label omitted traffic such as:
+
+- KV and activation reads/writes;
+- quantization scales/metadata;
+- page tables and cache misses;
+- output stores;
+- allocator/copy traffic.
+
+Do not publish a FLOP/byte ridge until the exact instruction path's sustainable compute rate is
+measured or authoritatively established.
+
+## Decode versus prefill
+
+- **Decode/GEMV/small-batch:** often streams weights per token and can approach the shared-memory wall;
+  fixed dispatch/host overhead is also significant.
+- **Prefill/large-M GEMM:** offers more reuse and may become compute, LDS or scheduling limited.
+- **Attention:** moves KV and can change classification with context length, page layout and cache dtype.
+- **MoE:** expert routing reduces active weight traffic but introduces irregularity and launch overhead.
+
+Never combine PP and TG into one “GPU bandwidth” claim.
+
+## GLOBAL, BUFFER and FLAT
+
+- Use contiguous, aligned GLOBAL/BUFFER vector accesses when the address space is known.
+- FLAT participates in both global and LDS dependency domains and may complete through different units.
+- A compiler emitting FLAT for a pure tensor-global hot loop is a signal to inspect pointer provenance.
+- Buffer descriptors can provide bounds semantics without branch-heavy per-lane guards.
+- Cache controls must match reuse/streaming and atomic semantics; measure rather than cargo-culting flags.
+
+## Layout and access
+
+- Put the contiguous tensor dimension across active lanes.
+- Preserve vector alignment after padding/slicing.
+- Separate global coalescing from LDS bank-conflict analysis.
+- Reorder/preshuffle off the hot path only when its storage and conversion cost amortize.
+- For one-use data, avoid LDS staging unless it removes another larger cost.
+- Include tails and non-power-of-two dimensions in correctness and performance tests.
+
+## What it means for kernels
+
+1. Count bytes and launches before optimizing arithmetic.
+2. Compare implied bandwidth against an on-box achievable probe, not HBM tables.
+3. Control CPU/co-tenant activity for memory-sensitive A/B tests.
+4. Include packing, scale and copy traffic in low-bit claims.
+5. Use global-address instructions when pointer provenance permits.
+6. Treat large shared-memory capacity as admission headroom, not guaranteed bandwidth.
+7. Monitor swap/PSI during long campaigns.
+
+## Pitfalls
+
+- Calling shared GTT “VRAM” and adding it to RAM.
+- Importing MI350 HBM/L2/Infinity Cache numbers.
+- Treating theoretical 256 GB/s as application-sustained bandwidth.
+- Inferring exact bytes/token from model file size alone.
+- Benchmarking while CPU memory traffic or another iGPU job is active.
+- Calling a small-model gap purely memory efficiency without separating launch overhead.
+- Assuming a source vector type produced a wide memory instruction.
+
+## Verify
+
+- Re-run a size-swept read/copy microbenchmark in the same runtime and thermal state.
+- Inspect device ISA for access width, address space and cache controls.
+- Capture device time, host wall time and dispatch count separately.
+- Record `free`, swap and PSI during the run.
+- Confirm model/request route, context, KV dtype and batch geometry.
+
+## Sources
+
+- AMD RDNA3.5 ISA guide, memory/cache, VMEM, GLOBAL/FLAT/SCRATCH and LDS chapters.
+- Live Linux/KFD data from the qualified EVO-X2.
+- Retained STREAM-style gfx1151 roofline measurements.
+
+## Related
+
+`gfx1151_topology.md` · `gfx1151_lds.md` · `gfx1151_execution.md` ·
+`gfx1151_clocks.md` · `common_methodology/optimization/lever_coalescing.md`

--- a/src/kernelforge/data/local_knowledge/hardware/gfx1151_overview.md
+++ b/src/kernelforge/data/local_knowledge/hardware/gfx1151_overview.md
@@ -1,0 +1,128 @@
+---
+title: Radeon 8060S / Strix Halo — gfx1151 orientation and cheat sheet
+kind: hardware
+topic: overview
+gens: [gfx1151]
+updated: 2026-09-02
+---
+
+# Radeon 8060S / Strix Halo (gfx1151) — orientation
+
+**Start here for the EVO-X2 target.** This card separates three evidence classes:
+
+- **ISA facts** from AMD's RDNA 3.5 ISA guide;
+- **live platform facts** from KFD/sysfs on the qualified EVO-X2;
+- **measured local observations** from retained gfx1151 campaigns.
+
+Do not import MI300/MI350 values merely because both stacks use ROCm.
+
+## One-screen cheat sheet
+
+| Fact | Radeon 8060S / EVO-X2 value | Why it matters |
+|---|---|---|
+| ISA target | **`gfx1151`**, compile with `--offload-arch=gfx1151` | Never spoof gfx1100/gfx1101/gfx942/gfx950 |
+| Architecture | **RDNA 3.5**, integrated Radeon 8060S | WMMA/VOPD model, not CDNA MFMA |
+| PCI identity | AMD `1002:1586` on this node | Confirms the physical device selected by KFD |
+| Native wave | **wave32**; wave64 is supported | The same `nwarps` means half the threads of a wave64 design |
+| Live compute topology | **40 CU**, **80 SIMD32**, 2 SIMD/CU | Size grids from 40 CUs, not MI tables |
+| Live wave-slot cap | **16 waves/SIMD** from KFD | Hard platform ceiling before VGPR/LDS limits |
+| WGP model | 2 CU / 4 SIMD32 per WGP | Work-groups and 128 KiB WGP LDS live at this level |
+| LDS | **64 KiB/CU**, **128 KiB/WGP**, 64 banks; one work-group ≤64 KiB | Re-derive every shared-memory tile/swizzle |
+| Matrix family | 16×16×16 **WMMA**: F16, BF16, IU8, IU4 | `AMD_WMMA_AVAILABLE`; CDNA `MFMA` is not the route |
+| Wave32-only lever | **VOPD** dual issue | Real opportunity, but strict bank/source/destination rules |
+| Memory model | **UMA/shared LPDDR**, not dedicated HBM | CPU, weights, KV, GTT and GPU share channels/capacity |
+| Host RAM on qualified node | 132,565,487,616 B physical (~123.5 GiB) | Dynamic availability matters more than nominal capacity |
+| Local bandwidth reference | 256 GB/s theoretical; ~241 GB/s read and ~209 GB/s copy measured | Node-specific roofline anchor, not an RDNA3.5 guarantee |
+| Qualified software baseline | Torch 2.13.0+rocm10.0.0, HIP 7.15.26333, native gfx1151 | Bind claims to the exact container/toolchain |
+
+## What is architectural and what is not
+
+### Architectural
+
+- RDNA3.5 supports wave32 and wave64.
+- A WGP contains four SIMD32s and two CU halves.
+- LDS is 128 KiB/WGP over 64 banks; one work-group may request at most 64 KiB.
+- VOPD is legal only for wave32.
+- WMMA includes F16/BF16 floating forms and IU8/IU4 integer forms.
+- FLAT participates in both global and LDS dependency domains.
+
+### Qualified EVO-X2 node
+
+- KFD reports `gfx_target_version=110501`, `simd_count=80`, `simd_per_cu=2`,
+  `wave_front_size=32`, `max_waves_per_simd=16`, `lds_size_in_kb=64`, and `num_xcc=1`.
+- The device is PCI `1002:1586` and exposes render node 128.
+- The system uses shared DDR/LPDDR capacity rather than discrete VRAM/HBM.
+
+### Measured, not universal
+
+- The 256 GB/s theoretical and ~241/~209 GB/s stream results belong to this memory
+  configuration and probe methodology.
+- Model PP/TG results, selected launch geometries and route wins belong to their exact model,
+  quantization, batch, context and runtime.
+- A software route working on gfx1151 does not prove the format is a native matrix dtype.
+
+## The deltas that break Instinct/CDNA ports
+
+1. **wave64 → native wave32** — lane collectives, masks, threads/block and occupancy change.
+2. **MFMA → WMMA/VOP3P** — operand layouts and instruction families are different.
+3. **HBM → UMA** — CPU and GPU contend for the same memory channels and capacity.
+4. **CDNA LDS rules → RDNA WGP/CU modes** — 128 KiB/WGP, two 64 KiB halves, 64 banks.
+5. **XCD topology → one live gfx1151 node/XCC** — no per-XCD L2 or CPX/NPS assumptions.
+6. **Instinct libraries are conditional** — AITER/CK kernels must prove exact gfx1151 support.
+7. **FP8/MX claims do not transfer** — validate the selected framework loader and physical route.
+
+## Roofline discipline
+
+Do not publish a compute ridge from an unverified peak-FLOP number. For this target:
+
+- establish achievable memory bandwidth with an on-box probe;
+- measure actual device time and bytes moved;
+- inspect whether the target path is WMMA, dot, VALU, Triton or a framework fallback;
+- report prefill and decode separately;
+- include host/dispatch time for small and decode-dominated workloads.
+
+The retained large-model decode evidence often approaches the shared-memory bandwidth ceiling,
+but that does not classify every prefill, attention, fusion or quantization shape.
+
+## Portable rules for gfx1151
+
+- Compile natively for `gfx1151`; never use `HSA_OVERRIDE_GFX_VERSION` as support evidence.
+- Assume wave32 unless the exact code object proves deliberate wave64.
+- Derive workgroup geometry from 40 live CUs and the kernel's resource metadata.
+- Use RDNA WMMA/VOPD rules; do not recommend CDNA MFMA instructions.
+- Keep one work-group at or below 64 KiB LDS and reason about all 64 banks.
+- Treat GTT and process RSS as views of shared physical memory, not additive pools.
+- Require route, correctness and code-object evidence before interpreting throughput.
+- Keep framework/version/image qualifications narrow.
+
+## Verify on box
+
+```bash
+rocminfo | grep -m1 -oE 'gfx[0-9a-f]+'
+cat /sys/class/kfd/kfd/topology/nodes/*/properties
+cat /sys/class/drm/card1/device/{vendor,device}
+hipcc --version
+```
+
+For generated kernels, retain:
+
+- native gfx1151 code-object identity;
+- wave size and launch geometry;
+- VGPR/SGPR/LDS/private/spill metadata;
+- target instruction/route proof;
+- correctness results and matched runtime measurements.
+
+## Sources
+
+- AMD, *RDNA 3.5 Instruction Set Architecture Reference Guide*:
+  https://docs.amd.com/v/u/en-US/rdna35_instruction_set_architecture
+- AMD/GPUOpen machine-readable ISA:
+  https://gpuopen.com/machine-readable-isa/
+- Live KFD/sysfs topology on the qualified EVO-X2.
+- Local measured reference: `evo-gfx1151-mmvq-tuning/references/gfx1151-architecture-and-benchmarks.md`.
+
+## Related
+
+`gfx1151_topology.md` · `gfx1151_execution.md` · `gfx1151_matrix_core.md` ·
+`gfx1151_dtypes.md` · `gfx1151_lds.md` · `gfx1151_memory.md` ·
+`gfx1151_isa.md` · `gfx1151_clocks.md`

--- a/src/kernelforge/data/local_knowledge/hardware/gfx1151_topology.md
+++ b/src/kernelforge/data/local_knowledge/hardware/gfx1151_topology.md
@@ -1,0 +1,149 @@
+---
+title: Radeon 8060S / gfx1151 — topology, WGP/CU layout, UMA placement
+kind: hardware
+topic: topology
+gens: [gfx1151]
+updated: 2026-09-02
+---
+
+# Topology — WGPs, CUs, SIMD32s and one UMA node
+
+This card combines AMD's RDNA3.5 execution hierarchy with the live KFD topology of the
+qualified EVO-X2. It replaces the XCD/chiplet assumptions used by Instinct cards.
+
+## Live KFD identity
+
+`/sys/class/kfd/kfd/topology/nodes/1/properties` reports:
+
+| KFD property | Live value | Interpretation |
+|---|---:|---|
+| `gfx_target_version` | `110501` | native `gfx1151` |
+| `simd_count` | 80 | total SIMD32 engines exposed |
+| `simd_per_cu` | 2 | two SIMD32s per logical CU |
+| derived CU count | **40** | `80 / 2` |
+| `array_count` | 4 | four live arrays reported by KFD |
+| `simd_arrays_per_engine` | 2 | live array grouping |
+| `cu_per_simd_array` | 10 | ten CUs per reported SIMD array |
+| `wave_front_size` | **32** | native compiled wave size reported to KFD |
+| `max_waves_per_simd` | **16** | live wave-slot ceiling |
+| `lds_size_in_kb` | **64** | LDS associated with one CU half |
+| `max_slots_scratch_cu` | 32 | live scratch-slot property |
+| `num_xcc` | **1** | no multi-XCD Instinct topology |
+| `mem_banks_count` | 1 | one KFD memory-bank record |
+| `drm_render_minor` | 128 | `/dev/dri/renderD128` |
+| `vendor_id` / `device_id` | 4098 / 5510 | hex `1002:1586` |
+
+The 40 KFD CUs map architecturally to 20 two-CU WGPs when all pairs are enabled. Use the
+KFD **40-CU count** for grid sizing and reporting; use the WGP model for wave/LDS placement.
+
+## Architecture hierarchy
+
+```text
+Radeon 8060S / one KFD GPU node / one XCC
+└── 20 two-CU WGPs implied by 40 live CUs
+    ├── CU0 half: 2 × SIMD32 + 64 KiB LDS half
+    └── CU1 half: 2 × SIMD32 + 64 KiB LDS half
+        WGP total: 4 × SIMD32 + 128 KiB LDS / 64 banks
+```
+
+AMD's RDNA3.5 model says:
+
+- one WGP has four SIMD32s;
+- the WGP is logically split into two CU halves;
+- all waves of one work-group stay on the same WGP;
+- wave placement and LDS visibility depend on CU mode versus WGP mode;
+- a work-group may contain at most 1024 work-items;
+- the WGP can hold multiple work-groups, subject to waves, registers and LDS.
+
+## CU mode versus WGP mode
+
+| Mode | Wave placement | LDS view | Important restriction |
+|---|---|---|---|
+| **CU mode** | all waves of a work-group remain on one CU's two SIMD32s | one 64 KiB LDS half | upper/lower halves cannot share; direct/parameter LDS loads are available |
+| **WGP mode** | waves may use all four SIMD32s across both CUs | contiguous 128 KiB WGP LDS | `LDS_PARAM_LOAD` and `LDS_DIRECT_LOAD` are unavailable |
+
+One work-group may still allocate at most **64 KiB**, even though WGP mode exposes a 128 KiB
+address space. Do not infer a 128 KiB per-work-group budget.
+
+## UMA placement
+
+This is an integrated GPU:
+
+```text
+CPU cores ─┐
+GPU/WGPs ──┼── shared memory controllers/channels ── LPDDR system memory
+other DMA ─┘
+```
+
+Consequences:
+
+- GPU global memory and CPU memory pressure draw from one physical capacity.
+- GTT accounting and process RSS can overlap; never add them as independent memory pools.
+- CPU traffic, page residency, display use and co-tenants can reduce available GPU bandwidth.
+- There is no HBM stack, XCD-local HBM, NPS mode or CPX slice to target.
+- The PCI function identity is not evidence that model data traverses a discrete PCIe VRAM link.
+
+## Grid sizing
+
+Start from **40 live CUs**, then account for the kernel:
+
+```text
+resident workgroups
+  <= wave-slot capacity
+  <= VGPR/SGPR capacity
+  <= LDS capacity
+  <= workgroup/dispatch limits
+```
+
+Rules:
+
+- Enough workgroups are needed to cover 40 CUs, but no fixed multiple is universally optimal.
+- A small decode kernel may be launch/dispatch-bound before it is occupancy-bound.
+- A large prefill kernel may prefer fewer, deeper tiled workgroups.
+- `nwarps` is a count of waves: on native wave32, `nwarps=4` means 128 threads.
+- Do not reuse an MI350 256-CU or MI300 304-CU grid heuristic.
+
+## No chiplet-locality claims
+
+The live node reports `num_xcc=1`. Therefore do not apply:
+
+- per-XCD L2 placement or XCD CTA swizzles;
+- XCD-count tile multiples;
+- CPX/DPX/SPX or NPS partition recommendations;
+- cross-XCD clock-spread explanations;
+- HBM stack locality.
+
+Locality still matters at WGP/LDS/cache/page/channel levels, but it must be measured with
+Strix-specific counters or controlled data-layout experiments.
+
+## What it means for kernels
+
+1. Size launch breadth from 40 CUs, not from a donor GPU name.
+2. Choose CU/WGP behavior deliberately when LDS communication spans waves.
+3. Keep a work-group's LDS allocation ≤64 KiB.
+4. Treat wave32 thread geometry as the native baseline.
+5. Keep CPU/co-tenant traffic controlled during memory-sensitive A/B tests.
+6. Do not claim chiplet locality unless a future device exposes and proves such topology.
+
+## Verify
+
+```bash
+cat /sys/class/kfd/kfd/topology/nodes/*/properties
+cat /sys/class/drm/card1/device/vendor
+cat /sys/class/drm/card1/device/device
+readlink -f /sys/class/drm/renderD128/device
+```
+
+For runtime APIs, compare KFD against `hipGetDeviceProperties` values such as
+`multiProcessorCount`, `warpSize`, shared memory and total visible memory. A discrepancy must
+be recorded rather than silently choosing the convenient value.
+
+## Sources
+
+- AMD RDNA3.5 ISA guide, Chapters 1–3 and 12.
+- Live KFD/sysfs topology on the qualified EVO-X2.
+
+## Related
+
+`gfx1151_overview.md` · `gfx1151_execution.md` · `gfx1151_lds.md` ·
+`gfx1151_memory.md` · `gfx1151_clocks.md`

--- a/src/kernelforge/fusion/command.py
+++ b/src/kernelforge/fusion/command.py
@@ -514,7 +514,7 @@ def _setup_logging(output_dir: Path, verbose: bool = False) -> None:
 @click.option("--gpu", default="0", help="HIP device id for author + A/B.")
 @click.option(
     "--agent-backend",
-    type=click.Choice(["auto", "claude", "codex"]),
+    type=click.Choice(["auto", "claude", "codex", "hermes"]),
     default="auto",
     show_default=True,
     help="Registered Agent provider for discovery and authoring.",

--- a/src/kernelforge/tests/test_codex_native_oauth.py
+++ b/src/kernelforge/tests/test_codex_native_oauth.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""RED contracts for native Codex OAuth and exact fallback disablement."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import kernelforge.agent_backends.registry as registry
+from kernelforge.agent_backends.base import (
+    AgentProviderUnavailableError,
+    AgentRunSpec,
+    AgentRuntimeConfig,
+)
+from kernelforge.agent_backends.codex import (
+    CodexBackend,
+    CodexUnavailableError,
+)
+from kernelforge.agent_backends.registry import (
+    create_registered_backend,
+    get_agent_provider,
+    resolve_agent_runtime,
+)
+from kernelforge.cli import _agent_runtime_overrides
+from kernelforge.config import Config
+
+
+class _Config:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class _Client:
+    created = []
+
+    def __init__(self, config):
+        self.config = config
+        self.created.append(config)
+
+    def close(self):
+        return None
+
+
+class _NativeSdk:
+    CodexConfig = _Config
+    Codex = _Client
+    ApprovalMode = SimpleNamespace(deny_all="deny_all")
+    Sandbox = SimpleNamespace(
+        full_access="full_access",
+        read_only="read_only",
+        workspace_write="workspace_write",
+    )
+
+
+def native_runtime(home: Path, *, fallback_model: str = "") -> AgentRuntimeConfig:
+    return AgentRuntimeConfig(
+        provider="codex",
+        model="gpt-5.6-sol-900k",
+        fallback_model=fallback_model,
+        sandbox_mode="read-only",
+        options={
+            "auth_mode": "native_oauth",
+            "home": str(home),
+        },
+    )
+
+
+def test_runtime_can_disable_registered_model_fallback_without_changing_defaults():
+    claude = get_agent_provider("claude")
+    codex = get_agent_provider("codex")
+    claude_before = (
+        claude.default_model,
+        claude.fallback_model,
+        claude.capabilities,
+    )
+
+    strict = resolve_agent_runtime(
+        "codex",
+        model="gpt-5.6-sol-900k",
+        fallback_model="none",
+        fallback_provider="none",
+    )
+
+    assert strict.fallback_model == ""
+    assert strict.fallback_provider == ""
+    assert resolve_agent_runtime("codex").fallback_model == "gpt-5.5"
+    assert get_agent_provider("codex") is codex
+    assert (
+        claude.default_model,
+        claude.fallback_model,
+        claude.capabilities,
+    ) == claude_before
+
+
+def test_no_fallback_runtime_never_tries_registered_model_or_provider(monkeypatch):
+    attempted = []
+
+    def unavailable(registration, runtime, **kwargs):
+        del registration, kwargs
+        attempted.append((runtime.provider, runtime.model))
+        raise AgentProviderUnavailableError("selected provider/model unavailable")
+
+    monkeypatch.setattr(registry, "_prepare_backend", unavailable)
+    runtime = resolve_agent_runtime(
+        "codex",
+        model="gpt-5.6-sol-900k",
+        fallback_model="none",
+        fallback_provider="none",
+    )
+
+    with pytest.raises(AgentProviderUnavailableError):
+        create_registered_backend(runtime)
+
+    assert attempted == [("codex", "gpt-5.6-sol-900k")]
+
+
+def test_config_and_cli_expose_model_fallback_none():
+    config = Config(
+        agent_backend="codex",
+        agent_model="gpt-5.6-sol-900k",
+        agent_fallback_provider="none",
+        agent_fallback_model="none",
+        agent_precheck=False,
+    )
+    runtime = config.agent_runtime()
+    assert config.agent_fallback_provider == ""
+    assert config.agent_fallback_model == ""
+    assert runtime.fallback_provider == ""
+    assert runtime.fallback_model == ""
+
+    overrides = _agent_runtime_overrides(
+        model="gpt-5.6-sol-900k",
+        agent_backend="codex",
+        agent_cli=None,
+        agent_timeout_sec=None,
+        agent_reasoning_effort=None,
+        agent_sandbox_mode=None,
+        agent_fallback_provider="",
+        agent_fallback_model="",
+        agent_precheck=None,
+        agent_options_json=None,
+    )
+    assert overrides == {
+        "agent_model": "gpt-5.6-sol-900k",
+        "agent_backend": "codex",
+        "agent_fallback_provider": "",
+        "agent_fallback_model": "",
+    }
+
+
+def test_native_oauth_uses_dedicated_home_and_strips_gateway_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    home = tmp_path / "codex-oauth"
+    home.mkdir()
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://wrong-gateway.invalid/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-reach-native-codex")
+    monkeypatch.setenv("OPENAI_CUSTOM_HEADERS", "X-Secret: must-not-reach-native-codex")
+    backend = CodexBackend(runtime=native_runtime(home))
+
+    child = backend._child_environment()
+    overrides = backend._config_overrides(None)
+
+    assert child["CODEX_HOME"] == str(home.resolve())
+    assert "OPENAI_BASE_URL" not in child
+    assert "OPENAI_API_KEY" not in child
+    assert "OPENAI_CUSTOM_HEADERS" not in child
+    assert overrides == ("features.memories=false",)
+    assert all("model_provider" not in item for item in overrides)
+    assert all("base_url" not in item for item in overrides)
+    assert all("env_key" not in item for item in overrides)
+
+
+def test_native_oauth_does_not_force_forge_model_provider(tmp_path: Path):
+    home = tmp_path / "codex-oauth"
+    home.mkdir()
+    backend = CodexBackend(runtime=native_runtime(home))
+    spec = AgentRunSpec(
+        system_prompt="Source only.",
+        user_prompt="Return one candidate.",
+        cwd=str(tmp_path),
+        model="gpt-5.6-sol-900k",
+        writable=False,
+    )
+
+    options = backend._thread_start_options(_NativeSdk, spec)
+
+    assert options["model"] == "gpt-5.6-sol-900k"
+    assert options["sandbox"] == "read_only"
+    assert "model_provider" not in options
+
+
+def test_gateway_mode_remains_unchanged(tmp_path: Path):
+    runtime = AgentRuntimeConfig(
+        provider="codex",
+        model="gpt-gateway",
+        options={"auth_mode": "gateway"},
+    )
+    backend = CodexBackend(
+        runtime=runtime,
+        gateway={
+            "base_url": "https://gateway.example.invalid/v1",
+            "key_env": "FAKE_CODEX_API_KEY",
+            "headers": {"user": "test-user"},
+        },
+    )
+    spec = AgentRunSpec("system", "user", str(tmp_path), model="gpt-gateway")
+
+    overrides = backend._config_overrides(None)
+    options = backend._thread_start_options(_NativeSdk, spec)
+
+    assert any(item == 'model_provider="forge"' for item in overrides)
+    assert any("base_url=" in item for item in overrides)
+    assert any("env_key=" in item for item in overrides)
+    assert options["model_provider"] == "forge"
+
+
+def test_native_oauth_rejects_ambiguous_gateway_and_unsafe_home(tmp_path: Path):
+    absolute = tmp_path / "codex-home"
+    absolute.mkdir()
+    gateway = {
+        "base_url": "https://gateway.example.invalid/v1",
+        "key_env": "FAKE_CODEX_API_KEY",
+    }
+    with pytest.raises(CodexUnavailableError, match="native_oauth.*gateway"):
+        CodexBackend(runtime=native_runtime(absolute), gateway=gateway)
+
+    relative = AgentRuntimeConfig(
+        provider="codex",
+        model="gpt-test",
+        options={"auth_mode": "native_oauth", "home": "relative-home"},
+    )
+    with pytest.raises(CodexUnavailableError, match="absolute"):
+        CodexBackend(runtime=relative)
+
+    target = tmp_path / "real-home"
+    target.mkdir()
+    link = tmp_path / "linked-home"
+    link.symlink_to(target, target_is_directory=True)
+    with pytest.raises(CodexUnavailableError, match="symlink"):
+        CodexBackend(runtime=native_runtime(link))
+
+
+def test_native_oauth_preflight_initializes_sdk_without_gateway(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    home = tmp_path / "codex-oauth"
+    home.mkdir()
+    _Client.created.clear()
+    monkeypatch.setattr("kernelforge.agent_backends.codex._load_codex_sdk", lambda: _NativeSdk)
+    monkeypatch.setattr(
+        "kernelforge.agent_backends.codex._resolve_gateway",
+        lambda: (_ for _ in ()).throw(AssertionError("gateway must not be resolved")),
+    )
+    backend = CodexBackend(runtime=native_runtime(home))
+
+    backend.preflight()
+
+    assert backend._preflight_done is True
+    assert len(_Client.created) == 1
+    config = _Client.created[0]
+    assert config.env["CODEX_HOME"] == str(home.resolve())
+    assert config.config_overrides == ("features.memories=false",)
+
+
+def test_claude_provider_remains_registered_and_unmodified():
+    claude = get_agent_provider("claude")
+    assert claude.name == "claude"
+    assert claude.default_model == "claude-opus-5"
+    assert claude.fallback_model == "claude-opus-4-8"
+    assert claude.capabilities.writable is True
+    assert claude.capabilities.resumable is True
+    assert claude.capabilities.stop_hooks is True
+    assert claude.capabilities.native_subagents is True
+    assert claude.capabilities.mcp is True

--- a/src/kernelforge/tests/test_hermes_backend.py
+++ b/src/kernelforge/tests/test_hermes_backend.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Hermes backend must honor KernelForge's shared policy contract."""
+
+from pathlib import Path
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from kernelforge.agent_backends.base import (
+    AgentProviderUnavailableError,
+    AgentRunSpec,
+    AgentRuntimeConfig,
+    AgentToolPolicy,
+)
+from kernelforge.agent_backends.hermes import HermesBackend
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    (path / "driver.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "add", "driver.py"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=path, check=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("writable", "toolsets"),
+    [(False, "todo"), (True, "terminal,file")],
+)
+async def test_hermes_backend_maps_writable_policy_and_guards_workspace(
+    tmp_path: Path,
+    monkeypatch,
+    writable: bool,
+    toolsets: str,
+) -> None:
+    calls: list[tuple[list[str], dict]] = []
+    _init_repo(tmp_path)
+    monkeypatch.setattr("kernelforge.agent_backends.hermes._running_in_container", lambda: True)
+
+    def fake_run(argv, **kwargs):
+        calls.append((list(argv), dict(kwargs)))
+        return SimpleNamespace(returncode=0, stdout="done", stderr="")
+
+    monkeypatch.setattr("kernelforge.agent_backends.hermes.subprocess.run", fake_run)
+    runtime = AgentRuntimeConfig(
+        provider="hermes",
+        model="gpt-5.6-sol",
+        executable="/runtime/hermes",
+        sandbox_mode="bypass",
+        options={"external_sandbox": True},
+    )
+    backend = HermesBackend(runtime)
+    spec = AgentRunSpec(
+        system_prompt="SYS",
+        user_prompt="USER",
+        cwd=str(tmp_path),
+        writable=writable,
+        tool_policy=(None if writable else AgentToolPolicy(write=False, shell=False)),
+    )
+
+    result = await backend.run(spec)
+
+    argv, _ = calls[0]
+    assert result.text == "done"
+    assert "--safe-mode" in argv
+    assert argv[argv.index("--toolsets") + 1] == toolsets
+    assert "--yolo" not in argv
+    assert backend.capabilities.workspace_guard
+    assert backend.capabilities.sandbox is False
+
+
+@pytest.mark.asyncio
+async def test_hermes_backend_rejects_unimplemented_native_sandbox(tmp_path: Path) -> None:
+    backend = HermesBackend(
+        AgentRuntimeConfig(
+            provider="hermes",
+            model="gpt-5.6-sol",
+            executable="/runtime/hermes",
+            sandbox_mode="workspace-write",
+        )
+    )
+    spec = AgentRunSpec(system_prompt="SYS", user_prompt="USER", cwd=str(tmp_path), writable=True)
+
+    with pytest.raises(AgentProviderUnavailableError, match="external sandbox"):
+        await backend.run(spec)
+
+
+@pytest.mark.asyncio
+async def test_hermes_backend_requires_declared_external_sandbox(tmp_path: Path) -> None:
+    backend = HermesBackend(
+        AgentRuntimeConfig(
+            provider="hermes",
+            model="gpt-5.6-sol",
+            executable="/runtime/hermes",
+            sandbox_mode="bypass",
+        )
+    )
+    spec = AgentRunSpec(system_prompt="SYS", user_prompt="USER", cwd=str(tmp_path), writable=True)
+
+    with pytest.raises(AgentProviderUnavailableError, match="external_sandbox=true"):
+        await backend.run(spec)
+
+
+@pytest.mark.asyncio
+async def test_hermes_backend_redacts_stderr_and_secret_values(tmp_path: Path, monkeypatch) -> None:
+    _init_repo(tmp_path)
+    monkeypatch.setattr("kernelforge.agent_backends.hermes._running_in_container", lambda: True)
+
+    def fake_run(argv, **kwargs):
+        return SimpleNamespace(
+            returncode=2,
+            stdout="",
+            stderr="Authorization: Bearer top-secret-value API_KEY=also-secret",
+        )
+
+    monkeypatch.setattr("kernelforge.agent_backends.hermes.subprocess.run", fake_run)
+    backend = HermesBackend(
+        AgentRuntimeConfig(
+            provider="hermes",
+            model="gpt-5.6-sol",
+            executable="/runtime/hermes",
+            sandbox_mode="bypass",
+            options={"external_sandbox": True},
+        )
+    )
+    spec = AgentRunSpec(
+        system_prompt="SYS",
+        user_prompt="USER",
+        cwd=str(tmp_path),
+        env={"PRIVATE_TOKEN": "top-secret-value"},
+    )
+
+    with pytest.raises(AgentProviderUnavailableError) as exc_info:
+        await backend.run(spec)
+
+    message = str(exc_info.value)
+    assert "top-secret-value" not in message
+    assert "also-secret" not in message
+    assert "[REDACTED]" in message

--- a/src/kernelforge/tests/test_provider_registry.py
+++ b/src/kernelforge/tests/test_provider_registry.py
@@ -121,6 +121,26 @@ def test_builtin_providers_are_registered() -> None:
     assert get_agent_provider("codex").capabilities.native_subagents
 
 
+def test_explicit_hermes_runtime_accepts_custom_executable_without_path(tmp_path, monkeypatch) -> None:
+    binary = tmp_path / "custom-hermes"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    binary.chmod(0o755)
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setattr("kernelforge.agent_backends.hermes._running_in_container", lambda: True)
+    runtime = resolve_agent_runtime(
+        "hermes",
+        executable=str(binary),
+        sandbox_mode="bypass",
+        fallback_provider="",
+        options={"external_sandbox": True},
+    )
+
+    backend = create_registered_backend(runtime, preflight=True)
+
+    assert getattr(backend, "_executable")() == str(binary)
+    assert backend.capabilities.workspace_guard
+
+
 def test_builtin_providers_declare_the_session_environment_they_apply() -> None:
     """Both built-ins apply AgentRunSpec.env to the session they spawn.
 


### PR DESCRIPTION
## Summary

Adds an upstream-faithful Strix Halo / Radeon 8060S (`gfx1151`, RDNA 3.5) port without replacing Hyperloom's existing workflows.

- registers `radeon8060s -> gfx1151` throughout GPU identity, runner selection, and bare-metal ROCm preflight
- preserves Claude while adding explicit native Codex OAuth and Hermes peer transports
- routes all providers through the original Quark prompt/skill/workspace/retry/validation contract
- adds Hermes to the existing Coordinator and Arbor specialist abstractions
- adds Hermes/native Codex support to KernelForge's existing backend registry
- adds source-backed `gfx1151` KernelForge hardware knowledge cards
- handles modular ROCm roots, Python 3.14/Ray compatibility, ROCm platform discovery, and current HIP visibility semantics

No replacement planner, readiness controller, deterministic substitute workflow, or automatic production-promotion mechanism is introduced.

Writable Hermes transports fail closed unless Hyperloom verifies a concrete outer-container runtime marker; Codex uses its native workspace-write sandbox, and Coordinator Hermes runs without local terminal/file tools.

## Physical qualification

Qualified on an AMD Radeon 8060S / Strix Halo APU reporting native `gfx1151` under Torch `2.13.0+rocm10.0.0` / HIP `7.15.26333`:

- original Coordinator through Hermes: 12 real turns with persisted state and PolicyGate enforcement
- original Arbor/EXPLORE: physical baseline `132.40` output tok/s; 3 specialists completed; `enable-cudagraphs` promoted to `137.72` output tok/s (`+4.01%`)
- original GEAK workflow: physical KNN correctness pass, 14 agent calls
- KernelForge `forge-loop`: physical candidate correctness pass (`103.87 dB` SNR), three timings, deterministic REVERT
- original Quark Codex and Hermes arms: W8A8 PTQ/export, 196 linear modules, 1,095 tensors, all four validators passed
- retained vLLM: 2/2 fixed `64 -> 16` requests; `131.03` output tok/s
- retained SGLang with Triton attention: 2/2 fixed `64 -> 16` requests; `82.19` output tok/s

Provider and model fallback were disabled for qualification. No production service, router, or registry was activated.

## Local verification

- `ruff check .`
- `ruff format --check .`
- shell syntax check for the modified bare-metal installer
- 637 focused tests passed (635 directly plus 2 checkout-path-sensitive tests through the same source mounted at a neutral path)
- 332 directly affected provider/security/startup/specialist tests passed after final transport hardening
- real confined Hermes one-shot smoke returned the exact expected response
- staged public-data scan: no credentials, private host/IP/path data, or unsafe execution patterns

Mypy remains advisory and reports the repository's existing type-check backlog.

## Known limits

- Current upstream AITER infrastructure can build/import several modules on `gfx1151`, but SGLang AITER attention is not qualified for the tested BF16 Qwen3 GQA2/head-size-128 geometry: CK prefill variants fail compilation and paged decode device-asserts. The qualified SGLang route uses explicit Triton attention.
- This PR establishes functional platform/workflow readiness; it does not automatically promote any candidate or mutate production serving.
