### PR TITLE
fix(enablement): archive what a failed round is actually diagnosed from

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_enablement_coordinator_wiring_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_enablement_coordinator_wiring_unit.py
@@ -307,7 +307,7 @@ def _enqueue_self(**state_kw):
     fake = types.SimpleNamespace(
         shared_state=state,
         tasks=_FakeTasks(),
-        session_dir="/tmp/session",
+        session_dir=state_kw.get("session_dir", "/tmp/session"),
         _run_deadline=state_kw.get("run_deadline", None),
         _warm_specialist_params=_warm,
         _record_observation=_record_obs,
@@ -729,6 +729,48 @@ async def test_rearm_kept_stores_accepted_config():
         }
     )
     assert fake.shared_state.enablement.accepted_config == effective
+
+
+@pytest.mark.asyncio
+async def test_rearm_kept_points_accepted_config_at_the_archived_copy(tmp_path):
+    """The path the round reports is under runs/, which never reaches the archive."""
+    cfg = tmp_path / "runs" / "integrate_patch" / "t1" / "integrate_patch.with_envs.yaml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text("tp: 8\n", encoding="utf-8")
+    fake = _enqueue_self(session_dir=tmp_path, enablement_inflight_task_id="spec-1")
+    # Read by the setting-script write that shares the rearm's archive block.
+    fake.shared_state.model_path = "/models/M"
+    fake.shared_state.reference_model = ""
+    fake.shared_state.tp = 8
+    fake.shared_state.max_model_len = 0
+    fake._maybe_rearm_enablement(
+        {
+            "status": "kept",
+            "enablement": True,
+            "specialist_task_id": "abc123",
+            "enablement_accepted_config_path": str(cfg),
+        }
+    )
+    archived = tmp_path / "reports" / "enablement" / "abc123" / "launch_config.yaml"
+    assert archived.is_file()
+    # Absolute: the revalidation baseline opens this file directly.
+    assert fake.shared_state.enablement.accepted_config_path == str(archived)
+
+
+@pytest.mark.asyncio
+async def test_rearm_kept_holds_the_source_path_when_the_copy_does_not_land(tmp_path):
+    """With no copy there is no archive path to record, so the live one stands."""
+    fake = _enqueue_self(session_dir=tmp_path, enablement_inflight_task_id="spec-1")
+    fake._maybe_rearm_enablement(
+        {
+            "status": "kept",
+            "enablement": True,
+            "specialist_task_id": "abc123",
+            "enablement_accepted_config_path": "/runs/integrate_patch/t1/vanished.yaml",
+        }
+    )
+    assert not (tmp_path / "reports" / "enablement" / "abc123" / "launch_config.yaml").exists()
+    assert fake.shared_state.enablement.accepted_config_path == "/runs/integrate_patch/t1/vanished.yaml"
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/orchestrator/enablement/lane.py
+++ b/src/hyperloom/orchestrator/enablement/lane.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 import hashlib
 import os
 import time
+from pathlib import Path
 from typing import Any
 
 from ..actions.executors._grid_server_args import merge_server_args
 from ..collaborator import CoordinatorCollaborator
 from ..loop.coordinator import _ENABLEMENT_MAX_STALL
 from ..loop.coordinator_helpers import _dedupe_extra_server_args
-from ..phases._enablement_artifacts import snapshot_round, write_setting_script
+from ..phases._enablement_artifacts import role_path, snapshot_round, write_setting_script
 
 import logging as _logging
 
@@ -397,8 +398,9 @@ class EnablementLane(CoordinatorCollaborator):
         res_fw_root = str(res.get("framework_root") or "").strip()
         if res_fw_root:
             state.enablement.framework_root = res_fw_root
+        archived: list[dict[str, str]] = []
         try:
-            snapshot_round(self.session_dir, res)
+            archived = snapshot_round(self.session_dir, res)
             if status in ("kept", "advanced"):
                 write_setting_script(
                     self.session_dir,
@@ -411,6 +413,12 @@ class EnablementLane(CoordinatorCollaborator):
                 )
         except Exception:  # noqa: BLE001 — archiving must not break the rearm
             log.warning("enablement: artifact write failed", exc_info=True)
