### PR TITLE
Estimate uplift and compare parallelism layouts without running

### DIFF
--- a/docs/reference/operator-scripts.md
+++ b/docs/reference/operator-scripts.md
@@ -1,15 +1,16 @@
 ---
 myst:
     html_meta:
-        "description": "Reference for Hyperloom operator scripts: dump_session_breakdown, dump_session_report, and event_counts. Use these utilities to inspect, export, and report on session data."
-        "keywords": "Hyperloom, operator scripts, session breakdown, session report, event counts, LLM inference, AMD GPU, ROCm, debugging, observability, operator tools"
+        "description": "Reference for Hyperloom operator scripts: dump_session_breakdown, dump_session_report, event_counts, and estimate_no_run. Use these utilities to inspect, export, and report on session data, and to estimate uplift before running."
+        "keywords": "Hyperloom, operator scripts, session breakdown, session report, event counts, uplift estimate, Recipe KB, LLM inference, AMD GPU, ROCm, debugging, observability, operator tools"
 ---
 # Hyperloom operator scripts
 
 A short reference for the operator-facing scripts under
 `src/hyperloom/inference_optimizer/tools/`. These are not part of the agent loop —
-they are utilities you run by hand against a finished or in-progress
-session directory.
+they are utilities you run by hand, most of them against a finished or
+in-progress session directory. The exception is `estimate_no_run.py`, which
+reads the Recipe KB rather than a session.
 
 When no explicit `--session-dir` is given, scripts resolve the active session in
 two steps: `INFERENCE_OPTIMIZER_CURRENT_SESSION_DIR` when set, otherwise the
@@ -172,6 +173,76 @@ shows many `kernel_request:*` and few `kernel_response:*`.
 
 ---
 
+## `estimate_no_run.py`
+
+Estimate uplift for a target from the Recipe KB, without running a session.
+Unlike the scripts above this one reads no session directory at all: it pulls
+per-session envelopes from the KB Store and reports what prior sessions already
+settled for a scope.
+
+Use this when:
+
+* You are triaging a queue of targets and want to know which ones prior
+  sessions suggest are worth GPU hours.
+* You want the parallelism layout that won inside a fixed GPU count for a
+  model/precision/shape you are about to launch.
+* You want a session's expected gain range to sanity-check a result you already
+  have.
+
+### Usage
+
+Use these commands to estimate uplift for a scope.
+
+```bash
+# Whole board, live store, token from a file
+python -m hyperloom.inference_optimizer.tools.estimate_no_run \
+    --kb-store-url https://host/knowledge-base \
+    --kb-store-token-file ~/.secrets/kb_store_token \
+    --hardware mi355x --framework-name sglang
+
+# One replay scope, credentials from the environment
+export KB_STORE_URL=... KB_STORE_TOKEN=...
+python -m hyperloom.inference_optimizer.tools.estimate_no_run \
+    --hardware mi355x --model <MODEL> --precision mxfp4 \
+    --tp 8 --isl 1024 --osl 256
+
+# Named identities instead of a search (repeatable; still reads the store)
+python -m hyperloom.inference_optimizer.tools.estimate_no_run \
+    --canonical-id <CID> --canonical-id <CID2>
+
+# A saved pool of session envelopes, no network at all
+python -m hyperloom.inference_optimizer.tools.estimate_no_run \
+    --input prior_sessions.json --tp 8 --isl 1024 --osl 256
+```
+
+Credentials resolve in the order `--kb-store-token`, then
+`--kb-store-token-file`, then `KB_STORE_TOKEN`; prefer the file form so the
+secret stays out of shell history and `ps`. Exit code 2 when no store URL is
+configured, and no network call is attempted in that case. See
+[Hyperloom authentication and credentials](authentication.md).
+
+### Output
+
+A JSON report on stdout, or to `--output`. It echoes the store URL but never
+the token. The fields to read first:
+
+* `historical`: p50 and p90 validated end-to-end (E2E) gain across the pool.
+* `by_shape`: per `tp/conc/isl/osl` bucket, the p50 gain plus p50 and best
+  throughput. Read this instead of `historical` when the pool spans shapes.
+* `sharding_whatif`: accepted parallelism layouts ranked per replay scope,
+  with the vLLM and SGLang spellings of tp/dp/ep/pp normalized.
+* `pool_warnings`: raised whenever the pool mixes models, boards, frameworks,
+  versions, precisions, or shapes — a median across those is not a prior for
+  any of them.
+* `limitations` and `sessions_scored`: how much the report is actually standing
+  on. Layout arms are frequently `n=1`, so treat rankings as directional.
+
+A KB record keeps only the layout its session settled on, so `sharding_whatif`
+carries `winners_only: true`: a layout that is absent was untried or
+unpublished, not beaten.
+
+---
+
 ## Additional operator tools
 
 The same tools package also contains smaller utilities that are useful during
@@ -199,3 +270,4 @@ Use these resources for related reference information:
 * [`session_breakdown.json` integration in Hyperloom](session-breakdown.md): The schema produced by `dump_session_breakdown.py`.
 * [Hyperloom self-hosting and operations guide](operations.md): Retention recommendations, including which scripts' outputs to back up long-term.
 * [Troubleshooting Hyperloom](troubleshooting.md): Symptoms vs which script to reach for first.
+* [Integrate Recipe knowledge base in Hyperloom](integrate-kb.md): The store `estimate_no_run.py` reads, and what a session publishes to it.

--- a/src/hyperloom/inference_optimizer/tests/test_no_run_estimate.py
+++ b/src/hyperloom/inference_optimizer/tests/test_no_run_estimate.py
@@ -22,19 +22,6 @@ from hyperloom.orchestrator.knowledge.remote_recipe.no_run import (
     sharding_whatif,
 )
 
-_CURRENT = {
-    "knowledge_schema_version": 1,
-    "record_kind": "hyperloom_recipe",
-    "optimized_throughput": 130.0,
-    "validated_e2e_gain": 30.0,
-    "value": {
-        "explore": {},
-        "framework": {},
-        "kernel": {},
-        "patch_timeline": [],
-    },
-}
-
 
 def test_percentile_interpolates() -> None:
     assert percentile([10.0, 20.0, 30.0], 50) == 20.0

