### PR TITLE
A roofline target, and a met target that ends in SWEEP

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -82,8 +82,9 @@ Set with CLI flags, not env vars. Pre-set `ISL` / `OSL` / `CONC` / `PRECISION` /
 - **Model / workload shape:** `--model`, `--model-class`, `--framework`,
   `--framework-version`, `--precision`, `--tp`, `--ep`, `--isl`, `--osl`,
   `--conc`, `--max-model-len`, `--profile-osl`.
-- **Goal / budget:** `--target-gain`, `--max-hours`, `--target-summary`,
-  `--target-tput`, `--compare-against-gpu`.
+- **Goal / budget:** `--target-gain`, `--target-roofline`, `--max-hours`,
+  `--target-summary`, `--target-tput`, `--compare-against-gpu`. The roofline
+  target composes with the others: whichever is met first ends the run.
 - **Cluster topology & multi-node backend:** `--nodes`, `--gpus-per-node`,
   `--gpu-type`, `--mn-backend` (`rayjob` / `infera`), `--server-args` (rayjob).
   Per-pod sizing, the pod image and pod-side env are the provisioning

--- a/src/hyperloom/agents/robustness/role/envelope.py
+++ b/src/hyperloom/agents/robustness/role/envelope.py
@@ -168,6 +168,8 @@ CORE_STATE_FIELDS: frozenset[str] = frozenset(
         "plateau_overrides",
         # CLOSE phase sequencer flag.
         "close_sequence_done",
+        # Objective-met marker; the Coordinator is its only writer.
+        "target_reached_at",
         # unified explore search ledger.
         "explore_search",
         # structured gaps ledger.

--- a/src/hyperloom/inference_optimizer/breakdown/schema.py
+++ b/src/hyperloom/inference_optimizer/breakdown/schema.py
@@ -121,13 +121,16 @@ class WorkloadObjective(TypedDict, total=False):
 
     Attributes:
         kind (str): Objective type (``gain_pct`` / ``tput`` / ``baseline`` /
-            ``time_only``).
+            ``roofline_pct`` / ``time_only``).
         value (Any): Goal value — a float target, a string (e.g.
             ``target_baseline_dir``), or None when not applicable.
+        objectives (list): Every target the run carried, present only when it
+            carried more than one; ``kind`` / ``value`` name the first.
     """
 
-    kind: str  # gain_pct / tput / baseline / time_only
+    kind: str  # gain_pct / tput / baseline / roofline_pct / time_only
     value: Any  # float or str (target_baseline_dir) or None
+    objectives: list[dict[str, Any]]
 
 
 class Workload(TypedDict, total=False):

--- a/src/hyperloom/inference_optimizer/cli/__init__.py
+++ b/src/hyperloom/inference_optimizer/cli/__init__.py
@@ -99,7 +99,7 @@ from ..session.manifest import load_manifest, write_manifest
 from ..protocol.action_surfaces import ACTION_CATALOGUE, ActionMetadata
 from hyperloom.orchestrator.loop.coordinator import Coordinator
 from hyperloom.orchestrator.framework.paths import resolve_source_file_allowlist
-from hyperloom.orchestrator.state.objective import Objective, build_objective
+from hyperloom.orchestrator.state.objective import AnyObjective, Objective, build_objective
 from hyperloom.orchestrator.state.shared_state import SharedState, timed_teardown_step
 from hyperloom.orchestrator.prompts.prompt_builder import (
     TRANSPORT_TOOLS,
@@ -350,7 +350,9 @@ def _objective_summary_for_prompt(objective: Objective) -> tuple[str, float | st
 
     Inspects the objective for the first recognised target attribute
     (``target_gain_pct`` → float, ``target_tput_per_gpu`` → float,
-    ``baseline_dir`` → str) and pairs it with the objective's ``kind()``.
+    ``target_within_pct`` → float, ``baseline_dir`` → str) and pairs it with the
+    objective's ``kind()``. A composite objective has no single value, so its
+    members' descriptions stand in for one.
 
     Args:
         objective (Objective): The run objective to summarise.
@@ -361,10 +363,14 @@ def _objective_summary_for_prompt(objective: Objective) -> tuple[str, float | st
     """
     kind = objective.kind()
     value: float | str | None = None
+    if isinstance(objective, AnyObjective):
+        return kind, objective.describe()
     if hasattr(objective, "target_gain_pct"):
         value = float(getattr(objective, "target_gain_pct"))
     elif hasattr(objective, "target_tput_per_gpu"):
         value = float(getattr(objective, "target_tput_per_gpu"))
+    elif hasattr(objective, "target_within_pct"):
+        value = float(getattr(objective, "target_within_pct"))
     elif hasattr(objective, "baseline_dir"):
         value = str(getattr(objective, "baseline_dir"))
     return kind, value
@@ -2611,6 +2617,7 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             "TARGET_GAIN_PCT": str(args.target_gain) if args.target_gain else "",
             "TARGET_TPUT_PER_GPU": str(args.target_tput) if args.target_tput else "",
             "TARGET_DIR": args.target_baseline_dir or "",
+            "TARGET_WITHIN_ROOFLINE_PCT": str(args.target_roofline) if args.target_roofline else "",
         }
     )
     print(f"Objective       : kind={objective.kind()} {objective.describe()}")