+        # Absolute and not the session-relative path just recorded: the
+        # revalidation baseline opens this file directly, and the breakdown
+        # collector relativizes it on the way into SBD.
+        archived_config = role_path(archived, "launch_config")
+        if status == "kept" and archived_config:
+            state.enablement.accepted_config_path = str(Path(self.session_dir) / archived_config)
         # A rearm always ends the round.
         state.enablement.inflight_task_id = ""
         try:

--- a/src/hyperloom/orchestrator/phases/_enablement_artifacts.py
+++ b/src/hyperloom/orchestrator/phases/_enablement_artifacts.py
@@ -4,8 +4,8 @@
 """Copy enablement round deliverables into ``reports/enablement/<task_id>/``.
 
 The archive collector drops ``runs/`` wholesale and retains ``reports/``, so a
-patch or launch config left in the specialist workspace never reaches the
-archive and the fix cannot be replayed by a later session.
+patch, launch config or server log left in the specialist workspace never
+reaches the archive and the fix cannot be replayed by a later session.
 """
 
 from __future__ import annotations
@@ -28,6 +28,13 @@ if TYPE_CHECKING:
 # eat into the archive's per-session budget.
 _FILE_SIZE_LIMIT = 2 * 1024 * 1024
 
+# Server logs routinely exceed _FILE_SIZE_LIMIT, so they are truncated rather
+# than skipped. Half the patch ceiling still holds tens of thousands of lines of
+# a crash while bounding what a many-round session adds to the archive.
+_SERVER_LOG_TAIL_LIMIT = 1024 * 1024
+
+_LOG_TRUNCATION_NOTE = "[hyperloom] truncated: the first {dropped} bytes are missing; the tail follows.\n"
+
 _LAUNCH_LOG_EXCERPT_CHARS = 1200
 
 
@@ -44,7 +51,43 @@ def _copy(src: Path, dest: Path) -> bool:
     return True
 
 
-def snapshot_round(session_dir: str | Path, res: dict[str, Any]) -> None:
+def _copy_log_tail(src: Path, dest: Path, limit: int = _SERVER_LOG_TAIL_LIMIT) -> bool:
+    """Copy at most the last ``limit`` bytes of ``src`` to ``dest``.
+
+    The tail and not the head: a launch failure writes its traceback at the end
+    of the log. What lands never exceeds ``limit`` plus the truncation note.
+
+    Returns:
+        ``True`` when the file landed at ``dest``.
+    """
+    if not src.is_file():
+        return False
+    dropped = max(0, src.stat().st_size - limit)
+    with src.open("rb") as fh:
+        if dropped:
+            fh.seek(dropped)
+        # Bounded here and not by EOF: the stat above can under-report a log
+        # that is still being appended to.
+        raw = fh.read(limit)
+    # The seek lands mid-codepoint, so the decode has to be lenient. It ignores
+    # rather than replaces: U+FFFD is three bytes, so a tail of binary noise
+    # would otherwise write three times ``limit``.
+    text = raw.decode("utf-8", errors="ignore")
+    if dropped:
+        text = _LOG_TRUNCATION_NOTE.format(dropped=dropped) + text
+    atomic_write_text(dest, text, make_parents=True)
+    return True
+
+
+def role_path(files: list[dict[str, str]], role: str) -> str:
+    """The session-relative path recorded for ``role``, or ``""`` when absent.
+
+    For the single-valued roles: ``patch`` repeats and needs the list itself.
+    """
+    return next((entry["path"] for entry in files if entry["role"] == role), "")
+
+
+def snapshot_round(session_dir: str | Path, res: dict[str, Any]) -> list[dict[str, str]]:
     """Archive one enablement round's patches, specialist result and launch config.
 
     Rounds the phase synthesises carry no task id and no deliverables, and are
@@ -53,14 +96,69 @@ def snapshot_round(session_dir: str | Path, res: dict[str, Any]) -> None:
     Args:
         session_dir: The session root directory.
         res: The ``integrate_patch`` result for an enablement round.
+
+    Returns:
+        One ``{"path", "role"}`` entry per deliverable that landed, ``path``
+        session-relative POSIX. Roles: ``patch`` (any number),
+        ``specialist_result``, ``prompt``, ``launch_config``, ``server_log``.
+        A copy the size ceiling refused is absent rather than listed.
     """
     task_id = str(res.get("specialist_task_id") or "").strip()
     if not task_id:
