### PR TITLE
[FIX] Follow-up on #1385: the sweep summary, and what the retired action left behind

### DIFF
--- a/src/hyperloom/common/gain_math.py
+++ b/src/hyperloom/common/gain_math.py
@@ -41,8 +41,10 @@ def conc_pair_comparison(
     """Pair curve points by CONC (outer join), compute per-conc speedup, and aggregate.
 
     Shared by the conc-sweep post-hook and the breakdown collector, which must
-    produce byte-identical rows/summary from the same curves. Stdlib-only so
-    the collector never drags in Magpie/torch at report time.
+    produce byte-identical rows/summary from the same curves on the same
+    ``metric_key`` -- the collector reads its key off the report it recovers
+    for. Stdlib-only so the collector never drags in Magpie/torch at report
+    time.
 
     Args:
         baseline_points: Curve rows for the baseline arm.

--- a/src/hyperloom/common/gain_math.py
+++ b/src/hyperloom/common/gain_math.py
@@ -35,6 +35,8 @@ def incremental_gain_pct(new: float, ref: float) -> float | None:
 def conc_pair_comparison(
     baseline_points: list[dict[str, Any]],
     optimized_points: list[dict[str, Any]],
+    *,
+    metric_key: str = "output_throughput",
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Pair curve points by CONC (outer join), compute per-conc speedup, and aggregate.
 
@@ -45,9 +47,13 @@ def conc_pair_comparison(
     Args:
         baseline_points: Curve rows for the baseline arm.
         optimized_points: Curve rows for the optimized arm.
+        metric_key: The point field the speedup is measured on. It has to be
+            the axis the session is ranked by, or the summary reports a
+            different quantity from the curve drawn beside it.
 
     Returns:
-        A tuple of ``(per_conc_rows, summary_dict)``.
+        A tuple of ``(per_conc_rows, summary_dict)``; the summary names the
+        metric it used.
     """
 
     def _norm_conc(p: dict[str, Any]) -> int | float | str:
@@ -67,8 +73,8 @@ def conc_pair_comparison(
     ):
         b = by_conc_b.get(c) or {}
         o = by_conc_o.get(c) or {}
-        bt = to_float(b.get("output_throughput"))
-        ot = to_float(o.get("output_throughput"))
+        bt = to_float(b.get(metric_key))
+        ot = to_float(o.get(metric_key))
         speedup: float | None = None
         delta_pct: float | None = None
         if bt is not None and bt > 0 and ot is not None and ot > 0:
@@ -90,6 +96,7 @@ def conc_pair_comparison(
             }
         )
     summary: dict[str, Any] = {
+        "metric": metric_key,
         "successful_pairs": successful_pairs,
         "failed_pairs": failed_pairs,
         "best_conc": None,

--- a/src/hyperloom/common/perf_metric.py
+++ b/src/hyperloom/common/perf_metric.py
@@ -79,6 +79,24 @@ def total_tput_grading_enabled(*, benchmark_mode: str = "") -> bool:
     return is_agentx_mode(benchmark_mode)
 
 
+GRADED_TOTAL = "total_throughput"
+GRADED_OUTPUT = "output_throughput"
+
+
+def graded_metric_key(*, benchmark_mode: str = "") -> str:
+    """The curve-row field a session's speedups are measured on.
+
+    Follows :func:`total_tput_grading_enabled`, so a summary is computed on
+    whatever axis the KEEP verdicts were taken on -- including when
+    ``HYPERLOOM_PERF_METRIC`` overrides the workload's default in either
+    direction. Curve rows name the total ``total_token_throughput``, unlike
+    the ``total_throughput`` a perf snapshot carries.
+    """
+    if total_tput_grading_enabled(benchmark_mode=benchmark_mode):
+        return "total_token_throughput"
+    return GRADED_OUTPUT
+
+
 def total_tput_serving_grading_enabled(*, scriptable: bool = False, benchmark_mode: str = "") -> bool:
     """Total-token-throughput grading, limited to non-scriptable serving runs.
 
@@ -137,10 +155,6 @@ def perf_snapshot_from_mapping(source: Mapping[str, Any] | None) -> dict[str, fl
         if value is not None:
             snap[key] = value
     return snap
-
-
-GRADED_TOTAL = "total_throughput"
-GRADED_OUTPUT = "output_throughput"
 
 
 def output_tput_of(source: Mapping[str, Any] | None) -> float:
@@ -258,6 +272,7 @@ __all__ = [
     "GRADED_OUTPUT",
     "GRADED_TOTAL",
     "graded_axes_of",
+    "graded_metric_key",
     "is_agentx_mode",
     "output_tput_of",
     "parse_intvty_noise_pct",

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/kernels.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from hyperloom.common.gain_math import conc_pair_comparison
+from hyperloom.common.perf_metric import GRADED_OUTPUT
 from hyperloom.common.io import safe_mtime
 
 from ._common import (
@@ -1040,8 +1041,15 @@ def _load_conc_variant_point(variant_dir: Path, *, arm: str, conc: int) -> dict[
 def _recover_conc_sweep_summary_from_runs(
     session_dir: Path,
     warnings: list[str],
+    *,
+    metric_key: str = GRADED_OUTPUT,
 ) -> dict[str, Any]:
-    """Recover a conc_sweep summary from raw run workspaces when the report is stale."""
+    """Recover a conc_sweep summary from raw run workspaces when the report is stale.
+
+    ``metric_key`` is the axis the recovered speedups are taken on. A recovery
+    that supersedes a report has to reuse that report's own axis, or the
+    section silently swaps one quantity for another.
+    """
     runs_dir = session_dir / "runs" / "conc_sweep"
     if not runs_dir.exists():
         return {}
@@ -1072,7 +1080,7 @@ def _recover_conc_sweep_summary_from_runs(
             continue
         baseline_points.sort(key=lambda p: p["conc"])
         optimized_points.sort(key=lambda p: p["conc"])
-        comparison, summary = conc_pair_comparison(baseline_points, optimized_points)
+        comparison, summary = conc_pair_comparison(baseline_points, optimized_points, metric_key=metric_key)
         pairs = int(summary.get("successful_pairs") or 0)
         payload = {
             "schema_version": "recovered-v1",
@@ -1103,7 +1111,9 @@ def collect_conc_sweep_summary(
     ``comparison`` shape-guarded) + ``report_path``, except that a mirrored
     report with zero successful pairs is superseded by the recovered payload
     (``source="recovered_from_runs"``, ``schema_version="recovered-v1"``, the
-    mirrored path kept as ``original_report_path``) when recovery finds pairs.
+    mirrored path kept as ``original_report_path``) when recovery finds pairs,
+    taken on the axis that report named. A recovery standing in for an absent
+    report has no axis to read and takes the default.
     Do not synthesize the optional blocks the producer omits when
     ``status="skipped"``.
 
@@ -1143,7 +1153,10 @@ def collect_conc_sweep_summary(
     # Fall back to run-workspace recovery only when the authoritative report
     # has no successful pairs (also skips the full runs/ scan on the healthy path).
     if _conc_sweep_successful_pairs(out) == 0:
-        recovered = _recover_conc_sweep_summary_from_runs(session_dir, warnings)
+        reported_metric = str((out.get("summary") or {}).get("metric") or "").strip()
+        recovered = _recover_conc_sweep_summary_from_runs(
+            session_dir, warnings, metric_key=reported_metric or GRADED_OUTPUT
+        )
         if _conc_sweep_successful_pairs(recovered) > 0:
             recovered["original_report_path"] = out["report_path"]
             warnings.append("conc_sweep_summary: recovered successful conc_sweep data from runs/conc_sweep")

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/v6_stages.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/v6_stages.py
@@ -526,8 +526,8 @@ def project_conc_sweep_event(
     comparison = [
         {
             "conc": _to_int(row.get("conc")),
-            "baseline_output_throughput": _to_float(row.get("baseline_tput")),
-            "optimized_output_throughput": _to_float(row.get("optimized_tput")),
+            "baseline_throughput": _to_float(row.get("baseline_tput")),
+            "optimized_throughput": _to_float(row.get("optimized_tput")),
             "speedup": _to_float(row.get("speedup")),
             "error": _conc_pair_error(row, points_by_arm),
         }
@@ -577,6 +577,8 @@ def project_conc_sweep_event(
             "comparison": comparison,
             "result": {
                 "status": result_status,
+                # The axis the speedups were taken on; it differs by workload.
+                "metric": _text(result_summary.get("metric")) or "output_throughput",
                 "best_conc": _to_int(result_summary.get("best_conc")),
                 "best_speedup": _to_float(result_summary.get("best_speedup")),
                 "skip_reason": _text(_first(summary.get("skip_reason"), last.get("skip_reason"))),

--- a/src/hyperloom/inference_optimizer/breakdown/schema.py
+++ b/src/hyperloom/inference_optimizer/breakdown/schema.py
@@ -2073,7 +2073,10 @@ class ConcSweepSummary(TypedDict, total=False):
     baseline: dict[str, Any]
     optimized: dict[str, Any]
     comparison: list[dict[str, Any]]  # per-CONC paired rows (feeds the dual curve + speedup bars)
-    summary: dict[str, Any]  # {successful_pairs, failed_pairs, best_conc, best_speedup, median_speedup, mean_speedup}
+    # {metric, successful_pairs, failed_pairs, best_conc, best_speedup,
+    # median_speedup, mean_speedup}. ``metric`` names the axis the speedups
+    # were taken on, which is the one that mode's chart is drawn on.
+    summary: dict[str, Any]
     workspace: str
     elapsed_sec: float
     total_budget_sec: int  # None when budget gate disabled

--- a/src/hyperloom/inference_optimizer/cli/__init__.py
+++ b/src/hyperloom/inference_optimizer/cli/__init__.py
@@ -1241,13 +1241,15 @@ def _reset_state_file(session_dir: Path) -> None:
 # layering (see AGENTX_EXPLORE_TIMEOUT_CEILING_SEC), which is the real fix.
 #
 # The total is that measured round times the ladder: seven agentic rungs on each
-# of the baseline and optimized arms, so fourteen. It is a ceiling rather than a
-# reservation -- the SWEEP phase clamps it to the session's own remaining time
-# before the task is enqueued, and an exhausted budget skips the rungs it cannot
-# pay for rather than failing the sweep. Sizing it below the ladder would instead
-# truncate every run by default.
+# of the baseline and optimized arms, so fourteen runs. It is a ceiling rather
+# than a reservation -- the SWEEP phase clamps it to the session's own remaining
+# time before the task is enqueued, and an exhausted budget skips the rungs it
+# cannot pay for rather than failing the sweep. Sizing it below the ladder would
+# instead truncate every run by default. The per-variant cap above stays higher
+# than the measured round: it bounds a hung one, it does not predict a healthy
+# one.
 _AGENTX_CONC_SWEEP_TIMEOUT_SEC = 9000  # 2.5 h per variant
-_AGENTX_CONC_SWEEP_TOTAL_BUDGET_SEC = 93600  # 26 h: ~111 min x 14 rungs
+_AGENTX_CONC_SWEEP_TOTAL_BUDGET_SEC = 93600  # 26 h: ~111 min x 14 runs
 
 
 def _preflight_agentx_backend(args: argparse.Namespace) -> None:

--- a/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
+++ b/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
@@ -1655,8 +1655,8 @@ class TestTheChartFollowsTheGradedAxis:
 
 
 class TestTheRooflineNeedsBothItsAxisAndARealShape:
-    """``_ceiling_series`` returns an output-throughput bound in the output
-    axis pair's units, computed from the session's ISL/OSL."""
+    """``_ceiling_series`` returns a decode-only output-throughput bound, in the
+    output pair's units, computed from the session's ISL/OSL."""
 
     def _payload(self, mode: str, metric: str) -> dict[str, Any]:
         return {
@@ -1676,28 +1676,23 @@ class TestTheRooflineNeedsBothItsAxisAndARealShape:
             "optimized": {"points": []},
         }
 
-    def _ceiling_calls(self, tmp_path: Path, monkeypatch, payload: dict[str, Any]) -> list[Any]:
-        from hyperloom.orchestrator.kernel import conc_sweep_plot as plot
+    def _drew_it(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, payload: dict[str, Any]) -> bool:
+        from hyperloom.orchestrator.kernel.conc_sweep_plot import render_conc_sweep_curve
 
-        calls: list[Any] = []
+        calls = _install_fake_matplotlib(monkeypatch)
+        out_path = tmp_path / "curve.png"
+        assert render_conc_sweep_curve(payload, out_path, tp=8, draw_ceiling=True) == out_path
+        return any("roofline" in str(kwargs.get("label", "")).lower() for _args, kwargs in calls["plots"])
 
-        def _spy(ceiling_data, tp_eff):
-            calls.append(ceiling_data)
-            return [], []
+    def test_a_synthetic_output_chart_draws_it(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Positive control: without it the two denials below prove nothing."""
+        assert self._drew_it(tmp_path, monkeypatch, self._payload("synthetic", "output_throughput")) is True
 
-        monkeypatch.setattr(plot, "_ceiling_series", _spy)
-        assert plot.render_conc_sweep_curve(payload, tmp_path / "c.png", tp=8, draw_ceiling=True) is not None
-        return calls
+    def test_a_total_y_axis_is_not_the_bounds_axis(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        assert self._drew_it(tmp_path, monkeypatch, self._payload("synthetic", "total_token_throughput")) is False
 
-    def test_a_synthetic_output_chart_draws_it(self, tmp_path: Path, monkeypatch):
-        """Positive control: the spy fires when both conditions hold."""
-        assert self._ceiling_calls(tmp_path, monkeypatch, self._payload("synthetic", "output_throughput"))
-
-    def test_a_total_y_axis_is_not_the_bounds_axis(self, tmp_path: Path, monkeypatch):
-        assert self._ceiling_calls(tmp_path, monkeypatch, self._payload("synthetic", "total_token_throughput")) == []
-
-    def test_an_agentic_replay_has_no_real_isl_to_bound(self, tmp_path: Path, monkeypatch):
-        assert self._ceiling_calls(tmp_path, monkeypatch, self._payload("agentx", "output_throughput")) == []
+    def test_an_agentic_replay_has_no_real_isl_to_bound(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        assert self._drew_it(tmp_path, monkeypatch, self._payload("agentx", "output_throughput")) is False
 
 
 def test_render_conc_sweep_curve_missing_matplotlib_returns_none(
@@ -1763,9 +1758,12 @@ def test_conc_sweep_plot_series_helpers_filter_and_sort_points():
     assert conc_sweep_plot._ceiling_series({"rows": [{"conc": 0, "t_peak_tok_s": 0}]}, 1.0) == ([], [])
 
 
-def test_render_conc_sweep_curve_with_fake_matplotlib(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    from hyperloom.orchestrator.kernel.conc_sweep_plot import render_conc_sweep_curve
+def _install_fake_matplotlib(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Render through a stand-in pyplot and return what the chart asked it to do.
 
+    Lets a chart's decisions be asserted where matplotlib is not installed,
+    which is most CI shards.
+    """
     calls: dict[str, Any] = {"plots": [], "annotations": [], "labels": [], "titles": [], "closed": False}
 
     class _FakePatch:
@@ -1833,7 +1831,13 @@ def test_render_conc_sweep_curve_with_fake_matplotlib(tmp_path: Path, monkeypatc
     fake_matplotlib.pyplot = fake_pyplot
     monkeypatch.setitem(sys.modules, "matplotlib", fake_matplotlib)
     monkeypatch.setitem(sys.modules, "matplotlib.pyplot", fake_pyplot)
+    return calls
 
+
+def test_render_conc_sweep_curve_with_fake_matplotlib(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from hyperloom.orchestrator.kernel.conc_sweep_plot import render_conc_sweep_curve
+
+    calls = _install_fake_matplotlib(monkeypatch)
     payload = {
         "baseline": {"points": [{"conc": 4, "output_throughput": 800.0}]},
         "optimized": {"points": [{"conc": 8, "output_throughput": 1200.0}]},

--- a/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
+++ b/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
@@ -1550,7 +1550,7 @@ class TestTheChartFollowsTheMode:
     def test_agentx_reads_interactivity_and_total(self):
         from hyperloom.orchestrator.kernel import conc_sweep_plot as plot
 
-        axes = plot.resolve_axes("agentx", tp_eff=8.0)
+        axes = plot._resolve_axes("agentx", tp_eff=8.0)
         xs, ys = plot._arm_series(self._payload("agentx")["baseline"]["points"], 8.0, axes)
         assert xs == [pytest.approx(447.2)]
         assert ys == [pytest.approx(25984.8 / 8.0)]
@@ -1560,7 +1560,7 @@ class TestTheChartFollowsTheMode:
     def test_synthetic_keeps_the_output_pair(self):
         from hyperloom.orchestrator.kernel import conc_sweep_plot as plot
 
-        axes = plot.resolve_axes("synthetic", tp_eff=8.0)
+        axes = plot._resolve_axes("synthetic", tp_eff=8.0)
         xs, ys = plot._arm_series(self._payload("synthetic")["baseline"]["points"], 8.0, axes)
         assert xs == [pytest.approx(183.44 / 8)]
         assert ys == [pytest.approx(183.44 / 8.0)]
@@ -1568,13 +1568,13 @@ class TestTheChartFollowsTheMode:
     def test_an_unset_mode_reads_as_synthetic(self):
         from hyperloom.orchestrator.kernel import conc_sweep_plot as plot
 
-        assert plot.resolve_axes("", tp_eff=1.0).agentic is False
-        assert plot.resolve_axes(None, tp_eff=1.0).agentic is False
+        assert plot._resolve_axes("", tp_eff=1.0).agentic is False
+        assert plot._resolve_axes(None, tp_eff=1.0).agentic is False
 
     def test_a_rung_missing_its_axis_is_dropped_not_zeroed(self):
         from hyperloom.orchestrator.kernel import conc_sweep_plot as plot
 
-        axes = plot.resolve_axes("agentx", tp_eff=1.0)
+        axes = plot._resolve_axes("agentx", tp_eff=1.0)
         points = [
             {"conc": 8, "total_token_throughput": 25984.8},
             {"conc": 4, "total_token_throughput": 20000.0, "intvty_p90": 500.0},
@@ -1614,7 +1614,7 @@ def test_render_conc_sweep_curve_missing_matplotlib_returns_none(
 def test_conc_sweep_plot_series_helpers_filter_and_sort_points():
     from hyperloom.orchestrator.kernel import conc_sweep_plot
 
-    axes = conc_sweep_plot.resolve_axes("synthetic", 2.0)
+    axes = conc_sweep_plot._resolve_axes("synthetic", 2.0)
     xs, ys = conc_sweep_plot._arm_series(
         [
             {"conc": 4, "output_throughput": 800.0},

--- a/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
+++ b/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
@@ -1550,7 +1550,7 @@ class TestTheChartFollowsTheMode:
     def test_agentx_reads_interactivity_and_total(self):
         from hyperloom.orchestrator.kernel import conc_sweep_plot as plot
 
-        axes = plot._resolve_axes("agentx", tp_eff=8.0)
+        axes = plot.resolve_axes("agentx", tp_eff=8.0)
         xs, ys = plot._arm_series(self._payload("agentx")["baseline"]["points"], 8.0, axes)
         assert xs == [pytest.approx(447.2)]
         assert ys == [pytest.approx(25984.8 / 8.0)]
@@ -1560,7 +1560,7 @@ class TestTheChartFollowsTheMode:
     def test_synthetic_keeps_the_output_pair(self):
         from hyperloom.orchestrator.kernel import conc_sweep_plot as plot
 
-        axes = plot._resolve_axes("synthetic", tp_eff=8.0)
+        axes = plot.resolve_axes("synthetic", tp_eff=8.0)
         xs, ys = plot._arm_series(self._payload("synthetic")["baseline"]["points"], 8.0, axes)
         assert xs == [pytest.approx(183.44 / 8)]
         assert ys == [pytest.approx(183.44 / 8.0)]
@@ -1568,13 +1568,13 @@ class TestTheChartFollowsTheMode:
     def test_an_unset_mode_reads_as_synthetic(self):
         from hyperloom.orchestrator.kernel import conc_sweep_plot as plot
 
-        assert plot._resolve_axes("", tp_eff=1.0).agentic is False
-        assert plot._resolve_axes(None, tp_eff=1.0).agentic is False
+        assert plot.resolve_axes("", tp_eff=1.0).agentic is False
+        assert plot.resolve_axes(None, tp_eff=1.0).agentic is False
 
     def test_a_rung_missing_its_axis_is_dropped_not_zeroed(self):
         from hyperloom.orchestrator.kernel import conc_sweep_plot as plot
 
-        axes = plot._resolve_axes("agentx", tp_eff=1.0)
+        axes = plot.resolve_axes("agentx", tp_eff=1.0)
         points = [
             {"conc": 8, "total_token_throughput": 25984.8},
             {"conc": 4, "total_token_throughput": 20000.0, "intvty_p90": 500.0},
@@ -1614,7 +1614,7 @@ def test_render_conc_sweep_curve_missing_matplotlib_returns_none(
 def test_conc_sweep_plot_series_helpers_filter_and_sort_points():
     from hyperloom.orchestrator.kernel import conc_sweep_plot
 
-    axes = conc_sweep_plot._resolve_axes("synthetic", 2.0)
+    axes = conc_sweep_plot.resolve_axes("synthetic", 2.0)
     xs, ys = conc_sweep_plot._arm_series(
         [
             {"conc": 4, "output_throughput": 800.0},

--- a/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
+++ b/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
@@ -31,11 +31,11 @@ from hyperloom.orchestrator.kernel.conc_sweep import (
     _has_optimization,
     _order_concs_desc,
     _point_from_variant,
-    graded_metric_key,
     conc_sweep_declined_to_run,
     run_conc_sweep,
 )
 from hyperloom.common.gain_math import conc_pair_comparison as _build_comparison
+from hyperloom.common.perf_metric import graded_metric_key
 from hyperloom.orchestrator.state.shared_state import SharedState
 
 
@@ -1312,7 +1312,7 @@ class TestTheSummaryIsTakenOnTheChartsAxis:
         comparison, summary = _build_comparison(
             self._pts("baseline", 183.0, 20000.0),
             self._pts("optimized", 183.0, 26000.0),
-            metric_key=graded_metric_key("agentx"),
+            metric_key=graded_metric_key(benchmark_mode="agentx"),
         )
         assert summary["metric"] == "total_token_throughput"
         assert summary["best_speedup"] == pytest.approx(26000.0 / 20000.0)
@@ -1322,16 +1322,29 @@ class TestTheSummaryIsTakenOnTheChartsAxis:
         _comparison, summary = _build_comparison(
             self._pts("baseline", 100.0, 20000.0),
             self._pts("optimized", 130.0, 26000.0),
-            metric_key=graded_metric_key(""),
+            metric_key=graded_metric_key(benchmark_mode=""),
         )
         assert summary["metric"] == "output_throughput"
         assert summary["best_speedup"] == pytest.approx(1.3)
 
     def test_the_key_follows_the_mode(self):
-        assert graded_metric_key("agentx") == "total_token_throughput"
-        assert graded_metric_key("AgentX") == "total_token_throughput"
-        assert graded_metric_key("synthetic") == "output_throughput"
-        assert graded_metric_key("") == "output_throughput"
+        assert graded_metric_key(benchmark_mode="agentx") == "total_token_throughput"
+        assert graded_metric_key(benchmark_mode="AgentX") == "total_token_throughput"
+        assert graded_metric_key(benchmark_mode="synthetic") == "output_throughput"
+        assert graded_metric_key(benchmark_mode="") == "output_throughput"
+
+    def test_an_explicit_grading_override_wins_over_the_mode(self, monkeypatch):
+        """The summary follows the axis the KEEP verdicts were taken on."""
+        monkeypatch.setenv("HYPERLOOM_PERF_METRIC", "output_throughput")
+        assert graded_metric_key(benchmark_mode="agentx") == "output_throughput"
+        monkeypatch.setenv("HYPERLOOM_PERF_METRIC", "composite_v1")
+        assert graded_metric_key(benchmark_mode="synthetic") == "total_token_throughput"
+
+    def test_the_ambient_agentx_signal_reaches_the_summary(self, monkeypatch):
+        """A session whose mode never persisted still grades on the total axis."""
+        monkeypatch.delenv("HYPERLOOM_PERF_METRIC", raising=False)
+        monkeypatch.setenv("HYPERLOOM_AGENTX", "1")
+        assert graded_metric_key(benchmark_mode="") == "total_token_throughput"
 
 
 # --- the chart's data contract ---

--- a/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
+++ b/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
@@ -1347,6 +1347,33 @@ class TestTheSummaryIsTakenOnTheChartsAxis:
         assert graded_metric_key(benchmark_mode="") == "total_token_throughput"
 
 
+class TestAnUnreportedTotalComesFromItsHalves:
+    """A row graded on the total axis must not read as unmeasured."""
+
+    def _variant(self, **kw: Any) -> VariantResult:
+        return VariantResult(
+            name="baseline_c8", extra_server_args="", extra_envs={"CONC": "8"}, status="succeeded", **kw
+        )
+
+    def test_the_halves_sum_when_the_parser_named_no_total(self):
+        point = _point_from_variant(
+            self._variant(input_throughput=24000.0, output_throughput=180.0),
+            arm="baseline",
+        )
+        assert point["total_token_throughput"] == pytest.approx(24180.0)
+
+    def test_a_reported_total_is_not_recomputed(self):
+        point = _point_from_variant(
+            self._variant(input_throughput=1.0, output_throughput=1.0, total_token_throughput=25984.8),
+            arm="baseline",
+        )
+        assert point["total_token_throughput"] == pytest.approx(25984.8)
+
+    def test_a_missing_half_leaves_the_total_unmeasured(self):
+        point = _point_from_variant(self._variant(output_throughput=180.0), arm="baseline")
+        assert point["total_token_throughput"] is None
+
+
 # --- the chart's data contract ---
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
+++ b/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
@@ -31,6 +31,7 @@ from hyperloom.orchestrator.kernel.conc_sweep import (
     _has_optimization,
     _order_concs_desc,
     _point_from_variant,
+    graded_metric_key,
     conc_sweep_declined_to_run,
     run_conc_sweep,
 )
@@ -1293,6 +1294,44 @@ def test_flush_conc_sweep_report_writes_json_and_csv(session_dir: Path):
     rows = list(csv.DictReader(csv_path.open()))
     assert len(rows) == 1
     assert rows[0]["arm"] == "baseline"
+
+
+class TestTheSummaryIsTakenOnTheChartsAxis:
+    """The headline speedup and the curve beside it have to be one quantity.
+
+    On the agentic corpus output throughput is about 1% of the token budget, so
+    a summary left on that axis reports a number the chart contradicts.
+    """
+
+    def _pts(self, arm: str, out: float, total: float) -> list[dict[str, Any]]:
+        return [
+            {"arm": arm, "conc": 8, "status": "succeeded", "output_throughput": out, "total_token_throughput": total}
+        ]
+
+    def test_agentx_grades_on_total_token_throughput(self):
+        comparison, summary = _build_comparison(
+            self._pts("baseline", 183.0, 20000.0),
+            self._pts("optimized", 183.0, 26000.0),
+            metric_key=graded_metric_key("agentx"),
+        )
+        assert summary["metric"] == "total_token_throughput"
+        assert summary["best_speedup"] == pytest.approx(26000.0 / 20000.0)
+        assert comparison[0]["baseline_tput"] == pytest.approx(20000.0)
+
+    def test_synthetic_stays_on_output_throughput(self):
+        _comparison, summary = _build_comparison(
+            self._pts("baseline", 100.0, 20000.0),
+            self._pts("optimized", 130.0, 26000.0),
+            metric_key=graded_metric_key(""),
+        )
+        assert summary["metric"] == "output_throughput"
+        assert summary["best_speedup"] == pytest.approx(1.3)
+
+    def test_the_key_follows_the_mode(self):
+        assert graded_metric_key("agentx") == "total_token_throughput"
+        assert graded_metric_key("AgentX") == "total_token_throughput"
+        assert graded_metric_key("synthetic") == "output_throughput"
+        assert graded_metric_key("") == "output_throughput"
 
 
 # --- the chart's data contract ---

--- a/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
+++ b/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
@@ -1564,16 +1564,17 @@ def test_render_conc_sweep_curve_from_file(tmp_path: Path):
     assert result.exists()
 
 
-class TestTheChartFollowsTheMode:
-    """Two workloads, two rankings, two axis pairs.
+class TestTheChartFollowsTheGradedAxis:
+    """The chart has to show the ranking the session was scored by.
 
-    Plotting an agentic ladder on ``output_throughput / conc`` would label a
-    number that is ~1% of the token budget as the thing being optimised.
+    A chart drawn on a different axis from the summary beside it invites
+    reading off a rung the grading did not pick.
     """
 
-    def _payload(self, mode: str) -> dict[str, Any]:
+    def _payload(self, mode: str, metric: str) -> dict[str, Any]:
         return {
             "benchmark_mode": mode,
+            "summary": {"metric": metric},
             "baseline": {
                 "points": [
                     {
@@ -1587,34 +1588,63 @@ class TestTheChartFollowsTheMode:
             "optimized": {"points": []},
         }
 
-    def test_agentx_reads_interactivity_and_total(self):
+    def test_the_total_axis_reads_interactivity_and_total(self):
         from hyperloom.orchestrator.kernel import conc_sweep_plot as plot
 
-        axes = plot._resolve_axes("agentx", tp_eff=8.0)
-        xs, ys = plot._arm_series(self._payload("agentx")["baseline"]["points"], 8.0, axes)
+        axes = plot._axes_for_metric("total_token_throughput", tp_eff=8.0)
+        xs, ys = plot._arm_series(self._payload("agentx", "total_token_throughput")["baseline"]["points"], 8.0, axes)
         assert xs == [pytest.approx(447.2)]
         assert ys == [pytest.approx(25984.8 / 8.0)]
         assert "P90 Interactivity" in axes.x_label
         assert "per Chip" in axes.y_label
 
-    def test_synthetic_keeps_the_output_pair(self):
+    def test_the_output_axis_keeps_the_output_pair(self):
         from hyperloom.orchestrator.kernel import conc_sweep_plot as plot
 
-        axes = plot._resolve_axes("synthetic", tp_eff=8.0)
-        xs, ys = plot._arm_series(self._payload("synthetic")["baseline"]["points"], 8.0, axes)
+        axes = plot._axes_for_metric("output_throughput", tp_eff=8.0)
+        xs, ys = plot._arm_series(self._payload("synthetic", "output_throughput")["baseline"]["points"], 8.0, axes)
         assert xs == [pytest.approx(183.44 / 8)]
         assert ys == [pytest.approx(183.44 / 8.0)]
 
-    def test_an_unset_mode_reads_as_synthetic(self):
+    def test_a_summary_naming_no_metric_reads_as_the_comparison_default(self):
         from hyperloom.orchestrator.kernel import conc_sweep_plot as plot
 
-        assert plot._resolve_axes("", tp_eff=1.0).agentic is False
-        assert plot._resolve_axes(None, tp_eff=1.0).agentic is False
+        assert plot._graded_metric_of({}) == "output_throughput"
+        assert plot._graded_metric_of({"summary": {"metric": ""}}) == "output_throughput"
+        assert plot._graded_metric_of({"summary": {"metric": "total_token_throughput"}}) == "total_token_throughput"
+
+    @pytest.mark.parametrize(
+        ("mode", "env"),
+        [
+            ("agentx", {}),
+            ("synthetic", {}),
+            ("agentx", {"HYPERLOOM_PERF_METRIC": "output_throughput"}),
+            ("synthetic", {"HYPERLOOM_PERF_METRIC": "composite_v1"}),
+            ("", {"HYPERLOOM_AGENTX": "1"}),
+        ],
+    )
+    def test_the_chart_plots_the_field_the_summary_graded(self, monkeypatch, mode: str, env: dict[str, str]):
+        """Binds both sides: whichever way the session resolved its axis, the
+        curve reads the same point field the summary took its speedups on."""
+        from hyperloom.orchestrator.kernel import conc_sweep_plot as plot
+
+        monkeypatch.delenv("HYPERLOOM_PERF_METRIC", raising=False)
+        monkeypatch.delenv("HYPERLOOM_AGENTX", raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+
+        metric = graded_metric_key(benchmark_mode=mode)
+        payload = self._payload(mode, metric)
+        axes = plot._axes_for_metric(plot._graded_metric_of(payload), tp_eff=8.0)
+
+        _xs, ys = plot._arm_series(payload["baseline"]["points"], 8.0, axes)
+
+        assert ys == [pytest.approx(payload["baseline"]["points"][0][metric] / 8.0)]
 
     def test_a_rung_missing_its_axis_is_dropped_not_zeroed(self):
         from hyperloom.orchestrator.kernel import conc_sweep_plot as plot
 
-        axes = plot._resolve_axes("agentx", tp_eff=1.0)
+        axes = plot._axes_for_metric("total_token_throughput", tp_eff=1.0)
         points = [
             {"conc": 8, "total_token_throughput": 25984.8},
             {"conc": 4, "total_token_throughput": 20000.0, "intvty_p90": 500.0},
@@ -1622,6 +1652,52 @@ class TestTheChartFollowsTheMode:
         xs, ys = plot._arm_series(points, 1.0, axes)
         assert xs == [pytest.approx(500.0)]
         assert ys == [pytest.approx(20000.0)]
+
+
+class TestTheRooflineNeedsBothItsAxisAndARealShape:
+    """``_ceiling_series`` returns an output-throughput bound in the output
+    axis pair's units, computed from the session's ISL/OSL."""
+
+    def _payload(self, mode: str, metric: str) -> dict[str, Any]:
+        return {
+            "benchmark_mode": mode,
+            "summary": {"metric": metric},
+            "roofline_ceiling": {"rows": [{"conc": 8, "t_peak_tok_s": 4000.0}]},
+            "baseline": {
+                "points": [
+                    {
+                        "conc": 8,
+                        "output_throughput": 183.44,
+                        "total_token_throughput": 25984.8,
+                        "intvty_p90": 447.2,
+                    }
+                ]
+            },
+            "optimized": {"points": []},
+        }
+
+    def _ceiling_calls(self, tmp_path: Path, monkeypatch, payload: dict[str, Any]) -> list[Any]:
+        from hyperloom.orchestrator.kernel import conc_sweep_plot as plot
+
+        calls: list[Any] = []
+
+        def _spy(ceiling_data, tp_eff):
+            calls.append(ceiling_data)
+            return [], []
+
+        monkeypatch.setattr(plot, "_ceiling_series", _spy)
+        assert plot.render_conc_sweep_curve(payload, tmp_path / "c.png", tp=8, draw_ceiling=True) is not None
+        return calls
+
+    def test_a_synthetic_output_chart_draws_it(self, tmp_path: Path, monkeypatch):
+        """Positive control: the spy fires when both conditions hold."""
+        assert self._ceiling_calls(tmp_path, monkeypatch, self._payload("synthetic", "output_throughput"))
+
+    def test_a_total_y_axis_is_not_the_bounds_axis(self, tmp_path: Path, monkeypatch):
+        assert self._ceiling_calls(tmp_path, monkeypatch, self._payload("synthetic", "total_token_throughput")) == []
+
+    def test_an_agentic_replay_has_no_real_isl_to_bound(self, tmp_path: Path, monkeypatch):
+        assert self._ceiling_calls(tmp_path, monkeypatch, self._payload("agentx", "output_throughput")) == []
 
 
 def test_render_conc_sweep_curve_missing_matplotlib_returns_none(
@@ -1654,7 +1730,7 @@ def test_render_conc_sweep_curve_missing_matplotlib_returns_none(
 def test_conc_sweep_plot_series_helpers_filter_and_sort_points():
     from hyperloom.orchestrator.kernel import conc_sweep_plot
 
-    axes = conc_sweep_plot._resolve_axes("synthetic", 2.0)
+    axes = conc_sweep_plot._axes_for_metric("output_throughput", 2.0)
     xs, ys = conc_sweep_plot._arm_series(
         [
             {"conc": 4, "output_throughput": 800.0},

--- a/src/hyperloom/inference_optimizer/tests/test_coverage_gap_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coverage_gap_units.py
@@ -1100,7 +1100,7 @@ def test_conc_sweep_plot_helper_series_and_payload_loading(tmp_path: Path) -> No
     assert plot._load_payload(payload) is payload
     assert plot._load_payload(payload_file) == payload
 
-    axes = plot.resolve_axes("synthetic", 2.0)
+    axes = plot._resolve_axes("synthetic", 2.0)
     xs, ys = plot._arm_series(payload["baseline"]["points"], 2.0, axes)
     assert xs == [200.0, 300.0]
     assert ys == [400.0, 300.0]

--- a/src/hyperloom/inference_optimizer/tests/test_coverage_gap_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coverage_gap_units.py
@@ -1100,7 +1100,7 @@ def test_conc_sweep_plot_helper_series_and_payload_loading(tmp_path: Path) -> No
     assert plot._load_payload(payload) is payload
     assert plot._load_payload(payload_file) == payload
 
-    axes = plot._resolve_axes("synthetic", 2.0)
+    axes = plot._axes_for_metric("output_throughput", 2.0)
     xs, ys = plot._arm_series(payload["baseline"]["points"], 2.0, axes)
     assert xs == [200.0, 300.0]
     assert ys == [400.0, 300.0]

--- a/src/hyperloom/inference_optimizer/tests/test_coverage_gap_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coverage_gap_units.py
@@ -1100,7 +1100,7 @@ def test_conc_sweep_plot_helper_series_and_payload_loading(tmp_path: Path) -> No
     assert plot._load_payload(payload) is payload
     assert plot._load_payload(payload_file) == payload
 
-    axes = plot._resolve_axes("synthetic", 2.0)
+    axes = plot.resolve_axes("synthetic", 2.0)
     xs, ys = plot._arm_series(payload["baseline"]["points"], 2.0, axes)
     assert xs == [200.0, 300.0]
     assert ys == [400.0, 300.0]

--- a/src/hyperloom/inference_optimizer/tests/test_report.py
+++ b/src/hyperloom/inference_optimizer/tests/test_report.py
@@ -135,6 +135,40 @@ def test_load_external_baseline_corrupt(tmp_path):
 
 
 # ---- _read_conc_sweep_pointer ----
+def test_the_chart_precheck_agrees_with_the_renderer(tmp_path, monkeypatch):
+    """A point the renderer would drop must not let the pre-check admit the chart.
+
+    The guard used to probe one field, so an agentic rung carrying throughput
+    but no interactivity passed it and then produced nothing to plot.
+    """
+    from hyperloom.inference_optimizer.session.session_paths import reports_dir
+
+    rdir = reports_dir(tmp_path)
+    rdir.mkdir(parents=True, exist_ok=True)
+    (rdir / "conc_sweep_summary.json").write_text(
+        json.dumps(
+            {
+                "benchmark_mode": "agentx",
+                "tp": 8,
+                "baseline": {"points": [{"conc": 8, "total_token_throughput": 25984.8}]},
+                "optimized": {"points": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    calls: list[object] = []
+    monkeypatch.setattr(rp, "render_conc_sweep_curve", lambda *a, **kw: calls.append(a), raising=False)
+
+    class _S:
+        tp = 8
+        model_name = "m"
+        gpu_type = "mi300x"
+
+    assert rp._render_conc_sweep_curve_for_report(tmp_path, tmp_path, _S()) is None
+    assert calls == []
+
+
 def test_read_conc_sweep_pointer_missing(tmp_path):
     assert rp._read_conc_sweep_pointer(tmp_path) is None
 

--- a/src/hyperloom/inference_optimizer/tests/test_report.py
+++ b/src/hyperloom/inference_optimizer/tests/test_report.py
@@ -135,38 +135,6 @@ def test_load_external_baseline_corrupt(tmp_path):
 
 
 # ---- _read_conc_sweep_pointer ----
-def test_the_chart_precheck_agrees_with_the_renderer(tmp_path, monkeypatch):
-    """A point the renderer would drop must not let the pre-check admit the chart.
-
-    The guard used to probe one field, so an agentic rung carrying throughput
-    but no interactivity passed it and then produced nothing to plot.
-    """
-    from hyperloom.inference_optimizer.session.session_paths import reports_dir
-
-    rdir = reports_dir(tmp_path)
-    rdir.mkdir(parents=True, exist_ok=True)
-    (rdir / "conc_sweep_summary.json").write_text(
-        json.dumps(
-            {
-                "benchmark_mode": "agentx",
-                "tp": 8,
-                "baseline": {"points": [{"conc": 8, "total_token_throughput": 25984.8}]},
-                "optimized": {"points": []},
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    calls: list[object] = []
-    monkeypatch.setattr(rp, "render_conc_sweep_curve", lambda *a, **kw: calls.append(a), raising=False)
-
-    class _S:
-        tp = 8
-        model_name = "m"
-        gpu_type = "mi300x"
-
-    assert rp._render_conc_sweep_curve_for_report(tmp_path, tmp_path, _S()) is None
-    assert calls == []
 
 
 def test_read_conc_sweep_pointer_missing(tmp_path):

--- a/src/hyperloom/inference_optimizer/tests/test_roofline_executor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_roofline_executor.py
@@ -489,10 +489,7 @@ from hyperloom.orchestrator.roles import (
     MockRobustnessBackend,
     ScriptedPlan,
 )
-from hyperloom.orchestrator.loop.coordinator import (
-    _AUDIT_ACTIONS as COORDINATOR_AUDIT_ACTIONS,
-    Coordinator,
-)
+from hyperloom.orchestrator.loop.coordinator import Coordinator
 from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
 from hyperloom.orchestrator.state.shared_state import (
     _AUDIT_ACTIONS as SHARED_STATE_AUDIT_ACTIONS,
@@ -552,9 +549,12 @@ def test_shared_state_has_roofline_audit_fields_by_default():
     assert {"roofline_attempts", "last_roofline"} <= set(s.to_dict())
 
 
-def test_audit_actions_includes_roofline_in_both_modules():
+def test_audit_actions_includes_roofline():
+    """One set gates both the recorder and writeback's failed-attempt row."""
+    from hyperloom.orchestrator.loop import writeback as wb
+
     assert "roofline" in SHARED_STATE_AUDIT_ACTIONS
-    assert "roofline" in COORDINATOR_AUDIT_ACTIONS
+    assert wb._AUDIT_ACTIONS is SHARED_STATE_AUDIT_ACTIONS
 
 
 def test_key_metric_map_has_roofline_snapshot_id():

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_v6_stages.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_v6_stages.py
@@ -179,8 +179,8 @@ def test_conc_sweep_renames_the_comparison_columns_and_keeps_the_arms(tmp_path):
     assert event["end_time"] == "2026-08-27T04:00:00+00:00"
     assert event["ext"]["comparison"][0] == {
         "conc": 8,
-        "baseline_output_throughput": 90.0,
-        "optimized_output_throughput": 99.0,
+        "baseline_throughput": 90.0,
+        "optimized_throughput": 99.0,
         "speedup": 1.1,
         "error": None,
     }

--- a/src/hyperloom/inference_optimizer/tests/test_sweep_phase_auto.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sweep_phase_auto.py
@@ -674,6 +674,26 @@ async def test_on_enter_sweep_ignores_full_sweep_recipe_for_auto_path(coord):
 
 
 @pytest.mark.asyncio
+async def test_a_state_with_no_ladder_lets_the_workload_pick(coord):
+    """An unseeded ladder must reach the engine as "unset", not as "none wanted".
+
+    The executor reads an empty list as a deliberate choice and skips the whole
+    sweep, so collapsing None into [] here would silently drop it for any state
+    the CLI did not seed.
+    """
+    coord.shared_state.phase_history = [
+        {"to_phase": "SWEEP", "reason": "plateau_kernel", "evidence": {}},
+    ]
+    coord.shared_state.conc_sweep_concs = []
+    await coord._on_enter_sweep(from_phase="KERNEL")
+
+    task = coord.tasks._tasks["internal-conc_sweep-phase_entry"]
+    assert task.params["concs"] is None
+    evidence = coord.shared_state.phase_history[-1]["evidence"]
+    assert evidence["auto_conc_sweep_concs"] is None
+
+
+@pytest.mark.asyncio
 async def test_on_enter_sweep_idempotent_on_reentry(coord):
     """Re-entering SWEEP twice hits the same conc_sweep idempotency_key."""
     coord.shared_state.phase_history = [

--- a/src/hyperloom/inference_optimizer/tests/test_sweep_phase_auto.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sweep_phase_auto.py
@@ -734,22 +734,17 @@ async def test_on_enter_sweep_failure_records_evidence(coord, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_on_enter_sweep_none_records_terminal_skip(coord, monkeypatch):
-    """If the enqueue helper returns None, SWEEP records a terminal skip."""
-
-    async def _none(*args, **kwargs):
-        return None
-
-    monkeypatch.setattr(coord.phase_sweep, "_enqueue_internal_conc_sweep_task", _none)
+async def test_on_enter_sweep_keeps_the_declines_own_skip_reason(coord):
+    """The helper's budget decline is terminal; the hook must not restate it."""
     coord.shared_state.phase_history = [
         {"to_phase": "SWEEP", "reason": "plateau_kernel", "evidence": {}},
     ]
+    coord.shared_state.remaining_minutes = lambda: 1.0
+
     await coord._on_enter_sweep(from_phase="KERNEL")
-    evidence = coord.shared_state.phase_history[-1]["evidence"]
-    assert evidence["auto_conc_sweep_error"] == "enqueue_returned_none"
+
     assert coord.tasks._tasks == {}
-    assert coord.shared_state.last_conc_sweep["status"] == "skipped"
-    assert coord.shared_state.last_conc_sweep["skip_reason"] == "enqueue_returned_none"
+    assert coord.shared_state.last_conc_sweep["skip_reason"] == "session_time_budget"
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/orchestrator/actions/executors/report.py
+++ b/src/hyperloom/orchestrator/actions/executors/report.py
@@ -1213,9 +1213,8 @@ def _render_conc_sweep_curve_for_report(
         Path to the written PNG, or ``None`` when the chart cannot be
         produced (missing data, missing matplotlib, IO error).
     """
-    from hyperloom.common.perf_metric import is_agentx_mode
     from hyperloom.inference_optimizer.session.session_paths import reports_dir as _reports_dir
-    from hyperloom.orchestrator.kernel.conc_sweep_plot import render_conc_sweep_curve
+    from hyperloom.orchestrator.kernel.conc_sweep_plot import render_conc_sweep_curve, resolve_axes
 
     json_path = _reports_dir(session_dir) / "conc_sweep_summary.json"
     if not json_path.exists():
@@ -1226,20 +1225,22 @@ def _render_conc_sweep_curve_for_report(
         log.debug("report_executor: cannot load conc_sweep_summary.json for plot: %s", exc)
         return None
 
-    # The axis the chart is drawn on differs by mode, so probe the one this
-    # payload will actually use.
-    axis_key = "total_token_throughput" if is_agentx_mode(payload.get("benchmark_mode")) else "output_throughput"
+    png_path = output_dir / "conc_sweep_curve.png"
+    tp = int(payload.get("tp") or getattr(state, "tp", 0) or 1)
+
+    # Ask the renderer's own axis pair whether a point is plottable, rather than
+    # probing one field: the two disagree on a point that carries throughput but
+    # no interactivity, and on a measured zero.
+    axes = resolve_axes(payload.get("benchmark_mode"), float(max(tp, 1)))
 
     def _has_data(arm_key: str) -> bool:
         pts = (payload.get(arm_key) or {}).get("points") or []
-        return any(p.get(axis_key) is not None for p in pts)
+        return any(axes.point_xy(p, float(max(tp, 1))) is not None for p in pts)
 
     if not _has_data("baseline") and not _has_data("optimized"):
-        log.debug("report_executor: conc_sweep_summary has no %s data — skipping plot", axis_key)
+        log.debug("report_executor: conc_sweep_summary has no plottable points — skipping plot")
         return None
 
-    png_path = output_dir / "conc_sweep_curve.png"
-    tp = int(payload.get("tp") or getattr(state, "tp", 0) or 1)
     model_label = str(getattr(state, "model_name", "") or "")
     gpu_label = str(getattr(state, "gpu_type", "") or "").upper()
     isl = int(payload.get("isl") or 0)

--- a/src/hyperloom/orchestrator/actions/executors/report.py
+++ b/src/hyperloom/orchestrator/actions/executors/report.py
@@ -1181,11 +1181,9 @@ def _format_conc_sweep_curve_section(summary: dict[str, Any]) -> list[str]:
     lines: list[str] = []
     lines.append("## Concurrency Sweep — Throughput vs Interactivity")
     lines.append("")
-    lines.append(
-        "Efficiency (tok/s/GPU) vs Interactivity (tok/s/user) across the "
-        "post-optimization concurrency ladder.  "
-        "Red = baseline, orange = optimized."
-    )
+    # The PNG draws its own axis labels, and they differ by workload; naming
+    # them here too drifts from the chart.
+    lines.append("The post-optimization concurrency ladder.  Red = baseline, orange = optimized.")
     lines.append("")
     lines.append(f"![Concurrency sweep curve]({png_md_rel})")
     lines.append("")
@@ -1200,7 +1198,8 @@ def _render_conc_sweep_curve_for_report(
     """Render the concurrency-sweep curve PNG into the reports directory.
 
     Loads the full ``conc_sweep_summary.json`` (not the slim pointer), calls
-    :func:`render_conc_sweep_curve`, and returns the path on success.
+    :func:`render_conc_sweep_curve`, and returns the path on success. The
+    renderer drops a payload with nothing plottable on its own axes.
 
     Args:
         session_dir: Session directory used to locate
@@ -1214,11 +1213,9 @@ def _render_conc_sweep_curve_for_report(
         produced (missing data, missing matplotlib, IO error).
     """
     from hyperloom.inference_optimizer.session.session_paths import reports_dir as _reports_dir
-    from hyperloom.orchestrator.kernel.conc_sweep_plot import render_conc_sweep_curve, resolve_axes
+    from hyperloom.orchestrator.kernel.conc_sweep_plot import render_conc_sweep_curve
 
     json_path = _reports_dir(session_dir) / "conc_sweep_summary.json"
-    if not json_path.exists():
-        return None
     try:
         payload = json.loads(json_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
@@ -1227,19 +1224,6 @@ def _render_conc_sweep_curve_for_report(
 
     png_path = output_dir / "conc_sweep_curve.png"
     tp = int(payload.get("tp") or getattr(state, "tp", 0) or 1)
-
-    # Ask the renderer's own axis pair whether a point is plottable, rather than
-    # probing one field: the two disagree on a point that carries throughput but
-    # no interactivity, and on a measured zero.
-    axes = resolve_axes(payload.get("benchmark_mode"), float(max(tp, 1)))
-
-    def _has_data(arm_key: str) -> bool:
-        pts = (payload.get(arm_key) or {}).get("points") or []
-        return any(axes.point_xy(p, float(max(tp, 1))) is not None for p in pts)
-
-    if not _has_data("baseline") and not _has_data("optimized"):
-        log.debug("report_executor: conc_sweep_summary has no plottable points — skipping plot")
-        return None
 
     model_label = str(getattr(state, "model_name", "") or "")
     gpu_label = str(getattr(state, "gpu_type", "") or "").upper()

--- a/src/hyperloom/orchestrator/kernel/conc_sweep.py
+++ b/src/hyperloom/orchestrator/kernel/conc_sweep.py
@@ -23,7 +23,7 @@ from typing import Any, Mapping
 from hyperloom.common import io as _common_io
 from hyperloom.common.gain_math import conc_pair_comparison
 from hyperloom.common.model_paths import resolve_session_model_path
-from hyperloom.common.perf_metric import is_agentx_mode
+from hyperloom.common.perf_metric import graded_metric_key, is_agentx_mode
 from hyperloom.common.timeutil import utc_now_compact
 from hyperloom.inference_optimizer.session.session_paths import reports_dir, runs_root
 from ..actions.executors._grid_runner import (
@@ -60,22 +60,6 @@ SCHEMA_VERSION = "1.0"
 # spaced across the interactivity range the chart is drawn over.
 DEFAULT_CONCS: list[int] = [256, 128, 64, 32, 16, 8, 4, 2]
 AGENTX_DEFAULT_CONCS: list[int] = [1, 4, 8, 10, 14, 20, 28]
-
-
-def graded_metric_key(benchmark_mode: Any = "") -> str:
-    """The point field a mode's speedup and its curve are both read on.
-
-    An agentic replay is ranked on total token throughput; output throughput is
-    about 1% of its token budget, so a summary computed there would report a
-    different quantity from the curve drawn beside it.
-
-    Args:
-        benchmark_mode: ``SharedState.benchmark_mode``.
-
-    Returns:
-        The point-record key holding that mode's graded throughput.
-    """
-    return "total_token_throughput" if is_agentx_mode(benchmark_mode) else "output_throughput"
 
 
 def default_concs_for_mode(benchmark_mode: Any = "") -> list[int]:
@@ -1199,7 +1183,7 @@ def _flush_partial_conc_sweep_report(  # noqa: PLR0913
         o_pts.sort(key=lambda p: p["conc"])
 
         comparison, summary = conc_pair_comparison(
-            b_pts, o_pts, metric_key=graded_metric_key(getattr(state, "benchmark_mode", ""))
+            b_pts, o_pts, metric_key=graded_metric_key(benchmark_mode=str(getattr(state, "benchmark_mode", "") or ""))
         )
         p: dict[str, Any] = {
             "schema_version": SCHEMA_VERSION,
@@ -1545,7 +1529,9 @@ async def run_conc_sweep(
     optimized_points.sort(key=lambda p: p["conc"])
 
     comparison, summary = conc_pair_comparison(
-        baseline_points, optimized_points, metric_key=graded_metric_key(getattr(state, "benchmark_mode", ""))
+        baseline_points,
+        optimized_points,
+        metric_key=graded_metric_key(benchmark_mode=str(getattr(state, "benchmark_mode", "") or "")),
     )
     budget_limited_no_pair = _budget_limited_without_valid_pair(
         budget_exhausted=budget_exhausted,
@@ -1629,6 +1615,5 @@ __all__ = [
     "_order_concs_desc",
     "conc_sweep_declined_to_run",
     "default_concs_for_mode",
-    "graded_metric_key",
     "run_conc_sweep",
 ]

--- a/src/hyperloom/orchestrator/kernel/conc_sweep.py
+++ b/src/hyperloom/orchestrator/kernel/conc_sweep.py
@@ -62,6 +62,22 @@ DEFAULT_CONCS: list[int] = [256, 128, 64, 32, 16, 8, 4, 2]
 AGENTX_DEFAULT_CONCS: list[int] = [1, 4, 8, 10, 14, 20, 28]
 
 
+def graded_metric_key(benchmark_mode: Any = "") -> str:
+    """The point field a mode's speedup and its curve are both read on.
+
+    An agentic replay is ranked on total token throughput; output throughput is
+    about 1% of its token budget, so a summary computed there would report a
+    different quantity from the curve drawn beside it.
+
+    Args:
+        benchmark_mode: ``SharedState.benchmark_mode``.
+
+    Returns:
+        The point-record key holding that mode's graded throughput.
+    """
+    return "total_token_throughput" if is_agentx_mode(benchmark_mode) else "output_throughput"
+
+
 def default_concs_for_mode(benchmark_mode: Any = "") -> list[int]:
     """The ladder a mode sweeps when the operator names none.
 
@@ -1182,7 +1198,9 @@ def _flush_partial_conc_sweep_report(  # noqa: PLR0913
         b_pts.sort(key=lambda p: p["conc"])
         o_pts.sort(key=lambda p: p["conc"])
 
-        comparison, summary = conc_pair_comparison(b_pts, o_pts)
+        comparison, summary = conc_pair_comparison(
+            b_pts, o_pts, metric_key=graded_metric_key(getattr(state, "benchmark_mode", ""))
+        )
         p: dict[str, Any] = {
             "schema_version": SCHEMA_VERSION,
             "status": "in_progress" if partial else "unknown",
@@ -1526,7 +1544,9 @@ async def run_conc_sweep(
     baseline_points.sort(key=lambda p: p["conc"])
     optimized_points.sort(key=lambda p: p["conc"])
 
-    comparison, summary = conc_pair_comparison(baseline_points, optimized_points)
+    comparison, summary = conc_pair_comparison(
+        baseline_points, optimized_points, metric_key=graded_metric_key(getattr(state, "benchmark_mode", ""))
+    )
     budget_limited_no_pair = _budget_limited_without_valid_pair(
         budget_exhausted=budget_exhausted,
         summary=summary,
@@ -1609,5 +1629,6 @@ __all__ = [
     "_order_concs_desc",
     "conc_sweep_declined_to_run",
     "default_concs_for_mode",
+    "graded_metric_key",
     "run_conc_sweep",
 ]

--- a/src/hyperloom/orchestrator/kernel/conc_sweep.py
+++ b/src/hyperloom/orchestrator/kernel/conc_sweep.py
@@ -192,13 +192,20 @@ def _point_from_variant(v: VariantResult, *, arm: str) -> dict[str, Any]:
         conc = int(envs.get("CONC", "0"))
     except (TypeError, ValueError):
         conc = 0
+    # aiperf reports the total; the other parsers pass through whatever the
+    # framework named, leaving it null on a run that measured both halves. The
+    # sum is the same identity ``perf_snapshot_from_mapping`` applies, and a
+    # session graded on the total axis fails outright without it.
+    total = v.total_token_throughput
+    if total is None and v.input_throughput is not None and v.output_throughput is not None:
+        total = v.input_throughput + v.output_throughput
     return {
         "arm": arm,
         "conc": conc,
         "status": v.status,
         "output_throughput": v.output_throughput,
         "request_throughput": v.request_throughput,
-        "total_token_throughput": v.total_token_throughput,
+        "total_token_throughput": total,
         "input_throughput": v.input_throughput,
         "intvty_p90": v.intvty_p90,
         "tpot_p90_ms": v.tpot_p90_ms,

--- a/src/hyperloom/orchestrator/kernel/conc_sweep_plot.py
+++ b/src/hyperloom/orchestrator/kernel/conc_sweep_plot.py
@@ -73,7 +73,7 @@ class _Axes:
     agentic: bool
 
 
-def _resolve_axes(benchmark_mode: Any, tp_eff: float) -> _Axes:
+def resolve_axes(benchmark_mode: Any, tp_eff: float) -> _Axes:
     """Pick the axis pair the payload's mode is ranked on."""
     if is_agentx_mode(benchmark_mode):
         return _Axes(
@@ -227,7 +227,7 @@ def _render(
 
     data = _load_payload(payload)
     tp_eff = float(max(tp, 1))
-    axes = _resolve_axes(data.get("benchmark_mode"), tp_eff)
+    axes = resolve_axes(data.get("benchmark_mode"), tp_eff)
 
     baseline_pts = (data.get("baseline") or {}).get("points") or []
     optimized_pts = (data.get("optimized") or {}).get("points") or []
@@ -321,4 +321,4 @@ def _render(
     return out_path
 
 
-__all__ = ["render_conc_sweep_curve"]
+__all__ = ["render_conc_sweep_curve", "resolve_axes"]

--- a/src/hyperloom/orchestrator/kernel/conc_sweep_plot.py
+++ b/src/hyperloom/orchestrator/kernel/conc_sweep_plot.py
@@ -73,7 +73,7 @@ class _Axes:
     agentic: bool
 
 
-def resolve_axes(benchmark_mode: Any, tp_eff: float) -> _Axes:
+def _resolve_axes(benchmark_mode: Any, tp_eff: float) -> _Axes:
     """Pick the axis pair the payload's mode is ranked on."""
     if is_agentx_mode(benchmark_mode):
         return _Axes(
@@ -227,7 +227,7 @@ def _render(
 
     data = _load_payload(payload)
     tp_eff = float(max(tp, 1))
-    axes = resolve_axes(data.get("benchmark_mode"), tp_eff)
+    axes = _resolve_axes(data.get("benchmark_mode"), tp_eff)
 
     baseline_pts = (data.get("baseline") or {}).get("points") or []
     optimized_pts = (data.get("optimized") or {}).get("points") or []
@@ -321,4 +321,4 @@ def _render(
     return out_path
 
 
-__all__ = ["render_conc_sweep_curve", "resolve_axes"]
+__all__ = ["render_conc_sweep_curve"]

--- a/src/hyperloom/orchestrator/kernel/conc_sweep_plot.py
+++ b/src/hyperloom/orchestrator/kernel/conc_sweep_plot.py
@@ -8,16 +8,23 @@ produced by :mod:`conc_sweep`.  The function is **best-effort**: any import
 failure (missing ``matplotlib``) or data / IO error is logged and ``None``
 is returned so callers can skip the chart without aborting the report.
 
-Axes follow the payload's ``benchmark_mode``; the two workloads are ranked on
-different quantities.
+Axes follow the metric the payload's ``summary`` was graded on, so the chart
+shows the ranking the session was actually scored by -- read off the record
+rather than re-derived, because the grading rule consults the environment of
+the process that ran the sweep.
 
-Agentic — the pair InferenceX ranks a submission by:
+Total token throughput — the pair InferenceX ranks a submission by:
   x = intvty_p90                     (p90 interactivity, tok/s/user)
   y = total_token_throughput / tp    (tok/s per chip)
 
-Synthetic — no aiperf export, so interactivity is approximated from concurrency:
+Output throughput — no aiperf export, so interactivity is approximated from
+concurrency:
   x = output_throughput / conc       (tok/s per user)
   y = output_throughput / tp         (tok/s per GPU)
+
+``benchmark_mode`` stays a separate question: it says whether the workload was
+an agentic replay, which decides whether the session's ISL/OSL are real and so
+whether the roofline can be drawn at all.
 
 Rendered on a black background for a high-contrast dashboard look. Colours:
   baseline  — red        ``#FF4C4C``
@@ -33,7 +40,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
-from hyperloom.common.perf_metric import is_agentx_mode
+from hyperloom.common.perf_metric import GRADED_OUTPUT, is_agentx_mode
 
 log = logging.getLogger(__name__)
 
@@ -65,28 +72,36 @@ def _synthetic_xy(point: Mapping[str, Any], tp_eff: float) -> tuple[float, float
 
 @dataclass(frozen=True)
 class _Axes:
-    """The pair one mode's points are plotted on."""
+    """The pair a graded metric is plotted on."""
 
     point_xy: Callable[[Mapping[str, Any], float], tuple[float, float] | None]
     x_label: str
     y_label: str
-    agentic: bool
 
 
-def _resolve_axes(benchmark_mode: Any, tp_eff: float) -> _Axes:
-    """Pick the axis pair the payload's mode is ranked on."""
-    if is_agentx_mode(benchmark_mode):
+def _graded_metric_of(data: Mapping[str, Any]) -> str:
+    """The axis this sweep was graded on, as the sweep recorded it.
+
+    Read rather than re-derived: the grading rule consults the environment,
+    which describes the process that ran the sweep, not the one drawing the
+    chart. A summary that names no metric was taken on
+    ``conc_pair_comparison``'s default.
+    """
+    return str((data.get("summary") or {}).get("metric") or "").strip() or GRADED_OUTPUT
+
+
+def _axes_for_metric(metric: str, tp_eff: float) -> _Axes:
+    """Pick the axis pair a graded metric is read on."""
+    if metric != GRADED_OUTPUT:
         return _Axes(
             point_xy=_agentx_xy,
             x_label="P90 Interactivity  (tok/s/user)",
             y_label=f"Token Throughput per Chip  (tok/s/chip, tp={int(tp_eff)})",
-            agentic=True,
         )
     return _Axes(
         point_xy=_synthetic_xy,
         x_label="Interactivity  (output_throughput / concurrency,  tok/s/user)",
         y_label=f"Efficiency  (output_throughput / tp={int(tp_eff)},  tok/s/GPU)",
-        agentic=False,
     )
 
 
@@ -227,7 +242,12 @@ def _render(
 
     data = _load_payload(payload)
     tp_eff = float(max(tp, 1))
-    axes = _resolve_axes(data.get("benchmark_mode"), tp_eff)
+    # Two independent facts the payload records separately: the axis the sweep
+    # was graded on, which an operator can pin against the workload's default,
+    # and whether the workload was an agentic replay at all.
+    metric = _graded_metric_of(data)
+    agentic = is_agentx_mode(data.get("benchmark_mode"))
+    axes = _axes_for_metric(metric, tp_eff)
 
     baseline_pts = (data.get("baseline") or {}).get("points") or []
     optimized_pts = (data.get("optimized") or {}).get("points") or []
@@ -253,8 +273,10 @@ def _render(
     ax.set_facecolor(bg)
 
     # The roofline is a decode-only output_throughput bound computed from the
-    # placeholder ISL/OSL, so it sits on neither agentic axis.
-    if draw_ceiling and not axes.agentic:
+    # session's ISL/OSL, and ``_ceiling_series`` returns it in that axis pair's
+    # units. It needs both: a workload whose ISL/OSL are real, and a chart whose
+    # y axis is the throughput the bound is on.
+    if draw_ceiling and not agentic and metric == GRADED_OUTPUT:
         ceiling_data = data.get("roofline_ceiling") or {}
         cx, cy = _ceiling_series(ceiling_data, tp_eff)
         if cx:
@@ -295,7 +317,7 @@ def _render(
     # An agentic replay takes its request shapes from the trace corpus, so the
     # session's ISL/OSL are inert placeholders and naming them would misreport
     # what was measured.
-    if axes.agentic:
+    if agentic:
         title_parts.append("Agentic")
     elif isl or osl:
         title_parts.append(f"ISL={isl} OSL={osl}")

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -97,19 +97,6 @@ from .coordinator_helpers import (
 log = logging.getLogger(__name__)
 
 
-# Audit-trail kinds (must match shared_state._AUDIT_ACTIONS).
-_AUDIT_ACTIONS: frozenset[str] = frozenset(
-    {
-        "baseline",
-        "profile",
-        "sweep",
-        "explore",
-        # Composite roofline runs profile + trace_analyze atomically.
-        "roofline",
-    }
-)
-
-
 def _extract_enablement_launch_log(result_payload: dict[str, Any] | None) -> str:
     """Extract launch/traceback text from a failed baseline result payload.
 

--- a/src/hyperloom/orchestrator/loop/writeback.py
+++ b/src/hyperloom/orchestrator/loop/writeback.py
@@ -47,7 +47,7 @@ from ..state.optimization_journal import (
 from ..actions.executors._accuracy_gate import ENABLEMENT_REVALIDATION_REASON
 from ..actions.executors._grid_server_args import strip_benchmark_harness_flags
 from ..actions.stop_attribution import stopped_by_the_run_class
-from ..state.shared_state import SharedState, resolve_graded_comparison
+from ..state.shared_state import _AUDIT_ACTIONS, SharedState, resolve_graded_comparison
 from hyperloom.inference_optimizer.protocol.intent import Intent
 from ..bus.message_bus import Message
 from .coordinator_helpers import (
@@ -85,7 +85,6 @@ from ..actions.executors._accuracy_gate import (
 from ..knowledge.agent_kb import PatchKB
 
 from .coordinator import (
-    _AUDIT_ACTIONS,
     _BASELINE_MAX_TOTAL_FAILURES,
     _DEFAULT_RESUME_DRIFT_FLOOR_PCT,
     _ENABLEMENT_MAX_STALL,

--- a/src/hyperloom/orchestrator/phases/sweep.py
+++ b/src/hyperloom/orchestrator/phases/sweep.py
@@ -101,7 +101,7 @@ class SweepPhase(PhaseHandler):
             task = await self._enqueue_internal_conc_sweep_task(
                 reason="phase_entry",
             )
-        except Exception as exc:  # noqa: BLE001 — defensive
+        except Exception as exc:  # noqa: BLE001 — a failed enqueue must still close the phase
             log.exception(
                 "SWEEP entry hook: failed to enqueue auto-conc-sweep: %r",
                 exc,
@@ -111,21 +111,15 @@ class SweepPhase(PhaseHandler):
                 auto_conc_sweep_error=repr(exc)[:240],
             )
             return
+        # The only None is the helper's own budget decline, which records its
+        # terminal skip before returning.
         if task is None:
-            # The enqueue helper declines with its own terminal skip when the
-            # session clock leaves nothing to spend; don't overwrite that reason.
-            last = getattr(state, "last_conc_sweep", None) or {}
-            if not str(last.get("status") or "").strip():
-                self._record_terminal_conc_sweep_skip(
-                    skip_reason="enqueue_returned_none",
-                    auto_conc_sweep_error="enqueue_returned_none",
-                )
             return
         log.info(
             "SWEEP entry (from=%s): auto-enqueued conc_sweep task=%s (concs=%s total_budget_sec=%s)",
             from_phase or "<unknown>",
             task.task_id,
-            task.params.get("concs") or [],
+            task.params.get("concs"),
             task.params.get("total_budget_sec"),
         )
         self._record_phase_entry_evidence(
@@ -141,7 +135,7 @@ class SweepPhase(PhaseHandler):
         *,
         reason: str,
     ) -> Task | None:
-        """Build + enqueue a Coordinator-internal ``conc_sweep`` task; returns None on error.
+        """Build + enqueue a Coordinator-internal ``conc_sweep`` task.
 
         Idempotency key + PolicyGate singleton ensure at most one per SWEEP.
 
@@ -149,8 +143,10 @@ class SweepPhase(PhaseHandler):
             reason: Tag used in the task's idempotency key and logging.
 
         Returns:
-            The created (or existing) ``conc_sweep`` task, or ``None`` on
-            enqueue error.
+            The created (or existing) ``conc_sweep`` task, or ``None`` when the
+            session clock leaves nothing to spend -- which records its own
+            terminal skip. An enqueue failure raises to the phase hook, which
+            records the error text a swallowed one would have lost.
         """
         state = self.shared_state
         configured_budget = int(state.conc_sweep_total_budget_sec or 0)
@@ -189,19 +185,12 @@ class SweepPhase(PhaseHandler):
             "variant_timeout_sec": int(state.conc_sweep_variant_timeout_sec or 0),
             "total_budget_sec": clamped_budget,
         }
-        try:
-            task, was_existing = await self.tasks.create_or_return_existing(
-                kind="conc_sweep",
-                params=params,
-                idempotency_key=f"internal-conc_sweep-{reason}{self._cycle_idem_suffix()}",
-                lease_ttl_sec=_conc_sweep_lease_ttl_sec(clamped_budget),
-            )
-        except Exception as exc:  # noqa: BLE001 — defensive
-            log.exception(
-                "conc_sweep: failed to enqueue internal task: %r",
-                exc,
-            )
-            return None
+        task, was_existing = await self.tasks.create_or_return_existing(
+            kind="conc_sweep",
+            params=params,
+            idempotency_key=f"internal-conc_sweep-{reason}{self._cycle_idem_suffix()}",
+            lease_ttl_sec=_conc_sweep_lease_ttl_sec(clamped_budget),
+        )
         if was_existing:
             log.info(
                 "internal-conc_sweep task already exists (idempotent: task_id=%s, state=%s)",

--- a/src/hyperloom/orchestrator/phases/sweep.py
+++ b/src/hyperloom/orchestrator/phases/sweep.py
@@ -46,10 +46,10 @@ class SweepPhase(PhaseHandler):
     """Extracted phase handler; delegates unknown attrs to its Coordinator."""
 
     async def _on_enter_sweep(self, *, from_phase: str) -> None:
-        """Auto-enqueue a ``conc_sweep`` task on SWEEP entry.
+        """Auto-enqueue the ``conc_sweep`` task on SWEEP entry.
 
-        The automatic phase path runs the baseline-vs-current concurrency curve
-        directly; the full workload ``sweep`` remains a manual executor.
+        It is the phase's only action: the baseline-vs-current concurrency
+        curve, on the ladder this workload sweeps.
 
         Args:
             from_phase: The phase being left, used only for logging.
@@ -216,9 +216,6 @@ class SweepPhase(PhaseHandler):
                 params["concs"],
                 params["total_budget_sec"],
             )
-        # Stamp evidence so PolicyGate's sweep_phase_singleton denies a later
-        # LLM full-workload ``sweep`` (conc_sweep already ran on SWEEP entry).
-        self._record_phase_entry_evidence(auto_conc_sweep_task_id=task.task_id)
         return task
 
     def _record_session_budget_conc_sweep_skip(self, *, denied: object) -> None:

--- a/src/hyperloom/orchestrator/phases/sweep.py
+++ b/src/hyperloom/orchestrator/phases/sweep.py
@@ -131,7 +131,9 @@ class SweepPhase(PhaseHandler):
         self._record_phase_entry_evidence(
             auto_conc_sweep_enqueued=True,
             auto_conc_sweep_task_id=task.task_id,
-            auto_conc_sweep_concs=list(task.params.get("concs") or []),
+            # Verbatim: None records "the workload picks", which is not the
+            # same statement as an empty ladder.
+            auto_conc_sweep_concs=task.params.get("concs"),
         )
 
     async def _enqueue_internal_conc_sweep_task(
@@ -180,7 +182,10 @@ class SweepPhase(PhaseHandler):
         params: dict[str, Any] = {
             "source": "coordinator_internal",
             "reason": str(reason),
-            "concs": list(state.conc_sweep_concs or []),
+            # None, not [], when the state carries no ladder: the executor reads
+            # [] as a deliberate "no concs" and skips, while None lets it fall
+            # back to the ladder for this workload.
+            "concs": list(state.conc_sweep_concs) if state.conc_sweep_concs else None,
             "variant_timeout_sec": int(state.conc_sweep_variant_timeout_sec or 0),
             "total_budget_sec": clamped_budget,
         }

--- a/src/hyperloom/orchestrator/policy/gate.py
+++ b/src/hyperloom/orchestrator/policy/gate.py
@@ -1002,10 +1002,10 @@ class PolicyGate:
         """Validate a ``PROPOSE_ACTION`` intent (the advisory channel).
 
         Requires ``action_name``, then hard-rejects kernel_agent-owned
-        actions (REQUEST-only). Mirrors the delegate channel's
-        sweep-singleton, per-action source, GEMM-tuning ownership, phase,
-        and external-tool collision gates so an LLM cannot sidestep them by
-        proposing instead of delegating.
+        actions (REQUEST-only). Mirrors the delegate channel's per-action
+        source, GEMM-tuning ownership, phase, and external-tool collision
+        gates so an LLM cannot sidestep them by proposing instead of
+        delegating.
 
         Args:
             role (AgentRole): the resolved role of the emitting agent.

--- a/src/hyperloom/orchestrator/policy/gate.py
+++ b/src/hyperloom/orchestrator/policy/gate.py
@@ -803,13 +803,8 @@ class PolicyGate:
             trusted_framework_targets=trusted_framework_targets,
         )
         # Coordinator-managed internal actions (roofline / profile /
-        # replay_warm_recipe / conc_sweep) are dispatched by
-        # the Coordinator itself, never LLM-delegated, so they receive path
-        # checks only. In particular the SWEEP-entry auto-enqueued conc_sweep
-        # must NOT be re-validated against the delegate-body sweep-family
-        # singleton guard here — that guard keys on auto_conc_sweep_task_id,
-        # which is the auto-enqueued task's own id, so it would deny the sole
-        # conc_sweep against itself and surface as a spurious sweep_failed.
+        # replay_warm_recipe / conc_sweep) are dispatched by the Coordinator
+        # itself, never LLM-delegated, so they receive path checks only.
         if kind in COORDINATOR_INTERNAL_ACTIONS:
             return
         skip_baseline_singleton = (

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -682,7 +682,8 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
     # epoch differs must not reuse the old KEEPs or baseline anchor.
     agentx_epoch: int = 0
     # CONC ladder for conc_sweep, seeded from the workload's own ladder by
-    # ``_parse_conc_sweep_concs``. Empty => skip_reason=empty_conc_list.
+    # ``_parse_conc_sweep_concs``. Empty is not an instruction: both readers
+    # send None instead, which resolves to the ladder for this workload.
     conc_sweep_concs: list[int] = field(default_factory=list)
     # Total wall-clock budget (s) for conc_sweep. 0 disables the gate.
     conc_sweep_total_budget_sec: int = 9000


### PR DESCRIPTION
# Follow-up on #1385: the sweep summary, and what the retired action left behind

Review findings from #1385, plus a second review round on this branch.
**20 files, +369 / −160.**

## The summary was on a different axis from its own chart

`conc_pair_comparison` measured every speedup on `output_throughput`
regardless of workload. #1385 moved the agentic chart to total token
throughput against p90 interactivity, so on that corpus — where output
throughput is ~1% of the token budget — a config that lifts prefill moved
every point on the chart and left `best_speedup` flat.

The metric is a parameter now, and the key comes from
`total_tput_grading_enabled` — the same rule the session's KEEP verdicts
are taken under, including when `HYPERLOOM_PERF_METRIC` overrides the
workload's default in either direction. Deriving it from `benchmark_mode`
alone reproduced the divergence one layer over: an agentic session pinned
to output grading reported `metric=total_token_throughput`, and a session
whose mode never persisted but whose shell carries the AgentX signal
graded on total and reported output.

The chart follows, by reading that decision rather than repeating it. The
grading rule consults the environment, which describes the process that
ran the sweep and not the one drawing the chart; `summary.metric` is
already in the payload, and the breakdown recovery already reads it. A
chart on a different axis from its summary invites reading off a rung the
grading did not pick.

`_Axes` had carried the axis pair and an `agentic` flag together, so a
session could not be graded on one axis while its workload was the other.
The payload records the two separately: the pair comes from the recorded
metric, and whether the workload was an agentic replay -- which decides
whether ISL/OSL are real -- from `benchmark_mode`. That splits the
roofline gate in two and it needs both halves: the bound is decode-only
output throughput returned in the output pair's units, so a total-token y
axis is not its axis, and ISL/OSL must be real for it to be computable.

The ladder still reads the mode directly. Which concurrencies a workload
sweeps is a property of the workload, not of how it is scored.

V6 comparison rows carried the axis in their field names
(`baseline_output_throughput`), true for one workload only; they are
`baseline_throughput` / `optimized_throughput` with `result.metric` naming
the source.

## A total nobody reported failed the sweep

`conc_pair_comparison` needs both sides positive to count a pair, and a
sweep with no counted pair reports `failed`, which ends the session. The
curve row took `total_token_throughput` straight off the variant, so a
session graded on that axis failed on measurements that were complete but
whose parser named only the halves. aiperf coalesces the same sum before
the report is written and `perf_snapshot_from_mapping` applies it again on
the way in; the curve row was the one place on the graded path that did
not.

## The breakdown recovered on a different axis than it replaced

A mirrored report with zero successful pairs is superseded by one rebuilt
from `runs/conc_sweep`, and the rebuild always graded on output. On the
agentic corpus that is the substitution the section is least able to show.
The recovery reuses the axis the superseded report names in
`summary.metric` rather than inferring a mode — report generation need not
run in the shell the sweep ran in.

## An unseeded ladder skipped the sweep

The phase collapsed a missing ladder into `[]` on the way to the task. The
executor reads `[]` as a deliberate "no concurrencies wanted" and
short-circuits, so any `SharedState` the CLI had not seeded skipped the
whole sweep with `empty_conc_list` while the phase still exited
`sweep_done`. `None` travels now, which both the executor and the engine
already read as "resolve the ladder for this workload" — and the entry log
prints it verbatim instead of as the `[]` this branch defines as "none".

## One set of audited action kinds

`_AUDIT_ACTIONS` existed twice — `shared_state`'s, which the recorder gates
on, and `coordinator`'s, which writeback's failed-attempt row gates on. A
comment asserted they matched and nothing enforced it, so #1385 removing
the retired `sweep` action from one left the other claiming an
undispatchable kind. Writeback reads the recorder's set; the copy is gone;
the test pins identity, not equality.

## Removed rather than fixed

- **The chart pre-check.** It asked the resolved axis pair whether any
  point was plottable; the renderer asks the same pair over the same points
  and returns `None` with an equivalent debug line. The check bought a
  skipped matplotlib import, at the cost of reaching into the plot module's
  private axis dataclass from the report executor. Its regression test was
  vacuous — the renderer is imported inside the function under test, so
  patching the name on the report module set an attribute nobody read, and
  the payload made the real renderer return `None` anyway. It passed
  against the code it was written to catch.
- **Two of three enqueue failure layers.** The helper swallowed everything
  `create_or_return_existing` could raise and returned `None`; the hook
  caught what the helper might still raise; a third check asked whether a
  `None` had already recorded its reason. An enqueue error arrived as
  `enqueue_returned_none` with the exception text discarded below. The
  helper raises, the hook records the repr, and the only remaining `None`
  is the budget decline that stamps its own skip.
- **The section caption's axis names**, which were fixed while the PNG
  draws labels that differ by workload.
- **Three comments and a docstring** describing the deleted workload sweep,
  its singleton guard, and an `empty_conc_list` that an unseeded ladder can
  no longer reach.

## Not addressed

- **Arm-level budget pricing** (`_granted_cap_sec` without a rung
  concurrency) — a coarser approximation, not a bug: inert unless both
  `AGENTX_WARMUP_GRACE_PERIOD` and `AGENTX_WARMUP_GRACE_CONC` are declared,
  and the rung-level gates catch what it admits.
- **Auditing `conc_sweep`** — its `record_action_attempt` extras are
  discarded because the kind is not audited, which is real but predates
  #1385. `record_action_attempt` writes `last_<action>`, which would collide
  with the `last_conc_sweep` that `exit_normal_sweep` and
  `conc_sweep_declined_to_run` read.