--- a/src/hyperloom/inference_optimizer/cli/__init__.py
+++ b/src/hyperloom/inference_optimizer/cli/__init__.py
@@ -362,9 +362,9 @@ def _objective_summary_for_prompt(objective: Objective) -> tuple[str, float | st
         objective's numeric / string target, or ``None`` when none is present.
     """
     kind = objective.kind()
-    value: float | str | None = None
     if isinstance(objective, AnyObjective):
         return kind, objective.describe()
+    value: float | str | None = None
     if hasattr(objective, "target_gain_pct"):
         value = float(getattr(objective, "target_gain_pct"))
     elif hasattr(objective, "target_tput_per_gpu"):

--- a/src/hyperloom/inference_optimizer/cli/bootstrap.py
+++ b/src/hyperloom/inference_optimizer/cli/bootstrap.py
@@ -727,7 +727,8 @@ def _default_target_summary(args: argparse.Namespace) -> str:
     Used as the fallback ``target_summary`` when the operator did not pass an
     explicit ``--target-summary``. The phrasing depends on which target flag is
     set: ``--target-gain`` (percentage), ``--target-roofline`` (percentage of
-    the modelled ceiling, additive to either), ``--target-tput`` (tok/s/GPU for
+    the modelled ceiling, which composes with the others), ``--target-tput``
+    (tok/s/GPU for
     serving; for scriptable xDiT the target throughput is img/s and is shown as
     the equivalent per-image latency e2el_mean_ms), or neither (open-ended
     optimization within the time budget).

--- a/src/hyperloom/inference_optimizer/cli/bootstrap.py
+++ b/src/hyperloom/inference_optimizer/cli/bootstrap.py
@@ -726,7 +726,8 @@ def _default_target_summary(args: argparse.Namespace) -> str:
 
     Used as the fallback ``target_summary`` when the operator did not pass an
     explicit ``--target-summary``. The phrasing depends on which target flag is
-    set: ``--target-gain`` (percentage), ``--target-tput`` (tok/s/GPU for
+    set: ``--target-gain`` (percentage), ``--target-roofline`` (percentage of
+    the modelled ceiling, additive to either), ``--target-tput`` (tok/s/GPU for
     serving; for scriptable xDiT the target throughput is img/s and is shown as
     the equivalent per-image latency e2el_mean_ms), or neither (open-ended
     optimization within the time budget).
@@ -738,17 +739,24 @@ def _default_target_summary(args: argparse.Namespace) -> str:
     Returns:
         str: A one-sentence description of the run's objective.
     """
+    roofline = getattr(args, "target_roofline", None)
+    also = f" or {roofline}% of the roofline ceiling" if roofline else ""
     if args.target_gain:
         return (
             f"Establish baseline on {Path(args.model).name} then drive "
-            f"cumulative_gain_validated to >= {args.target_gain}% within "
+            f"cumulative_gain_validated to >= {args.target_gain}%{also} within "
             f"{args.max_hours}h."
         )
     if args.target_tput:
         from .. import framework_registry
 
         target = framework_registry.format_primary_metric(getattr(args, "framework", None), args.target_tput)
-        return f"Establish baseline on {Path(args.model).name} then reach {target} within {args.max_hours}h."
+        return f"Establish baseline on {Path(args.model).name} then reach {target}{also} within {args.max_hours}h."
+    if roofline:
+        return (
+            f"Establish baseline on {Path(args.model).name} then reach {roofline}% "
+            f"of the roofline ceiling within {args.max_hours}h."
+        )
     return f"Optimize {Path(args.model).name} for up to {args.max_hours}h (no target)."
 
 

--- a/src/hyperloom/inference_optimizer/cli/parser.py
+++ b/src/hyperloom/inference_optimizer/cli/parser.py
@@ -630,6 +630,18 @@ def _build_parser() -> argparse.ArgumentParser:
     grp.add_argument(
         "--target-baseline-dir", type=str, default=None, help="Stop when current best matches the baseline in DIR"
     )
+    # Outside the group: it measures a different axis, so it ORs with whichever
+    # of the three above is set rather than competing with them.
+    opt.add_argument(
+        "--target-roofline",
+        type=float,
+        default=None,
+        help=(
+            "Stop when the latest roofline snapshot reaches N%% of its modelled "
+            "ceiling. Inert until a roofline has been measured, and satisfied "
+            "independently of --target-gain / --target-tput / --target-baseline-dir."
+        ),
+    )
     opt.add_argument(
         "--resume-from",
         type=str,

--- a/src/hyperloom/inference_optimizer/session/manifest.py
+++ b/src/hyperloom/inference_optimizer/session/manifest.py
@@ -217,21 +217,34 @@ def _detect_image() -> str | None:
 def _objective_summary(args: argparse.Namespace) -> dict[str, Any]:
     """Mirror cli._run_optimize's objective derivation, without importing it.
 
+    ``kind`` / ``value`` keep naming one target because every consumer reads
+    that pair. A run with a roofline target alongside it carries the full set in
+    ``objectives`` as well.
+
     Args:
         args (argparse.Namespace): Parsed CLI args; checked for
-            ``target_gain``, ``target_tput``, and ``target_baseline_dir``.
+            ``target_gain``, ``target_tput``, ``target_baseline_dir``, and
+            ``target_roofline``.
 
     Returns:
         dict[str, Any]: Objective mapping with ``kind`` (one of ``gain_pct``,
-        ``tput``, ``baseline``, ``time_only``) and an associated ``value``.
+        ``tput``, ``baseline``, ``roofline_pct``, ``time_only``), an associated
+        ``value``, and ``objectives`` when more than one target is set.
     """
+    targets: list[dict[str, Any]] = []
     if getattr(args, "target_gain", None):
-        return {"kind": "gain_pct", "value": float(args.target_gain)}
-    if getattr(args, "target_tput", None):
-        return {"kind": "tput", "value": float(args.target_tput)}
-    if getattr(args, "target_baseline_dir", None):
-        return {"kind": "baseline", "value": str(args.target_baseline_dir)}
-    return {"kind": "time_only", "value": None}
+        targets.append({"kind": "gain_pct", "value": float(args.target_gain)})
+    elif getattr(args, "target_tput", None):
+        targets.append({"kind": "tput", "value": float(args.target_tput)})
+    elif getattr(args, "target_baseline_dir", None):
+        targets.append({"kind": "baseline", "value": str(args.target_baseline_dir)})
+    if getattr(args, "target_roofline", None):
+        targets.append({"kind": "roofline_pct", "value": float(args.target_roofline)})
+    if not targets:
+        return {"kind": "time_only", "value": None}
+    if len(targets) == 1:
+        return dict(targets[0])
+    return {**targets[0], "objectives": targets}
 
 
 def build_session_id(model_name: str = "") -> str:

--- a/src/hyperloom/inference_optimizer/session/manifest.py
+++ b/src/hyperloom/inference_optimizer/session/manifest.py
@@ -243,7 +243,7 @@ def _objective_summary(args: argparse.Namespace) -> dict[str, Any]:
     if not targets:
         return {"kind": "time_only", "value": None}
     if len(targets) == 1:
-        return dict(targets[0])
+        return targets[0]
     return {**targets[0], "objectives": targets}
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
@@ -2485,18 +2485,19 @@ async def test_dispatch_audit_logs_task_without_executor(session_dir, caplog):
 
 @pytest.mark.asyncio
 @pytest.mark.asyncio
-async def test_target_reached_routes_through_close_phase(session_dir):
-    """A met objective transitions to CLOSE instead of breaking out of the loop.
+async def test_target_reached_routes_through_sweep_then_close(session_dir):
+    """A met objective goes to SWEEP first, then closes on the target.
 
-    ``machine_state`` registers ``target_reached`` as an "any phase -> CLOSE"
-    transition reason, so a met target must reach the close sequencer rather
-    than leaving the run with only the cli safety-net report.
+    The concurrency curve has to measure the configuration the target was met
+    on, so the run cannot jump straight to CLOSE; and it must still reach the
+    close sequencer rather than leaving only the cli safety-net report.
     """
     _write_marker_target_baseline(session_dir)
     c = Coordinator(session_dir, backends=_silent_backends())
     c.sub.register_executor("report", report_executor)
     c.shared_state.baseline_tput = 100.0
     c.shared_state.cumulative_gain_validated = 50.0
+    c.shared_state.last_conc_sweep = {"status": "succeeded"}
     c.shared_state.save(session_dir)
     try:
         reason = await c.run(
@@ -2504,6 +2505,10 @@ async def test_target_reached_routes_through_close_phase(session_dir):
             max_ticks=6,
         )
         assert reason == "target_reached"
+        assert c.shared_state.target_reached_at
+        hops = [(r.get("to_phase"), r.get("reason")) for r in c.shared_state.phase_history]
+        assert ("SWEEP", "target_reached") in hops
+        assert ("CLOSE", "target_reached") in hops
         assert (c.shared_state.phase or "").upper() == "CLOSE"
         # The close sequencer actually ran; this is what separates a real close
         # from the cli safety-net path.
@@ -2527,6 +2532,7 @@ async def test_target_reached_at_session_bound_still_closes(session_dir):
     c.sub.register_executor("report", report_executor)
     c.shared_state.baseline_tput = 100.0
     c.shared_state.cumulative_gain_validated = 50.0
+    c.shared_state.last_conc_sweep = {"status": "succeeded"}
     c.shared_state.save(session_dir)
     try:
         reason = await c.run(
@@ -2552,13 +2558,14 @@ async def test_target_reached_closes_despite_a_failed_state_save(session_dir):
     c.sub.register_executor("report", report_executor)
     c.shared_state.baseline_tput = 100.0
     c.shared_state.cumulative_gain_validated = 50.0
+    c.shared_state.last_conc_sweep = {"status": "succeeded"}
     c.shared_state.save(session_dir)
 
     real_save = c.shared_state.save
     state = {"tripped": False}
 
     def flaky_save(*args, **kwargs):
-        if c.shared_state.stop_reason == "target_reached" and not state["tripped"]:
+        if c.shared_state.target_reached_at and not state["tripped"]:
             state["tripped"] = True
             raise OSError("simulated transient state-save failure")
         return real_save(*args, **kwargs)
@@ -2592,6 +2599,7 @@ async def test_target_reached_close_still_runs_the_post_opt_roofline(session_dir
     c.sub.register_executor("report", report_executor)
     c.shared_state.baseline_tput = 100.0
     c.shared_state.cumulative_gain_validated = 50.0
+    c.shared_state.last_conc_sweep = {"status": "succeeded"}
     # A kernel-level optimization landed, so the roofline step applies.
     c.shared_state.optimization_stack = [{"action": "integrate", "tput": 150.0}]
     c.shared_state.save(session_dir)
@@ -2629,14 +2637,15 @@ async def test_target_reached_close_is_not_cancelled_by_an_outer_bound(session_d
     c.sub.register_executor("report", report_executor)
     c.shared_state.baseline_tput = 100.0
     c.shared_state.cumulative_gain_validated = 50.0
+    c.shared_state.last_conc_sweep = {"status": "succeeded"}
     c.shared_state.save(session_dir)
 
     # The bound is armed and elapsed; the terminal close must ignore it.
     c._run_deadline = time.monotonic() - 1.0
     assert c._seconds_until_session_bound() is not None
-    c._terminal_closing = True
-    assert c._seconds_until_session_bound() is None, "terminal close must be unbounded"
-    c._terminal_closing = False
+    c._unbounded_advance = True
+    assert c._seconds_until_session_bound() is None, "the target advance must be unbounded"
+    c._unbounded_advance = False
 
     real_advance = c.phase_machine._advance_phase_if_needed
     completed: list[bool] = []

--- a/src/hyperloom/inference_optimizer/tests/test_objective.py
+++ b/src/hyperloom/inference_optimizer/tests/test_objective.py
@@ -257,7 +257,8 @@ async def test_run_stops_on_max_ticks(session_dir):
 
 
 @pytest.mark.asyncio
-async def test_run_stops_on_objective_reached(session_dir):
+async def test_run_routes_a_met_objective_through_sweep(session_dir):
+    """A met target marks the session and leaves through SWEEP, not straight to CLOSE."""
     c = Coordinator(session_dir, backends=_backends_silent())
     try:
         c.shared_state.baseline_tput = 1000.0
@@ -267,7 +268,11 @@ async def test_run_stops_on_objective_reached(session_dir):
             objective=TargetGainObjective(target_gain_pct=10.0),
             max_ticks=10,
         )
-        assert reason == "target_reached"
+        assert c.shared_state.target_reached_at
+        assert [row.get("to_phase") for row in c.shared_state.phase_history].count("SWEEP") == 1
+        # The ladder never ran in this harness, so SWEEP names its own failure
+        # rather than borrowing the target's success.
+        assert reason == "sweep_failed"
     finally:
         await c.stop()
 

--- a/src/hyperloom/inference_optimizer/tests/test_objective.py
+++ b/src/hyperloom/inference_optimizer/tests/test_objective.py
@@ -23,7 +23,9 @@ from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
 from hyperloom.orchestrator.state.objective import (
     ObjectiveError,
     TargetBaselineObjective,
+    AnyObjective,
     TargetGainObjective,
+    TargetRooflineObjective,
     TargetTputObjective,
     TimeOnlyObjective,
     build_objective,
@@ -575,3 +577,117 @@ async def test_run_async_stop_when_callback(session_dir):
         assert reason == "custom"
     finally:
         await c.stop()
+
+
+# --- the roofline target ---
+
+
+def _state_with_within(value: object) -> SharedState:
+    st = SharedState(session_id="s")
+    st.roofline_snapshots = [{"snapshot_id": 1, "within_roofline_pct": value}]
+    return st
+
+
+class TestARooflineTargetOnlyCountsAMeasuredRoofline:
+    """The objective has no separate "was it profiled" gate; an unmeasured
+    ceiling simply reads as zero progress."""
+
+    def test_no_snapshot_reads_as_unmeasured(self):
+        st = SharedState(session_id="s")
+        assert st.current_within_roofline_pct() is None
+        obj = TargetRooflineObjective(80.0)
+        assert obj.reached(st) is False
+        assert obj.progress(st) == 0.0
+        assert obj.gap_pct(st) == pytest.approx(80.0)
+
+    @pytest.mark.parametrize("value", [None, "62.5", True])
+    def test_a_non_numeric_within_reads_as_unmeasured(self, value):
+        st = _state_with_within(value)
+        assert st.current_within_roofline_pct() is None
+        assert TargetRooflineObjective(80.0).reached(st) is False
+
+    def test_the_latest_snapshot_wins(self):
+        st = _state_with_within(20.0)
+        st.roofline_snapshots.append({"snapshot_id": 2, "within_roofline_pct": 81.0})
+        assert st.current_within_roofline_pct() == pytest.approx(81.0)
+        assert TargetRooflineObjective(80.0).reached(st) is True
+
+    def test_below_and_at_the_bar(self):
+        obj = TargetRooflineObjective(80.0)
+        assert obj.reached(_state_with_within(79.99)) is False
+        assert obj.reached(_state_with_within(80.0)) is True
+        assert obj.gap_pct(_state_with_within(62.5)) == pytest.approx(17.5)
+        assert obj.progress(_state_with_within(40.0)) == pytest.approx(0.5)
+
+    @pytest.mark.parametrize("bad", [0.0, -1.0, 100.1])
+    def test_the_target_is_a_percentage(self, bad):
+        with pytest.raises(ObjectiveError):
+            TargetRooflineObjective(bad)
+
+
+class TestEitherTargetEndsTheRun:
+    """Gain and roofline measure different axes, so they compose rather than
+    compete."""
+
+    def _both(self) -> AnyObjective:
+        return AnyObjective([TargetGainObjective(300.0), TargetRooflineObjective(80.0)])
+
+    def test_the_roofline_alone_is_enough(self):
+        st = _state_with_within(81.0)
+        st.cumulative_gain_validated = 5.0
+        assert self._both().reached(st) is True
+
+    def test_the_gain_alone_is_enough(self):
+        st = _state_with_within(10.0)
+        st.cumulative_gain_validated = 301.0
+        assert self._both().reached(st) is True
+
+    def test_neither_leaves_the_run_going(self):
+        st = _state_with_within(10.0)
+        st.cumulative_gain_validated = 5.0
+        assert self._both().reached(st) is False
+
+    def test_the_gap_comes_from_the_closest_member_not_the_smaller_number(self):
+        """The two gaps are percentage points of different quantities, so the
+        smaller number is not the nearer target.
+
+        Gain is 100 points short of 300 and roofline 40 short of 80, yet gain is
+        the two-thirds-done one and roofline only half. A numeric minimum would
+        report 40 and hand the specialists the wrong target to chase.
+        """
+        st = _state_with_within(40.0)
+        st.cumulative_gain_validated = 200.0
+        both = self._both()
+        assert both.progress(st) == pytest.approx(2 / 3)
+        assert both.gap_pct(st) == pytest.approx(100.0)
+
+    def test_a_composite_needs_two_members(self):
+        with pytest.raises(ObjectiveError):
+            AnyObjective([TargetGainObjective(1.0)])
+
+
+class TestBuildObjectiveComposesTheRooflineTarget:
+    def test_the_roofline_target_alone(self):
+        obj = build_objective({"MAX_HOURS": 1, "TARGET_WITHIN_ROOFLINE_PCT": "80"})
+        assert isinstance(obj, TargetRooflineObjective)
+        assert obj.kind() == "roofline_pct"
+
+    def test_composed_with_the_gain_target(self):
+        obj = build_objective({"MAX_HOURS": 1, "TARGET_GAIN_PCT": "300", "TARGET_WITHIN_ROOFLINE_PCT": "80"})
+        assert isinstance(obj, AnyObjective)
+        assert obj.kind() == "gain_pct+roofline_pct"
+
+    def test_the_throughput_targets_stay_mutually_exclusive(self):
+        with pytest.raises(ObjectiveError):
+            build_objective({"MAX_HOURS": 1, "TARGET_GAIN_PCT": "300", "TARGET_TPUT_PER_GPU": "900"})
+
+    def test_it_does_not_relax_that_when_a_roofline_target_is_present(self):
+        with pytest.raises(ObjectiveError):
+            build_objective(
+                {
+                    "MAX_HOURS": 1,
+                    "TARGET_GAIN_PCT": "300",
+                    "TARGET_TPUT_PER_GPU": "900",
+                    "TARGET_WITHIN_ROOFLINE_PCT": "80",
+                }
+            )

--- a/src/hyperloom/inference_optimizer/tests/test_objective.py
+++ b/src/hyperloom/inference_optimizer/tests/test_objective.py
@@ -661,10 +661,6 @@ class TestEitherTargetEndsTheRun:
         assert both.progress(st) == pytest.approx(2 / 3)
         assert both.gap_pct(st) == pytest.approx(100.0)
 
-    def test_a_composite_needs_two_members(self):
-        with pytest.raises(ObjectiveError):
-            AnyObjective([TargetGainObjective(1.0)])
-
 
 class TestBuildObjectiveComposesTheRooflineTarget:
     def test_the_roofline_target_alone(self):

--- a/src/hyperloom/orchestrator/actions/executors/report.py
+++ b/src/hyperloom/orchestrator/actions/executors/report.py
@@ -352,7 +352,7 @@ def _build_failure_summary(
 
 _STOP_REASON_EXPLANATIONS: dict[str, str] = {
     # Terminal reasons the coordinator loop sets directly.
-    "target_reached": "Target reached: the requested --target-gain / --target-tput was met.",
+    "target_reached": "Target reached: a requested --target-gain / --target-tput / --target-roofline was met.",
     "time_exhausted": "Wall-clock budget (--max-hours) was exhausted; the best validated result was kept.",
     "max_ticks": "The coordinator hit its max-ticks safety cap; the best validated result was kept.",
     "signal": "Stopped on an OS stop signal (e.g. SIGINT / SIGTERM).",

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -52,6 +52,7 @@ _DEFAULT_WARM_REPLAY_MIN_CONFIDENCE: float = 0.7
 # Default resume-drift floor (%): a re-measured current_best below this fraction
 # of its recorded tput is flagged as drift.
 _DEFAULT_RESUME_DRIFT_FLOOR_PCT: float = 95.0
+from hyperloom.common.timeutil import now_iso
 from ..phases import machine_state as _phase_state
 from ..state.failure_evidence import UNMEASURED_OUTCOMES, render_failure_line
 from ..state.optimization_journal import Journal
@@ -864,12 +865,12 @@ class Coordinator(metaclass=_CoordinatorMeta):
         # Closing-grace bound; used only while ``closing_phase`` is set so CLOSE
         # work is not skipped just because the session deadline has passed.
         self._closing_deadline: float | None = None
-        # Set while a success terminal (a met objective) is being routed into
-        # CLOSE. Distinct from ``closing_phase``, which means the wall clock ran
-        # out and the sequencer should shed expensive work; a met target has to
-        # produce the full set of artifacts. ``True`` lifts the session bound for
-        # that routing without claiming a rescue is under way.
-        self._terminal_closing: bool = False
+        # Set while a met objective is being routed onward. Distinct from
+        # ``closing_phase``, which means the wall clock ran out and the sequencer
+        # should shed expensive work; a met target has to produce the full set of
+        # artifacts. ``True`` lifts the session bound for that one advance
+        # without claiming a rescue is under way.
+        self._unbounded_advance: bool = False
         # Latest objective wired by run(); refreshes target_gap_pct each tick. None outside a run.
         self._current_objective: Objective | None = None
 
@@ -1646,7 +1647,7 @@ class Coordinator(metaclass=_CoordinatorMeta):
         Returns:
             Remaining seconds, or ``None`` when no bound is armed.
         """
-        if self._terminal_closing:
+        if self._unbounded_advance:
             return None
         if bool(getattr(self.shared_state, "closing_phase", False)):
             bound = self._closing_deadline
@@ -1699,7 +1700,7 @@ class Coordinator(metaclass=_CoordinatorMeta):
         crash_emergency_threshold: int = 25,
         closing_grace_sec: float | None = None,
     ) -> str:
-        """Run reactor + dispatcher until a stop condition fires (priority order): signal, target_reached (via the CLOSE phase sequencer), time_exhausted (via closing phase), emergency, custom, max_ticks. Sets + saves + returns shared_state.stop_reason.
+        """Run reactor + dispatcher until a stop condition fires (priority order): signal, target_reached (routed through SWEEP, then the CLOSE phase sequencer), time_exhausted (via closing phase), emergency, custom, max_ticks. Sets + saves + returns shared_state.stop_reason.
 
         Args:
             objective: Stop objective; ``None`` uses a :class:`TimeOnlyObjective`.
@@ -1838,39 +1839,34 @@ class Coordinator(metaclass=_CoordinatorMeta):
                     stop_reason = self.shared_state.stop_reason
                     break
                 if objective.reached(self.shared_state):
-                    # Route the terminal through CLOSE. ``machine_state``
-                    # registers ``target_reached`` as an "any phase -> CLOSE"
-                    # transition reason, but nothing ever produced it, so a met
-                    # target skipped the 7-step close sequencer and left only
-                    # the cli safety-net report.
-                    #
                     # The transition runs in THIS tick rather than the next one.
                     # Every ``_advance_phase_if_needed`` in the tick body sits
                     # behind ``_await_within_session_bound``, which skips the
                     # step once the session bound has elapsed -- so a target met
-                    # at or after the deadline would never get another advance,
-                    # and deferring the close would silently fall back to the
-                    # safety net.
-                    if not self.shared_state.stop_reason:
-                        self.shared_state.set_stop_reason("target_reached")
-                        # Best-effort: the terminal is already set in memory and
-                        # CLOSE persists state itself, so a failed write must not
-                        # cost the run its close sequence.
+                    # at or after the deadline would never get another advance.
+                    if not self.shared_state.target_reached_at:
+                        self.shared_state.target_reached_at = now_iso()
+                        # Best-effort: the marker is already set in memory and
+                        # the phases persist state themselves, so a failed write
+                        # must not cost the run its close sequence.
                         try:
                             self.shared_state.save(self.session_dir)
                         except Exception:  # noqa: BLE001
                             log.exception(
-                                "Coordinator: persisting target_reached failed; closing anyway",
+                                "Coordinator: persisting target_reached_at failed; routing anyway",
                             )
+                    routed_to_sweep = _phase_state.phase_index(
+                        str(self.shared_state.phase or "")
+                    ) < _phase_state.phase_index(_phase_state.PHASE_SWEEP)
+                    if routed_to_sweep or not self.shared_state.stop_reason:
                         # Lift the session bound for this one advance so the
                         # elapsed run deadline cannot skip it. ``closing_phase``
                         # is deliberately NOT set: that flag means the wall clock
                         # ran out, and CLOSE reads it to shed expensive work --
                         # ``_maybe_run_close_post_opt_roofline`` returns early on
                         # it, which would drop the very artifact this routing
-                        # exists to produce. The sequencer's own per-step
-                        # timeouts bound the work.
-                        self._terminal_closing = True
+                        # exists to produce.
+                        self._unbounded_advance = True
                         try:
                             await self._await_within_session_bound(
                                 self._advance_phase_if_needed,
@@ -1878,13 +1874,31 @@ class Coordinator(metaclass=_CoordinatorMeta):
                             )
                         except Exception:  # noqa: BLE001
                             log.exception(
-                                "Coordinator: close transition on target_reached failed",
+                                "Coordinator: target_reached transition failed",
                             )
                         finally:
-                            self._terminal_closing = False
-                    stop_reason = self.shared_state.stop_reason or "target_reached"
-                    break
-                if deadline is not None and time.monotonic() >= deadline and not in_closing:
+                            self._unbounded_advance = False
+                    # SWEEP has to run before the session can close on the
+                    # target, so only a phase that already has its measurement
+                    # stops here; the rest leave through the stop_reason check
+                    # once SWEEP names the exit.
+                    if not routed_to_sweep:
+                        if not self.shared_state.stop_reason:
+                            self.shared_state.set_stop_reason("target_reached")
+                        stop_reason = self.shared_state.stop_reason
+                        break
+                # A met target outranks the wall clock for the two hops it
+                # needs. conc_sweep clamps itself to the remaining session
+                # budget and declines outright when nothing is left, so SWEEP
+                # collapses to an immediate terminal skip rather than running
+                # past --max-hours; max_ticks, emergency and signal still bound
+                # the loop.
+                if (
+                    deadline is not None
+                    and time.monotonic() >= deadline
+                    and not in_closing
+                    and not self.shared_state.target_reached_at
+                ):
                     if grace_sec <= 0:
                         stop_reason = "time_exhausted"
                         break

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -19,6 +19,7 @@ from typing import Any, Awaitable, Callable
 from hyperloom.orchestrator.actions.executors._grid_server_args import (
     tokenize_server_args_preserving_json,
 )
+from hyperloom.common.timeutil import now_iso
 from hyperloom.orchestrator.knowledge.config import KnowledgeConfig, KnowledgeStoreMode
 from hyperloom.orchestrator.knowledge.recipe_kb import RecipeKB
 
@@ -52,7 +53,6 @@ _DEFAULT_WARM_REPLAY_MIN_CONFIDENCE: float = 0.7
 # Default resume-drift floor (%): a re-measured current_best below this fraction
 # of its recorded tput is flagged as drift.
 _DEFAULT_RESUME_DRIFT_FLOOR_PCT: float = 95.0
-from hyperloom.common.timeutil import now_iso
 from ..phases import machine_state as _phase_state
 from ..state.failure_evidence import UNMEASURED_OUTCOMES, render_failure_line
 from ..state.optimization_journal import Journal
@@ -865,11 +865,10 @@ class Coordinator(metaclass=_CoordinatorMeta):
         # Closing-grace bound; used only while ``closing_phase`` is set so CLOSE
         # work is not skipped just because the session deadline has passed.
         self._closing_deadline: float | None = None
-        # Set while a met objective is being routed onward. Distinct from
-        # ``closing_phase``, which means the wall clock ran out and the sequencer
-        # should shed expensive work; a met target has to produce the full set of
-        # artifacts. ``True`` lifts the session bound for that one advance
-        # without claiming a rescue is under way.
+        # Set while a met objective's transition is forced. Distinct from
+        # ``closing_phase``, which means the wall clock ran out and CLOSE should
+        # shed expensive work; a met target has to produce the full set of
+        # artifacts. ``True`` lifts the session bound for that one advance.
         self._unbounded_advance: bool = False
         # Latest objective wired by run(); refreshes target_gap_pct each tick. None outside a run.
         self._current_objective: Objective | None = None
@@ -1638,11 +1637,10 @@ class Coordinator(metaclass=_CoordinatorMeta):
         During CLOSE the session deadline has already passed, so the bound
         switches to ``_closing_deadline`` and CLOSE work is not skipped.
 
-        A success terminal is unbounded here: the sequencer's own per-step
-        timeouts (``CLOSE_POST_OPT_ROOFLINE_TIMEOUT_SEC`` is 600s on its own)
-        are the budget. An outer bound short enough to matter would cancel the
-        step mid-flight and drop the run onto the safety net -- the very outcome
-        routing into CLOSE exists to avoid.
+        A met target's forced advance is unbounded here: the phases' own
+        per-step timeouts (``CLOSE_POST_OPT_ROOFLINE_TIMEOUT_SEC`` is 600s on
+        its own) are the budget, and an outer bound short enough to matter would
+        cancel a step mid-flight.
 
         Returns:
             Remaining seconds, or ``None`` when no bound is armed.
@@ -1839,60 +1837,45 @@ class Coordinator(metaclass=_CoordinatorMeta):
                     stop_reason = self.shared_state.stop_reason
                     break
                 if objective.reached(self.shared_state):
-                    # The transition runs in THIS tick rather than the next one.
-                    # Every ``_advance_phase_if_needed`` in the tick body sits
-                    # behind ``_await_within_session_bound``, which skips the
-                    # step once the session bound has elapsed -- so a target met
-                    # at or after the deadline would never get another advance.
                     if not self.shared_state.target_reached_at:
                         self.shared_state.target_reached_at = now_iso()
-                        # Best-effort: the marker is already set in memory and
-                        # the phases persist state themselves, so a failed write
-                        # must not cost the run its close sequence.
+                        # The marker is already set in memory and the phases
+                        # persist state themselves, so a failed write must not
+                        # cost the run its close sequence.
                         try:
                             self.shared_state.save(self.session_dir)
                         except Exception:  # noqa: BLE001
-                            log.exception(
-                                "Coordinator: persisting target_reached_at failed; routing anyway",
-                            )
+                            log.exception("Coordinator: persisting target_reached_at failed; routing anyway")
+                    # In this tick, not the next: every advance in the tick body
+                    # sits behind ``_await_within_session_bound``, so a target
+                    # met at or after the deadline would never get another one.
+                    # ``closing_phase`` stays unset -- CLOSE reads it to shed
+                    # expensive work, including the post-opt roofline this
+                    # routing exists to produce.
                     routed_to_sweep = _phase_state.phase_index(
                         str(self.shared_state.phase or "")
                     ) < _phase_state.phase_index(_phase_state.PHASE_SWEEP)
-                    if routed_to_sweep or not self.shared_state.stop_reason:
-                        # Lift the session bound for this one advance so the
-                        # elapsed run deadline cannot skip it. ``closing_phase``
-                        # is deliberately NOT set: that flag means the wall clock
-                        # ran out, and CLOSE reads it to shed expensive work --
-                        # ``_maybe_run_close_post_opt_roofline`` returns early on
-                        # it, which would drop the very artifact this routing
-                        # exists to produce.
-                        self._unbounded_advance = True
-                        try:
-                            await self._await_within_session_bound(
-                                self._advance_phase_if_needed,
-                                stage="advance_phase_target_reached",
-                            )
-                        except Exception:  # noqa: BLE001
-                            log.exception(
-                                "Coordinator: target_reached transition failed",
-                            )
-                        finally:
-                            self._unbounded_advance = False
-                    # SWEEP has to run before the session can close on the
-                    # target, so only a phase that already has its measurement
-                    # stops here; the rest leave through the stop_reason check
+                    self._unbounded_advance = True
+                    try:
+                        await self._await_within_session_bound(
+                            self._advance_phase_if_needed,
+                            stage="advance_phase_target_reached",
+                        )
+                    except Exception:  # noqa: BLE001
+                        log.exception("Coordinator: target_reached transition failed")
+                    finally:
+                        self._unbounded_advance = False
+                    # The SWEEP hop leaves through the stop_reason check instead,
                     # once SWEEP names the exit.
                     if not routed_to_sweep:
                         if not self.shared_state.stop_reason:
                             self.shared_state.set_stop_reason("target_reached")
                         stop_reason = self.shared_state.stop_reason
                         break
-                # A met target outranks the wall clock for the two hops it
-                # needs. conc_sweep clamps itself to the remaining session
-                # budget and declines outright when nothing is left, so SWEEP
-                # collapses to an immediate terminal skip rather than running
-                # past --max-hours; max_ticks, emergency and signal still bound
-                # the loop.
+                # A met target outranks the wall clock for the hops it needs.
+                # conc_sweep clamps to the remaining session budget and declines
+                # when nothing is left, so SWEEP cannot run past --max-hours;
+                # max_ticks, emergency and signal still bound the loop.
                 if (
                     deadline is not None
                     and time.monotonic() >= deadline

--- a/src/hyperloom/orchestrator/phases/machine.py
+++ b/src/hyperloom/orchestrator/phases/machine.py
@@ -245,7 +245,7 @@ class MachinePhase(PhaseHandler):
     async def _advance_phase_if_needed(self) -> None:
         """Scan exit conditions and transition phase at most once per tick.
 
-        Priority order (Inv-8.2): global terminal > exit_terminal > exit_normal, per phase_state.compute_next_phase.
+        Priority order (Inv-8.2): met target > global terminal > exit_terminal > exit_normal, per phase_state.compute_next_phase.
         """
         state = self.shared_state
         await self._track_kernel_idle_streak()

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -181,6 +181,7 @@ PHASE_EXIT_REASONS: frozenset[str] = frozenset(
         "global_converged",  # SWEEP → CLOSE; cyclic leverage exhausted across macro-cycles (also a terminal stop_reason)
         # Terminal exits (any phase → CLOSE)
         "robustness_escalated",
+        # Any phase → SWEEP on the way in, then SWEEP → CLOSE on the way out.
         "target_reached",
         "time_exhausted",
         "time_exhausted_during_prelude",
@@ -531,10 +532,10 @@ def should_reloop_to_explore(
     carries the *effective* no-gain streak for the cycle that just completed so
     the Coordinator can persist it on the loopback/close transition.
 
-    Loops back iff below the macro-cycle safety cap AND the run has not globally
-    converged (R7: ``no_gain_cycles`` consecutive no-gain cycles) AND no
-    roofline direction is saturated AND enough session budget remains to use a
-    fresh cycle.
+    Loops back iff the run objective is unmet AND below the macro-cycle safety
+    cap AND the run has not globally converged (R7: ``no_gain_cycles``
+    consecutive no-gain cycles) AND no roofline direction is saturated AND
+    enough session budget remains to use a fresh cycle.
 
     Args:
         state (Any): Frozen SharedState view.
@@ -2806,8 +2807,9 @@ def compute_next_phase(
 ) -> tuple[str, str, dict[str, Any]] | None:
     """Return ``(next_phase, reason, evidence)`` or ``None``.
 
-    Priority (Inv-8.2): global terminal first, then the wall-clock closing
-    phase, then exit_terminal > exit_normal.
+    Priority (Inv-8.2): a met target's forward jump to SWEEP first, then the
+    global terminal, then the wall-clock closing phase, then exit_terminal >
+    exit_normal.
 
     Args:
         state (Any): Frozen SharedState view exposing the current ``phase``.
@@ -2825,10 +2827,9 @@ def compute_next_phase(
     current = (getattr(state, "phase", "") or "").strip().upper() or PHASE_PRELUDE
     overrides = _resolve_plateau_overrides(state)
 
-    # A met target closes through SWEEP, so the concurrency curve measures the
-    # configuration the target was met on. A forward jump on the monotonic
-    # chain, and deliberately not terminal: marking it so would mirror the
-    # reason onto ``stop_reason``, which routes the next tick to CLOSE.
+    # A met target closes through SWEEP so the concurrency curve measures the
+    # configuration it was met on. Not terminal: that would mirror the reason
+    # onto ``stop_reason``, which routes the next tick to CLOSE instead.
     if target_was_reached(state) and phase_index(current) < phase_index(PHASE_SWEEP):
         return PHASE_SWEEP, "target_reached", {"target_reached_at": str(getattr(state, "target_reached_at", "") or "")}
 
@@ -2915,8 +2916,7 @@ def compute_next_phase(
             # stop_reason instead of opening another macro-cycle.
             if exit_reason == "sweep_failed":
                 return PHASE_CLOSE, exit_reason, exit_evidence
-            # The target is why the run stopped optimizing, so it names the
-            # exit -- but only a clean one. A sweep that failed still says so:
+            # The target names a clean exit. A failed sweep keeps its own name:
             # its exit code is the signal that the closing curve is missing.
             if exit_reason == "sweep_done" and target_was_reached(state):
                 return PHASE_CLOSE, "target_reached", {**exit_evidence, "terminal": True}

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -504,6 +504,18 @@ def _cumulative_gain_validated(state: Any) -> float:
         return 0.0
 
 
+def target_was_reached(state: Any) -> bool:
+    """Whether the run objective has been met.
+
+    Args:
+        state (Any): Frozen SharedState view exposing ``target_reached_at``.
+
+    Returns:
+        bool: True once the Coordinator has stamped the marker.
+    """
+    return bool(str(getattr(state, "target_reached_at", "") or "").strip())
+
+
 def should_reloop_to_explore(
     state: Any,
     *,
@@ -546,6 +558,10 @@ def should_reloop_to_explore(
     """
     cycle = int(getattr(state, "macro_cycle", 0) or 0)
     evidence: dict[str, Any] = {"macro_cycle": cycle}
+
+    if target_was_reached(state):
+        evidence["reloop_blocked"] = "target_reached"
+        return False, evidence
 
     # Per-cycle gain since this cycle started → effective no-gain streak. A cycle
     # "gained" only when its validated gain rose by at least the decaying KEEP bar.
@@ -2809,6 +2825,13 @@ def compute_next_phase(
     current = (getattr(state, "phase", "") or "").strip().upper() or PHASE_PRELUDE
     overrides = _resolve_plateau_overrides(state)
 
+    # A met target closes through SWEEP, so the concurrency curve measures the
+    # configuration the target was met on. A forward jump on the monotonic
+    # chain, and deliberately not terminal: marking it so would mirror the
+    # reason onto ``stop_reason``, which routes the next tick to CLOSE.
+    if target_was_reached(state) and phase_index(current) < phase_index(PHASE_SWEEP):
+        return PHASE_SWEEP, "target_reached", {"target_reached_at": str(getattr(state, "target_reached_at", "") or "")}
+
     # Global terminal stop_reason overrides phase-local judgments.
     terminal = _global_terminal(state)
     if terminal is not None and current != PHASE_CLOSE:
@@ -2892,6 +2915,11 @@ def compute_next_phase(
             # stop_reason instead of opening another macro-cycle.
             if exit_reason == "sweep_failed":
                 return PHASE_CLOSE, exit_reason, exit_evidence
+            # The target is why the run stopped optimizing, so it names the
+            # exit -- but only a clean one. A sweep that failed still says so:
+            # its exit code is the signal that the closing curve is missing.
+            if exit_reason == "sweep_done" and target_was_reached(state):
+                return PHASE_CLOSE, "target_reached", {**exit_evidence, "terminal": True}
             # R1: open a new macro-cycle while budget remains and the run
             # hasn't globally converged (R7); wind down to CLOSE only when
             # reloop is blocked (budget, convergence, or max_cycles).
@@ -3380,6 +3408,7 @@ __all__ = [
     "is_long_run",
     "resolve_keep_threshold",
     "should_reloop_to_explore",
+    "target_was_reached",
     "allowed_actions_for",
     "apply_escalate_budget_bump",
     "bank_phase_segment",

--- a/src/hyperloom/orchestrator/policy/gate.py
+++ b/src/hyperloom/orchestrator/policy/gate.py
@@ -614,6 +614,8 @@ CORE_STATE_FIELDS: frozenset[str] = frozenset(
         "plateau_overrides",
         # CLOSE-phase sequencer flag; LLM must not toggle it.
         "close_sequence_done",
+        # Objective-met marker; the Coordinator is its only writer.
+        "target_reached_at",
         # explore search ledger; Coordinator-only writers (LLM rewrite would bypass dedup-by-fingerprint).
         "explore_search",
         # structured gaps ledger; Coordinator-only writers (``_refresh_gaps``,

--- a/src/hyperloom/orchestrator/state/objective.py
+++ b/src/hyperloom/orchestrator/state/objective.py
@@ -169,9 +169,8 @@ class TargetGainObjective(_RatioObjective):
 class TargetRooflineObjective(_RatioObjective):
     """Reach ``target_within_pct`` % of the modelled roofline ceiling.
 
-    The live metric is the latest roofline snapshot's ``within_roofline_pct``.
-    It reads 0 until a roofline has been measured, so the objective cannot be
-    met on a session that never profiled one.
+    The live metric reads 0 until a roofline has been measured, so the
+    objective cannot be met on a session that never profiled one.
     """
 
     target_within_pct: float
@@ -220,24 +219,12 @@ class TargetRooflineObjective(_RatioObjective):
 class AnyObjective(Objective):
     """Met when any member is met.
 
-    ``progress`` is the closest member's, because that is the one about to end
-    the run. ``gap_pct`` is that same member's gap rather than the smallest:
-    the members measure different quantities -- gain percentage points against
-    roofline percentage points -- so a numeric minimum across them compares
-    unlike units. ``progress`` is the only normalised quantity the members
-    share.
+    ``progress`` and ``gap_pct`` come from the closest member, the one about to
+    end the run. Not the smallest gap: members count percentage points of
+    different quantities, so ``progress`` is the only comparable one.
     """
 
     objectives: list[Objective]
-
-    def __post_init__(self) -> None:
-        """Validate the member list.
-
-        Raises:
-            ObjectiveError: If fewer than two objectives are supplied.
-        """
-        if len(self.objectives) < 2:
-            raise ObjectiveError(f"AnyObjective: needs at least two objectives, got {len(self.objectives)}")
 
     def kind(self) -> str:
         """Return the members' kinds joined by ``+``."""
@@ -430,17 +417,6 @@ class TimeOnlyObjective(Objective):
         return 0.0
 
 
-def _primary_objective(env: dict[str, Any]) -> Objective | None:
-    """Return the throughput-side objective named by *env*, or None."""
-    if env.get("TARGET_GAIN_PCT") not in (None, ""):
-        return TargetGainObjective(float(env["TARGET_GAIN_PCT"]))
-    if env.get("TARGET_TPUT_PER_GPU") not in (None, ""):
-        return TargetTputObjective(float(env["TARGET_TPUT_PER_GPU"]))
-    if env.get("TARGET_DIR") not in (None, ""):
-        return TargetBaselineObjective(str(env["TARGET_DIR"]))
-    return None
-
-
 def build_objective(env: dict[str, Any]) -> Objective:
     """Factory: requires MAX_HOURS; at most one throughput target, plus an optional roofline one.
 
@@ -475,7 +451,13 @@ def build_objective(env: dict[str, Any]) -> Objective:
     if len(targets) > 1:
         raise ObjectiveError(f"build_objective: at most one TARGET_* allowed, got {targets}")
 
-    primary = _primary_objective(env)
+    primary: Objective | None = None
+    if env.get("TARGET_GAIN_PCT") not in (None, ""):
+        primary = TargetGainObjective(float(env["TARGET_GAIN_PCT"]))
+    elif env.get("TARGET_TPUT_PER_GPU") not in (None, ""):
+        primary = TargetTputObjective(float(env["TARGET_TPUT_PER_GPU"]))
+    elif env.get("TARGET_DIR") not in (None, ""):
+        primary = TargetBaselineObjective(str(env["TARGET_DIR"]))
     if env.get("TARGET_WITHIN_ROOFLINE_PCT") in (None, ""):
         return primary or TimeOnlyObjective()
     roofline = TargetRooflineObjective(float(env["TARGET_WITHIN_ROOFLINE_PCT"]))

--- a/src/hyperloom/orchestrator/state/objective.py
+++ b/src/hyperloom/orchestrator/state/objective.py
@@ -166,6 +166,105 @@ class TargetGainObjective(_RatioObjective):
 
 
 @dataclass
+class TargetRooflineObjective(_RatioObjective):
+    """Reach ``target_within_pct`` % of the modelled roofline ceiling.
+
+    The live metric is the latest roofline snapshot's ``within_roofline_pct``.
+    It reads 0 until a roofline has been measured, so the objective cannot be
+    met on a session that never profiled one.
+    """
+
+    target_within_pct: float
+
+    def __post_init__(self) -> None:
+        """Validate the configured target after dataclass initialization.
+
+        Raises:
+            ObjectiveError: If ``target_within_pct`` is outside ``(0, 100]``.
+        """
+        if not 0 < self.target_within_pct <= 100:
+            raise ObjectiveError(
+                f"TargetRooflineObjective: target_within_pct must be in (0, 100], got {self.target_within_pct}"
+            )
+
+    def kind(self) -> str:
+        """Return the objective kind tag.
+
+        Returns:
+            str: Always ``"roofline_pct"``.
+        """
+        return "roofline_pct"
+
+    def _current(self, state: "SharedState") -> float:
+        """Return the latest measured share of the roofline ceiling."""
+        return float(state.current_within_roofline_pct() or 0.0)
+
+    def _target(self) -> float:
+        """Return the configured roofline-percentage target."""
+        return self.target_within_pct
+
+    def gap_pct(self, state: "SharedState") -> float:
+        """Return the roofline percentage points still missing (both sides are already percentages)."""
+        return max(0.0, self._target() - self._current(state))
+
+    def describe(self) -> str:
+        """Return a one-line summary of the configured roofline target.
+
+        Returns:
+            str: Description of the form ``"target_within_roofline_pct=<value>"``.
+        """
+        return f"target_within_roofline_pct={self.target_within_pct}"
+
+
+@dataclass
+class AnyObjective(Objective):
+    """Met when any member is met.
+
+    ``progress`` is the closest member's, because that is the one about to end
+    the run. ``gap_pct`` is that same member's gap rather than the smallest:
+    the members measure different quantities -- gain percentage points against
+    roofline percentage points -- so a numeric minimum across them compares
+    unlike units. ``progress`` is the only normalised quantity the members
+    share.
+    """
+
+    objectives: list[Objective]
+
+    def __post_init__(self) -> None:
+        """Validate the member list.
+
+        Raises:
+            ObjectiveError: If fewer than two objectives are supplied.
+        """
+        if len(self.objectives) < 2:
+            raise ObjectiveError(f"AnyObjective: needs at least two objectives, got {len(self.objectives)}")
+
+    def kind(self) -> str:
+        """Return the members' kinds joined by ``+``."""
+        return "+".join(o.kind() for o in self.objectives)
+
+    def _closest(self, state: "SharedState") -> Objective:
+        """Return the member nearest to being met."""
+        return max(self.objectives, key=lambda o: o.progress(state))
+
+    def progress(self, state: "SharedState") -> float:
+        """Return the closest member's progress."""
+        return self._closest(state).progress(state)
+
+    def reached(self, state: "SharedState") -> bool:
+        """Report whether any member is satisfied."""
+        return any(o.reached(state) for o in self.objectives)
+
+    def gap_pct(self, state: "SharedState") -> float:
+        """Return the closest member's remaining distance."""
+        return self._closest(state).gap_pct(state)
+
+    def describe(self) -> str:
+        """Return the members' descriptions joined by ``or``."""
+        return " or ".join(o.describe() for o in self.objectives)
+
+
+@dataclass
 class TargetTputObjective(_RatioObjective):
     """Reach an absolute throughput number (progress against best-so-far tput, not baseline).
 
@@ -331,21 +430,37 @@ class TimeOnlyObjective(Objective):
         return 0.0
 
 
+def _primary_objective(env: dict[str, Any]) -> Objective | None:
+    """Return the throughput-side objective named by *env*, or None."""
+    if env.get("TARGET_GAIN_PCT") not in (None, ""):
+        return TargetGainObjective(float(env["TARGET_GAIN_PCT"]))
+    if env.get("TARGET_TPUT_PER_GPU") not in (None, ""):
+        return TargetTputObjective(float(env["TARGET_TPUT_PER_GPU"]))
+    if env.get("TARGET_DIR") not in (None, ""):
+        return TargetBaselineObjective(str(env["TARGET_DIR"]))
+    return None
+
+
 def build_objective(env: dict[str, Any]) -> Objective:
-    """Factory: requires MAX_HOURS; at most one of TARGET_GAIN_PCT / TARGET_TPUT_PER_GPU / TARGET_DIR (none → TimeOnly).
+    """Factory: requires MAX_HOURS; at most one throughput target, plus an optional roofline one.
+
+    ``TARGET_GAIN_PCT`` / ``TARGET_TPUT_PER_GPU`` / ``TARGET_DIR`` measure the
+    same axis three ways and stay mutually exclusive.
+    ``TARGET_WITHIN_ROOFLINE_PCT`` measures a different one, so it composes with
+    whichever of those is set: either being met ends the run.
 
     Args:
-        env: Environment mapping; must contain ``MAX_HOURS`` and may contain at
-            most one of ``TARGET_GAIN_PCT``, ``TARGET_TPUT_PER_GPU``, or
-            ``TARGET_DIR``.
+        env: Environment mapping; must contain ``MAX_HOURS``, may contain at
+            most one of ``TARGET_GAIN_PCT``, ``TARGET_TPUT_PER_GPU`` or
+            ``TARGET_DIR``, and may contain ``TARGET_WITHIN_ROOFLINE_PCT``.
 
     Returns:
-        The objective matching the supplied target, or a ``TimeOnlyObjective``
-        when no target is given.
+        The objective matching the supplied targets, an :class:`AnyObjective`
+        when both sides are named, or a ``TimeOnlyObjective`` when none is.
 
     Raises:
         ObjectiveError: If ``MAX_HOURS`` is missing, non-numeric, or
-            non-positive, or if more than one ``TARGET_*`` key is supplied.
+            non-positive, or if more than one throughput target is supplied.
     """
     if "MAX_HOURS" not in env:
         raise ObjectiveError("build_objective: MAX_HOURS is required")
@@ -360,20 +475,20 @@ def build_objective(env: dict[str, Any]) -> Objective:
     if len(targets) > 1:
         raise ObjectiveError(f"build_objective: at most one TARGET_* allowed, got {targets}")
 
-    if "TARGET_GAIN_PCT" in env and env["TARGET_GAIN_PCT"] not in (None, ""):
-        return TargetGainObjective(float(env["TARGET_GAIN_PCT"]))
-    if "TARGET_TPUT_PER_GPU" in env and env["TARGET_TPUT_PER_GPU"] not in (None, ""):
-        return TargetTputObjective(float(env["TARGET_TPUT_PER_GPU"]))
-    if "TARGET_DIR" in env and env["TARGET_DIR"] not in (None, ""):
-        return TargetBaselineObjective(str(env["TARGET_DIR"]))
-    return TimeOnlyObjective()
+    primary = _primary_objective(env)
+    if env.get("TARGET_WITHIN_ROOFLINE_PCT") in (None, ""):
+        return primary or TimeOnlyObjective()
+    roofline = TargetRooflineObjective(float(env["TARGET_WITHIN_ROOFLINE_PCT"]))
+    return AnyObjective([primary, roofline]) if primary is not None else roofline
 
 
 __all__ = [
+    "AnyObjective",
     "Objective",
     "ObjectiveError",
     "TargetBaselineObjective",
     "TargetGainObjective",
+    "TargetRooflineObjective",
     "TargetTputObjective",
     "TimeOnlyObjective",
     "build_objective",

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -647,6 +647,10 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
     # corpus generation, a fixed measurement defect). A resume whose stored
     # epoch differs must not reuse the old KEEPs or baseline anchor.
     agentx_epoch: int = 0
+    # Stamped once when the run objective is first met. Separate from
+    # ``stop_reason`` because that routes to CLOSE from any phase, which is what
+    # this exists to avoid: a met target goes to SWEEP first.
+    target_reached_at: str = ""
     # CONC ladder for conc_sweep, seeded from the workload's own ladder by
     # ``_parse_conc_sweep_concs``. Empty is not an instruction: both readers
     # send None instead, which resolves to the ladder for this workload.

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -2088,6 +2088,27 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
             return str(latest.get("top_bottleneck") or "")
         return ""
 
+    def current_within_roofline_pct(self) -> float | None:
+        """Return the latest snapshot's achieved share of its roofline ceiling.
+
+        ``None`` until a roofline has been measured, which is what keeps a
+        roofline target inert on a session that never ran one.
+
+        Returns:
+            float | None: ``within_roofline_pct`` from the newest snapshot, or
+                ``None`` when no snapshot carries a numeric one.
+        """
+        snaps = self.roofline_snapshots if isinstance(self.roofline_snapshots, list) else []
+        if not snaps:
+            return None
+        latest = snaps[-1]
+        if not isinstance(latest, dict):
+            return None
+        value = latest.get("within_roofline_pct")
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        return float(value)
+
     def current_comm_pct(self) -> float | None:
         """Return the latest exposed-communication percentage."""
         snaps = self.roofline_snapshots if isinstance(self.roofline_snapshots, list) else []


### PR DESCRIPTION
# A roofline target, and a met target that ends in SWEEP

Two changes. `--target-gain` measures distance travelled from the baseline
and says nothing about how much of the hardware is left; recorded sessions
have stopped on it at 45% and 8% of their modelled ceiling.

## `--target-roofline N`

Stops the run when the latest roofline snapshot reaches N% of its modelled
ceiling. It measures a different axis from `--target-gain` / `--target-tput` /
`--target-baseline-dir`, so it sits outside the mutually exclusive group that
holds those three — they measure one axis three ways and still exclude each
other — and composes with whichever is set. Either being met ends the run.

"Only once a roofline has been measured" needs no separate gate:
`current_within_roofline_pct` reads `None` until a snapshot carries a numeric
one, which folds to zero progress against a positive target.

`AnyObjective.gap_pct` reports the **closest** member's gap, not the smallest
number. The members count percentage points of different quantities, so a
numeric minimum compares unlike units — and this value is not display: it
becomes a severity-graded `#throughput_below_target` row the specialists
chase. `progress` is the only normalised quantity they share.

The manifest keeps the flat `kind` / `value` pair seven readers depend on, and
carries the full set in `objectives` alongside it when there is more than one.

## A met target ends in SWEEP

A met objective jumped straight to CLOSE, so the run closed on the concurrency
curve of whatever configuration was current when the last sweep ran — or on no
curve at all. The target is met on a specific configuration; that is the one
worth measuring.

`stop_reason` could not carry the signal: `_global_terminal` routes any
non-empty value to CLOSE from any phase, and the run loop breaks on it. The
objective stamps `target_reached_at` instead, and the phase machine reads that
ahead of the terminal check to jump forward to SWEEP — legal on the monotonic
chain, and deliberately not marked terminal, which would mirror the reason back
onto `stop_reason` and undo the routing.

A clean SWEEP exit then reports `target_reached` rather than `sweep_done`,
keeping the resume gate and the exit code on the honest reason. Only a clean
one: `sweep_failed` keeps its name and its exit code 1, because a validation
curve that could not be built is a failure whether or not the target was met.

A met target also blocks the macro-cycle reloop, which would otherwise open
another cycle on a run that is finishing and advertise `cycle_reloop_feasible`
to the LLM while it does.

The route outranks the wall clock for the two hops it needs. `conc_sweep`
already clamps itself to the remaining session budget and declines outright
when nothing is left, so SWEEP collapses to a terminal skip instead of running
past `--max-hours`; `max_ticks`, emergency and signal still bound the loop.

## Notes

- `_terminal_closing` is now `_unbounded_advance`: it lifts the session bound
  for one forced advance, and that advance no longer only closes.
- An overshot ceiling (`roofline_ceiling_exceeded`) does not disqualify a
  snapshot from satisfying the target. It has never occurred in 60 recorded
  snapshots, and the report already warns about it where it would matter.
- The five tests that asserted the old straight-to-CLOSE routing were rewritten
  to drive the full two-hop path, not re-pointed at new values.