### PR TITLE
fix(profile): stop the per-batch-size graph-capture exporter taking the server down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- **Graph-capture traces go through the single-trace exporter, and the shape
+  manifest says when that costs it something.**
+  `SGLANG_ENABLE_CUDA_GRAPH_CAPTURE_TRACE` replaces
+  `SGLANG_GRAPH_BATCH_CAPTURE`, which selected a per-batch-size exporter that
+  cannot survive a model capturing more than one variant per batch size. It
+  indexes a list built from `capture_bs` once per profiler callback, but
+  `capture()` fires one callback per `(bs, lora, dsa)` combination, so a DSA
+  dual-graph model — dense and sparse for every batch size — walks off the end
+  of the list and takes the server down during graph capture, before it is
+  ready to serve. Upstream gives the single-trace flag precedence when both are
+  set (`decode_cuda_graph_runner.py::_graph_batch_capture_active`, from
+  sgl-project/sglang#24370), so an inherited `SGLANG_GRAPH_BATCH_CAPTURE=1`
+  cannot re-select the crashing path.<br/>
+  **The layout it writes is not a drop-in.** One combined file per rank holds
+  every batch size at once and carries no variant identity in its name, so the
+  shape-manifest classifier rejects it — deliberately, since admitting it would
+  mint one shape-identical variant per rank and defeat the dedup behind
+  `variant_count`. The identity is not recoverable from inside the file either:
+  the capture-phase `record_function` spans are not emitted on this path
+  (measured on a GLM-5.2 MI355X capture — 15166 `user_annotation` events, not
+  one of them a capture span). The manifest therefore falls back to eager and
+  Forge loses the per-batch-size dense shapes.<br/>
+  That fallback is also what an eager profile produces legitimately, so until
+  now the two were indistinguishable downstream. The manifest now emits
+  `shape_manifest_capture_not_indexable` when capture ran and only its layout
+  was unreadable, naming the files. A server that starts takes precedence over
+  a manifest that indexes, but the trade is recorded rather than silent.
+
 - **AgentX installs its own benchmark client instead of letting an agent guess
   at it.** `HYPERLOOM_AGENTX` declares aiperf as a required, version-pinned
   dependency and `install.sh` already owned that install, but it was gated on a

--- a/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_trace_analysis.py
@@ -895,7 +895,7 @@ def test_discover_capture_shards_dedups_tp_ranks(tmp_path):
 
 
 def test_discover_capture_shards_dedups_a_runner_prefixed_batch(tmp_path):
-    # An SGLang without the profiler patch prefixes the runner name:
+    # The upstream per-bs exporter prefixes the runner name:
     # DecodeCudaGraphRunner_bs_104_rank0. The batch token is still what
     # identifies the variant, so the ranks must collapse the same way — an
     # anchored read finds nothing here and falls back to the per-rank stem,
@@ -924,6 +924,74 @@ def test_discover_capture_shards_skips_a_whole_capture_per_rank_file(tmp_path):
     for rank in range(3):
         (d / f"cuda_graph_capture-DecodeCudaGraphRunner-TP-{rank}.json").write_text("{}", encoding="utf-8")
     assert bta._discover_capture_shards(str(d), str(d)) == []
+
+
+def test_unindexable_capture_names_reports_the_combined_layout(tmp_path):
+    # Skipping the combined layout is right; skipping it silently is not. The
+    # manifest degrades to eager exactly as it does when capture never ran, so
+    # the files have to be named for the two to be told apart downstream.
+    d = tmp_path / "graph_capture_profile"
+    d.mkdir()
+    for rank in range(2):
+        (d / f"cuda_graph_capture-DecodeCudaGraphRunner-TP-{rank}.json").write_text("{}", encoding="utf-8")
+
+    assert bta._unindexable_capture_names(str(d), str(d)) == [
+        "cuda_graph_capture-DecodeCudaGraphRunner-TP-0.json",
+        "cuda_graph_capture-DecodeCudaGraphRunner-TP-1.json",
+    ]
+
+
+def test_unindexable_capture_names_ignores_indexable_and_metadata(tmp_path):
+    # A per-bs shard is indexed, not reported, or every healthy profile would
+    # carry the warning. execution_details.json sits in the same directory and
+    # is metadata, not a trace.
+    d = tmp_path / "graph_capture_profile"
+    d.mkdir()
+    (d / "DecodeCudaGraphRunner_bs_8_rank0.json").write_text("{}", encoding="utf-8")
+    (d / "execution_details.json").write_text("[]", encoding="utf-8")
+
+    assert bta._unindexable_capture_names(str(d), str(d)) == []
+
+
+def test_shape_manifest_warns_when_capture_cannot_be_indexed(tmp_path, monkeypatch):
+    # End of the chain: a combined-layout profile still writes a manifest, but
+    # an eager one, and the run has to be able to see that from the result
+    # rather than by diffing variant_count against a healthy run.
+    monkeypatch.delenv("HYPERLOOM_TRACE_SHAPE_MANIFEST", raising=False)
+    d = tmp_path / "graph_capture_profile"
+    d.mkdir()
+    (d / "cuda_graph_capture-DecodeCudaGraphRunner-TP-0.json").write_text("{}", encoding="utf-8")
+
+    res = bta._maybe_build_shape_manifest(
+        _mk_args(trace_input=str(d), capture_folder=str(d)),
+        {"trace_file": ""},
+        tmp_path,
+        generated_at="t0",
+    )
+
+    assert res["status"] == "ok"
+    assert res["variant_count"] == 0
+    codes = [w.get("code") for w in res["warnings"] if isinstance(w, dict)]
+    assert "shape_manifest_capture_not_indexable" in codes
+    warning = next(
+        w for w in res["warnings"] if isinstance(w, dict) and w.get("code") == "shape_manifest_capture_not_indexable"
+    )
+    assert "cuda_graph_capture-DecodeCudaGraphRunner-TP-0.json" in warning["capture_files"]
+
+
+def test_shape_manifest_stays_quiet_when_capture_never_ran(tmp_path, monkeypatch):
+    # An eager manifest is the correct answer for an eager profile. Warning
+    # there would train the reader to ignore the one case that matters.
+    monkeypatch.delenv("HYPERLOOM_TRACE_SHAPE_MANIFEST", raising=False)
+    res = bta._maybe_build_shape_manifest(
+        _mk_args(trace_input=str(tmp_path), capture_folder=""),
+        {"trace_file": ""},
+        tmp_path,
+        generated_at="t0",
+    )
+
+    codes = [w.get("code") for w in res["warnings"] if isinstance(w, dict)]
+    assert "shape_manifest_capture_not_indexable" not in codes
 
 
 # ── CUDA/HIP graph-mode under-recording ──────────────────────────────────────

--- a/src/hyperloom/agents/kernel/tools/_capture_shapes.py
+++ b/src/hyperloom/agents/kernel/tools/_capture_shapes.py
@@ -21,10 +21,17 @@ useless to a steady-state splitter and must never be mistaken for the workload
 trace beside it.
 
 Matching is by *shape*, not by an exact name, because the profile's layout
-varies with framework and patch level: an SGLang carrying Hyperloom's profiler
-patch writes ``capture_traces/bs_<batch>_rank<n>``, an unpatched one writes
-``graph_capture_profile/cuda_graph_capture-<runner>-TP-<n>``, and vLLM writes
-``graph_capture_*``. An exact-name whitelist silently misses the shapes it has
+varies with the framework and with which exporter the run selected. SGLang has
+three, all of them upstream: ``capture_traces/bs_<batch>_rank<n>`` predates
+sgl-project/sglang#24370, and since that PR the choice is between
+``graph_capture_profile/<runner>_bs_<batch>_rank<n>`` (per batch size,
+``SGLANG_GRAPH_BATCH_CAPTURE``) and
+``graph_capture_profile/cuda_graph_capture-<runner>-TP-<n>`` (one combined file
+per rank, ``SGLANG_ENABLE_CUDA_GRAPH_CAPTURE_TRACE``, which takes precedence
+when both are set). vLLM writes ``graph_capture_*``. None of these indicates a
+patch level, so a reader that treats one as "unpatched" misreads a
+configuration choice as a deployment defect.
+An exact-name whitelist silently misses the shapes it has
 not been taught, and a missed sidecar is not merely ranked late: it shares the
 default discovery bucket with the workload trace, where the tie-break is
 descending file size, and a capture is the larger file.

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -40,6 +40,7 @@ from typing import Any
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import _bypass_report as _report  # noqa: E402
 import _bypass_trace_reader as _reader  # noqa: E402
+import _capture_shapes as _capshapes  # noqa: E402
 import _trace_shape_manifest as _tsm  # noqa: E402
 
 # Shared provenance builder (WP-0). Optional import: this tool is also invoked
@@ -191,7 +192,8 @@ def _emit_quality_warnings(analyze: dict[str, Any], warnings: list[dict[str, Any
                 "message": (
                     "no main profiler trace found; analysis ran on a sglang CUDA-graph "
                     "capture shard (device-kernel sparse). Ensure the main "
-                    "*-TP-*.trace.json.gz (not just capture_traces/bs_*) was captured."
+                    "*-TP-*.trace.json.gz was captured, not just the graph_capture_profile/ "
+                    "sidecars."
                 ),
             }
         )
@@ -211,19 +213,24 @@ _SHAPE_MANIFEST_OFF_VALUES = frozenset({"", "0", "false", "no", "off", "none", "
 _GFX_ENV = "HYPERLOOM_GFX_ARCH"
 #: sglang capture shard filename -> ``bs_<batch>`` variant. vLLM instead emits
 #: ``graph_capture_rank_*`` files whose batch/mode live in execution_details.json.
-#: Searched rather than matched from the start: an SGLang without the profiler
-#: patch prefixes the runner name, as in ``DecodeCudaGraphRunner_bs_104_rank0``,
+#: Searched rather than matched from the start: the upstream per-bs exporter
+#: prefixes the runner name, as in ``DecodeCudaGraphRunner_bs_104_rank0``,
 #: and an anchored read falls through to the bare stem -- which differs per rank,
 #: so the label dedup below stops collapsing the ranks of one batch.
 _VARIANT_RE = re.compile(r"(bs_\d+)", re.IGNORECASE)
 #: Which files carry an indexable per-variant shape. Deliberately NOT the shared
 #: ``_capture_shapes`` classifier: that one answers "is this a sidecar rather
 #: than a workload trace", which is a wider question than this one. A
-#: whole-capture-per-rank file such as an unpatched SGLang's
-#: ``cuda_graph_capture-<runner>-TP-<n>`` is certainly a sidecar, but it holds
+#: whole-capture-per-rank file, which is what ``SGLANG_ENABLE_CUDA_GRAPH_CAPTURE_TRACE``
+#: writes as ``cuda_graph_capture-<runner>-TP-<n>``, is certainly a sidecar, but it holds
 #: every batch size at once and carries no variant identity, so admitting it
 #: mints one bogus variant per rank -- TP=8 would inflate ``variant_count`` by
-#: eight shape-identical entries and defeat the dedup a few lines down. Admit a
+#: eight shape-identical entries and defeat the dedup a few lines down. The
+#: identity is not inside the file either: the capture-phase ``record_function``
+#: spans are not emitted on that path (measured on a GLM-5.2 MI355X capture:
+#: 15166 user_annotation events, none of them a capture span), so there is
+#: nothing to split it on -- ``_unindexable_capture_names`` says so out loud
+#: rather than letting it read as an ordinary eager fallback. Admit a
 #: ``bs_<batch>`` token anywhere (both SGLang layouts) or the vLLM prefix whose
 #: batch/mode arrive via execution_details.json.
 _CAPTURE_FILE_RE = re.compile(r"bs_\d+|\Agraph_capture", re.IGNORECASE)
@@ -234,6 +241,9 @@ _CAPTURE_FILE_RE = re.compile(r"bs_\d+|\Agraph_capture", re.IGNORECASE)
 #: drop is logged.
 _MAX_CAPTURES_ENV = "HYPERLOOM_TRACE_SHAPE_MANIFEST_MAX_CAPTURES"
 _DEFAULT_MAX_CAPTURES = 64
+#: Sidecar metadata written beside the capture files, not a trace itself. Named
+#: once because both the reader below and the unindexable-layout probe need it.
+_EXECUTION_DETAILS_NAME = "execution_details.json"
 
 
 def _sha256_file(path: str | Path) -> str:
@@ -257,13 +267,69 @@ def _load_execution_details(capdir: Path) -> dict[str, dict[str, Any]]:
     """
     out: dict[str, dict[str, Any]] = {}
     try:
-        data = json.loads((capdir / "execution_details.json").read_text(encoding="utf-8"))
+        data = json.loads((capdir / _EXECUTION_DETAILS_NAME).read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return out
     for e in data if isinstance(data, list) else []:
         if isinstance(e, dict) and e.get("file"):
             out[str(e["file"])] = {"batch_size": e.get("batch_size"), "mode": e.get("mode")}
     return out
+
+
+def _capture_roots(trace_input: str, capture_folder: str) -> list[Path]:
+    """Directories a capture sidecar may live in, in priority order.
+
+    ``capture_folder`` when the coordinator resolved one, then the trace input
+    itself (or its parent, for a single-file input).
+    """
+    roots: list[Path] = []
+    if capture_folder:
+        roots.append(Path(capture_folder))
+    ti = Path(trace_input)
+    roots.append(ti if ti.is_dir() else ti.parent)
+    return roots
+
+
+def _unindexable_capture_names(trace_input: str, capture_folder: str) -> list[str]:
+    """Capture sidecars that are present but carry no per-variant identity.
+
+    The combined layout -- one ``cuda_graph_capture-<runner>-TP-<n>`` per rank,
+    which ``SGLANG_ENABLE_CUDA_GRAPH_CAPTURE_TRACE`` selects -- holds every
+    batch size in a single file, so :data:`_CAPTURE_FILE_RE` rejects it on
+    purpose (see the note there: admitting it mints one bogus variant per rank).
+
+    Rejecting it is right; rejecting it *silently* is not. Without this the
+    manifest falls back to eager exactly as it does when graph capture never
+    ran, and the two are indistinguishable downstream -- Forge loses the per-bs
+    dense shapes with nothing in the output saying why. Naming the files lets
+    the caller separate "no capture" from "capture this manifest cannot index".
+
+    The sibling ``execution_details.json`` is not a way out, though it looks
+    like one: it carries the schema :func:`_load_execution_details` reads, but
+    on this layout it records a single ``batch_size`` for a file holding every
+    batch size (measured on a GLM-5.2 MI355X capture: 256 for all eight decode
+    ranks, 8 for all eight EAGLE draft ranks). Admitting the file on the
+    strength of that would not recover the variants -- it would label one
+    all-batch aggregate as a single batch and hand Forge a dense shape that is
+    wrong rather than missing.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    for root in _capture_roots(trace_input, capture_folder):
+        if not root.exists():
+            continue
+        for cand in _reader._trace_candidates(root):
+            key = str(cand.resolve())
+            if key in seen:
+                continue
+            seen.add(key)
+            if cand.name == _EXECUTION_DETAILS_NAME:
+                continue
+            if _CAPTURE_FILE_RE.search(cand.name):
+                continue
+            if _capshapes.is_capture_fragment(cand, root):
+                out.append(cand.name)
+    return sorted(out)
 
 
 def _discover_capture_shards(trace_input: str, capture_folder: str) -> list[tuple[Path, str, str | None]]:
@@ -276,11 +342,7 @@ def _discover_capture_shards(trace_input: str, capture_folder: str) -> list[tupl
 
     Looks in ``capture_folder`` when given, else under the trace-input tree.
     """
-    roots: list[Path] = []
-    if capture_folder:
-        roots.append(Path(capture_folder))
-    ti = Path(trace_input)
-    roots.append(ti if ti.is_dir() else ti.parent)
+    roots = _capture_roots(trace_input, capture_folder)
     seen: set[str] = set()
     seen_labels: set[str] = set()
     exec_cache: dict[Path, dict[str, dict[str, Any]]] = {}
@@ -468,12 +530,39 @@ def _maybe_build_shape_manifest(
             f"rows={len(manifest.get('rows', []))} path={out_path}",
             file=sys.stderr,
         )
+        warnings = list(manifest.get("warnings", []))
+        # An eager manifest is the right answer when graph capture never ran. It
+        # is a silent regression when capture *did* run and only the layout is
+        # unreadable, so separate the two before the distinction leaves here --
+        # downstream sees one eager manifest either way. Probed only on the
+        # empty path: it costs a directory walk.
+        unindexable = (
+            [] if capture_variants else _unindexable_capture_names(args.trace_input, args.capture_folder or "")
+        )
+        if unindexable:
+            message = (
+                "graph capture ran, but its trace carries no per-batch-size identity, so the "
+                "shape manifest fell back to eager and Forge has no per-bs dense shapes. The "
+                "combined layout (SGLANG_ENABLE_CUDA_GRAPH_CAPTURE_TRACE) writes one file per "
+                "rank holding every batch size at once; the per-bs exporter that would carry "
+                "the identity crashes the server during capture on any model that captures "
+                f"more than one variant per batch size. Files: {', '.join(unindexable[:4])}"
+            )
+            warnings.append(
+                {
+                    "code": "shape_manifest_capture_not_indexable",
+                    "severity": "warning",
+                    "message": message,
+                    "capture_files": unindexable[:8],
+                }
+            )
+            print(f"[trace_shape_manifest] {message}", file=sys.stderr)
         return {
             "status": "ok",
             "path": str(out_path),
             "variant_count": len(capture_variants),
             "row_count": len(manifest.get("rows", [])),
-            "warnings": manifest.get("warnings", []),
+            "warnings": warnings,
         }
     except Exception as exc:  # noqa: BLE001 — manifest must never break bypass
         msg = f"error: {type(exc).__name__}: {exc}"

--- a/src/hyperloom/inference_optimizer/assets/configs/profile_sglang.yaml
+++ b/src/hyperloom/inference_optimizer/assets/configs/profile_sglang.yaml
@@ -51,10 +51,29 @@ benchmark:
     # --- Profiler: shape + callstack annotations (#126) ---
     SGLANG_PROFILE_WITH_STACK: "true"
     SGLANG_PROFILE_RECORD_SHAPE: "true"
-    SGLANG_GRAPH_BATCH_CAPTURE: "1"
     # --- Profiler: graph capture (#126; shape-discovery flag dropped
     # because the deployed SGLang argparse rejects it) ---
     EXTRA_SGLANG_ARGS: "--enable-profile-cuda-graph"
+    # One combined capture trace per TP rank instead of one per batch size.
+    # The per-bs exporter indexes a list built from capture_bs once per
+    # profiler callback, but capture() fires one callback per
+    # (bs, lora, dsa) combination: a DSA dual-graph model captures dense and
+    # sparse for every bs, so the index walks off the end of the list and
+    # takes the server down during graph capture, before it is ready to
+    # serve. Upstream gives this flag precedence over SGLANG_GRAPH_BATCH_CAPTURE
+    # when both are set, so an inherited environment cannot re-select the
+    # per-bs path (decode_cuda_graph_runner.py::_graph_batch_capture_active,
+    # added by upstream sgl-project/sglang#24370).
+    #
+    # Known cost: the combined layout carries no per-bs variant identity in
+    # the filename, and the capture spans that would carry it inside the file
+    # are not emitted on this path, so the shape manifest degrades to eager
+    # and Forge loses the per-bs dense shapes. That degrade is reported as
+    # shape_manifest_capture_not_indexable
+    # (bypass_trace_analysis.py::_maybe_build_shape_manifest) rather than left
+    # to look like an ordinary eager profile. The server starting at all takes
+    # precedence.
+    SGLANG_ENABLE_CUDA_GRAPH_CAPTURE_TRACE: "1"
     # --- Profiler: steady-state window via extra_body (#194) ---
     # PROFILE_EXTRA_BODY is consumed by InferenceX benchmark_lib.sh to inject
     # into the benchmark request body. start_step skips warmup, num_steps


### PR DESCRIPTION
## Why

`profile_sglang.yaml` selects SGLang's per-batch-size graph-capture exporter.
That exporter cannot survive a DSA dual-graph model: it names each trace after a
batch size, tracked by one index advanced once per profiler callback.

```python
self._profile_bs_list = list(reversed(self.capture_bs))
self._profile_bs_idx = 0

def on_trace_ready(prof):
    bs = self._profile_bs_list[self._profile_bs_idx]
```

But `capture()` fires one callback per `(bs, lora, dsa)` combination. A model
that captures a dense and a sparse graph for each batch size therefore raises
the index past the end of the list, and the server goes down during graph
capture — before it is ready to serve a single request.

Switching to the single-trace exporter takes that path out of play. Upstream
gates the per-bs branch on the single-trace flag being unset
(`decode_cuda_graph_runner.py:765-766`), so setting it is enough; the buggy
indexing is never reached.

## Behaviour change and blast radius

**Breaking changes: no.** This is a profile-time capture setting; nothing in the
serving or baseline path reads it.

**Graph-capture trace layout changes.** One combined trace instead of one file
per `(batch size, rank)`. `_capture_shapes.py` classifies capture sidecars by
shape rather than by an exact name, and matches `graph_capture` anywhere in a
filename, so the combined trace is still recognised as a capture rather than
mistaken for the workload trace.

## What this does not fix

Stated so the PR is not read as closing more than it does. A profile round can
still come back with an empty hot-kernel table, for reasons this change does not
touch:

- the TraceLens 0.5.18 patch set being short three annotation patches — a
  TraceLens issue, tracked there;
- per-kernel device time folding into `hipGraphLaunch` under cuda-graph capture
  (#431), which is what actually empties the steady-state window in the captures
  looked at here;
- the AgentX `_AGENTX_PROFILE_MAX_ITERS = 8` capture cap, which lives in
  `_workload_envs.py` and carries its own host-RAM rationale.

## Dropped from the first revision of this PR

The first revision also set `SGLANG_PROFILE_WITH_STACK` to `false`, on the
argument that callstacks crowd GPU kernels out of the steady-state window. That
argument does not hold and the change has been reverted.

`python_function` events carry no correlation id — 0 of 641782 in the capture
that was quoted — and the splitter counts a chunk's GPU events solely by
collecting correlation ids from the CPU events inside a step window and looking
up the GPU events they map to. Callstacks never enter that count; removing them
changes it by zero.

A closer control says the same. Qwen3-0.6B `20260826T072156Z-edacec52` profiled
at **97.33%** `python_function`, *higher* than the 94.62% capture quoted as
evidence, under the same concurrency, the same two profiler env vars and the
same 128 steps — and did not hit `steady_state_chunk_empty`. Both captures
collapse the same way instead: 128 `hipGraphLaunch`, exactly one of which
carries GPU events, leaving 127 of 128 steps with zero. Which chunk the splitter
lands on decides whether a run survives.

The blast-radius check in that revision was also wrong to conclude nothing reads
a callstack. It searched for the env var name, which does appear once. But
`_trace_launcher_resolver` reads the `python_function` chain rather than the env
var, and runs unconditionally from `tracelens_analysis.py:5064` to recover a
Python launcher frame for the kernels TraceLens files as `(Synthetic Op)` with
`launcher_path = "Not found"` — hand-written Triton and AITER kernels, the ones
kernel optimisation is most likely to want. Without callstacks it falls back to
name-grep, which yields no line number and can match a test file or a CPU
implementation. TraceLens' own `mla_decode_pseudo_ops` matches `python_function`
names too.

## Verification

The four suites that read this config: **381 passed**.

```
pytest src/hyperloom/inference_optimizer/tests/test_workload_envs.py \
       src/hyperloom/inference_optimizer/tests/test_workload_envs_branches_unit.py \
       src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py \
       src/hyperloom/inference_optimizer/tests/test_aiperf_client_sh.py
```

The config parses and materialises the intended values, and no reference to the
replaced env var remains anywhere in the tree.