-        return
-    round_dir = enablement_round_dir(Path(session_dir), task_id)
+        return []
+    root = Path(session_dir)
+    round_dir = enablement_round_dir(root, task_id)
     round_dir.mkdir(parents=True, exist_ok=True)
+    written: list[dict[str, str]] = []
+
+    def _record(role: str, dest: Path) -> None:
+        written.append({"path": dest.relative_to(root).as_posix(), "role": role})
+
+    patches_dir = round_dir / "patches"
+    copied: set[str] = set()
+    for applied in res.get("patches_applied") or []:
+        src = Path(str(applied))
+        dest = patches_dir / src.name
+        if _copy(src, dest):
+            _record("patch", dest)
+        # Marked seen even when refused, so the sweep below does not retry it.
+        copied.add(src.name)
+
+    workspace = runs_dir(root, "specialist", task_id)
+    for name, role in (("specialist_done.json", "specialist_result"), ("prompt.md", "prompt")):
+        dest = round_dir / name
+        if _copy(workspace / name, dest):
+            _record(role, dest)
+
+    # Patches the round did not apply still explain what was attempted.
+    for base in (workspace, workspace / "worktree"):
+        for pattern in ("*.patch", "*.diff"):
+            for src in sorted((base / "patches").glob(pattern)):
+                if src.name in copied:
+                    continue
+                dest = patches_dir / src.name
+                if _copy(src, dest):
+                    _record("patch", dest)
+                copied.add(src.name)
+
+    accepted_config = str(res.get("enablement_accepted_config_path") or "").strip()
+    if accepted_config:
+        dest = round_dir / "launch_config.yaml"
+        if _copy(Path(accepted_config), dest):
+            _record("launch_config", dest)
+
+    # Only a round that reached a bench has one: a rejected patch or a broken
+    # build never started a server, so an absent log is normal.
+    bench = res.get("bench_result")
+    server_log = str(bench.get("server_log_path") or "").strip() if isinstance(bench, dict) else ""
+    if server_log:
+        dest = round_dir / "server.log"
+        if _copy_log_tail(Path(server_log), dest):
+            _record("server_log", dest)
 
     launch_log = str(res.get("enablement_launch_log") or "")
+    # Written last so the config path it names is the copy that just landed
+    # under ``reports/``, not the ``runs/`` original the collector drops.
     atomic_write_json(
         round_dir / "round.json",
         {
@@ -82,34 +180,12 @@ def snapshot_round(session_dir: str | Path, res: dict[str, Any]) -> None:
             "setup_commands_applied": [_sanitize_setup_command(c) for c in (res.get("setup_commands_applied") or [])],
             "framework_switch_problems": res.get("framework_switch_problems") or [],
             "after_signature": res.get("after_signature") or {},
-            "enablement_accepted_config_path": res.get("enablement_accepted_config_path") or "",
+            "enablement_accepted_config_path": role_path(written, "launch_config"),
             "enablement_effective_config": res.get("enablement_effective_config") or {},
             "launch_log_excerpt": launch_log[:_LAUNCH_LOG_EXCERPT_CHARS],
         },
     )