--- a/src/hyperloom/inference_optimizer/tests/test_no_run_estimate.py
+++ b/src/hyperloom/inference_optimizer/tests/test_no_run_estimate.py
@@ -1,0 +1,336 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hyperloom.inference_optimizer.tools import estimate_no_run
+from hyperloom.inference_optimizer.tools.estimate_no_run import main as estimate_main
+from hyperloom.orchestrator.knowledge.remote_recipe.no_run import (
+    DEFAULT_PARALLELISM_LABEL,
+    estimate_from_sessions,
+    extract_parallelism,
+    identity_dimensions,
+    parallelism_whatif,
+    percentile,
+    project_session,
+    shape_key,
+    sharding_whatif,
+)
+
+_CURRENT = {
+    "knowledge_schema_version": 1,
+    "record_kind": "hyperloom_recipe",
+    "optimized_throughput": 130.0,
+    "validated_e2e_gain": 30.0,
+    "value": {
+        "explore": {},
+        "framework": {},
+        "kernel": {},
+        "patch_timeline": [],
+    },
+}
+
+
+def test_percentile_interpolates() -> None:
+    assert percentile([10.0, 20.0, 30.0], 50) == 20.0
+    assert percentile([], 50) is None
+
+
+def _shaped(
+    *,
+    cid: str,
+    gain: float,
+    optimized: float,
+    tp: int,
+    conc: int = 64,
+    isl: int = 1024,
+    osl: int = 256,
+) -> dict:
+    return {
+        "canonical_id": cid,
+        "session_id": f"{cid}-tp{tp}-{gain}",
+        "knowledge": {
+            "knowledge_schema_version": 1,
+            "record_kind": "hyperloom_recipe",
+            "optimized_throughput": optimized,
+            "validated_e2e_gain": gain,
+            "workload_shape": {"tp": tp, "conc": conc, "isl": isl, "osl": osl},
+            "value": {"explore": {}, "framework": {}, "kernel": {}, "patch_timeline": []},
+        },
+    }
+
+
+_MI355_SGLANG = "inference:llama:mi355x:sglang:llama:llamaforcausallm:0.5.17:bf16"
+_MI300_VLLM = "inference:llama:mi300x:vllm:llama:llamaforcausallm:0.9.1:bf16"
+
+
+def _sharded(
+    *,
+    cid: str = _MI355_SGLANG,
+    gain: float,
+    optimized: float = 1000.0,
+    tp: int = 2,
+    args: str = "",
+) -> dict:
+    doc = _shaped(cid=cid, gain=gain, optimized=optimized, tp=tp)
+    doc["session_id"] = f"{cid}-{gain}-{args}"
+    doc["knowledge"]["value"]["config"] = {"extra_server_args": args, "extra_envs": {}}
+    return doc
+
+
+def test_extract_parallelism_normalizes_across_frameworks() -> None:
+    sglang = extract_parallelism("--kv-cache-dtype fp8_e4m3 --tp-size 1 --dp-size 2 --schedule-policy fcfs")
+    vllm = extract_parallelism("--tensor-parallel-size=1 --data-parallel-size=2 --block-size 128")
+    assert sglang == {"tp": "1", "dp": "2"}
+    assert vllm == sglang
+
+
+def test_extract_parallelism_reads_boolean_switches_and_moe_knobs() -> None:
+    knobs = extract_parallelism(
+        "--ep-size 4 --enable-dp-attention --dp-size 8 --enable-dp-lm-head --moe-dense-tp-size 1"
+    )
+    assert knobs == {
+        "ep": "4",
+        "dp": "8",
+        "dp_attention": "on",
+        "dp_lm_head": "on",
+        "moe_dense_tp": "1",
+    }
+    assert extract_parallelism("--kv-cache-dtype fp8_e4m3") == {}
+    assert extract_parallelism("") == {}
+
+
+def test_project_session_labels_the_accepted_layout() -> None:
+    row = project_session(_sharded(gain=23.0, args="--tp-size 1 --dp-size 2"))
+    assert row["parallelism"] == {"tp": "1", "dp": "2"}
+    assert row["parallelism_label"] == "dp=2 tp=1"
+    assert project_session(_sharded(gain=5.0))["parallelism_label"] == DEFAULT_PARALLELISM_LABEL
+
+
+def test_sharding_whatif_ranks_layouts_at_fixed_world_size() -> None:
+    rows = [
+        project_session(_sharded(gain=8.0, tp=8)),
+        project_session(_sharded(gain=6.0, tp=8)),
+        project_session(_sharded(gain=23.0, tp=8, args="--ep-size 4 --enable-dp-attention")),
+    ]
+    report = sharding_whatif(rows)
+    assert report["sessions_with_parallelism_config"] == 1
+    assert report["knobs_seen"] == {"dp_attention": 1, "ep": 1}
+    scope = "llama/bf16/sglang/tp8/conc64/isl1024/osl256"
+    entry = report["scopes_with_alternatives"][scope]
+    assert entry["ranked_by_p50_gain"][0] == "dp_attention=on ep=4"
+    assert entry["best"]["p50_validated_e2e_gain_pct"] == 23.0
+    assert entry["strategies"][DEFAULT_PARALLELISM_LABEL]["sessions"] == 2
+    # 23.0 against the 7.0 median of the two default runs
+    assert entry["gain_pct_points_over_default"] == pytest.approx(16.0)
+
+
+def test_sharding_whatif_does_not_compare_layouts_across_world_sizes() -> None:
+    rows = [
+        project_session(_sharded(gain=23.0, tp=2, args="--tp-size 1 --dp-size 2")),
+        project_session(_sharded(gain=8.0, tp=8, args="--tp-size 1 --dp-size 2")),
+    ]
+    report = sharding_whatif(rows)
+    assert report["scopes_with_alternatives"] == {}
+    assert report["scopes_without_alternatives"] == 2
+
+
+def test_estimate_flags_winners_only_visibility() -> None:
+    # A record keeps the layout its session settled on and nothing it rejected,
+    # so silence about a layout has to read as untried rather than as beaten.
+    report = estimate_from_sessions([_sharded(gain=23.0, args="--tp-size 1 --dp-size 2")])
+    assert report["sharding_whatif"]["winners_only"] is True
+    assert any("not worse" in item for item in report["limitations"])
+
+
+def test_identity_dimensions_split_the_canonical_id() -> None:
+    dims = identity_dimensions(_MI355_SGLANG)
+    assert dims["hardware"] == "mi355x"
+    assert dims["framework_name"] == "sglang"
+    assert dims["precision"] == "bf16"
+    assert identity_dimensions("inference:too:short") == {}
+
+
+def test_project_session_carries_shape_and_per_gpu_throughput() -> None:
+    row = project_session(_shaped(cid=_MI355_SGLANG, gain=20.0, optimized=800.0, tp=8))
+    assert (row["tp"], row["conc"], row["isl"], row["osl"]) == (8, 64, 1024, 256)
+    assert row["tput_per_gpu"] == 100.0
+    assert shape_key(row) == "tp8/conc64/isl1024/osl256"
+
+
+def test_mixed_hardware_and_framework_pool_is_flagged() -> None:
+    report = estimate_from_sessions(
+        [
+            _shaped(cid=_MI355_SGLANG, gain=20.0, optimized=800.0, tp=8),
+            _shaped(cid=_MI300_VLLM, gain=40.0, optimized=400.0, tp=4),
+        ]
+    )
+    joined = " ".join(report["pool_warnings"])
+    assert "mixes hardware" in joined
+    assert "mixes frameworks" in joined
+    assert report["identity_mix"]["model"] == ["llama"]
+    assert report["identity_mix"]["framework_name"] == ["sglang", "vllm"]
+
+
+def test_shape_filter_scopes_the_pool_and_counts_drops() -> None:
+    docs = [
+        _shaped(cid=_MI355_SGLANG, gain=10.0, optimized=800.0, tp=8),
+        _shaped(cid=_MI355_SGLANG, gain=50.0, optimized=200.0, tp=1),
+    ]
+    scoped = estimate_from_sessions(docs, shape={"tp": 8})
+    assert scoped["sessions_scored"] == 1
+    assert scoped["sessions_dropped_by_shape_filter"] == 1
+    assert scoped["historical"]["p50_validated_e2e_gain_pct"] == 10.0
+    assert not any("workload shapes" in w for w in scoped["pool_warnings"])
+
+    pooled = estimate_from_sessions(docs)
+    assert pooled["historical"]["p50_validated_e2e_gain_pct"] == 30.0
+    assert any("workload shapes" in w for w in pooled["pool_warnings"])
+    assert set(pooled["by_shape"]) == {
+        "tp8/conc64/isl1024/osl256",
+        "tp1/conc64/isl1024/osl256",
+    }
+
+
+def test_parallelism_whatif_measures_retention_and_projects_target() -> None:
+    rows = [
+        project_session(_shaped(cid=_MI355_SGLANG, gain=10.0, optimized=200.0, tp=2)),
+        project_session(_shaped(cid=_MI355_SGLANG, gain=12.0, optimized=600.0, tp=8)),
+    ]
+    report = parallelism_whatif(rows, target_tp=4)
+    assert report["observed_tp"] == [2, 8]
+    assert report["replayable_across_tp"] is False
+    family = report["families"]["llama/bf16/conc64/isl1024/osl256"]
+    # per-GPU falls 100 -> 75 tok/s across the 4x TP step
+    assert family["measured_scaling"]["per_gpu_retention"] == pytest.approx(0.75)
+    projection = family["projection"]
+    assert projection["source_tp"] == 2
+    assert projection["ideal_flat_per_gpu"] == pytest.approx(400.0)
+    assert projection["efficiency_adjusted"] == pytest.approx(300.0)
+
+    observed = parallelism_whatif(rows, target_tp=8)["families"]["llama/bf16/conc64/isl1024/osl256"]["projection"]
+    assert observed["source"] == "observed"
+    assert observed["p50_optimized_throughput"] == 600.0
+
+    assert parallelism_whatif([], target_tp=4)["projection"]["reason"]
+
+
+def test_whatif_does_not_compare_tp_across_different_models() -> None:
+    """A small model at TP1 must not set the scaling baseline for a large model at TP8."""
+    small = "inference:qwen3-0.6b:mi355x:sglang:qwen3:qwen3forcausallm:0.5.17:bf16"
+    large = "inference:llama-70b:mi355x:sglang:llama:llamaforcausallm:0.5.17:bf16"
+    rows = [
+        project_session(_shaped(cid=small, gain=30.0, optimized=20000.0, tp=1)),
+        project_session(_shaped(cid=large, gain=14.0, optimized=1200.0, tp=8)),
+    ]
+    report = parallelism_whatif(rows, target_tp=4)
+    assert set(report["families"]) == {
+        "qwen3-0.6b/bf16/conc64/isl1024/osl256",
+        "llama-70b/bf16/conc64/isl1024/osl256",
+    }
+    for family in report["families"].values():
+        assert "measured_scaling" not in family
+
+
+def test_whatif_does_not_compare_tp_across_different_isl() -> None:
+    """A short-ISL TP1 run must not set the scaling baseline for a long-ISL TP8 run."""
+    rows = [
+        project_session(_shaped(cid=_MI355_SGLANG, gain=30.0, optimized=20000.0, tp=1, isl=1024)),
+        project_session(_shaped(cid=_MI355_SGLANG, gain=14.0, optimized=1200.0, tp=8, isl=8192)),
+    ]
+    report = parallelism_whatif(rows, target_tp=4)
+    assert set(report["families"]) == {"llama/bf16/conc64/isl1024/osl256", "llama/bf16/conc64/isl8192/osl256"}
+    for family in report["families"].values():
+        assert "measured_scaling" not in family
+        assert family["projection"]["source"] == "scaled"
+        assert family["projection"]["ideal_flat_per_gpu"] == family["projection"]["efficiency_adjusted"]
+
+
+def test_whatif_reaches_the_cli(tmp_path: Path) -> None:
+    docs = [
+        _shaped(cid=_MI355_SGLANG, gain=10.0, optimized=200.0, tp=2),
+        _shaped(cid=_MI355_SGLANG, gain=12.0, optimized=600.0, tp=8),
+    ]
+    src = tmp_path / "sessions.json"
+    src.write_text(json.dumps(docs), encoding="utf-8")
+    out = tmp_path / "report.json"
+    assert estimate_main(["--input", str(src), "--target-tp", "4", "--output", str(out)]) == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    family = report["parallelism_whatif"]["families"]["llama/bf16/conc64/isl1024/osl256"]
+    assert family["projection"]["target_tp"] == 4
+
+
+def _args(**overrides):
+    from argparse import Namespace
+
+    base = {"kb_store_url": "", "kb_store_token": "", "kb_store_token_file": None}
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def test_credentials_prefer_flags_then_file_then_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_STORE_URL", "https://env-host/kb")
+    monkeypatch.setenv("KB_STORE_TOKEN", "env-token")
+
+    assert estimate_no_run.resolve_credentials(_args()) == ("https://env-host/kb", "env-token")
+
+    token_file = tmp_path / "kb_store_token"
+    token_file.write_text("file-token\n", encoding="utf-8")
+    url, token = estimate_no_run.resolve_credentials(
+        _args(kb_store_url="https://flag-host/kb/", kb_store_token_file=token_file)
+    )
+    assert (url, token) == ("https://flag-host/kb", "file-token")
+
+    _, token = estimate_no_run.resolve_credentials(_args(kb_store_token="flag-token", kb_store_token_file=token_file))
+    assert token == "flag-token"
+
+
+def test_missing_store_url_exits_without_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_STORE_URL", raising=False)
+    monkeypatch.delenv("KB_STORE_TOKEN", raising=False)
+    assert estimate_main([]) == 2
+
+
+def test_report_never_echoes_the_token(tmp_path: Path) -> None:
+    src = tmp_path / "sessions.json"
+    src.write_text(json.dumps([_sharded(gain=10.0)]), encoding="utf-8")
+    out = tmp_path / "report.json"
+    assert estimate_main(["--input", str(src), "--kb-store-token", "super-secret", "--output", str(out)]) == 0
+    assert "super-secret" not in out.read_text(encoding="utf-8")
+
+
+def test_estimate_cli_offline(tmp_path: Path) -> None:
+    payload = [
+        _sharded(gain=30.0, args="--tp-size 2 --enable-dp-attention"),
+        _sharded(gain=10.0, args=""),
+    ]
+    src = tmp_path / "sessions.json"
+    src.write_text(json.dumps(payload), encoding="utf-8")
+    out = tmp_path / "report.json"
+    rc = estimate_main(["--input", str(src), "--output", str(out)])
+    assert rc == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["sessions_scored"] == 2
+    assert report["historical"]["p50_validated_e2e_gain_pct"] == pytest.approx(20.0)
+
+
+def test_the_estimator_reads_only_replay_fields(tmp_path: Path) -> None:
+    """Execution evidence is the session pipeline's to report, not the KB's.
+
+    Pinned as a test rather than left to review, because the cheap way to add
+    a headroom forecast later is to start reading roofline arms back out of a
+    replay record, which is the boundary this tool was split to respect.
+    """
+    src = tmp_path / "sessions.json"
+    src.write_text(json.dumps([_sharded(gain=30.0, args="--tp-size 2")]), encoding="utf-8")
+    out = tmp_path / "report.json"
+    assert estimate_main(["--input", str(src), "--output", str(out)]) == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    for section in ("forecast", "savings_prior"):
+        assert section not in report
+    assert set(report["coverage"]) == {"with_gain"}

