### PR TITLE
fix(kernel): stop the name heuristic unresolving lane-identified collectives

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_collective_candidate_routing.py
+++ b/src/hyperloom/agents/kernel/tests/test_collective_candidate_routing.py
@@ -128,3 +128,70 @@ def test_nccl_marker_check_precedes_source_resolution():
     item = _candidate("ncclDevKernel_AllReduce", _AITER_SRC)
     reusable, _reason = tl.classify_patchability(item)
     assert reusable is False
+
+
+# --- A resolved lane verdict outranks the name heuristic ---------------------
+
+
+def _nccl_summary_row(name: str, source_file: str) -> dict:
+    """A row shaped like the one _nccl_summary_candidates.py:266-267 emits."""
+    return _candidate(name, source_file, candidate_source="nccl_summary")
+
+
+def test_lane_resolved_collective_is_not_unresolved_by_its_name():
+    """A name the heuristic reads as single-GPU must not clobber the lane's verdict.
+
+    _nccl_summary_candidates sets is_multigpu=True from TraceLens' nccl_summary
+    table plus a resolved device symbol. Re-deriving from the name flips these
+    rows to False, and is_collective_candidate then refuses them because it
+    gates on candidate_source == "nccl_summary" AND is_multigpu -- the lane
+    rejecting its own output.
+    """
+    for name in ("small_collective", "EpDispatchIntraNodeKernel_bf16", "ncclDevKernel_Generic_1"):
+        assert tl.is_multigpu_kernel(name, "") is False, f"{name} should be a name-heuristic miss"
+        item = _nccl_summary_row(name, "/sgl-workspace/aiter/csrc/include/other.cuh")
+        tl._stamp_candidate_metadata(item, None)
+        assert item["is_multigpu"] is True, name
+        assert item["num_gpus_recommended"] == 2, name
+
+
+def test_the_name_heuristic_still_runs_without_a_lane_verdict():
+    """The override is scoped: only a positive nccl_summary verdict is preserved."""
+    # No candidate_source at all -> derived from the name.
+    item = _candidate("small_collective", "/w/other.cuh")
+    tl._stamp_candidate_metadata(item, None)
+    assert item["is_multigpu"] is False
+    assert item["num_gpus_recommended"] == 1
+
+    # A different lane does not get the same authority.
+    item = _candidate("small_collective", "/w/other.cuh", candidate_source="other_bucket_fallback")
+    tl._stamp_candidate_metadata(item, None)
+    assert item["is_multigpu"] is False
+
+    # nccl_summary that did NOT claim multi-GPU is still derived, not forced True.
+    item = _candidate("plain_gemm_kernel", "/w/gemm.cu", candidate_source="nccl_summary")
+    item["is_multigpu"] = False
+    tl._stamp_candidate_metadata(item, None)
+    assert item["is_multigpu"] is False
+    assert item["num_gpus_recommended"] == 1
+
+    # ...and the derivation still RUNS for such a row rather than being skipped:
+    # the lane left is_multigpu False, but the name is an unmistakable collective,
+    # so the heuristic must be allowed to raise it. Without the is_multigpu
+    # qualifier on `authoritative` this row would stay False.
+    item = _candidate("ncclDevKernel_AllReduce_Sum_bf16_RING_LL", "/w/nccl.cu", candidate_source="nccl_summary")
+    item["is_multigpu"] = False
+    tl._stamp_candidate_metadata(item, None)
+    assert item["is_multigpu"] is True
+    assert item["num_gpus_recommended"] == 2
+
+
+def test_collective_vocabulary_covers_the_undelimited_and_all_to_all_spellings():
+    """reduce_scatter/all_gather had both spellings; reducescatter and all-to-all had none."""
+    for name in ("ReduceScatterFusion", "all_to_all_dispatch", "rccl_AllToAll", "ncclDevKernel_AllToAllv"):
+        assert tl.is_multigpu_kernel(name, "") is True, name
+        assert kernel_name_implies_multigpu(name) is True, f"{name}: sibling disagrees"
+
+    # Still not a collective just because it reduces something.
+    assert tl.is_multigpu_kernel("block_reduce_kernel", "") is False
+    assert tl.is_multigpu_kernel("layernorm_kernel", "") is False

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -3688,6 +3688,9 @@ def is_multigpu_kernel(name: str, source_file: str) -> bool:
             "all_gather",
             "allgather",
             "reduce_scatter",
+            "reducescatter",
+            "all_to_all",
+            "alltoall",
             "broadcast",
             "p2p",
             "send_recv",