-
-    patches_dir = round_dir / "patches"
-    copied: set[str] = set()
-    for applied in res.get("patches_applied") or []:
-        src = Path(str(applied))
-        _copy(src, patches_dir / src.name)
-        copied.add(src.name)
-
-    workspace = runs_dir(Path(session_dir), "specialist", task_id)
-    _copy(workspace / "specialist_done.json", round_dir / "specialist_done.json")
-    _copy(workspace / "prompt.md", round_dir / "prompt.md")
-
-    # Patches the round did not apply still explain what was attempted.
-    for base in (workspace, workspace / "worktree"):
-        for pattern in ("*.patch", "*.diff"):
-            for src in sorted((base / "patches").glob(pattern)):
-                if src.name not in copied:
-                    _copy(src, patches_dir / src.name)
-                    copied.add(src.name)
-
-    accepted_config = str(res.get("enablement_accepted_config_path") or "").strip()
-    if accepted_config:
-        _copy(Path(accepted_config), round_dir / "launch_config.yaml")
+    return written
 
 
 def write_setting_script(
@@ -210,4 +286,4 @@ def write_setting_script(
     return str(out.relative_to(session_dir))
 
 
-__all__ = ["snapshot_round", "write_setting_script"]
+__all__ = ["role_path", "snapshot_round", "write_setting_script"]

--- a/src/hyperloom/orchestrator/phases/tests/test_enablement_artifacts.py
+++ b/src/hyperloom/orchestrator/phases/tests/test_enablement_artifacts.py
@@ -6,12 +6,17 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
 from hyperloom.orchestrator.phases._enablement_artifacts import (
     _FILE_SIZE_LIMIT,
+    _LOG_TRUNCATION_NOTE,
+    _SERVER_LOG_TAIL_LIMIT,
+    role_path,
     snapshot_round,
     write_setting_script,
 )
@@ -51,9 +56,21 @@ def test_applied_patch_is_copied(tmp_path):
     src = tmp_path / "runs" / "specialist" / "abc123" / "patches"
     src.mkdir(parents=True)
     (src / "001_fix.patch").write_text("diff --git a/f b/f\n", encoding="utf-8")
-    snapshot_round(tmp_path, _res(patches_applied=[str(src / "001_fix.patch")]))
+    written = snapshot_round(tmp_path, _res(patches_applied=[str(src / "001_fix.patch")]))
     dest = tmp_path / "reports" / "enablement" / "abc123" / "patches" / "001_fix.patch"
     assert dest.read_text() == "diff --git a/f b/f\n"
+    assert written == [{"path": "reports/enablement/abc123/patches/001_fix.patch", "role": "patch"}]
+
+
+def test_every_patch_of_a_round_is_reported(tmp_path):
+    """A round applies any number of patches, and every one of them is reported."""
+    src = tmp_path / "runs" / "specialist" / "abc123" / "patches"
+    src.mkdir(parents=True)
+    for name in ("001_a.patch", "002_b.patch", "003_c.patch"):
+        (src / name).write_text("diff\n", encoding="utf-8")
+    written = snapshot_round(tmp_path, _res(patches_applied=[str(p) for p in sorted(src.iterdir())]))
+    patches = [e["path"] for e in written if e["role"] == "patch"]
+    assert patches == [f"reports/enablement/abc123/patches/{n}" for n in ("001_a.patch", "002_b.patch", "003_c.patch")]
 
 
 def test_unapplied_workspace_patch_is_still_copied(tmp_path):
@@ -61,8 +78,9 @@ def test_unapplied_workspace_patch_is_still_copied(tmp_path):
     src = tmp_path / "runs" / "specialist" / "abc123" / "worktree" / "patches"
     src.mkdir(parents=True)
     (src / "002_try.diff").write_text("diff\n", encoding="utf-8")
-    snapshot_round(tmp_path, _res())
+    written = snapshot_round(tmp_path, _res())
     assert (tmp_path / "reports" / "enablement" / "abc123" / "patches" / "002_try.diff").is_file()
+    assert written == [{"path": "reports/enablement/abc123/patches/002_try.diff", "role": "patch"}]
 
 
 def test_specialist_result_and_prompt_are_copied(tmp_path):
@@ -70,18 +88,129 @@ def test_specialist_result_and_prompt_are_copied(tmp_path):
     ws.mkdir(parents=True)
     (ws / "specialist_done.json").write_text('{"summary": "ok"}', encoding="utf-8")
     (ws / "prompt.md").write_text("# prompt", encoding="utf-8")
-    snapshot_round(tmp_path, _res())
+    written = snapshot_round(tmp_path, _res())
     out = tmp_path / "reports" / "enablement" / "abc123"
     assert (out / "specialist_done.json").is_file()
     assert (out / "prompt.md").is_file()
+    assert role_path(written, "specialist_result") == "reports/enablement/abc123/specialist_done.json"
+    assert role_path(written, "prompt") == "reports/enablement/abc123/prompt.md"
+
+
+def _launch_config(tmp_path, body=b"tp: 8\n"):
+    """The materialized config a bench launched from, where integrate_patch leaves it."""
+    cfg = tmp_path / "runs" / "integrate_patch" / "t1" / "integrate_patch.with_envs.yaml"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_bytes(body)
+    return cfg
 
 
 def test_launch_config_is_copied(tmp_path):
-    cfg = tmp_path / "runs" / "integrate_patch" / "t1" / "integrate_patch.with_envs.yaml"
-    cfg.parent.mkdir(parents=True)
-    cfg.write_text("tp: 8\n", encoding="utf-8")
+    cfg = _launch_config(tmp_path)
     snapshot_round(tmp_path, _res(enablement_accepted_config_path=str(cfg)))
     assert (tmp_path / "reports" / "enablement" / "abc123" / "launch_config.yaml").is_file()
+
+
+def test_recorded_config_path_is_the_archived_copy(tmp_path):
+    """The runs/ original is dropped by the collector, so only the copy resolves."""
+    cfg = _launch_config(tmp_path)
+    written = snapshot_round(tmp_path, _res(enablement_accepted_config_path=str(cfg)))
+    data = json.loads((tmp_path / "reports" / "enablement" / "abc123" / "round.json").read_text())
+    assert role_path(written, "launch_config") == "reports/enablement/abc123/launch_config.yaml"
+    assert data["enablement_accepted_config_path"] == "reports/enablement/abc123/launch_config.yaml"
+
+
+def test_config_the_copy_refused_is_not_recorded(tmp_path):
+    """Naming a file the archive does not hold is worse than naming none."""
+    cfg = _launch_config(tmp_path, body=b"x" * (_FILE_SIZE_LIMIT + 1))
+    written = snapshot_round(tmp_path, _res(enablement_accepted_config_path=str(cfg)))
+    data = json.loads((tmp_path / "reports" / "enablement" / "abc123" / "round.json").read_text())
+    assert role_path(written, "launch_config") == ""
+    assert data["enablement_accepted_config_path"] == ""
+
+
+def test_server_log_is_archived(tmp_path):
+    """The bench error string cannot cluster failures; the server's own log can."""
+    log = tmp_path / "runs" / "integrate_patch" / "t1" / "server.log"
+    log.parent.mkdir(parents=True)
+    log.write_text("booting\nImportError: no module named aiter\n", encoding="utf-8")
+    written = snapshot_round(tmp_path, _res(bench_result={"server_log_path": str(log)}))
+    dest = tmp_path / "reports" / "enablement" / "abc123" / "server.log"
+    assert dest.read_text() == "booting\nImportError: no module named aiter\n"
+    assert role_path(written, "server_log") == "reports/enablement/abc123/server.log"
+
+
+def test_oversized_server_log_keeps_its_tail(tmp_path):
+    """A crash is written at the end, and the largest logs are the ones worth reading."""
+    log = tmp_path / "server.log"
+    log.write_bytes(b"START OF LOG\n" + b"x" * _SERVER_LOG_TAIL_LIMIT + b"\nSIGSEGV in fused_moe\n")
+    snapshot_round(tmp_path, _res(bench_result={"server_log_path": str(log)}))
+    text = (tmp_path / "reports" / "enablement" / "abc123" / "server.log").read_text(encoding="utf-8")
+    assert "SIGSEGV in fused_moe" in text
+    assert "START OF LOG" not in text
+    assert text.startswith("[hyperloom] truncated")
+
+
+def test_server_log_tail_survives_a_split_codepoint(tmp_path):
+    """A byte offset lands mid-character; the decode must not cost the whole log."""
+    log = tmp_path / "server.log"
+    log.write_bytes("码".encode() * (_SERVER_LOG_TAIL_LIMIT // 3 + 1))
+    snapshot_round(tmp_path, _res(bench_result={"server_log_path": str(log)}))
+    text = (tmp_path / "reports" / "enablement" / "abc123" / "server.log").read_text(encoding="utf-8")
+    body = text[len(_LOG_TRUNCATION_NOTE.format(dropped=2)) :]
+    # Only the character the seek landed inside is lost, and nothing is replaced.
+    assert set(body) == {"码"}
+    assert len(body) == _SERVER_LOG_TAIL_LIMIT // 3
+
+
+def test_a_log_still_growing_cannot_exceed_the_bound(tmp_path, monkeypatch):
+    """The seek offset comes from a stat taken before the read; the read must not trust it."""
+    log = tmp_path / "server.log"
+    log.write_bytes(b"y" * (_SERVER_LOG_TAIL_LIMIT * 3))
+    real_stat = Path.stat
+
+    def _stale_size(self, *args, **kwargs):
+        st = real_stat(self, *args, **kwargs)
+        if self != log:
+            return st
+        fields = list(st)
+        fields[6] = _SERVER_LOG_TAIL_LIMIT  # st_size, as of a moment ago
+        return os.stat_result(fields)
+
+    monkeypatch.setattr(Path, "stat", _stale_size)
+    snapshot_round(tmp_path, _res(bench_result={"server_log_path": str(log)}))
+    dest = tmp_path / "reports" / "enablement" / "abc123" / "server.log"
+    assert real_stat(dest).st_size == _SERVER_LOG_TAIL_LIMIT
+
+
+def test_round_json_redacts_the_setup_commands(tmp_path):
+    """The field is also the replay channel, so a token must not land in it."""
+    cmd = "pip install --index-url https://ghp_0123456789abcdefghij@host/simple foo"
+    snapshot_round(tmp_path, _res(setup_commands_applied=[cmd]))
+    data = json.loads((tmp_path / "reports" / "enablement" / "abc123" / "round.json").read_text())
+    assert "0123456789abcdefghij" not in data["setup_commands_applied"][0]
+
+
+def test_binary_noise_cannot_inflate_the_archived_log(tmp_path):
+    """Replacing malformed bytes would triple them; the archive bound must hold."""
+    log = tmp_path / "server.log"
+    log.write_bytes(b"\xff" * (_SERVER_LOG_TAIL_LIMIT * 2) + b"\nSIGSEGV in fused_moe\n")
+    snapshot_round(tmp_path, _res(bench_result={"server_log_path": str(log)}))
+    dest = tmp_path / "reports" / "enablement" / "abc123" / "server.log"
+    note = _LOG_TRUNCATION_NOTE.format(dropped=log.stat().st_size - _SERVER_LOG_TAIL_LIMIT)
+    assert dest.stat().st_size <= _SERVER_LOG_TAIL_LIMIT + len(note)
+    assert "SIGSEGV in fused_moe" in dest.read_text(encoding="utf-8")
+
+
+def test_round_before_a_bench_has_no_server_log(tmp_path):
+    """A patch rejected or a build broken never started a server to log."""
+    written = snapshot_round(tmp_path, _res())
+    assert role_path(written, "server_log") == ""
+    assert not (tmp_path / "reports" / "enablement" / "abc123" / "server.log").exists()
+
+
+def test_missing_server_log_is_skipped(tmp_path):
+    written = snapshot_round(tmp_path, _res(bench_result={"server_log_path": str(tmp_path / "gone.log")}))
+    assert role_path(written, "server_log") == ""
 
 
 def test_oversized_artifact_is_skipped(tmp_path):
@@ -89,8 +218,9 @@ def test_oversized_artifact_is_skipped(tmp_path):
     src.mkdir(parents=True)
     big = src / "003_big.patch"
     big.write_bytes(b"x" * (_FILE_SIZE_LIMIT + 1))
-    snapshot_round(tmp_path, _res(patches_applied=[str(big)]))
+    written = snapshot_round(tmp_path, _res(patches_applied=[str(big)]))
     assert not (tmp_path / "reports" / "enablement" / "abc123" / "patches" / "003_big.patch").exists()
+    assert written == []
 
 
 def test_launch_log_excerpt_is_bounded(tmp_path):
@@ -112,7 +242,8 @@ def test_demoted_switch_gate_is_recorded(tmp_path):
 
 def test_round_without_a_specialist_is_skipped(tmp_path):
     """Phase-synthesised rounds carry no task id and would all collide."""
-    snapshot_round(tmp_path, {"enablement": True, "status": "reverted", "reason": "artifact_unreadable"})
+    written = snapshot_round(tmp_path, {"enablement": True, "status": "reverted", "reason": "artifact_unreadable"})
+    assert written == []
     assert not (tmp_path / "reports" / "enablement").exists()
 
 


### PR DESCRIPTION
## What

Two archive-layer defects in enablement round snapshots.

**`accepted_config_path` named a file the archive never holds.** A round
recorded the `runs/` original it was benched from, and the collector drops
`runs/` wholesale, so every consumer that resolved it got a 404 — **214
production sessions published such a path**. The file was never missing:
`snapshot_round` already copied it to
`reports/enablement/<task_id>/launch_config.yaml`.

**A failed round archived no server log** — only `launch_log_excerpt`, 1200
characters of the bench error string. The traceback saying which deeper gap the
boot reached is in the server's own log, which lives under `runs/`.

## How

`snapshot_round` now reports every deliverable that landed as a `{path, role}`
entry, so `round.json` and the lane's state field name a path only once the copy
exists instead of each deriving the string ahead of the write. A list and not a
role-keyed map because a round applies any number of patches; all five roles
rather than the two consumed here so a reader never re-derives the layout.

The server log is copied under a 1 MiB cap, tail first — it routinely exceeds
the 2 MiB ceiling `_copy` refuses at, and the traceback is at the end. Malformed
bytes are ignored rather than replaced (U+FFFD is three bytes, so binary noise
would otherwise write three times the cap), and the read is bounded by the cap
rather than by EOF.

## Notes

**The state field stays absolute** while the reported path is relative. The
revalidation baseline opens the file directly, so it needs a usable filesystem
path; the breakdown collector relativizes it on the way into SBD, which is what
lands the projected value on `reports/`. The baseline re-renders into its own
output dir and never writes back, so pointing it at the archived copy cannot
mutate it.

**A copy that did not land is absent from the report**, so no writer can name a
file the archive lacks; the lane keeps the original `runs/` value, still the
best thing to point at in-session. Archiving stays inside the lane's existing
`try/except`.

## Test plan

- [x] `pytest src/hyperloom/orchestrator/phases/tests/test_enablement_artifacts.py
      src/hyperloom/inference_optimizer/tests/test_enablement_coordinator_wiring_unit.py`
      — 116 passed
- [x] `ruff check` clean, `ruff format --check` clean, `mypy` reports nothing new
      on either changed module
- [x] `snapshot_round` has one production caller (`lane.py`), updated with the
      new signature

New coverage: every patch of a round is reported; the server log is archived and
tail-truncated; the tail survives a split codepoint; neither binary noise nor a
still-growing log inflates it past the cap; a round before a bench and a missing
log are no-ops; `round.json` keeps the setup-command redaction through the
relocation; a refused copy records no path.

_Made with Cursor_