--- a/src/hyperloom/inference_optimizer/tools/estimate_no_run.py
+++ b/src/hyperloom/inference_optimizer/tools/estimate_no_run.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Estimate Hyperloom uplift from the Recipe KB without running a session.
+
+Pulls per-session documents (or reads a local JSON list) and prints what prior
+sessions already settled for a scope: the distribution of validated gain, and
+which parallelism layout won inside a fixed GPU count. Scoped by identity and
+by the full tp/conc/isl/osl replay scope, because a pooled median across
+models or shapes is not a prior for any of them.
+
+Credentials are parameters, never literals in this file. Resolution order is
+``--kb-store-token`` then ``--kb-store-token-file`` then ``KB_STORE_TOKEN``;
+prefer the file form so the secret stays out of shell history and ``ps``.
+The report echoes the store URL but never the token.
+
+Examples
+--------
+
+::
+
+    python -m hyperloom.inference_optimizer.tools.estimate_no_run \\
+        --kb-store-url https://host/knowledge-base \\
+        --kb-store-token-file ~/.secrets/kb_store_token \\
+        --hardware mi355x --framework-name sglang
+
+    export KB_STORE_URL=... KB_STORE_TOKEN=...
+    python -m hyperloom.inference_optimizer.tools.estimate_no_run --hardware mi355x
+
+    python -m hyperloom.inference_optimizer.tools.estimate_no_run \\
+        --input prior_sessions.json --tp 8 --isl 1024 --osl 256
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from hyperloom.orchestrator.knowledge.remote_recipe.no_run import (
+    estimate_from_sessions,
+    fetch_session_documents,
+)
+from hyperloom.orchestrator.knowledge.remote_recipe._vendor.kb_store_client import (
+    KBStoreClient,
+    KBStoreError,
+)
+
+
+def _load_input(path: Path) -> list[dict[str, Any]]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(raw, list):
+        return [item for item in raw if isinstance(item, dict)]
+    if isinstance(raw, dict) and isinstance(raw.get("sessions"), list):
+        return [item for item in raw["sessions"] if isinstance(item, dict)]
+    if isinstance(raw, dict):
+        return [raw]
+    raise SystemExit(f"{path}: expected a session object, a list, or {{sessions: [...]}}")
+
+
+def resolve_credentials(args: argparse.Namespace) -> tuple[str, str]:
+    """Resolve store URL + token from flags, then a token file, then env."""
+    url = (args.kb_store_url or os.environ.get("KB_STORE_URL") or "").strip().rstrip("/")
+    token = (args.kb_store_token or "").strip()
+    if not token and args.kb_store_token_file is not None:
+        path = Path(args.kb_store_token_file).expanduser()
+        try:
+            token = path.read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            raise SystemExit(f"cannot read --kb-store-token-file {path}: {exc}")
+    if not token:
+        token = (os.environ.get("KB_STORE_TOKEN") or "").strip()
+    return url, token
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        help="Offline JSON of session envelopes (skips the live store).",
+    )
+    parser.add_argument(
+        "--kb-store-url",
+        dest="kb_store_url",
+        default="",
+        help="KB Store base URL; falls back to $KB_STORE_URL.",
+    )
+    parser.add_argument(
+        "--kb-store-token",
+        dest="kb_store_token",
+        default="",
+        help="Bearer token. Visible in ps/history; prefer --kb-store-token-file.",
+    )
+    parser.add_argument(
+        "--kb-store-token-file",
+        dest="kb_store_token_file",
+        type=Path,
+        default=None,
+        help="File holding only the bearer token; falls back to $KB_STORE_TOKEN.",
+    )
+    parser.add_argument("--hardware", help="Search match: hardware (e.g. mi355x).")
+    parser.add_argument("--framework-name", dest="framework_name", help="Search match: framework_name.")
+    parser.add_argument("--model", help="Search match: model.")
+    parser.add_argument("--precision", help="Search match: precision.")
+    parser.add_argument("--canonical-id", action="append", default=[], help="Fetch this identity (repeatable).")
+    parser.add_argument("--max-identities", type=int, default=50)
+    for key, helptext in (
+        ("tp", "tensor parallelism"),
+        ("conc", "concurrency"),
+        ("isl", "input sequence length"),
+        ("osl", "output sequence length"),
+    ):
+        parser.add_argument(
+            f"--{key}",
+            type=int,
+            default=None,
+            help=f"Restrict the pool to this {helptext} (replay scope dimension).",
+        )
+    parser.add_argument(
+        "--target-tp",
+        dest="target_tp",
+        type=int,
+        default=None,
+        help="Project this TP from observed per-GPU throughput (prior, not a replay).",
+    )
+    parser.add_argument("--output", type=Path, help="Write JSON here; default stdout.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    errors: list[str] = []
+    store_url = ""
+    if args.input is not None:
+        documents = _load_input(args.input)
+    else:
+        store_url, token = resolve_credentials(args)
+        if not store_url:
+            print(
+                "KB store is not configured: pass --kb-store-url or set KB_STORE_URL",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            store = KBStoreClient(store_url, token)
+        except KBStoreError as exc:
+            print(f"KB store is not configured: {exc}", file=sys.stderr)
+            return 2
+        match: dict[str, str] = {}
+        if args.model:
+            match["model"] = args.model
+        if args.hardware:
+            match["hardware"] = args.hardware
+        if args.framework_name:
+            match["framework_name"] = args.framework_name
+        if args.precision:
+            match["precision"] = args.precision
+        hardware_in = [args.hardware] if args.hardware and not match else None
+        # Prefer exact match; hardware_in is for multi-board scans without a match dict.
+        if match:
+            hardware_in = None
+        try:
+            documents, errors = fetch_session_documents(
+                store,
+                match=match or None,
+                hardware_in=hardware_in,
+                max_identities=max(1, args.max_identities),
+                canonical_ids=list(args.canonical_id) or None,
+            )
+        except KBStoreError as exc:
+            print(f"KB fetch failed: {exc}", file=sys.stderr)
+            return 1
+    report = estimate_from_sessions(
+        documents,
+        shape={key: getattr(args, key) for key in ("tp", "conc", "isl", "osl")},
+        target_tp=args.target_tp,
+    )
+    report["fetch_errors"] = errors
+    report["kb_store_url"] = store_url
+    text = json.dumps(report, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/hyperloom/orchestrator/knowledge/remote_recipe/no_run.py
+++ b/src/hyperloom/orchestrator/knowledge/remote_recipe/no_run.py
@@ -1,0 +1,633 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""No-run uplift estimates mined from Recipe KB session documents.
+
+Deciding whether a target is worth a session meant running one. This reads
+per-session envelopes instead (``GET /v1/kb/{id}/sessions/{sid}``, or an
+offline JSON list) and reports what prior sessions already settled: the
+distribution of ``validated_e2e_gain``, and which parallelism layout won
+inside a fixed GPU count.
+
+It reads only what the Recipe KB already owns as replay material --
+``validated_e2e_gain``, ``workload_shape``, and the accepted
+``value.config.extra_server_args`` a layout is read out of. Execution
+evidence such as roofline arms, host platform, or token spend belongs to the
+session-evidence pipeline rather than to a replay record, so a
+remaining-headroom forecast is deliberately not attempted here.
+
+Scoping is the whole difficulty. Pooling every session a search returns makes
+the median meaningless, so rows are grouped by identity and by the full
+``tp/conc/isl/osl`` replay scope, and ``pool_warnings`` names any pool that
+spans models, boards, frameworks, versions, or precisions.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Any
+
+from ._vendor.kb_store_client import KBStoreClient, KBStoreError
+
+_SEARCH_PAGE = 50
+_SEARCH_PAGE_CAP = 20
+
+#: Order of the seven identity dimensions inside an ``inference:`` canonical id.
+_IDENTITY_DIMENSIONS = (
+    "model",
+    "hardware",
+    "framework_name",
+    "model_type",
+    "architectures",
+    "framework_version",
+    "precision",
+)
+#: Replay-sensitive workload dimensions; RecipeScope demands an exact match on
+#: all four, so pooling gains across them is a prior, never a replayable claim.
+_SHAPE_KEYS = ("tp", "conc", "isl", "osl")
+
+#: Server-arg flags that re-shard the model, normalized across frameworks so a
+#: vLLM ``--tensor-parallel-size`` and an SGLang ``--tp-size`` compare as ``tp``.
+#: ``workload_shape.tp`` is the GPU count; these decide the layout inside it.
+_PARALLELISM_VALUE_FLAGS = {
+    "tp-size": "tp",
+    "tensor-parallel-size": "tp",
+    "dp-size": "dp",
+    "data-parallel-size": "dp",
+    "ep-size": "ep",
+    "expert-parallel-size": "ep",
+    "pp-size": "pp",
+    "pipeline-parallel-size": "pp",
+    "moe-dense-tp-size": "moe_dense_tp",
+    "decode-tp-size": "decode_tp",
+    "prefill-tp-size": "prefill_tp",
+}
+#: Boolean parallelism switches; presence alone changes the layout.
+_PARALLELISM_BOOL_FLAGS = {
+    "enable-dp-attention": "dp_attention",
+    "enable-dp-lm-head": "dp_lm_head",
+    "enable-expert-parallel": "expert_parallel",
+    "enable-ep-moe": "ep_moe",
+    "enable-deepep-moe": "deepep_moe",
+}
+#: Label used when a session accepted no explicit parallelism flag.
+DEFAULT_PARALLELISM_LABEL = "framework-default"
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def identity_dimensions(canonical_id: str) -> dict[str, str]:
+    """Split an ``inference:`` canonical id into its identity dimensions."""
+    parts = str(canonical_id or "").split(":")
+    if len(parts) != len(_IDENTITY_DIMENSIONS) + 1:
+        return {}
+    return dict(zip(_IDENTITY_DIMENSIONS, (part.strip() for part in parts[1:])))
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        resolved = int(value)
+    except (TypeError, ValueError):
+        return None
+    return resolved if resolved > 0 else None
+
+
+def _finite(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def percentile(values: list[float], p: float) -> float | None:
+    """Linear interpolation percentile; ``None`` when ``values`` is empty."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * (max(0.0, min(100.0, p)) / 100.0)
+    lo = int(math.floor(rank))
+    hi = int(math.ceil(rank))
+    if lo == hi:
+        return ordered[lo]
+    frac = rank - lo
+    return ordered[lo] * (1.0 - frac) + ordered[hi] * frac
+
+
+def project_session(document: Mapping[str, Any]) -> dict[str, Any]:
+    """Flatten one session envelope into miner fields."""
+    knowledge = _mapping(document.get("knowledge")) or (
+        dict(document) if document.get("record_kind") or document.get("knowledge_schema_version") else {}
+    )
+    value = _mapping(knowledge.get("value"))
+    gain = _finite(knowledge.get("validated_e2e_gain"))
+    canonical_id = str(document.get("canonical_id") or knowledge.get("canonical_id") or "")
+    dims = identity_dimensions(canonical_id)
+    shape_source = _mapping(knowledge.get("workload_shape"))
+    optimized_throughput = _finite(knowledge.get("optimized_throughput"))
+    tp = _positive_int(shape_source.get("tp"))
+    row = {
+        "canonical_id": canonical_id,
+        "session_id": str(document.get("session_id") or ""),
+        "model": dims.get("model", ""),
+        "hardware": dims.get("hardware", ""),
+        "framework_name": dims.get("framework_name", ""),
+        "framework_version": dims.get("framework_version", ""),
+        "precision": dims.get("precision", ""),
+        "optimized_throughput": optimized_throughput,
+        "validated_e2e_gain": gain,
+    }
+    for key in _SHAPE_KEYS:
+        row[key] = _positive_int(shape_source.get(key))
+    accepted_args = str(_mapping(value.get("config")).get("extra_server_args") or "")
+    knobs = extract_parallelism(accepted_args)
+    row["parallelism"] = knobs
+    row["parallelism_label"] = parallelism_label(knobs)
+    # Per-GPU throughput is the only cross-TP comparable figure; total tok/s
+    # rises with TP even when parallel efficiency is falling.
+    row["tput_per_gpu"] = (
+        optimized_throughput / tp if optimized_throughput is not None and optimized_throughput > 0 and tp else None
+    )
+    return row
+
+
+def shape_key(row: Mapping[str, Any]) -> str:
+    """Render a row's replay scope as ``tp8/conc64/isl1024/osl256``."""
+    parts = []
+    for key in _SHAPE_KEYS:
+        value = row.get(key)
+        parts.append(f"{key}{value}" if value else f"{key}?")
+    return "/".join(parts)
+
+
+def matches_shape(row: Mapping[str, Any], shape: Mapping[str, Any] | None) -> bool:
+    """True when a row satisfies every requested workload dimension."""
+    if not shape:
+        return True
+    for key in _SHAPE_KEYS:
+        wanted = _positive_int(shape.get(key))
+        if wanted is None:
+            continue
+        if _positive_int(row.get(key)) != wanted:
+            return False
+    return True
+
+
+def _bucket_stats(rows: list[Mapping[str, Any]]) -> dict[str, Any]:
+    gains = [row["validated_e2e_gain"] for row in rows if row.get("validated_e2e_gain") is not None]
+    tputs = [row["optimized_throughput"] for row in rows if row.get("optimized_throughput") is not None]
+    per_gpu = [row["tput_per_gpu"] for row in rows if row.get("tput_per_gpu") is not None]
+    return {
+        "sessions": len(rows),
+        "p50_validated_e2e_gain_pct": percentile(gains, 50),
+        "p50_optimized_throughput": percentile(tputs, 50),
+        "best_optimized_throughput": max(tputs) if tputs else None,
+        "p50_tput_per_gpu": percentile(per_gpu, 50),
+    }
+
+
+def extract_parallelism(server_args: str) -> dict[str, str]:
+    """Pull normalized parallelism knobs out of an accepted server-arg string.
+
+    Handles both ``--flag value`` and ``--flag=value`` spellings and maps
+    framework-specific names onto shared keys, so ``--tp-size 1 --dp-size 2``
+    and ``--tensor-parallel-size 1 --data-parallel-size 2`` both read as
+    ``{"tp": "1", "dp": "2"}``.
+    """
+    tokens = str(server_args or "").split()
+    knobs: dict[str, str] = {}
+    for index, token in enumerate(tokens):
+        if not token.startswith("--"):
+            continue
+        name, _, inline = token[2:].partition("=")
+        name = name.strip().lower()
+        if name in _PARALLELISM_BOOL_FLAGS:
+            knobs[_PARALLELISM_BOOL_FLAGS[name]] = "on"
+            continue
+        canonical = _PARALLELISM_VALUE_FLAGS.get(name)
+        if canonical is None:
+            continue
+        value = inline.strip() if inline else ""
+        if not value and index + 1 < len(tokens) and not tokens[index + 1].startswith("--"):
+            value = tokens[index + 1].strip()
+        if value:
+            knobs[canonical] = value
+    return knobs
+
+
+def parallelism_label(knobs: Mapping[str, str]) -> str:
+    """Render parallelism knobs as a stable, sortable label."""
+    if not knobs:
+        return DEFAULT_PARALLELISM_LABEL
+    return " ".join(f"{key}={knobs[key]}" for key in sorted(knobs))
+
+
+def workload_family(row: Mapping[str, Any]) -> str:
+    """Everything a TP comparison must hold fixed, e.g.
+    ``qwen3-32b/bf16/conc64/isl8192/osl1024``.
+
+    TP is only comparable inside one family. Two confounds otherwise dominate
+    and both were observed in live data: ISL changes arithmetic intensity, and
+    model size dictates the TP that fits at all, so a 0.6B at TP1 against a
+    70B at TP8 reads as catastrophic scaling when nothing scaled.
+    """
+    parts = [row.get("model") or "model?", row.get("precision") or "precision?"]
+    for key in _SHAPE_KEYS:
+        if key == "tp":
+            continue
+        value = row.get(key)
+        parts.append(f"{key}{value}" if value else f"{key}?")
+    return "/".join(str(part) for part in parts)
+
+
+def _family_whatif(rows: list[Mapping[str, Any]], target_tp: int | None) -> dict[str, Any]:
+    by_tp: dict[int, list[Mapping[str, Any]]] = {}
+    for row in rows:
+        tp = _positive_int(row.get("tp"))
+        if tp is not None:
+            by_tp.setdefault(tp, []).append(row)
+    buckets = {str(tp): _bucket_stats(items) for tp, items in sorted(by_tp.items())}
+    report: dict[str, Any] = {"observed_tp": sorted(by_tp), "by_tp": buckets}
+    comparable = {
+        tp: buckets[str(tp)]["p50_tput_per_gpu"]
+        for tp in sorted(by_tp)
+        if buckets[str(tp)]["p50_tput_per_gpu"] is not None
+    }
+    efficiency: float | None = None
+    if len(comparable) >= 2:
+        lo_tp = min(comparable)
+        hi_tp = max(comparable)
+        if comparable[lo_tp] > 0:
+            efficiency = comparable[hi_tp] / comparable[lo_tp]
+            report["measured_scaling"] = {
+                "from_tp": lo_tp,
+                "to_tp": hi_tp,
+                "per_gpu_retention": efficiency,
+                "reading": "1.0 = flat per-GPU throughput; below 1.0 means each added GPU returns less",
+            }
+    if target_tp is None:
+        return report
+    if not comparable:
+        report["projection"] = {"target_tp": target_tp, "reason": "no per-GPU baseline in this family"}
+        return report
+    if target_tp in comparable:
+        report["projection"] = {
+            "target_tp": target_tp,
+            "source": "observed",
+            "sessions": buckets[str(target_tp)]["sessions"],
+            "p50_optimized_throughput": buckets[str(target_tp)]["p50_optimized_throughput"],
+            "p50_validated_e2e_gain_pct": buckets[str(target_tp)]["p50_validated_e2e_gain_pct"],
+        }
+        return report
+    source_tp = min(comparable, key=lambda tp: (abs(tp - target_tp), tp))
+    per_gpu = comparable[source_tp]
+    ideal = per_gpu * target_tp
+    adjusted = ideal * efficiency if efficiency is not None and target_tp > source_tp else ideal
+    report["projection"] = {
+        "target_tp": target_tp,
+        "source": "scaled",
+        "source_tp": source_tp,
+        "source_p50_tput_per_gpu": per_gpu,
+        "ideal_flat_per_gpu": ideal,
+        "efficiency_adjusted": adjusted,
+        "range": sorted({round(min(ideal, adjusted), 4), round(max(ideal, adjusted), 4)}),
+        "assumption": "flat per-GPU is the optimistic bound; adjusted applies the measured retention",
+    }
+    return report
+
+
+def replay_scope_key(row: Mapping[str, Any]) -> str:
+    """Everything a sharding comparison must hold fixed, GPU count included.
+
+    Comparing layouts only makes sense at a fixed world size: ``tp=1 dp=2`` on
+    two GPUs against ``tp=2`` on two GPUs is a real choice, while the same
+    label on eight GPUs is a different experiment.
+    """
+    return "/".join(
+        (
+            str(row.get("model") or "model?"),
+            str(row.get("precision") or "precision?"),
+            str(row.get("framework_name") or "framework?"),
+            shape_key(row),
+        )
+    )
+
+
+def sharding_whatif(rows: list[Mapping[str, Any]]) -> dict[str, Any]:
+    """Rank the parallelism layouts prior runs accepted, at fixed world size.
+
+    This is the parallelism what-if the store can actually answer today:
+    ``workload_shape.tp`` fixes the GPU count, and the accepted server args
+    show how the model was sharded inside it. A record keeps only the layout
+    its session settled on, so an absent layout was never tried or never
+    published rather than tried and beaten -- which is what ``winners_only``
+    says, and why these rank rather than score.
+    """
+    scopes: dict[str, dict[str, list[Mapping[str, Any]]]] = {}
+    knobs_seen: dict[str, int] = {}
+    configured = 0
+    for row in rows:
+        knobs = _mapping(row.get("parallelism"))
+        if knobs:
+            configured += 1
+            for key in knobs:
+                knobs_seen[key] = knobs_seen.get(key, 0) + 1
+        label = str(row.get("parallelism_label") or DEFAULT_PARALLELISM_LABEL)
+        scopes.setdefault(replay_scope_key(row), {}).setdefault(label, []).append(row)
+
+    compared: dict[str, Any] = {}
+    single = 0
+    for scope, by_label in sorted(scopes.items()):
+        if len(by_label) < 2:
+            single += 1
+            continue
+        strategies = {}
+        for label, items in by_label.items():
+            stats = _bucket_stats(items)
+            strategies[label] = {
+                "sessions": stats["sessions"],
+                "p50_validated_e2e_gain_pct": stats["p50_validated_e2e_gain_pct"],
+                "best_validated_e2e_gain_pct": max(
+                    (row["validated_e2e_gain"] for row in items if row.get("validated_e2e_gain") is not None),
+                    default=None,
+                ),
+                "p50_optimized_throughput": stats["p50_optimized_throughput"],
+            }
+        ranked = sorted(
+            (label for label, s in strategies.items() if s["p50_validated_e2e_gain_pct"] is not None),
+            key=lambda label: -strategies[label]["p50_validated_e2e_gain_pct"],
+        )
+        entry: dict[str, Any] = {"strategies": strategies, "ranked_by_p50_gain": ranked}
+        if ranked:
+            best = ranked[0]
+            entry["best"] = {"label": best, **strategies[best]}
+            baseline = strategies.get(DEFAULT_PARALLELISM_LABEL)
+            if (
+                baseline is not None
+                and baseline["p50_validated_e2e_gain_pct"] is not None
+                and best != DEFAULT_PARALLELISM_LABEL
+            ):
+                entry["gain_pct_points_over_default"] = (
+                    strategies[best]["p50_validated_e2e_gain_pct"] - baseline["p50_validated_e2e_gain_pct"]
+                )
+        compared[scope] = entry
+
+    return {
+        "sessions_with_parallelism_config": configured,
+        "knobs_seen": dict(sorted(knobs_seen.items())),
+        "scopes_with_alternatives": compared,
+        "scopes_without_alternatives": single,
+        "winners_only": True,
+        "note": (
+            "layouts are compared at a fixed GPU count (workload_shape.tp); "
+            "only accepted layouts are published, so a missing layout means "
+            "untried or unpublished, not worse"
+        ),
+    }
+
+
+def parallelism_whatif(
+    rows: list[Mapping[str, Any]],
+    *,
+    target_tp: int | None = None,
+) -> dict[str, Any]:
+    """Compare TP within each workload family and project a target TP.
+
+    Cross-TP is never a replay: ``RecipeScope`` requires an exact
+    ``tp/conc/isl/osl`` match, so a different TP is a fresh run whose only
+    inherited asset is the recipe's direction. Every figure is grouped by
+    :func:`workload_family` so TP scaling is not confounded by ISL/OSL.
+    """
+    families: dict[str, list[Mapping[str, Any]]] = {}
+    observed: set[int] = set()
+    for row in rows:
+        tp = _positive_int(row.get("tp"))
+        if tp is None:
+            continue
+        observed.add(tp)
+        families.setdefault(workload_family(row), []).append(row)
+    report: dict[str, Any] = {
+        "observed_tp": sorted(observed),
+        "families": {key: _family_whatif(items, target_tp) for key, items in sorted(families.items())},
+        "replayable_across_tp": False,
+        "note": (
+            "TP is compared only within a fixed conc/isl/osl family; cross-TP "
+            "figures are priors, since RecipeScope requires an exact scope match"
+        ),
+    }
+    if target_tp is not None and not families:
+        report["projection"] = {"target_tp": target_tp, "reason": "no session carried a workload shape"}
+    return report
+
+
+def estimate_from_sessions(
+    documents: list[Mapping[str, Any]],
+    *,
+    shape: Mapping[str, Any] | None = None,
+    target_tp: int | None = None,
+) -> dict[str, Any]:
+    """Aggregate prior sessions into a scoped gain prior and layout ranking.
+
+    ``shape`` restricts the pool to one replay scope (any subset of
+    ``tp``/``conc``/``isl``/``osl``). Without it the headline numbers pool
+    every workload shape, which is a weaker prior — ``by_shape`` and
+    ``pool_warnings`` make that visible.
+    """
+    all_rows = [project_session(doc) for doc in documents if isinstance(doc, Mapping)]
+    rows = [row for row in all_rows if matches_shape(row, shape)]
+    gains = [row["validated_e2e_gain"] for row in rows if row.get("validated_e2e_gain") is not None]
+
+    limitations: list[str] = []
+    if not rows:
+        limitations.append("no session documents")
+    if rows and not gains:
+        limitations.append("no validated_e2e_gain on any pooled session; nothing to form a prior from")
+    # Only accepted layouts are published, so an absent arm is untried or
+    # unpublished rather than beaten. Said once here so a reader does not have
+    # to infer it from the winners_only flag alone.
+    limitations.append("only winning layouts are published, so an absent layout is untried or unpublished, not worse")
+
+    model_mix = sorted({row["model"] for row in rows if row.get("model")})
+    hardware_mix = sorted({row["hardware"] for row in rows if row.get("hardware")})
+    framework_mix = sorted({row["framework_name"] for row in rows if row.get("framework_name")})
+    version_mix = sorted({row["framework_version"] for row in rows if row.get("framework_version")})
+    precision_mix = sorted({row["precision"] for row in rows if row.get("precision")})
+    shape_groups: dict[str, list[Mapping[str, Any]]] = {}
+    for row in rows:
+        shape_groups.setdefault(shape_key(row), []).append(row)
+
+    pool_warnings: list[str] = []
+    if len(model_mix) > 1:
+        pool_warnings.append(
+            f"pool mixes {len(model_mix)} models {model_mix[:6]}; absolute throughput is not comparable across them"
+        )
+    if len(hardware_mix) > 1:
+        pool_warnings.append(f"pool mixes hardware {hardware_mix}; gains are not comparable across boards")
+    if len(framework_mix) > 1:
+        pool_warnings.append(f"pool mixes frameworks {framework_mix}; vllm and sglang gains are not interchangeable")
+    if len(version_mix) > 1:
+        pool_warnings.append(f"pool mixes framework versions {version_mix}; a fixed upstream regression inflates gain")
+    if len(precision_mix) > 1:
+        pool_warnings.append(f"pool mixes precisions {precision_mix}; replay requires an exact precision match")
+    if shape is None and len(shape_groups) > 1:
+        pool_warnings.append(
+            f"pool mixes {len(shape_groups)} workload shapes; pass tp/conc/isl/osl to scope, or read by_shape"
+        )
+
+    n = len(rows)
+    return {
+        "sessions_scored": n,
+        "sessions_dropped_by_shape_filter": len(all_rows) - n,
+        "identity_mix": {
+            "model": model_mix,
+            "hardware": hardware_mix,
+            "framework_name": framework_mix,
+            "framework_version": version_mix,
+            "precision": precision_mix,
+        },
+        "pool_warnings": pool_warnings,
+        "requested_shape": {key: _positive_int((shape or {}).get(key)) for key in _SHAPE_KEYS},
+        "by_shape": {key: _bucket_stats(items) for key, items in sorted(shape_groups.items())},
+        "parallelism_whatif": parallelism_whatif(rows, target_tp=target_tp),
+        "sharding_whatif": sharding_whatif(rows),
+        "coverage": {
+            "with_gain": len(gains),
+        },
+        "historical": {
+            "p50_validated_e2e_gain_pct": percentile(gains, 50),
+            "p90_validated_e2e_gain_pct": percentile(gains, 90),
+        },
+        "limitations": limitations,
+        "sessions": rows,
+    }
+
+
+def _session_ids_from_rollup(rollup: Mapping[str, Any] | None) -> list[str]:
+    if not isinstance(rollup, Mapping):
+        return []
+    ids: list[str] = []
+    for row in rollup.get("sessions") or []:
+        if isinstance(row, str) and row.strip():
+            ids.append(row.strip())
+        elif isinstance(row, Mapping):
+            sid = str(row.get("session_id") or "").strip()
+            if sid:
+                ids.append(sid)
+    champion = rollup.get("champion")
+    if isinstance(champion, Mapping):
+        sid = str(champion.get("session_id") or "").strip()
+        if sid:
+            ids.append(sid)
+    seen: set[str] = set()
+    unique: list[str] = []
+    for sid in ids:
+        if sid not in seen:
+            seen.add(sid)
+            unique.append(sid)
+    return unique
+
+
+def search_inference_identities(
+    store: KBStoreClient,
+    *,
+    match: dict[str, str] | None = None,
+    hardware_in: list[str] | None = None,
+    max_identities: int = 200,
+) -> list[dict[str, Any]]:
+    """Page ``POST /v1/kb/search`` for inference identities."""
+    items: list[dict[str, Any]] = []
+    offset = 0
+    for _ in range(_SEARCH_PAGE_CAP):
+        if len(items) >= max_identities:
+            break
+        result = store.search_identities(
+            scheme="inference",
+            match=match,
+            hardware_in=hardware_in,
+            offset=offset,
+            limit=min(_SEARCH_PAGE, max_identities - len(items)),
+        )
+        page = result.get("items") if isinstance(result, Mapping) else None
+        if not isinstance(page, list) or not page:
+            break
+        for item in page:
+            if isinstance(item, Mapping):
+                items.append(dict(item))
+                if len(items) >= max_identities:
+                    break
+        if len(page) < _SEARCH_PAGE:
+            break
+        offset += len(page)
+    return items
+
+
+def fetch_session_documents(
+    store: KBStoreClient,
+    *,
+    match: dict[str, str] | None = None,
+    hardware_in: list[str] | None = None,
+    max_identities: int = 50,
+    canonical_ids: list[str] | None = None,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Download per-session envelopes for matching identities."""
+    errors: list[str] = []
+    if canonical_ids:
+        identities = [{"canonical_id": cid} for cid in canonical_ids]
+    else:
+        identities = search_inference_identities(
+            store,
+            match=match,
+            hardware_in=hardware_in,
+            max_identities=max_identities,
+        )
+    documents: list[dict[str, Any]] = []
+    for item in identities:
+        cid = str(item.get("canonical_id") or "").strip()
+        if not cid:
+            continue
+        try:
+            rollup = store.get_rollup(cid)
+        except KBStoreError as exc:
+            errors.append(f"{cid}: rollup {exc}")
+            continue
+        session_ids = _session_ids_from_rollup(rollup)
+        if not session_ids:
+            errors.append(f"{cid}: no sessions in rollup")
+            continue
+        for sid in session_ids:
+            try:
+                envelope = store.get_session(cid, sid)
+            except KBStoreError as exc:
+                errors.append(f"{cid}/{sid}: {exc}")
+                continue
+            if isinstance(envelope, Mapping):
+                documents.append(dict(envelope))
+    return documents, errors
+
+
+__all__ = [
+    "DEFAULT_PARALLELISM_LABEL",
+    "estimate_from_sessions",
+    "extract_parallelism",
+    "fetch_session_documents",
+    "identity_dimensions",
+    "matches_shape",
+    "parallelism_label",
+    "parallelism_whatif",
+    "percentile",
+    "project_session",
+    "replay_scope_key",
+    "search_inference_identities",
+    "shape_key",
+    "sharding_whatif",
+    "workload_family",
+]


### PR DESCRIPTION
## Why

Deciding whether a target is worth a session meant running one. This mines the
Recipe KB instead and reports what prior sessions already settled for a scope:
the distribution of validated gain, and which parallelism layout won inside a
fixed GPU count.

## Scope

This is the read half of #1353, re-opened on its own after that PR was closed.
The publish half is not here and is not coming back: roofline arms, host
platform, token spend and elapsed time are execution evidence rather than replay
data, so they do not belong in the Recipe KB or its `value{}` schema.

This reads only fields the KB already owns as replay material —
`validated_e2e_gain`, `workload_shape`, and the accepted
`value.config.extra_server_args` that a layout is read out of. Nothing is added
to the schema, and no publish path is touched. A test pins the boundary rather
than leaving it to review, because the cheap way to add a headroom forecast
later is to start reading roofline arms back out of a replay record.

Worth being explicit that this costs nothing: every number in the table below,
across 103 live MI355X sessions, came from those three fields. The forecast and
spend priors in #1353 were the parts reading the contested fields, and their
coverage counters were zero because no record in the store carries them.

## Why the scoping matters

Pooling every session a search returns makes the median meaningless. Sessions
are grouped by identity and by the full `tp/conc/isl/osl` replay scope, and
`pool_warnings` names it whenever a pool spans models, boards, frameworks,
versions, or precisions. On live MI355X/sglang data a 23.4% pooled median hides
per-family medians ranging from 6.2% to 311%.

Parallelism gets the same treatment. TP is only compared within a fixed model,
precision, and ISL/OSL: ISL changes arithmetic intensity and model size dictates
the TP that fits at all, so without that grouping a 0.6B at TP1 against a 70B at
TP8 reads as 3% scaling retention when nothing scaled. Across 103 live MI355X
sessions every workload family has exactly one TP, so cross-TP projection
honestly reports "no per-GPU baseline in this family" instead of a fabricated
number.

The parallelism question the store *can* answer today is the layout inside a
fixed GPU count. `sharding_whatif` normalizes the vLLM and SGLang spellings of
tp/dp/ep/pp and ranks accepted layouts per replay scope. Live results:

| scope (tp = GPU count)             | layout                               | n | p50 gain |
| ---------------------------------- | ------------------------------------ | - | -------- |
| deepseek-v4-pro/mxfp4/sglang/tp8   | dp_attention=on                      | 1 | 297.4%   |
| deepseek-v4-pro/mxfp4/sglang/tp8   | framework-default                    | 1 | 0.0%     |
| minimax-m3-mxfp4/mxfp4/sglang/tp8  | ep=4 dp=8 dp_attention dp_lm_head    | 1 | 23.3%    |
| minimax-m3-mxfp4/mxfp4/sglang/tp8  | framework-default                    | 2 | 12.5%    |
| qwen3.8-2.4t-a95b/mxfp4/sglang/tp8 | ep=8 moe_dense_tp=1                  | 1 | 14.2%    |
| qwen3.8-2.4t-a95b/mxfp4/sglang/tp8 | moe_dense_tp=1                       | 1 | 7.2%     |
| qwen3.8-2.4t-a95b/mxfp4/sglang/tp8 | framework-default                    | 2 | 6.8%     |

Read these as directional, not statistical: the arms are n=1 or n=2, and 40 of
43 scopes have only a single layout. Note also that the winning-by-gain minimax
layout has *lower* absolute throughput than its default arm (2675 vs 2835
tok/s), because gain is measured against each session's own baseline — rank on
whichever metric you care about.

A record keeps only the layout its session settled on, so the report carries
`winners_only: true` and says in `limitations` that an absent layout is untried
or unpublished rather than beaten.

## Follow-ups, not in this PR

Archived `session_breakdown.json` is a strict superset of what this reads: its
`workload` block carries the identity dimensions and the full replay scope, and
its `final` block carries `cumulative_gain_pct_validated`,
`throughput_tok_s_per_gpu` and `extra_server_args`. A second projector plus a
`--sessions-root` flag would let the estimator mine archived sessions directly,
and since SBD already carries `roofline`, `token_usage` and elapsed time, it
would restore the headroom forecast without a single field going into the KB.
Left out here to keep this reviewable on its own.

## Test plan

* `pytest test_no_run_estimate.py` — 20 pass
* `pytest test_remote_recipe_v2.py test_warm_replay.py test_specialist_lessons_section.py test_no_run_estimate.py` — 249 pass
* Scoping regressions pinned: layouts are never compared across world sizes, and
  TP is never compared across models or across ISL
* Boundary pinned: the report carries no `forecast` or `savings_prior` section
  and `coverage` is exactly `{with_gain}`
* Credential order (flag → file → env), missing URL exits 2 with no network
  call, and the token never appears in the report
* `ruff check` and `ruff format --check` clean
