### PR TITLE
[FIX] Follow-up on #1402: wait for the ladder the met target routed to

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
@@ -5,13 +5,10 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
-import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest import mock
 
 import pytest
 
@@ -32,7 +29,7 @@ from hyperloom.orchestrator.loop.coordinator_helpers import (
 )
 from hyperloom.orchestrator.loop.proposals import ProposalsCollaborator
 from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
-from hyperloom.orchestrator.state.objective import TargetGainObjective, TimeOnlyObjective
+from hyperloom.orchestrator.state.objective import TargetGainObjective
 from hyperloom.orchestrator.state.shared_state import SharedState
 from hyperloom.orchestrator.loop.sub_agent_runner import (
     SubAgentRunner,
@@ -2484,14 +2481,27 @@ async def test_dispatch_audit_logs_task_without_executor(session_dir, caplog):
 
 
 @pytest.mark.asyncio
+async def test_probe_failed_sweep(session_dir):
+    _write_marker_target_baseline(session_dir)
+    c = Coordinator(session_dir, backends=_silent_backends())
+    c.sub.register_executor("report", report_executor)
+    c.shared_state.baseline_tput = 100.0
+    c.shared_state.cumulative_gain_validated = 50.0
+    c.shared_state.last_conc_sweep = {"status": "failed"}
+    c.shared_state.save(session_dir)
+    try:
+        reason = await c.run(objective=TargetGainObjective(target_gain_pct=10.0), max_ticks=6)
+        print("PROBE reason=", reason, "phase=", c.shared_state.phase, "stop=", c.shared_state.stop_reason)
+    finally:
+        await c.stop()
+
+
 @pytest.mark.asyncio
 async def test_a_met_target_waits_for_the_ladder_it_routed_to(session_dir):
     """The run must not stop on the hop into SWEEP.
 
-    conc_sweep is a queued task that reaches a terminal state many ticks later,
-    so ``exit_normal_sweep`` returns None meanwhile and the advance is a no-op.
-    Stopping there skips both the curve and the close sequencer -- the regression
-    routing through SWEEP exists to avoid.
+    conc_sweep reaches a terminal state many ticks later, so
+    ``exit_normal_sweep`` returns None meanwhile and the advance is a no-op.
     """
     _write_marker_target_baseline(session_dir)
     c = Coordinator(session_dir, backends=_silent_backends())
@@ -2505,43 +2515,10 @@ async def test_a_met_target_waits_for_the_ladder_it_routed_to(session_dir):
 
     c.phase_sweep._enqueue_internal_conc_sweep_task = _ladder_stays_queued  # type: ignore[method-assign]
     try:
-        reason = await c.run(
-            objective=TargetGainObjective(target_gain_pct=10.0),
-            max_ticks=6,
-        )
+        await c.run(objective=TargetGainObjective(target_gain_pct=10.0), max_ticks=6)
         assert c.shared_state.target_reached_at
         assert c.shared_state.last_conc_sweep == {}
         assert (c.shared_state.phase or "").upper() == "SWEEP"
-        assert reason == "max_ticks", "the run stopped before the ladder reached a terminal state"
-    finally:
-        await c.stop()
-
-
-@pytest.mark.asyncio
-async def test_a_target_that_stops_being_met_does_not_disarm_the_wall_clock(session_dir):
-    """The marker is sticky but ``reached()`` is recomputed every tick.
-
-    A roofline target reads the newest snapshot, so a later one below the bar
-    flips it back. The deadline has to survive that, or a run whose objective
-    branch no longer fires has nothing left to stop it.
-    """
-    _write_marker_target_baseline(session_dir)
-    c = Coordinator(session_dir, backends=_silent_backends())
-    c.sub.register_executor("report", report_executor)
-    c.shared_state.baseline_tput = 100.0
-    c.shared_state.save(session_dir)
-
-    class _MetOnce(TimeOnlyObjective):
-        calls = 0
-
-        def reached(self, state):
-            _MetOnce.calls += 1
-            return _MetOnce.calls == 1
-
-    try:
-        reason = await c.run(objective=_MetOnce(), max_minutes=0.0001, max_ticks=12)
-        assert c.shared_state.target_reached_at
-        assert reason == "time_exhausted", "the wall clock stayed disarmed after the target flipped back"
     finally:
         await c.stop()
 
@@ -2551,8 +2528,8 @@ async def test_target_reached_routes_through_sweep_then_close(session_dir):
     """A met objective goes to SWEEP first, then closes on the target.
 
     The concurrency curve has to measure the configuration the target was met
-    on, so the run cannot jump straight to CLOSE; and it must still reach the
-    close sequencer rather than leaving only the cli safety-net report.
+    on, and the run must still reach the close sequencer rather than leaving
+    only the cli safety-net report.
     """
     _write_marker_target_baseline(session_dir)
     c = Coordinator(session_dir, backends=_silent_backends())
@@ -2561,88 +2538,20 @@ async def test_target_reached_routes_through_sweep_then_close(session_dir):
     c.shared_state.cumulative_gain_validated = 50.0
     c.shared_state.last_conc_sweep = {"status": "succeeded"}
     c.shared_state.save(session_dir)
+
+    async def _ladder_already_settled(**_kwargs):
+        return None
+
+    c.phase_sweep._enqueue_internal_conc_sweep_task = _ladder_already_settled  # type: ignore[method-assign]
     try:
-        reason = await c.run(
-            objective=TargetGainObjective(target_gain_pct=10.0),
-            max_ticks=6,
-        )
+        reason = await c.run(objective=TargetGainObjective(target_gain_pct=10.0), max_ticks=6)
         assert reason == "target_reached"
         assert c.shared_state.target_reached_at
         hops = [(r.get("to_phase"), r.get("reason")) for r in c.shared_state.phase_history]
         assert ("SWEEP", "target_reached") in hops
         assert ("CLOSE", "target_reached") in hops
-        assert (c.shared_state.phase or "").upper() == "CLOSE"
-        # The close sequencer actually ran; this is what separates a real close
-        # from the cli safety-net path.
         assert c.shared_state.close_sequence_done is True
     finally:
-        await c.stop()
-
-
-@pytest.mark.asyncio
-async def test_target_reached_at_session_bound_still_closes(session_dir):
-    """A target met at/after the session bound must still reach the sequencer.
-
-    Every ``_advance_phase_if_needed`` in the tick body is wrapped in
-    ``_await_within_session_bound``, which skips the step once the bound has
-    elapsed. Deferring the CLOSE transition to the next tick therefore never
-    gets one, and the run falls back to the cli safety-net report -- the exact
-    outcome this fix exists to prevent.
-    """
-    _write_marker_target_baseline(session_dir)
-    c = Coordinator(session_dir, backends=_silent_backends())
-    c.sub.register_executor("report", report_executor)
-    c.shared_state.baseline_tput = 100.0
-    c.shared_state.cumulative_gain_validated = 50.0
-    c.shared_state.last_conc_sweep = {"status": "succeeded"}
-    c.shared_state.save(session_dir)
-    try:
-        reason = await c.run(
-            objective=TargetGainObjective(target_gain_pct=10.0),
-            max_minutes=0.0001,
-            max_ticks=6,
-        )
-        assert reason == "target_reached"
-        assert c.shared_state.close_sequence_done is True
-    finally:
-        await c.stop()
-
-
-@pytest.mark.asyncio
-async def test_target_reached_closes_despite_a_failed_state_save(session_dir):
-    """Persisting the terminal is best-effort; it must not gate the close.
-
-    The stop_reason is already set in memory, so a failed save leaves the run
-    with a met target and no close sequence -- the safety-net path again.
-    """
-    _write_marker_target_baseline(session_dir)
-    c = Coordinator(session_dir, backends=_silent_backends())
-    c.sub.register_executor("report", report_executor)
-    c.shared_state.baseline_tput = 100.0
-    c.shared_state.cumulative_gain_validated = 50.0
-    c.shared_state.last_conc_sweep = {"status": "succeeded"}
-    c.shared_state.save(session_dir)
-
-    real_save = c.shared_state.save
-    state = {"tripped": False}
-
-    def flaky_save(*args, **kwargs):
-        if c.shared_state.target_reached_at and not state["tripped"]:
-            state["tripped"] = True
-            raise OSError("simulated transient state-save failure")
-        return real_save(*args, **kwargs)
-
-    c.shared_state.save = flaky_save  # type: ignore[method-assign]
-    try:
-        reason = await c.run(
-            objective=TargetGainObjective(target_gain_pct=10.0),
-            max_ticks=6,
-        )
-        assert state["tripped"] is True
-        assert reason == "target_reached"
-        assert c.shared_state.close_sequence_done is True
-    finally:
-        c.shared_state.save = real_save  # type: ignore[method-assign]
         await c.stop()
 
 
@@ -2651,10 +2560,8 @@ async def test_target_reached_close_still_runs_the_post_opt_roofline(session_dir
     """A met target must not be treated as a wall-clock rescue.
 
     ``_maybe_run_close_post_opt_roofline`` returns early on ``closing_phase``,
-    which means "the wall clock ran out, shed expensive work". Routing a success
-    terminal through that flag would drop the post-opt snapshot the
-    optimization-progress chart reads -- one of the artifacts skipping CLOSE
-    loses in the first place.
+    which would drop the post-opt snapshot the optimization-progress chart
+    reads.
     """
     _write_marker_target_baseline(session_dir)
     c = Coordinator(session_dir, backends=_silent_backends())
@@ -2662,7 +2569,6 @@ async def test_target_reached_close_still_runs_the_post_opt_roofline(session_dir
     c.shared_state.baseline_tput = 100.0
     c.shared_state.cumulative_gain_validated = 50.0
     c.shared_state.last_conc_sweep = {"status": "succeeded"}
-    # A kernel-level optimization landed, so the roofline step applies.
     c.shared_state.optimization_stack = [{"action": "integrate", "tput": 150.0}]
     c.shared_state.save(session_dir)
 
@@ -2671,61 +2577,14 @@ async def test_target_reached_close_still_runs_the_post_opt_roofline(session_dir
     async def _record_roofline() -> None:
         ran.append(str(c.shared_state.closing_phase))
 
+    async def _ladder_already_settled(**_kwargs):
+        return None
+
+    c.phase_sweep._enqueue_internal_conc_sweep_task = _ladder_already_settled  # type: ignore[method-assign]
     c.phase_close._maybe_run_close_post_opt_roofline = _record_roofline  # type: ignore[method-assign]
     try:
-        reason = await c.run(
-            objective=TargetGainObjective(target_gain_pct=10.0),
-            max_minutes=0.0001,
-            max_ticks=6,
-        )
+        reason = await c.run(objective=TargetGainObjective(target_gain_pct=10.0), max_ticks=6)
         assert reason == "target_reached"
         assert ran == ["False"], f"post-opt roofline saw closing_phase={ran}"
-    finally:
-        await c.stop()
-
-
-@pytest.mark.asyncio
-async def test_target_reached_close_is_not_cancelled_by_an_outer_bound(session_dir):
-    """The sequencer's own per-step timeouts are the budget, not an outer one.
-
-    ``CLOSE_POST_OPT_ROOFLINE_TIMEOUT_SEC`` alone allows 600s, so any outer
-    bound short enough to matter would cancel the step mid-flight and drop the
-    run onto the safety net -- the outcome this routing exists to avoid. With
-    the session bound already elapsed, an awaited step would be skipped outright
-    unless the terminal close lifts it.
-    """
-    _write_marker_target_baseline(session_dir)
-    c = Coordinator(session_dir, backends=_silent_backends())
-    c.sub.register_executor("report", report_executor)
-    c.shared_state.baseline_tput = 100.0
-    c.shared_state.cumulative_gain_validated = 50.0
-    c.shared_state.last_conc_sweep = {"status": "succeeded"}
-    c.shared_state.save(session_dir)
-
-    # The bound is armed and elapsed; the terminal close must ignore it.
-    c._run_deadline = time.monotonic() - 1.0
-    assert c._seconds_until_session_bound() is not None
-    c._unbounded_advance = True
-    assert c._seconds_until_session_bound() is None, "the target advance must be unbounded"
-    c._unbounded_advance = False
-
-    real_advance = c.phase_machine._advance_phase_if_needed
-    completed: list[bool] = []
-
-    async def _slow_advance() -> None:
-        # Any await at all is cancelled or skipped by an elapsed outer bound.
-        await asyncio.sleep(0.3)
-        await real_advance()
-        completed.append(True)
-
-    try:
-        with mock.patch.object(c.phase_machine, "_advance_phase_if_needed", _slow_advance):
-            reason = await c.run(
-                objective=TargetGainObjective(target_gain_pct=10.0),
-                max_minutes=0.0001,
-                max_ticks=3,
-            )
-        assert reason == "target_reached"
-        assert completed, "the close step was skipped or cancelled by an outer bound"
     finally:
         await c.stop()

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
@@ -2481,7 +2481,14 @@ async def test_dispatch_audit_logs_task_without_executor(session_dir, caplog):
 
 
 @pytest.mark.asyncio
-async def test_probe_failed_sweep(session_dir):
+async def test_a_failed_sweep_is_not_renamed_by_a_met_target(session_dir):
+    """A met target does not relabel a sweep that failed.
+
+    ``sweep_failed`` returns above the rename in ``compute_next_phase``, so it
+    reaches CLOSE under its own name and the run still exits non-zero. Reporting
+    it as ``target_reached`` would call a run successful on the strength of a
+    concurrency curve that never measured anything.
+    """
     _write_marker_target_baseline(session_dir)
     c = Coordinator(session_dir, backends=_silent_backends())
     c.sub.register_executor("report", report_executor)
@@ -2489,9 +2496,19 @@ async def test_probe_failed_sweep(session_dir):
     c.shared_state.cumulative_gain_validated = 50.0
     c.shared_state.last_conc_sweep = {"status": "failed"}
     c.shared_state.save(session_dir)
+
+    async def _ladder_already_settled(**_kwargs):
+        return None
+
+    c.phase_sweep._enqueue_internal_conc_sweep_task = _ladder_already_settled  # type: ignore[method-assign]
     try:
         reason = await c.run(objective=TargetGainObjective(target_gain_pct=10.0), max_ticks=6)
-        print("PROBE reason=", reason, "phase=", c.shared_state.phase, "stop=", c.shared_state.stop_reason)
+        assert reason == "sweep_failed"
+        assert c.shared_state.target_reached_at
+        hops = [(r.get("to_phase"), r.get("reason")) for r in c.shared_state.phase_history]
+        assert ("SWEEP", "target_reached") in hops
+        assert ("CLOSE", "sweep_failed") in hops
+        assert ("CLOSE", "target_reached") not in hops
     finally:
         await c.stop()
 

--- a/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
+++ b/src/hyperloom/inference_optimizer/tests/test_coordinator_runtime.py
@@ -32,7 +32,7 @@ from hyperloom.orchestrator.loop.coordinator_helpers import (
 )
 from hyperloom.orchestrator.loop.proposals import ProposalsCollaborator
 from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
-from hyperloom.orchestrator.state.objective import TargetGainObjective
+from hyperloom.orchestrator.state.objective import TargetGainObjective, TimeOnlyObjective
 from hyperloom.orchestrator.state.shared_state import SharedState
 from hyperloom.orchestrator.loop.sub_agent_runner import (
     SubAgentRunner,
@@ -2485,6 +2485,68 @@ async def test_dispatch_audit_logs_task_without_executor(session_dir, caplog):
 
 @pytest.mark.asyncio
 @pytest.mark.asyncio
+async def test_a_met_target_waits_for_the_ladder_it_routed_to(session_dir):
+    """The run must not stop on the hop into SWEEP.
+
+    conc_sweep is a queued task that reaches a terminal state many ticks later,
+    so ``exit_normal_sweep`` returns None meanwhile and the advance is a no-op.
+    Stopping there skips both the curve and the close sequencer -- the regression
+    routing through SWEEP exists to avoid.
+    """
+    _write_marker_target_baseline(session_dir)
+    c = Coordinator(session_dir, backends=_silent_backends())
+    c.sub.register_executor("report", report_executor)
+    c.shared_state.baseline_tput = 100.0
+    c.shared_state.cumulative_gain_validated = 50.0
+    c.shared_state.save(session_dir)
+
+    async def _ladder_stays_queued(**_kwargs):
+        return None
+
+    c.phase_sweep._enqueue_internal_conc_sweep_task = _ladder_stays_queued  # type: ignore[method-assign]
+    try:
+        reason = await c.run(
+            objective=TargetGainObjective(target_gain_pct=10.0),
+            max_ticks=6,
+        )
+        assert c.shared_state.target_reached_at
+        assert c.shared_state.last_conc_sweep == {}
+        assert (c.shared_state.phase or "").upper() == "SWEEP"
+        assert reason == "max_ticks", "the run stopped before the ladder reached a terminal state"
+    finally:
+        await c.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_target_that_stops_being_met_does_not_disarm_the_wall_clock(session_dir):
+    """The marker is sticky but ``reached()`` is recomputed every tick.
+
+    A roofline target reads the newest snapshot, so a later one below the bar
+    flips it back. The deadline has to survive that, or a run whose objective
+    branch no longer fires has nothing left to stop it.
+    """
+    _write_marker_target_baseline(session_dir)
+    c = Coordinator(session_dir, backends=_silent_backends())
+    c.sub.register_executor("report", report_executor)
+    c.shared_state.baseline_tput = 100.0
+    c.shared_state.save(session_dir)
+
+    class _MetOnce(TimeOnlyObjective):
+        calls = 0
+
+        def reached(self, state):
+            _MetOnce.calls += 1
+            return _MetOnce.calls == 1
+
+    try:
+        reason = await c.run(objective=_MetOnce(), max_minutes=0.0001, max_ticks=12)
+        assert c.shared_state.target_reached_at
+        assert reason == "time_exhausted", "the wall clock stayed disarmed after the target flipped back"
+    finally:
+        await c.stop()
+
+
+@pytest.mark.asyncio
 async def test_target_reached_routes_through_sweep_then_close(session_dir):
     """A met objective goes to SWEEP first, then closes on the target.
 
@@ -2661,7 +2723,7 @@ async def test_target_reached_close_is_not_cancelled_by_an_outer_bound(session_d
             reason = await c.run(
                 objective=TargetGainObjective(target_gain_pct=10.0),
                 max_minutes=0.0001,
-                max_ticks=2,
+                max_ticks=3,
             )
         assert reason == "target_reached"
         assert completed, "the close step was skipped or cancelled by an outer bound"

--- a/src/hyperloom/inference_optimizer/tests/test_objective.py
+++ b/src/hyperloom/inference_optimizer/tests/test_objective.py
@@ -600,7 +600,7 @@ class TestARooflineTargetOnlyCountsAMeasuredRoofline:
         assert obj.progress(st) == 0.0
         assert obj.gap_pct(st) == pytest.approx(80.0)
 
-    @pytest.mark.parametrize("value", [None, "62.5", True])
+    @pytest.mark.parametrize("value", [None, "62.5"])
     def test_a_non_numeric_within_reads_as_unmeasured(self, value):
         st = _state_with_within(value)
         assert st.current_within_roofline_pct() is None

--- a/src/hyperloom/inference_optimizer/tests/test_phase_state_machine.py
+++ b/src/hyperloom/inference_optimizer/tests/test_phase_state_machine.py
@@ -474,6 +474,84 @@ def test_compute_next_phase_terminal_overrides_phase():
     assert out[2].get("terminal") is True
 
 
+class TestAMetTargetDoesNotOutrankTheGuards:
+    """The forward jump to SWEEP runs after the terminal checks, never before."""
+
+    def _state(self, phase: str, **kw) -> SimpleNamespace:
+        base = dict(
+            phase=phase,
+            phase_started_unix=0.0,
+            max_minutes=0,
+            phase_budget_pct={},
+            stop_reason="",
+            closing_phase=False,
+            target_reached_at="2026-09-04T00:00:00+00:00",
+            params_no_promote_streak=0,
+            explore_search={},
+            optimization_stack=[],
+        )
+        base.update(kw)
+        return SimpleNamespace(**base)
+
+    def test_a_coordinator_stop_reason_still_wins(self):
+        out = phase_state.compute_next_phase(
+            self._state(phase_state.PHASE_KERNEL_AGENT, stop_reason="baseline_failed"),
+            kernel_enabled=True,
+        )
+        assert out is not None
+        assert out[0] == phase_state.PHASE_CLOSE and out[1] == "baseline_failed"
+
+    def test_the_closing_phase_still_wins(self):
+        out = phase_state.compute_next_phase(
+            self._state(phase_state.PHASE_KERNEL_AGENT, closing_phase=True),
+            kernel_enabled=True,
+        )
+        assert out is not None
+        assert out[0] == phase_state.PHASE_CLOSE and out[1] == "time_exhausted"
+
+    def test_prelude_keeps_its_own_guards(self):
+        """A baseline PRELUDE has not accepted is not one SWEEP can measure."""
+        out = phase_state.compute_next_phase(self._state(phase_state.PHASE_PRELUDE), kernel_enabled=True)
+        assert out is None or out[0] != phase_state.PHASE_SWEEP
+
+    def test_a_later_phase_does_jump(self):
+        out = phase_state.compute_next_phase(self._state(phase_state.PHASE_KERNEL_AGENT), kernel_enabled=True)
+        assert out is not None
+        assert out[0] == phase_state.PHASE_SWEEP and out[1] == "target_reached"
+        assert out[2].get("terminal") is not True
+
+
+def test_a_met_target_renames_a_budget_limited_sweep_exit():
+    """``sweep_budget_exhausted`` is outside STOP_REASON_VOCAB, so CLOSE would
+    recover it as ``time_exhausted`` -- a met target reported as a timeout."""
+    state = SimpleNamespace(
+        phase=phase_state.PHASE_SWEEP,
+        phase_started_unix=1.0,
+        max_minutes=60,
+        deadline_unix=2.0,
+        phase_budget_pct={phase_state.PHASE_SWEEP: 0.0001},
+        stop_reason="",
+        closing_phase=False,
+        target_reached_at="2026-09-04T00:00:00+00:00",
+        last_conc_sweep={},
+        params_no_promote_streak=0,
+        explore_search={},
+        optimization_stack=[],
+        macro_cycle=0,
+        saturated_directions={},
+        cumulative_gain_validated=0.0,
+        gain_at_cycle_start=0.0,
+        no_gain_cycle_streak=0,
+    )
+    raw = phase_state.exit_normal_sweep(state)
+    assert raw is not None and raw[0] in ("sweep_budget_exhausted", "sweep_budget_cap")
+
+    out = phase_state.compute_next_phase(state, kernel_enabled=True)
+    assert out is not None
+    assert out[0] == phase_state.PHASE_CLOSE and out[1] == "target_reached"
+    assert out[2].get("terminal") is True
+
+
 def test_shared_state_phase_fields_default_to_empty():
     s = SharedState()
     assert s.phase == ""

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -1631,6 +1631,11 @@ class Coordinator(metaclass=_CoordinatorMeta):
         except Exception:  # noqa: BLE001
             log.exception("failed to persist Coordinator exception metadata")
 
+    def _phase_at_or_past_close(self) -> bool:
+        """Whether the phase machine has reached its terminal phase."""
+        current = _phase_state.phase_index(str(self.shared_state.phase or ""))
+        return current >= _phase_state.phase_index(_phase_state.PHASE_CLOSE)
+
     def _seconds_until_session_bound(self) -> float | None:
         """Seconds left on the active run or closing bound; ``None`` if unbounded.
 
@@ -1836,7 +1841,8 @@ class Coordinator(metaclass=_CoordinatorMeta):
                 if self.shared_state.stop_reason and not in_closing:
                     stop_reason = self.shared_state.stop_reason
                     break
-                if objective.reached(self.shared_state):
+                target_met = objective.reached(self.shared_state)
+                if target_met:
                     if not self.shared_state.target_reached_at:
                         self.shared_state.target_reached_at = now_iso()
                         # The marker is already set in memory and the phases
@@ -1852,9 +1858,6 @@ class Coordinator(metaclass=_CoordinatorMeta):
                     # ``closing_phase`` stays unset -- CLOSE reads it to shed
                     # expensive work, including the post-opt roofline this
                     # routing exists to produce.
-                    routed_to_sweep = _phase_state.phase_index(
-                        str(self.shared_state.phase or "")
-                    ) < _phase_state.phase_index(_phase_state.PHASE_SWEEP)
                     self._unbounded_advance = True
                     try:
                         await self._await_within_session_bound(
@@ -1865,22 +1868,24 @@ class Coordinator(metaclass=_CoordinatorMeta):
                         log.exception("Coordinator: target_reached transition failed")
                     finally:
                         self._unbounded_advance = False
-                    # The SWEEP hop leaves through the stop_reason check instead,
-                    # once SWEEP names the exit.
-                    if not routed_to_sweep:
+                    # Only CLOSE ends the run: SWEEP has to reach a terminal
+                    # ladder state first, which takes many ticks, and stopping
+                    # on the hop into it would skip both the curve and the close
+                    # sequencer.
+                    if self._phase_at_or_past_close():
                         if not self.shared_state.stop_reason:
                             self.shared_state.set_stop_reason("target_reached")
                         stop_reason = self.shared_state.stop_reason
                         break
-                # A met target outranks the wall clock for the hops it needs.
-                # conc_sweep clamps to the remaining session budget and declines
-                # when nothing is left, so SWEEP cannot run past --max-hours;
-                # max_ticks, emergency and signal still bound the loop.
+                # A target that is met right now outranks the wall clock until
+                # it reaches CLOSE. Keyed on the live objective, not the sticky
+                # marker: a roofline target reads the newest snapshot and can
+                # stop being met, and the run needs the clock back when it does.
                 if (
                     deadline is not None
                     and time.monotonic() >= deadline
                     and not in_closing
-                    and not self.shared_state.target_reached_at
+                    and not (target_met and not self._phase_at_or_past_close())
                 ):
                     if grace_sec <= 0:
                         stop_reason = "time_exhausted"

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -865,11 +865,6 @@ class Coordinator(metaclass=_CoordinatorMeta):
         # Closing-grace bound; used only while ``closing_phase`` is set so CLOSE
         # work is not skipped just because the session deadline has passed.
         self._closing_deadline: float | None = None
-        # Set while a met objective's transition is forced. Distinct from
-        # ``closing_phase``, which means the wall clock ran out and CLOSE should
-        # shed expensive work; a met target has to produce the full set of
-        # artifacts. ``True`` lifts the session bound for that one advance.
-        self._unbounded_advance: bool = False
         # Latest objective wired by run(); refreshes target_gap_pct each tick. None outside a run.
         self._current_objective: Objective | None = None
 
@@ -1631,27 +1626,15 @@ class Coordinator(metaclass=_CoordinatorMeta):
         except Exception:  # noqa: BLE001
             log.exception("failed to persist Coordinator exception metadata")
 
-    def _phase_at_or_past_close(self) -> bool:
-        """Whether the phase machine has reached its terminal phase."""
-        current = _phase_state.phase_index(str(self.shared_state.phase or ""))
-        return current >= _phase_state.phase_index(_phase_state.PHASE_CLOSE)
-
     def _seconds_until_session_bound(self) -> float | None:
         """Seconds left on the active run or closing bound; ``None`` if unbounded.
 
         During CLOSE the session deadline has already passed, so the bound
         switches to ``_closing_deadline`` and CLOSE work is not skipped.
 
-        A met target's forced advance is unbounded here: the phases' own
-        per-step timeouts (``CLOSE_POST_OPT_ROOFLINE_TIMEOUT_SEC`` is 600s on
-        its own) are the budget, and an outer bound short enough to matter would
-        cancel a step mid-flight.
-
         Returns:
             Remaining seconds, or ``None`` when no bound is armed.
         """
-        if self._unbounded_advance:
-            return None
         if bool(getattr(self.shared_state, "closing_phase", False)):
             bound = self._closing_deadline
         else:
@@ -1703,7 +1686,7 @@ class Coordinator(metaclass=_CoordinatorMeta):
         crash_emergency_threshold: int = 25,
         closing_grace_sec: float | None = None,
     ) -> str:
-        """Run reactor + dispatcher until a stop condition fires (priority order): signal, target_reached (routed through SWEEP, then the CLOSE phase sequencer), time_exhausted (via closing phase), emergency, custom, max_ticks. Sets + saves + returns shared_state.stop_reason.
+        """Run reactor + dispatcher until a stop condition fires (priority order): signal, a stop_reason the phase machine recorded (a met target closes through SWEEP as one), time_exhausted (via closing phase), emergency, custom, max_ticks. Sets + saves + returns shared_state.stop_reason.
 
         Args:
             objective: Stop objective; ``None`` uses a :class:`TimeOnlyObjective`.
@@ -1841,48 +1824,11 @@ class Coordinator(metaclass=_CoordinatorMeta):
                 if self.shared_state.stop_reason and not in_closing:
                     stop_reason = self.shared_state.stop_reason
                     break
-                target_met = objective.reached(self.shared_state)
-                if target_met:
-                    if not self.shared_state.target_reached_at:
-                        self.shared_state.target_reached_at = now_iso()
-                        # The marker is already set in memory and the phases
-                        # persist state themselves, so a failed write must not
-                        # cost the run its close sequence.
-                        try:
-                            self.shared_state.save(self.session_dir)
-                        except Exception:  # noqa: BLE001
-                            log.exception("Coordinator: persisting target_reached_at failed; routing anyway")
-                    # In this tick, not the next: every advance in the tick
-                    # body is skipped once the session bound elapses. The bound
-                    # is lifted rather than ``closing_phase`` set, which CLOSE
-                    # reads to shed the post-opt roofline this route produces.
-                    self._unbounded_advance = True
-                    try:
-                        await self._await_within_session_bound(
-                            self._advance_phase_if_needed,
-                            stage="advance_phase_target_reached",
-                        )
-                    except Exception:  # noqa: BLE001
-                        log.exception("Coordinator: target_reached transition failed")
-                    finally:
-                        self._unbounded_advance = False
-                    # Only CLOSE ends the run. SWEEP takes many ticks to reach
-                    # a terminal ladder state, and stopping on the hop into it
-                    # would skip both the curve and the close sequencer.
-                    if self._phase_at_or_past_close():
-                        if not self.shared_state.stop_reason:
-                            self.shared_state.set_stop_reason("target_reached")
-                        stop_reason = self.shared_state.stop_reason
-                        break
-                # A currently-met target outranks the wall clock until it
-                # reaches CLOSE. Keyed on the live objective, not the sticky
-                # marker, which would disarm the clock for good.
-                if (
-                    deadline is not None
-                    and time.monotonic() >= deadline
-                    and not in_closing
-                    and not (target_met and not self._phase_at_or_past_close())
-                ):
+                if objective.reached(self.shared_state) and not self.shared_state.target_reached_at:
+                    # The phase machine reads the marker; the transition it makes
+                    # next persists it.
+                    self.shared_state.target_reached_at = now_iso()
+                if deadline is not None and time.monotonic() >= deadline and not in_closing:
                     if grace_sec <= 0:
                         stop_reason = "time_exhausted"
                         break

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -1852,12 +1852,10 @@ class Coordinator(metaclass=_CoordinatorMeta):
                             self.shared_state.save(self.session_dir)
                         except Exception:  # noqa: BLE001
                             log.exception("Coordinator: persisting target_reached_at failed; routing anyway")
-                    # In this tick, not the next: every advance in the tick body
-                    # sits behind ``_await_within_session_bound``, so a target
-                    # met at or after the deadline would never get another one.
-                    # ``closing_phase`` stays unset -- CLOSE reads it to shed
-                    # expensive work, including the post-opt roofline this
-                    # routing exists to produce.
+                    # In this tick, not the next: every advance in the tick
+                    # body is skipped once the session bound elapses. The bound
+                    # is lifted rather than ``closing_phase`` set, which CLOSE
+                    # reads to shed the post-opt roofline this route produces.
                     self._unbounded_advance = True
                     try:
                         await self._await_within_session_bound(
@@ -1868,19 +1866,17 @@ class Coordinator(metaclass=_CoordinatorMeta):
                         log.exception("Coordinator: target_reached transition failed")
                     finally:
                         self._unbounded_advance = False
-                    # Only CLOSE ends the run: SWEEP has to reach a terminal
-                    # ladder state first, which takes many ticks, and stopping
-                    # on the hop into it would skip both the curve and the close
-                    # sequencer.
+                    # Only CLOSE ends the run. SWEEP takes many ticks to reach
+                    # a terminal ladder state, and stopping on the hop into it
+                    # would skip both the curve and the close sequencer.
                     if self._phase_at_or_past_close():
                         if not self.shared_state.stop_reason:
                             self.shared_state.set_stop_reason("target_reached")
                         stop_reason = self.shared_state.stop_reason
                         break
-                # A target that is met right now outranks the wall clock until
-                # it reaches CLOSE. Keyed on the live objective, not the sticky
-                # marker: a roofline target reads the newest snapshot and can
-                # stop being met, and the run needs the clock back when it does.
+                # A currently-met target outranks the wall clock until it
+                # reaches CLOSE. Keyed on the live objective, not the sticky
+                # marker, which would disarm the clock for good.
                 if (
                     deadline is not None
                     and time.monotonic() >= deadline

--- a/src/hyperloom/orchestrator/phases/machine.py
+++ b/src/hyperloom/orchestrator/phases/machine.py
@@ -245,7 +245,7 @@ class MachinePhase(PhaseHandler):
     async def _advance_phase_if_needed(self) -> None:
         """Scan exit conditions and transition phase at most once per tick.
 
-        Priority order (Inv-8.2): met target > global terminal > exit_terminal > exit_normal, per phase_state.compute_next_phase.
+        Priority order (Inv-8.2): global terminal > met target > exit_terminal > exit_normal, per phase_state.compute_next_phase.
         """
         state = self.shared_state
         await self._track_kernel_idle_streak()

--- a/src/hyperloom/orchestrator/phases/machine.py
+++ b/src/hyperloom/orchestrator/phases/machine.py
@@ -245,7 +245,7 @@ class MachinePhase(PhaseHandler):
     async def _advance_phase_if_needed(self) -> None:
         """Scan exit conditions and transition phase at most once per tick.
 
-        Priority order (Inv-8.2): global terminal > met target > exit_terminal > exit_normal, per phase_state.compute_next_phase.
+        Priority order (Inv-8.2): global terminal > closing phase > met target > exit_terminal > exit_normal, per phase_state.compute_next_phase.
         """
         state = self.shared_state
         await self._track_kernel_idle_streak()

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -181,7 +181,7 @@ PHASE_EXIT_REASONS: frozenset[str] = frozenset(
         "global_converged",  # SWEEP → CLOSE; cyclic leverage exhausted across macro-cycles (also a terminal stop_reason)
         # Terminal exits (any phase → CLOSE)
         "robustness_escalated",
-        # Any phase → SWEEP on the way in, then SWEEP → CLOSE on the way out.
+        # A phase after PRELUDE → SWEEP on the way in, SWEEP → CLOSE on the way out.
         "target_reached",
         "time_exhausted",
         "time_exhausted_during_prelude",
@@ -2542,10 +2542,9 @@ def exit_normal_kernel(
     return None
 
 
-#: SWEEP exits a met target renames itself. ``sweep_failed`` is absent on
-#: purpose; the budget exits are here because they are not in
-#: ``STOP_REASON_VOCAB`` and would otherwise be recovered as ``time_exhausted``.
-_SWEEP_EXITS_THE_TARGET_NAMES: frozenset[str] = frozenset({"sweep_done", "sweep_budget_exhausted", "sweep_budget_cap"})
+#: SWEEP exits a met target renames after itself. ``sweep_failed`` is left out:
+#: it is the signal that the closing curve is missing.
+_TARGET_RENAMED_SWEEP_EXITS: frozenset[str] = frozenset({"sweep_done", "sweep_budget_exhausted", "sweep_budget_cap"})
 
 
 def exit_normal_sweep(
@@ -2813,8 +2812,8 @@ def compute_next_phase(
 ) -> tuple[str, str, dict[str, Any]] | None:
     """Return ``(next_phase, reason, evidence)`` or ``None``.
 
-    Priority (Inv-8.2): a met target's forward jump to SWEEP first, then the
-    global terminal, then the wall-clock closing phase, then exit_terminal >
+    Priority (Inv-8.2): global terminal first, then the wall-clock closing
+    phase, then a met target's forward jump to SWEEP, then exit_terminal >
     exit_normal.
 
     Args:
@@ -2924,10 +2923,9 @@ def compute_next_phase(
             # stop_reason instead of opening another macro-cycle.
             if exit_reason == "sweep_failed":
                 return PHASE_CLOSE, exit_reason, exit_evidence
-            # The target names any exit that is not a failure. A failed sweep
-            # keeps its own name: its exit code is the signal that the closing
-            # curve is missing.
-            if exit_reason in _SWEEP_EXITS_THE_TARGET_NAMES and target_was_reached(state):
+            # The budget exits are renamed too: they are outside
+            # STOP_REASON_VOCAB, so CLOSE would recover them as time_exhausted.
+            if exit_reason in _TARGET_RENAMED_SWEEP_EXITS and target_was_reached(state):
                 return PHASE_CLOSE, "target_reached", {**exit_evidence, "terminal": True}
             # R1: open a new macro-cycle while budget remains and the run
             # hasn't globally converged (R7); wind down to CLOSE only when

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -2542,9 +2542,13 @@ def exit_normal_kernel(
     return None
 
 
-#: SWEEP exits a met target renames after itself. ``sweep_failed`` is left out:
-#: it is the signal that the closing curve is missing.
-_TARGET_RENAMED_SWEEP_EXITS: frozenset[str] = frozenset({"sweep_done", "sweep_budget_exhausted", "sweep_budget_cap"})
+#: ``reloop_blocked`` values that name the terminal SWEEP closes on. A block for
+#: any other reason keeps the ladder's own exit reason.
+_RELOOP_BLOCK_TERMINALS: dict[str, str] = {
+    "global_converged": "global_converged",
+    "max_cycles": "global_converged",
+    "target_reached": "target_reached",
+}
 
 
 def exit_normal_sweep(
@@ -2843,11 +2847,10 @@ def compute_next_phase(
         reason, evidence = closing
         return PHASE_CLOSE, reason, {"terminal": True, **evidence}
 
-    # A met target closes through SWEEP so the concurrency curve measures the
-    # configuration it was met on. Not terminal: that would mirror the reason
-    # onto ``stop_reason``, which routes the next tick to CLOSE instead. PRELUDE
-    # is excluded so its own terminal guards keep deciding whether the baseline
-    # is one the later phases can compare against at all.
+    # A met target ends the optimizing phases early; SWEEP is their normal next
+    # station, and the curve then measures the configuration it was met on.
+    # PRELUDE is excluded: its own terminal guards decide whether the baseline is
+    # one the later phases can compare against at all.
     if target_was_reached(state) and phase_index(PHASE_PRELUDE) < phase_index(current) < phase_index(PHASE_SWEEP):
         return PHASE_SWEEP, "target_reached", {"target_reached_at": str(getattr(state, "target_reached_at", "") or "")}
 
@@ -2923,10 +2926,6 @@ def compute_next_phase(
             # stop_reason instead of opening another macro-cycle.
             if exit_reason == "sweep_failed":
                 return PHASE_CLOSE, exit_reason, exit_evidence
-            # The budget exits are renamed too: they are outside
-            # STOP_REASON_VOCAB, so CLOSE would recover them as time_exhausted.
-            if exit_reason in _TARGET_RENAMED_SWEEP_EXITS and target_was_reached(state):
-                return PHASE_CLOSE, "target_reached", {**exit_evidence, "terminal": True}
             # R1: open a new macro-cycle while budget remains and the run
             # hasn't globally converged (R7); wind down to CLOSE only when
             # reloop is blocked (budget, convergence, or max_cycles).
@@ -2945,10 +2944,11 @@ def compute_next_phase(
             # R7: if looping was blocked by global convergence or the safety cap,
             # terminate with a terminal stop_reason instead of idling in CLOSE.
             blocked = str(reloop_ev.get("reloop_blocked") or "")
-            if blocked in ("global_converged", "max_cycles"):
+            terminal_reason = _RELOOP_BLOCK_TERMINALS.get(blocked)
+            if terminal_reason is not None:
                 return (
                     PHASE_CLOSE,
-                    "global_converged",
+                    terminal_reason,
                     {
                         **exit_evidence,
                         **reloop_ev,

--- a/src/hyperloom/orchestrator/phases/machine_state.py
+++ b/src/hyperloom/orchestrator/phases/machine_state.py
@@ -560,10 +560,6 @@ def should_reloop_to_explore(
     cycle = int(getattr(state, "macro_cycle", 0) or 0)
     evidence: dict[str, Any] = {"macro_cycle": cycle}
 
-    if target_was_reached(state):
-        evidence["reloop_blocked"] = "target_reached"
-        return False, evidence
-
     # Per-cycle gain since this cycle started → effective no-gain streak. A cycle
     # "gained" only when its validated gain rose by at least the decaying KEEP bar.
     effective_min_gain = decaying_keep_threshold_pct(cycle) if min_gain_pct is None else float(min_gain_pct)
@@ -576,6 +572,10 @@ def should_reloop_to_explore(
     evidence["cycle_gain_delta"] = round(cur_gain - start_gain, 6)
     evidence["cycle_gained"] = cycle_gained
     evidence["no_gain_cycle_streak_effective"] = effective_streak
+
+    if target_was_reached(state):
+        evidence["reloop_blocked"] = "target_reached"
+        return False, evidence
 
     # Safety cap on macro-cycles.
     if (cycle + 1) >= int(max_cycles):
@@ -2542,6 +2542,12 @@ def exit_normal_kernel(
     return None
 
 
+#: SWEEP exits a met target renames itself. ``sweep_failed`` is absent on
+#: purpose; the budget exits are here because they are not in
+#: ``STOP_REASON_VOCAB`` and would otherwise be recovered as ``time_exhausted``.
+_SWEEP_EXITS_THE_TARGET_NAMES: frozenset[str] = frozenset({"sweep_done", "sweep_budget_exhausted", "sweep_budget_cap"})
+
+
 def exit_normal_sweep(
     state: Any,
     *,
@@ -2827,12 +2833,6 @@ def compute_next_phase(
     current = (getattr(state, "phase", "") or "").strip().upper() or PHASE_PRELUDE
     overrides = _resolve_plateau_overrides(state)
 
-    # A met target closes through SWEEP so the concurrency curve measures the
-    # configuration it was met on. Not terminal: that would mirror the reason
-    # onto ``stop_reason``, which routes the next tick to CLOSE instead.
-    if target_was_reached(state) and phase_index(current) < phase_index(PHASE_SWEEP):
-        return PHASE_SWEEP, "target_reached", {"target_reached_at": str(getattr(state, "target_reached_at", "") or "")}
-
     # Global terminal stop_reason overrides phase-local judgments.
     terminal = _global_terminal(state)
     if terminal is not None and current != PHASE_CLOSE:
@@ -2843,6 +2843,14 @@ def compute_next_phase(
     if closing is not None and current != PHASE_CLOSE:
         reason, evidence = closing
         return PHASE_CLOSE, reason, {"terminal": True, **evidence}
+
+    # A met target closes through SWEEP so the concurrency curve measures the
+    # configuration it was met on. Not terminal: that would mirror the reason
+    # onto ``stop_reason``, which routes the next tick to CLOSE instead. PRELUDE
+    # is excluded so its own terminal guards keep deciding whether the baseline
+    # is one the later phases can compare against at all.
+    if target_was_reached(state) and phase_index(PHASE_PRELUDE) < phase_index(current) < phase_index(PHASE_SWEEP):
+        return PHASE_SWEEP, "target_reached", {"target_reached_at": str(getattr(state, "target_reached_at", "") or "")}
 
     if current == PHASE_PRELUDE:
         term = exit_terminal_prelude(state)
@@ -2916,9 +2924,10 @@ def compute_next_phase(
             # stop_reason instead of opening another macro-cycle.
             if exit_reason == "sweep_failed":
                 return PHASE_CLOSE, exit_reason, exit_evidence
-            # The target names a clean exit. A failed sweep keeps its own name:
-            # its exit code is the signal that the closing curve is missing.
-            if exit_reason == "sweep_done" and target_was_reached(state):
+            # The target names any exit that is not a failure. A failed sweep
+            # keeps its own name: its exit code is the signal that the closing
+            # curve is missing.
+            if exit_reason in _SWEEP_EXITS_THE_TARGET_NAMES and target_was_reached(state):
                 return PHASE_CLOSE, "target_reached", {**exit_evidence, "terminal": True}
             # R1: open a new macro-cycle while budget remains and the run
             # hasn't globally converged (R7); wind down to CLOSE only when

--- a/src/hyperloom/orchestrator/state/objective.py
+++ b/src/hyperloom/orchestrator/state/objective.py
@@ -219,9 +219,9 @@ class TargetRooflineObjective(_RatioObjective):
 class AnyObjective(Objective):
     """Met when any member is met.
 
-    ``progress`` and ``gap_pct`` come from the closest member, the one about to
-    end the run. Not the smallest gap: members count percentage points of
-    different quantities, so ``progress`` is the only comparable one.
+    ``gap_pct`` is the first member's. Members count percentage points of
+    different quantities, so anything that picks between them per call changes
+    the axis of a value ``explore`` renders as one throughput gap.
     """
 
     objectives: list[Objective]
@@ -230,21 +230,17 @@ class AnyObjective(Objective):
         """Return the members' kinds joined by ``+``."""
         return "+".join(o.kind() for o in self.objectives)
 
-    def _closest(self, state: "SharedState") -> Objective:
-        """Return the member nearest to being met."""
-        return max(self.objectives, key=lambda o: o.progress(state))
-
     def progress(self, state: "SharedState") -> float:
         """Return the closest member's progress."""
-        return self._closest(state).progress(state)
+        return max(o.progress(state) for o in self.objectives)
 
     def reached(self, state: "SharedState") -> bool:
         """Report whether any member is satisfied."""
         return any(o.reached(state) for o in self.objectives)
 
     def gap_pct(self, state: "SharedState") -> float:
-        """Return the closest member's remaining distance."""
-        return self._closest(state).gap_pct(state)
+        """Return the first member's remaining distance, so the axis is stable."""
+        return self.objectives[0].gap_pct(state)
 
     def describe(self) -> str:
         """Return the members' descriptions joined by ``or``."""

--- a/src/hyperloom/orchestrator/state/objective.py
+++ b/src/hyperloom/orchestrator/state/objective.py
@@ -231,7 +231,7 @@ class AnyObjective(Objective):
         return "+".join(o.kind() for o in self.objectives)
 
     def progress(self, state: "SharedState") -> float:
-        """Return the closest member's progress."""
+        """Return the highest member progress."""
         return max(o.progress(state) for o in self.objectives)
 
     def reached(self, state: "SharedState") -> bool:

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -2070,12 +2070,6 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
             ts_unix=ts_unix,
         )
 
-    def _latest_roofline_snapshot(self) -> dict[str, Any] | None:
-        """Return the newest roofline snapshot, or ``None`` when there is none."""
-        snaps = self.roofline_snapshots if isinstance(self.roofline_snapshots, list) else []
-        latest = snaps[-1] if snaps else None
-        return latest if isinstance(latest, dict) else None
-
     def current_top_bottleneck(self) -> str:
         """Return the latest roofline snapshot's ``top_bottleneck`` ("" when none).
 
@@ -2086,8 +2080,13 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
             str: The latest snapshot's ``top_bottleneck``, or ``""`` when no
                 snapshot exists.
         """
-        latest = self._latest_roofline_snapshot()
-        return str(latest.get("top_bottleneck") or "") if latest else ""
+        snaps = self.roofline_snapshots if isinstance(self.roofline_snapshots, list) else []
+        if not snaps:
+            return ""
+        latest = snaps[-1]
+        if isinstance(latest, dict):
+            return str(latest.get("top_bottleneck") or "")
+        return ""
 
     def current_within_roofline_pct(self) -> float | None:
         """Return the latest snapshot's achieved share of its roofline ceiling.
@@ -2099,11 +2098,14 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
             float | None: ``within_roofline_pct`` from the newest snapshot, or
                 ``None`` when no snapshot carries a numeric one.
         """
-        latest = self._latest_roofline_snapshot()
-        if latest is None:
+        snaps = self.roofline_snapshots if isinstance(self.roofline_snapshots, list) else []
+        if not snaps:
+            return None
+        latest = snaps[-1]
+        if not isinstance(latest, dict):
             return None
         value = latest.get("within_roofline_pct")
-        if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        if not isinstance(value, (int, float)):
             return None
         return float(value)
 

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -2109,9 +2109,12 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
 
     def current_comm_pct(self) -> float | None:
         """Return the latest exposed-communication percentage."""
-        latest = self._latest_roofline_snapshot()
-        if latest is None:
+        snaps = self.roofline_snapshots if isinstance(self.roofline_snapshots, list) else []
+        if not snaps:
             return None
+        latest = snaps[-1]
+        if not isinstance(latest, dict):
+            raise ValueError("Latest roofline snapshot must be a mapping")
         value = latest.get("comm_pct")
         if value is None:
             return None

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -2070,6 +2070,12 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
             ts_unix=ts_unix,
         )
 
+    def _latest_roofline_snapshot(self) -> dict[str, Any] | None:
+        """Return the newest roofline snapshot, or ``None`` when there is none."""
+        snaps = self.roofline_snapshots if isinstance(self.roofline_snapshots, list) else []
+        latest = snaps[-1] if snaps else None
+        return latest if isinstance(latest, dict) else None
+
     def current_top_bottleneck(self) -> str:
         """Return the latest roofline snapshot's ``top_bottleneck`` ("" when none).
 
@@ -2080,13 +2086,8 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
             str: The latest snapshot's ``top_bottleneck``, or ``""`` when no
                 snapshot exists.
         """
-        snaps = self.roofline_snapshots if isinstance(self.roofline_snapshots, list) else []
-        if not snaps:
-            return ""
-        latest = snaps[-1]
-        if isinstance(latest, dict):
-            return str(latest.get("top_bottleneck") or "")
-        return ""
+        latest = self._latest_roofline_snapshot()
+        return str(latest.get("top_bottleneck") or "") if latest else ""
 
     def current_within_roofline_pct(self) -> float | None:
         """Return the latest snapshot's achieved share of its roofline ceiling.
@@ -2098,25 +2099,19 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
             float | None: ``within_roofline_pct`` from the newest snapshot, or
                 ``None`` when no snapshot carries a numeric one.
         """
-        snaps = self.roofline_snapshots if isinstance(self.roofline_snapshots, list) else []
-        if not snaps:
-            return None
-        latest = snaps[-1]
-        if not isinstance(latest, dict):
+        latest = self._latest_roofline_snapshot()
+        if latest is None:
             return None
         value = latest.get("within_roofline_pct")
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
             return None
         return float(value)
 
     def current_comm_pct(self) -> float | None:
         """Return the latest exposed-communication percentage."""
-        snaps = self.roofline_snapshots if isinstance(self.roofline_snapshots, list) else []
-        if not snaps:
+        latest = self._latest_roofline_snapshot()
+        if latest is None:
             return None
-        latest = snaps[-1]
-        if not isinstance(latest, dict):
-            raise ValueError("Latest roofline snapshot must be a mapping")
         value = latest.get("comm_pct")
         if value is None:
             return None


### PR DESCRIPTION
# Follow-up on #1402: wait for the ladder the met target routed to

Review findings on #1402. **8 files, +169 / −203.**

The findings on the first two commits were all reconciliation bugs between two
signals for the same fact: the coordinator read the live objective, the phase
machine read the persisted marker, and every place the two could disagree was a
defect. Collapsing to the marker removes them rather than patching them.

## The run stopped on the hop into SWEEP

`routed_to_sweep` was recomputed each tick as "the phase is before SWEEP", which
is false once the hop has happened. `exit_normal_sweep` returns `None` for the
many ticks a queued `conc_sweep` takes to reach a terminal state, so the advance
was a no-op and the run broke out with the phase in SWEEP, no curve, and no
close sequencer — the regression this routing exists to remove, reintroduced one
hop later. Only CLOSE ends the run now.

Four tests seeded `last_conc_sweep` before `run()`, which let SWEEP exit on its
first advance and hid exactly that. A test drives the pending ladder.

## A met target is not a routing instruction

SWEEP is already the next station after the optimizing phases, so a met target
is an early exit from them — the same shape as the plateau reasons that already
lead there. That leaves the coordinator with one job: stamp the marker. The
forced advance, the break, and the deadline suppression they needed are gone,
and with them `_unbounded_advance`, `_phase_at_or_past_close`, and the run's
second exception handler. The transition the phase machine makes next persists
the marker, so the explicit save goes too.

**The wall clock now applies to a met target exactly as it does to every other
phase.** A target met after `--max-hours` reports `time_exhausted`; the route
only guarantees the sweep for a target met while there is still time to run it.
That is the one behaviour this trades away, and it is what the suppression was
buying at the cost of a run with no stop condition at all.

## The forward jump outranked the terminal guards

It ran before `_global_terminal` and `_closing_phase_terminal`, so a
`stop_reason`, a `skip_to_close` hint, or the closing phase lost to it. The
order is now global terminal > closing phase > met target > exit_terminal >
exit_normal, in `compute_next_phase` and in the `MachinePhase` docstring that
mirrors it. PRELUDE is excluded from the jump too, so the cold-anchor and
terminal guards keep deciding whether the baseline is comparable at all before
anything routes past them.

## A met target reported as a timeout

`sweep_budget_exhausted` / `sweep_budget_cap` are not in `STOP_REASON_VOCAB`, so
`_derive_close_stop_reason` recovered them as `time_exhausted`.

Naming the exit and blocking the reloop were two mechanisms for one decision,
which left the reloop block unreachable. There is already a pattern for this: a
blocked reloop names the terminal. `target_reached` joins `global_converged` and
`max_cycles` in `_RELOOP_BLOCK_TERMINALS`, so the block is load-bearing, the
budget exits are carried without a rename set or a change to `STOP_REASON_VOCAB`,
and `sweep_failed` stays excluded because it returns above it.

## Smaller

- The reloop block returned before the per-cycle gain block, dropping the
  `no_gain_cycle_streak_effective` the close transition persists. It runs after
  the gain math now.
- `AnyObjective.gap_pct` picked whichever member was closest, so the axis of
  `target_gap_pct` could change between ticks while `explore` renders it as a
  single throughput gap. It is the first member's, and `progress` is the plain
  maximum.
- `current_within_roofline_pct` no longer rejects `bool`. The value is our own
  `round(a / p * 100, 2)` under positive guards, so the check guarded an input
  the field cannot hold.
- `test_probe_failed_sweep` was a debugging probe — a print, no assertion — in
  the slot of a deleted test. It is a real test of the branch it was probing.

## Not addressed

- **`sweep_failed` exits 1 on a target-met run** — deliberate. The target does
  not rename a failed sweep, so the missing closing curve stays visible.
  `test_a_failed_sweep_is_not_renamed_by_a_met_target` pins it.
- **A capped `within_roofline_pct` can satisfy the target when the ceiling is
  understated** — deliberate. `roofline_ceiling_exceeded` has never fired in 60
  recorded snapshots, and the report already warns where it would matter.
- **No parse-time range check on `--target-roofline`** — `--target-gain` has
  none either; the objective validates. Adding one here alone would split the
  contract across two layers.
