### PR TITLE
test: pin the _CallStats.first_s sentinel against a 0.0 mutation

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_framework_rewrite_evidence.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_rewrite_evidence.py
@@ -317,6 +317,76 @@ def test_deep_probe_counts_calls_and_argument_repeats(probe_module, tmp_path):
         assert row["last_s"] >= row["first_s"]
 
 
+def test_deep_probe_timestamps_the_first_outermost_call(probe_module, tmp_path):
+    """Tier 2's ``first_s`` must latch a real timestamp, not sit on its sentinel.
+
+    ``_CallStats.first_s`` starts at ``-1.0`` and the hook latches with
+    ``if stats.first_s < 0``, so a sentinel of ``0.0`` would leave every tier-2
+    row reporting ``first_s == 0.0`` for the process lifetime. The aggregator
+    reads that field as "started at probe init", which is its set-up-work
+    signal, so the mutant silently demotes every hot-path function.
+
+    ``first_s >= 0.0`` cannot see that. Instead the probe's monotonic baseline
+    is shifted back by a known offset, so every timestamp the hook derives is
+    provably past the offset while the sentinel is not.
+    """
+    framework_root = tmp_path / "fake_framework"
+    framework_root.mkdir()
+    module_path = framework_root / "stepper.py"
+    module_path.write_text(
+        "def step(i):\n"
+        "    return (i * 3) % 7\n"
+        "\n"
+        "def run(n):\n"
+        "    total = 0\n"
+        "    for i in range(n):\n"
+        "        total += step(i)\n"
+        "    return total\n",
+        encoding="utf-8",
+    )
+    spec = importlib.util.spec_from_file_location("fake_framework_stepper", module_path)
+    assert spec is not None and spec.loader is not None
+    target = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(target)
+
+    probe = probe_module.HostProbe(
+        out_dir=str(tmp_path / "out"),
+        roots=(str(framework_root) + "/",),
+        deep=True,
+    )
+    # ``at_s = perf_counter() - _perf_started`` is the hook's only time base and
+    # perf_counter is monotonic, so shifting the origin back puts every observed
+    # timestamp at or beyond the offset by construction -- no clock patching and
+    # no dependence on the workload taking a measurable amount of time.
+    offset_s = 100.0
+    probe._perf_started -= offset_s
+
+    probe._install_tier2()
+    try:
+        target.run(8)
+    finally:
+        probe.uninstall()
+
+    written = probe.write_report()
+    assert written
+    payload = json.loads(Path(written).read_text(encoding="utf-8"))
+    rows = {row["function"].rsplit(":", 1)[-1]: row for row in payload["framework_calls"]}
+    assert rows["step"]["count"] == 8
+
+    for row in payload["framework_calls"]:
+        # A sentinel the ``< 0`` latch can never replace reports 0.0 and fails here.
+        assert row["first_s"] >= offset_s, row
+        assert row["first_s"] <= offset_s + 60.0, row
+        assert row["last_s"] >= row["first_s"], row
+
+    # The latch kept the FIRST timestamp instead of overwriting it every call.
+    # Read the accumulator, not the report: report() rounds to 3 decimals, which
+    # can collapse two genuinely distinct sub-millisecond timestamps.
+    step_label = next(label for label in probe._calls if label.endswith(":step"))
+    step_stats = probe._calls[step_label]
+    assert step_stats.last_s > step_stats.first_s
+
+
 def test_probe_wraps_the_implicit_conversion_dunders(probe_module, tmp_path):
     """``if scalar_tensor == 0`` syncs, and the probe has to count it as one.
 


### PR DESCRIPTION
Closes #1356.

`_SiteStats.first_s` is pinned by #1328, but the identical sentinel on `_CallStats` (`hl_host_probe.py:290`) is a **different class** and the same mutation stayed green. The tier-2 latch lives in the profile hook, not the class:

```python
if stats.first_s < 0:      # hl_host_probe.py:777
    stats.first_s = at_s
```

With a `0.0` sentinel that latch never fires, so `first_s` stays `0.0` for the process lifetime.

That is not cosmetic. `_framework_rewrite_evidence.py:597-600` reads `first_s` as the **setup-versus-hot-path discriminator**, so the mutant silently demotes every tier-2 function to "ran during probe init" — exactly the rows the aggregator then discounts.

### Why the existing assertion can't see it

`test_deep_probe_counts_calls_and_argument_repeats` already asserts `row["first_s"] >= 0.0`, which passes at `0.0`. Rather than patch the clock, this shifts the probe's monotonic baseline back by a known offset:

```python
probe._perf_started -= 100.0
```

`at_s = perf_counter() - _perf_started` is the hook's only time base and `perf_counter` is monotonic, so every observed timestamp is at or beyond the offset **by construction** — no dependence on the workload taking a measurable amount of time, and a 100s margin no clock resolution or jitter can close.

It asserts through `write_report()` and the serialised JSON rather than the private attribute, except the final first-vs-last check, which `report()` would round away at 3 decimals.

### Mutation results

| mutation | result |
|---|---|
| `hl_host_probe.py:290` `-1.0` → `0.0` (the issue's exact mutation) | 🔴 red |
| `hl_host_probe.py:777` latch always fires | 🔴 red |
| `hl_host_probe.py:223` `_SiteStats` sentinel (control, owned by #1328) | 🟢 green here, red in #1328's tier-1 tests |

75 passed, ruff check and format clean.

### Follow-up, not in scope

Line 911 (`host_calls` `first_s` in the report) is a separate read path — the tier-1 tests assert on the `_SiteStats` object rather than the serialised row, so replacing `round(stats.first_s, 3)` there with a constant is still unpinned.