@@ -4860,7 +4863,17 @@ def _stamp_candidate_metadata(item: dict[str, Any], op_cat_map: dict[str, str] |
     item["benchmark_files"] = find_benchmark_files(
         item["name"], item.get("kernel_repo", ""), item.get("source_file", "")
     )
-    item["is_multigpu"] = is_multigpu_kernel(item["name"], item.get("source_file", ""))
+    # The nccl-summary lane identifies collectives from TraceLens' own
+    # nccl_summary table plus a resolved device symbol, which outranks a name
+    # guess. Re-deriving over it unresolves rows the lane already resolved:
+    # small_collective, EpDispatchIntraNodeKernel_bf16 and ncclDevKernel_Generic_1
+    # all carry is_multigpu=True from _nccl_summary_candidates and all read False
+    # by name. That flip also disqualifies them at is_collective_candidate
+    # (_kernel_decisions.py), which gates the lane on candidate_source ==
+    # "nccl_summary" AND is_multigpu -- so the lane refuses its own rows.
+    authoritative = bool(item.get("is_multigpu")) and str(item.get("candidate_source") or "") == "nccl_summary"
+    if not authoritative:
+        item["is_multigpu"] = is_multigpu_kernel(item["name"], item.get("source_file", ""))
     item["num_gpus_recommended"] = 2 if item["is_multigpu"] else 1
     item["recommended_backends"] = recommend_backends(item)
     item["optimization_notes"] = build_notes(item)


### PR DESCRIPTION
Refs #1320. **Please read the correction below — I filed #1320 and its stated impact was wrong.**

## The claim in #1320 that does not hold

#1320 says a false positive "reserves a second GPU" via `forge.submit(num_gpus=...)` → Ray `--num-gpus`. I traced the call chain when I filed it but never checked whether the far end consumed the argument. It didn't: #1381 removed the parameter with the message *"submit() accepted num_gpus and prefer_ray and **read neither**"*. So the reservation cost was never real, and today `num_gpus_recommended` only reaches prompt text (`kernel_optimization.py:1663-1668`, `:1831-1833`) and `_invocation_spec.py:872`.

Investigating properly also inverted the priority. The false positives #1320 leads with — `smallreduce`, `broadcastable_check` — appear **only as probe names in `test_collective_names.py`**. Sweeping every kernel-name-shaped literal in the repo turned up no false positive in trace-derived data, and no non-collective source path matches either (`dist-packages` ≠ `dist/`; `torch/distributed/` doesn't contain `dist/`; `communicator` doesn't match `communication.py`).

The **false negatives are the observed ones**, and this PR fixes those.

## The defect

`_stamp_candidate_metadata` recomputed `is_multigpu` from the name, overwriting what `_nccl_summary_candidates.py:266` had established from TraceLens' `nccl_summary` table plus a resolved device symbol:

| row | lane | after the stamp |
|---|---|---|
| `small_collective` | True | **False** |
| `EpDispatchIntraNodeKernel_bf16` | True | **False** |
| `ncclDevKernel_Generic_1` | True | **False** |
| `all_to_all_dispatch` | True | **False** |
| `cross_device_reduce_2stage` | True | True |

The flip is self-defeating. `is_collective_candidate` (`_kernel_decisions.py`) gates the collective lane on `candidate_source == "nccl_summary"` **and** `is_multigpu` — so the lane refuses rows it produced itself, and an 8-rank collective gets told it has one GPU and should write a rank-slice surrogate.

`small_collective` isn't hypothetical: it's a real `__global__` in the repo's own fixture, resolved by device-symbol lookup and then un-resolved by a substring guess.

## The change

A positive `nccl_summary` verdict now outranks the name. The heuristic still runs for every other row, **and** still runs for an `nccl_summary` row that did not claim multi-GPU, so it can still raise a collective the lane missed.

Also fills three vocabulary gaps. The list carried both spellings of `all_reduce` and `all_gather` but only the delimited `reduce_scatter`, and no all-to-all form at all — so `ReduceScatterFusion`, `all_to_all_dispatch` and `rccl_AllToAll` read as single-GPU while `ncclDevKernel_AllGather` did not. The word-bounded sibling `kernel_name_implies_multigpu` already agrees with all three.

## Mutation results

| mutation | result |
|---|---|
| delete the guard (restore the clobber) | 🔴 |
| guard always on (never re-derive) | 🔴 |
| drop the `candidate_source` qualifier | 🔴 |
| drop the `is_multigpu` qualifier | 🔴 |
| remove `reducescatter` / `all_to_all` / `alltoall` | 🔴 ×3 |

Tests drive the real `_stamp_candidate_metadata` and assert `num_gpus_recommended`, not the bare boolean. Kernel suite: 2049 passed vs 2046 on `main`, same 10 pre-existing failures.

## Deliberately not in this PR

**Word-bounding the tags.** Delegating to `kernel_name_implies_multigpu` is a **regression** — it returns False for `cross_device_reduce_2stage`, `cross_device_reduce_1stage`, `send_recv_kernel` and `p2p_copy`, all of which `_enrich_kernel_contract` enumerates as an all-reduce family. It also fixes only 2 of the 3 FPs #1320 names (`broadcast_add` still matches). Doing it safely needs the sibling's normalisation machinery plus restored `cross_device`/`p2p`/`send_recv` patterns, and it would flip one real trace row (`EpCombineIntraNodeKernel_bf16_nop2p`, which currently matches on the *negation* `nop2p`). That is a real decision with a real cost, and with the GPU-reservation impact gone the remaining cost is prompt wording — so it should be weighed on its own, not smuggled in here.

I'll update #1320 with the corrected analysis so the FP question isn't ranked off a chain that no longer exists.
