### PR TITLE
Fix secret redaction and contain accidental agent writes

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_bypass_benchmark_resolver.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_benchmark_resolver.py
@@ -72,3 +72,26 @@ def test_no_source_or_repo_returns_empty(tmp_path):
     lonely.parent.mkdir(parents=True)
     lonely.write_text("// x\n", encoding="utf-8")
     assert find_benchmark_files("aiter::rmsnorm", str(lonely)) == []
+
+
+def test_find_benchmark_files_inserts_double_dash(tmp_path, monkeypatch):
+    repo = _fake_repo(tmp_path)
+    captured: list[list[str]] = []
+
+    class _Proc:
+        returncode = 1
+        stdout = ""
+
+    def fake_run(cmd, **kwargs):
+        captured.append(list(cmd))
+        return _Proc()
+
+    import _bypass_benchmark_resolver as bbr
+
+    monkeypatch.setattr(bbr.subprocess, "run", fake_run)
+    bbr.find_benchmark_files("aiter::rmsnorm", str(repo / "csrc" / "kernels" / "rmsnorm_quant_kernels.cu"))
+    assert captured
+    cmd = captured[0]
+    assert "--" in cmd
+    dash = cmd.index("--")
+    assert cmd[dash + 1] == "rmsnorm"

--- a/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
@@ -83,8 +83,9 @@ def test_long_kernel_names_are_not_merged_before_display_truncation(tmp_path):
 def test_gpu_event_cap_returns_truncated_analysis(tmp_path, monkeypatch):
     """An oversized trace returns the retained prefix instead of failing."""
     events = [
-        {"cat": "kernel", "ph": "X", "name": f"kernel_{i}", "ts": i * 10, "dur": 1, "args": {}}
-        for i in range(3)
+        {"cat": "kernel", "ph": "X", "name": "kernel_0", "ts": 0, "dur": 1, "args": {}},
+        {"cat": "kernel", "ph": "X", "name": "kernel_1", "ts": 10, "dur": 1, "args": {}},
+        {"cat": "kernel", "ph": "X", "name": "kernel_2", "ts": 20, "dur": 1, "args": {}},
     ]
     tf = tmp_path / "capped.trace.json"
     tf.write_text(json.dumps({"traceEvents": events}), encoding="utf-8")

--- a/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
@@ -969,3 +969,16 @@ def test_severity_grades_with_share_of_device_time():
     out_severe = reader._stream_overlap_health({(1, 1): list(severe)})
     assert out_severe and out_severe["severity"] == "warning"
     assert out_severe["excess_share"] >= 0.25
+
+
+def test_analyze_trace_caps_annotation_buffers(tmp_path, monkeypatch):
+    monkeypatch.setattr(reader, "_MAX_ANNOTATION_WINDOWS", 2)
+    events = [
+        {"cat": "gpu_user_annotation", "ph": "X", "name": f"step{i}", "ts": i, "dur": 1}
+        for i in range(5)
+    ]
+    path = tmp_path / "cap.trace.json"
+    path.write_text(json.dumps({"traceEvents": events}), encoding="utf-8")
+    out = reader.analyze_trace(path, top_k=0)
+    assert out["status"] == "failed"
+    assert "annotation_windows" in out["error"]

--- a/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
@@ -63,6 +63,41 @@ def test_analyze_basic_aggregates(tmp_path):
     assert kernels["paged_attention_v1"]["count"] == 1
 
 
+def test_long_kernel_names_are_not_merged_before_display_truncation(tmp_path):
+    """Kernel aggregation retains distinguishing suffixes beyond 256 chars."""
+    prefix = "templated_kernel_" + "x" * 300
+    events = [
+        {"cat": "kernel", "ph": "X", "name": prefix + "_a", "ts": 0, "dur": 10, "args": {}},
+        {"cat": "kernel", "ph": "X", "name": prefix + "_b", "ts": 20, "dur": 20, "args": {}},
+    ]
+    tf = tmp_path / "long-names.trace.json"
+    tf.write_text(json.dumps({"traceEvents": events}), encoding="utf-8")
+
+    out = reader.analyze_trace(tf, top_k=0)
+
+    assert len(out["kernels"]) == 2
+    assert sorted(row["gpu_time_us"] for row in out["kernels"]) == [10.0, 20.0]
+    assert all(len(row["name"]) == reader._MAX_EVENT_NAME_CHARS for row in out["kernels"])
+
+
+def test_gpu_event_cap_returns_truncated_analysis(tmp_path, monkeypatch):
+    """An oversized trace returns the retained prefix instead of failing."""
+    events = [
+        {"cat": "kernel", "ph": "X", "name": f"kernel_{i}", "ts": i * 10, "dur": 1, "args": {}}
+        for i in range(3)
+    ]
+    tf = tmp_path / "capped.trace.json"
+    tf.write_text(json.dumps({"traceEvents": events}), encoding="utf-8")
+    monkeypatch.setattr(reader, "_MAX_BUFFERED_GPU_EVENTS", 2)
+
+    out = reader.analyze_trace(tf, top_k=0)
+
+    assert out["status"] == "ok"
+    assert out["truncated"] is True
+    assert out["truncation_reason"] == "gpu_events"
+    assert out["attribution"]["kernel_count"] == 2
+
+
 def test_correlation_attribution(tmp_path):
     tf = _write_trace(tmp_path / "t.trace.json")
     out = reader.analyze_trace(tf, top_k=0)
@@ -977,5 +1012,7 @@ def test_analyze_trace_caps_annotation_buffers(tmp_path, monkeypatch):
     path = tmp_path / "cap.trace.json"
     path.write_text(json.dumps({"traceEvents": events}), encoding="utf-8")
     out = reader.analyze_trace(path, top_k=0)
-    assert out["status"] == "failed"
-    assert "annotation_windows" in out["error"]
+    assert out["status"] == "ok"
+    assert out["truncated"] is True
+    assert out["truncation_reason"] == "annotation_windows"
+    assert len(out["annotation_windows"]) == 2

--- a/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
+++ b/src/hyperloom/agents/kernel/tests/test_bypass_reader.py
@@ -973,10 +973,7 @@ def test_severity_grades_with_share_of_device_time():
 
 def test_analyze_trace_caps_annotation_buffers(tmp_path, monkeypatch):
     monkeypatch.setattr(reader, "_MAX_ANNOTATION_WINDOWS", 2)
-    events = [
-        {"cat": "gpu_user_annotation", "ph": "X", "name": f"step{i}", "ts": i, "dur": 1}
-        for i in range(5)
-    ]
+    events = [{"cat": "gpu_user_annotation", "ph": "X", "name": f"step{i}", "ts": i, "dur": 1} for i in range(5)]
     path = tmp_path / "cap.trace.json"
     path.write_text(json.dumps({"traceEvents": events}), encoding="utf-8")
     out = reader.analyze_trace(path, top_k=0)

--- a/src/hyperloom/agents/kernel/tests/test_other_bucket_candidate_fallback.py
+++ b/src/hyperloom/agents/kernel/tests/test_other_bucket_candidate_fallback.py
@@ -347,6 +347,11 @@ def test_clean_category_label_handles_list_repr():
     assert tla._clean_category_label("") == ""
 
 
+def test_clean_category_label_swallows_oversized_literal():
+    nested = "[" * 9000 + "]" * 9000
+    assert tla._clean_category_label(nested) == ""
+
+
 def test_recover_moe_fused_real_schema(tmp_path):
     """The dominant MoE_fused row (67% GPU time) is recovered from the REAL
     ops_summary.csv schema even though it is NOT an "other"-bucket op."""

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -3590,6 +3590,11 @@ def test_parse_launcher_path_returns_none_for_empty_and_garbage():
     assert func is None
 
 
+def test_parse_launcher_path_swallows_deep_dict_repr():
+    payload = "{'entry_point': " + "(" * 9000 + "'a.py(1): f'" + ")" * 9000 + "}"
+    assert tlr._parse_launcher_path(payload) == ("", None, None)
+
+
 # ---------------------------------------------------------------------------
 # _resolve_launcher_to_abs_source — TraceLens launcher path → absolute file.
 # Pins the three resolution paths (importlib spec, env override, hardcoded fallback) plus no-op cases.

--- a/src/hyperloom/agents/kernel/tools/_bypass_benchmark_resolver.py
+++ b/src/hyperloom/agents/kernel/tools/_bypass_benchmark_resolver.py
@@ -103,7 +103,7 @@ def find_benchmark_files(op_name: str, source_file: str, *, max_files: int = 10)
         for kw in keywords:
             try:
                 proc = subprocess.run(
-                    [grep, "-rlnI", "--include=*.py", kw, str(subp)],
+                    [grep, "-rlnI", "--include=*.py", "--", kw, str(subp)],
                     text=True,
                     capture_output=True,
                     timeout=15,

--- a/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
+++ b/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
@@ -62,10 +62,8 @@ _DECODER = json.JSONDecoder()
 # events a few KiB, so these retain generous headroom for embedded metadata.
 _MAX_TRACE_PREFIX_CHARS = 16 * 1024 * 1024
 _MAX_EVENT_CHARS = 64 * 1024 * 1024
-_MAX_BUFFERED_KERNEL_EVENTS = 100_000
-_MAX_BUFFERED_MEMCPY_EVENTS = 100_000
 _MAX_ANNOTATION_WINDOWS = 100_000
-_MAX_STREAM_INTERVALS = 100_000
+_MAX_BUFFERED_GPU_EVENTS = 100_000
 _MAX_EVENT_NAME_CHARS = 256
 
 
@@ -923,7 +921,7 @@ def _finalize(
         rows = []
         for nm, a in agg.items():
             row: dict[str, Any] = {
-                "name": nm,
+                "name": nm[:_MAX_EVENT_NAME_CHARS],
                 "gpu_time_us": round(a.dur_us, 3),
                 "gpu_time_ms": round(a.dur_us / 1000.0, 4),
                 "count": a.count,
@@ -965,7 +963,7 @@ def _finalize(
             _meta = _meta or {}
             kernel_launches.append(
                 {
-                    "name": _name,
+                    "name": _name[:_MAX_EVENT_NAME_CHARS],
                     "op_name": _op or "",
                     "ts": _ts,
                     "dur": _dur,
@@ -1139,17 +1137,14 @@ def analyze_trace(
                 dur = float(ev.get("dur", 0) or 0)
                 ts = float(ev.get("ts", 0) or 0)
                 end = ts + dur
-                name = str(ev.get("name", "") or "")[:_MAX_EVENT_NAME_CHARS]
+                name = str(ev.get("name", "") or "")
                 stream_key = (ev.get("pid"), ev.get("tid"))
-                if stream_interval_count >= _MAX_STREAM_INTERVALS:
-                    cap_exceeded = "stream_intervals"
+                if stream_interval_count >= _MAX_BUFFERED_GPU_EVENTS:
+                    cap_exceeded = "gpu_events"
                     break
-                stream_intervals.setdefault(stream_key, []).append((ts, end, name))
+                stream_intervals.setdefault(stream_key, []).append((ts, end, name[:_MAX_EVENT_NAME_CHARS]))
                 stream_interval_count += 1
                 if cat == _GPU_KERNEL_CAT:
-                    if len(k_events) >= _MAX_BUFFERED_KERNEL_EVENTS:
-                        cap_exceeded = "k_events"
-                        break
                     kargs = ev.get("args") or {}
                     corr = kargs.get("correlation")
                     # Retain launch grid/block: for Triton (hipModuleLaunchKernel)
@@ -1161,20 +1156,9 @@ def analyze_trace(
                         corr_to_launch_geom[corr] = (grid, block)
                     k_events.append((name, dur, corr, ts, end))
                 else:
-                    if len(m_events) >= _MAX_BUFFERED_MEMCPY_EVENTS:
-                        cap_exceeded = "m_events"
-                        break
                     m_events.append((dur, ts, end))
     finally:
         fobj.close()
-
-    if cap_exceeded:
-        return {
-            "status": "failed",
-            "error": f"trace aggregation cap exceeded ({cap_exceeded})",
-            "trace_file": str(tf),
-            "event_total": event_total,
-        }
 
     scope = "full_trace"
     steady_window: dict[str, Any] | None = None
@@ -1212,6 +1196,7 @@ def analyze_trace(
         "status": "ok",
         "trace_file": str(tf),
         "event_total": event_total,
+        "truncated": bool(cap_exceeded),
         "stream_errors": stream_errors,
         "aggregation_scope": scope,
         "analyzed_rank": _rank_of(tf),
@@ -1224,4 +1209,6 @@ def analyze_trace(
         result["steady_window"] = steady_window
     elif steady_state:
         result["steady_window_status"] = "no_repeating_window_fell_back_to_full_trace"
+    if cap_exceeded:
+        result["truncation_reason"] = cap_exceeded
     return result

--- a/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
+++ b/src/hyperloom/agents/kernel/tools/_bypass_trace_reader.py
@@ -62,6 +62,11 @@ _DECODER = json.JSONDecoder()
 # events a few KiB, so these retain generous headroom for embedded metadata.
 _MAX_TRACE_PREFIX_CHARS = 16 * 1024 * 1024
 _MAX_EVENT_CHARS = 64 * 1024 * 1024
+_MAX_BUFFERED_KERNEL_EVENTS = 100_000
+_MAX_BUFFERED_MEMCPY_EVENTS = 100_000
+_MAX_ANNOTATION_WINDOWS = 100_000
+_MAX_STREAM_INTERVALS = 100_000
+_MAX_EVENT_NAME_CHARS = 256
 
 
 def _backfill_shape_signature(meta: dict[str, Any]) -> tuple[tuple[tuple[int, ...], ...], tuple[str, ...]]:
@@ -1082,8 +1087,10 @@ def analyze_trace(
     graph_launch_corrs: set[int] = set()
     # (pid, tid) -> [(ts, end, name), ...] for the duration-sanity check.
     stream_intervals: dict[Any, list[tuple[float, float, str]]] = {}
+    stream_interval_count = 0
     event_total = 0
     stream_errors: list[str] = []
+    cap_exceeded = ""
 
     fobj = _open_trace_binary(tf)
     try:
@@ -1120,17 +1127,29 @@ def analyze_trace(
                             extid_to_opmeta[extid] = meta
                 continue
             if cat == "gpu_user_annotation" and ev.get("ph") == "X":
+                if len(annotation_windows) >= _MAX_ANNOTATION_WINDOWS:
+                    cap_exceeded = "annotation_windows"
+                    break
                 ts = ev.get("ts", 0) or 0
                 dur = ev.get("dur", 0) or 0
-                annotation_windows.append({"name": ev.get("name", "") or "", "ts": float(ts), "dur": float(dur)})
+                name = str(ev.get("name", "") or "")[:_MAX_EVENT_NAME_CHARS]
+                annotation_windows.append({"name": name, "ts": float(ts), "dur": float(dur)})
                 continue
             if cat in _GPU_CATS and ev.get("ph") == "X":
                 dur = float(ev.get("dur", 0) or 0)
                 ts = float(ev.get("ts", 0) or 0)
                 end = ts + dur
-                name = ev.get("name", "") or ""
-                stream_intervals.setdefault((ev.get("pid"), ev.get("tid")), []).append((ts, end, name))
+                name = str(ev.get("name", "") or "")[:_MAX_EVENT_NAME_CHARS]
+                stream_key = (ev.get("pid"), ev.get("tid"))
+                if stream_interval_count >= _MAX_STREAM_INTERVALS:
+                    cap_exceeded = "stream_intervals"
+                    break
+                stream_intervals.setdefault(stream_key, []).append((ts, end, name))
+                stream_interval_count += 1
                 if cat == _GPU_KERNEL_CAT:
+                    if len(k_events) >= _MAX_BUFFERED_KERNEL_EVENTS:
+                        cap_exceeded = "k_events"
+                        break
                     kargs = ev.get("args") or {}
                     corr = kargs.get("correlation")
                     # Retain launch grid/block: for Triton (hipModuleLaunchKernel)
@@ -1142,9 +1161,20 @@ def analyze_trace(
                         corr_to_launch_geom[corr] = (grid, block)
                     k_events.append((name, dur, corr, ts, end))
                 else:
+                    if len(m_events) >= _MAX_BUFFERED_MEMCPY_EVENTS:
+                        cap_exceeded = "m_events"
+                        break
                     m_events.append((dur, ts, end))
     finally:
         fobj.close()
+
+    if cap_exceeded:
+        return {
+            "status": "failed",
+            "error": f"trace aggregation cap exceeded ({cap_exceeded})",
+            "trace_file": str(tf),
+            "event_total": event_total,
+        }
 
     scope = "full_trace"
     steady_window: dict[str, Any] | None = None

--- a/src/hyperloom/agents/kernel/tools/_literal_utils.py
+++ b/src/hyperloom/agents/kernel/tools/_literal_utils.py
@@ -1,0 +1,17 @@
+"""Bounded parsing helpers for trace metadata literals."""
+
+from __future__ import annotations
+
+import ast
+from typing import Any
+
+
+LITERAL_EVAL_MAX_CHARS = 8192
+LITERAL_EVAL_ERRORS = (ValueError, SyntaxError, RecursionError, MemoryError, TypeError)
+
+
+def safe_literal_eval(text: str) -> Any:
+    """Parse a bounded Python literal value."""
+    if len(text) > LITERAL_EVAL_MAX_CHARS:
+        raise ValueError("literal too large")
+    return ast.literal_eval(text)

--- a/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/bypass_trace_analysis.py
@@ -438,7 +438,7 @@ def _maybe_build_shape_manifest(
         variant_meta: dict[str, dict[str, Any]] = {}
         for path, label, mode in shards:
             shard_an = _reader.analyze_trace(path, top_k=0, steady_state=False, emit_launches=True)
-            if shard_an.get("status") != "ok":
+            if shard_an.get("status") != "ok" or shard_an.get("truncated"):
                 continue
             capture_variants.append((label, shard_an))
             capture_hashes[label] = _sha256_file(path)
@@ -725,6 +725,17 @@ def main(argv: list[str] | None = None) -> int:
                 "code": "bypass_trace_parse_failed",
                 "severity": "warning",
                 "message": f"bypass reader could not analyze trace: {analyze.get('error', 'unknown')}",
+            }
+        )
+    elif analyze.get("truncated"):
+        trace_health_warnings.append(
+            {
+                "code": "bypass_trace_aggregation_truncated",
+                "severity": "warning",
+                "message": (
+                    "trace aggregation reached its safety cap; kernel rankings use only "
+                    f"the retained prefix ({analyze.get('truncation_reason', 'unknown')})."
+                ),
             }
         )
         analyze = {

--- a/src/hyperloom/agents/kernel/tools/trace_selfcert.py
+++ b/src/hyperloom/agents/kernel/tools/trace_selfcert.py
@@ -1123,7 +1123,8 @@ def certify_trace_dir(
             "certified_path": selected,
             "kernel_count": (probe.get("attribution") or {}).get("kernel_count") or 0,
             "event_total": probe.get("event_total"),
-            "parse_ok": not probe_errors,
+            "parse_ok": not probe_errors and not probe.get("truncated"),
+            "truncated": bool(probe.get("truncated")),
         }
         record["trace_dir_level"]["production_pick_probe"] = production_pick
 
@@ -1138,6 +1139,10 @@ def certify_trace_dir(
     coverage_block = analysis.get("graph_coverage") or {}
     timeline = analysis.get("timeline") or {}
     stream_errors = list(analysis.get("stream_errors") or []) + pass2_errors
+    if analysis.get("truncated"):
+        stream_errors.append(
+            f"trace aggregation truncated at safety cap ({analysis.get('truncation_reason', 'unknown')})"
+        )
 
     ann = annotation_report(sp, framework=framework, min_repeats=min_repeats)
     forecast = forecast_split(sp, num_steps=num_steps, conc=conc, osl=osl, r=r)

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -3332,6 +3332,7 @@ def find_benchmark_files(name: str, repo_root: str, source_file: str = "") -> li
                         "--include=*.cuh",
                         "--include=*.hip",
                         "--include=*.sh",
+                        "--",
                         keyword,
                         str(sub_root),
                     ],
@@ -4011,6 +4012,17 @@ def _format_trace_shape(dims: Any, dtype: Any) -> str | None:
     return f"{shape} {suffix}" if suffix else shape
 
 
+_LITERAL_EVAL_MAX_CHARS = 8192
+_LITERAL_EVAL_ERRORS = (ValueError, SyntaxError, RecursionError, MemoryError, TypeError)
+
+
+def _safe_literal_eval(text: str) -> Any:
+    """Parse a short Python literal; fail the cell rather than the process."""
+    if len(text) > _LITERAL_EVAL_MAX_CHARS:
+        raise ValueError("literal too large")
+    return ast.literal_eval(text)
+
+
 def _resolve_shapes_from_ops_unique_args_csv(
     perf_report_csv_dir: Path | str | None,
     row_matches: Callable[[str], bool],
@@ -4042,9 +4054,9 @@ def _resolve_shapes_from_ops_unique_args_csv(
                 if not row_matches(name):
                     continue
                 try:
-                    dims = ast.literal_eval(str(row.get("Input Dims") or "").strip() or "()")
-                    dtypes = ast.literal_eval(str(row.get("Input type") or "").strip() or "()")
-                except (ValueError, SyntaxError):
+                    dims = _safe_literal_eval(str(row.get("Input Dims") or "").strip() or "()")
+                    dtypes = _safe_literal_eval(str(row.get("Input type") or "").strip() or "()")
+                except _LITERAL_EVAL_ERRORS:
                     continue
                 if not isinstance(dims, (list, tuple)):
                     continue
@@ -4067,9 +4079,9 @@ def _invocation_case_from_csv_row(row: dict[str, str]) -> dict[str, Any] | None:
     raw_types = str(row.get("Input type") or "").strip()
     raw_concrete = str(row.get("Concrete Inputs") or "").strip()
     try:
-        dims = ast.literal_eval(raw_dims or "()")
-        dtypes = ast.literal_eval(raw_types or "()")
-    except (ValueError, SyntaxError):
+        dims = _safe_literal_eval(raw_dims or "()")
+        dtypes = _safe_literal_eval(raw_types or "()")
+    except _LITERAL_EVAL_ERRORS:
         return None
     if not isinstance(dims, (list, tuple)):
         return None
@@ -4368,12 +4380,12 @@ def _clean_category_label(raw: str) -> str:
     s = str(raw or "").strip()
     if s.startswith("[") and s.endswith("]"):
         try:
-            val = ast.literal_eval(s)
+            val = _safe_literal_eval(s)
             if isinstance(val, (list, tuple)) and val:
                 return str(val[0]).strip()
             if isinstance(val, (list, tuple)):
                 return ""
-        except (ValueError, SyntaxError):
+        except _LITERAL_EVAL_ERRORS:
             s = s.strip("[]")
     return s.strip().strip("'\"").strip()
 

--- a/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_analysis.py
@@ -9,7 +9,6 @@ capture directories, and has a dry-run path that works without TraceLens install
 """
 
 import argparse
-import ast
 import asyncio
 import contextlib
 import csv
@@ -90,6 +89,8 @@ from tracelens_skill_runner import (
 )
 
 from _io_utils import append_log, atomic_write_json, read_last_lines, safe_float, utc_now
+from _literal_utils import LITERAL_EVAL_ERRORS as _LITERAL_EVAL_ERRORS
+from _literal_utils import safe_literal_eval as _safe_literal_eval
 from _nccl_summary_candidates import extract_collective_candidates
 
 # Standalone-tool workspace-root resolver (cannot import hyperloom.inference_optimizer.session.paths; see _paths.py).
@@ -440,6 +441,8 @@ def _graph_coverage_from_raw_trace(trace_path: str | Path | None) -> dict[str, A
         import _bypass_trace_reader as _reader
 
         analyze = _reader.analyze_trace(str(trace_path), top_k=1, emit_launches=False)
+        if analyze.get("truncated"):
+            return {}
         cov = analyze.get("graph_coverage") if isinstance(analyze, dict) else None
         return cov if isinstance(cov, dict) else {}
     except Exception:  # noqa: BLE001 - guard is advisory; never block on it
@@ -4010,17 +4013,6 @@ def _format_trace_shape(dims: Any, dtype: Any) -> str | None:
     shape = f"({body},)" if len(dims) == 1 else f"({body})"
     suffix = _TRACE_DTYPE_SUFFIX.get(str(dtype or "").strip().lower())
     return f"{shape} {suffix}" if suffix else shape
-
-
-_LITERAL_EVAL_MAX_CHARS = 8192
-_LITERAL_EVAL_ERRORS = (ValueError, SyntaxError, RecursionError, MemoryError, TypeError)
-
-
-def _safe_literal_eval(text: str) -> Any:
-    """Parse a short Python literal; fail the cell rather than the process."""
-    if len(text) > _LITERAL_EVAL_MAX_CHARS:
-        raise ValueError("literal too large")
-    return ast.literal_eval(text)
 
 
 def _resolve_shapes_from_ops_unique_args_csv(

--- a/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
@@ -1311,6 +1311,17 @@ _LAUNCHER_PATH_PLACEHOLDERS: frozenset[str] = frozenset(
 )
 
 
+_LITERAL_EVAL_MAX_CHARS = 8192
+_LITERAL_EVAL_ERRORS = (ValueError, SyntaxError, RecursionError, MemoryError, TypeError)
+
+
+def _safe_literal_eval(text: str) -> Any:
+    """Parse a short Python literal; fail the cell rather than the process."""
+    if len(text) > _LITERAL_EVAL_MAX_CHARS:
+        raise ValueError("literal too large")
+    return ast.literal_eval(text)
+
+
 def _launcher_frame_from_dict(obj: dict) -> str | None:
     """Pull the first ``<path>(<line>): <func>`` frame out of a TraceLens launcher dict.
 
@@ -1326,8 +1337,8 @@ def _launcher_frame_from_dict(obj: dict) -> str | None:
     wrappers = obj.get("wrappers")
     if isinstance(wrappers, str):
         try:
-            wrappers = ast.literal_eval(wrappers)
-        except (ValueError, SyntaxError):
+            wrappers = _safe_literal_eval(wrappers)
+        except _LITERAL_EVAL_ERRORS:
             wrappers = []
     if isinstance(wrappers, (list, tuple)):
         for frame in wrappers:
@@ -1364,8 +1375,8 @@ def _parse_launcher_path(kernel_path: str) -> tuple[str, int | None, str | None]
         stripped = kernel_path.strip()
         if stripped.startswith("{") and stripped.endswith("}") and "entry_point" in stripped:
             try:
-                parsed_obj = ast.literal_eval(stripped)
-            except (ValueError, SyntaxError):
+                parsed_obj = _safe_literal_eval(stripped)
+            except _LITERAL_EVAL_ERRORS:
                 parsed_obj = None
             frame = _launcher_frame_from_dict(parsed_obj) if isinstance(parsed_obj, dict) else None
             if not frame:

--- a/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
@@ -36,6 +36,8 @@ from hyperloom.orchestrator.roles.agent_role import DEFAULT_CODEX_MODEL
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _capture_shapes import is_capture_dir_name  # noqa: E402
 from _io_utils import safe_float  # noqa: E402
+from _literal_utils import LITERAL_EVAL_ERRORS as _LITERAL_EVAL_ERRORS  # noqa: E402
+from _literal_utils import safe_literal_eval as _safe_literal_eval  # noqa: E402
 from _task_group_contract import (  # noqa: E402
     build_operator_identity,
     build_task_group_shape_cases,
@@ -1309,17 +1311,6 @@ _LAUNCHER_PATH_PLACEHOLDERS: frozenset[str] = frozenset(
         "unknown",
     }
 )
-
-
-_LITERAL_EVAL_MAX_CHARS = 8192
-_LITERAL_EVAL_ERRORS = (ValueError, SyntaxError, RecursionError, MemoryError, TypeError)
-
-
-def _safe_literal_eval(text: str) -> Any:
-    """Parse a short Python literal; fail the cell rather than the process."""
-    if len(text) > _LITERAL_EVAL_MAX_CHARS:
-        raise ValueError("literal too large")
-    return ast.literal_eval(text)
 
 
 def _launcher_frame_from_dict(obj: dict) -> str | None:

--- a/src/hyperloom/agents/quantization/SKILL.md
+++ b/src/hyperloom/agents/quantization/SKILL.md
@@ -40,12 +40,46 @@ quark_root, classify the outcome as `upstream_change_required` (writes
 `outcome_id: upstream_change_required` to `<workspace>/blocked.md`) and stop
 — Python will surface it as Auto-fail.
 
+### 1.1 Hyperloom workspace I/O
+
+Hyperloom pins `cwd` to `<workspace>`. That is a convention, not an OS jail.
+Python only accepts artifacts that resolve inside `<workspace>` after
+`Path.resolve()`. Writes that land outside are discarded by the collector.
+
+**Write** (all tools: Bash, Write, Edit, Quark export):
+
+* Only create or modify files under `<workspace>/`.
+* Do not use `../`, absolute paths outside `<workspace>`, or a symlink
+  whose resolved target is outside `<workspace>`.
+* If the user prompt names an output directory outside `<workspace>`,
+  ignore that location. Write under `<workspace>/` (typical:
+  `<workspace>/quantized_model/`) and put that relative path in the
+  manifest.
+
+**Read**:
+
+* Source model weights, calibration data, eval datasets, and `quark_root`
+  may live outside `<workspace>`. Read them in place.
+* Do not copy `quark_root`. You may copy source `config.json` / tokenizer /
+  aux files into `<quantized_model_dir>` *after* that directory exists
+  inside `<workspace>`.
+
+**Manifest (`run_manifest.yaml`)**:
+
+* `outputs.quantized_model_dir` must resolve to a directory inside
+  `<workspace>`. Prefer a workspace-relative path (`quantized_model`,
+  `out`).
+* An absolute path, `../…`, or a symlink that escapes `<workspace>` is
+  rejected as `quantized_model_dir_outside_workspace`. The classifier
+  treats that as `manifest_artifact_invalid_or_missing` (#12) — Auto-recover
+  by rewriting the manifest to a path under `<workspace>` and re-exporting.
+
 ## 2. Inputs you receive
 
 The Python runner pins this run context into your prompt:
 
-* `workspace` — the only directory you may write to (besides the
-  `quantized_model_dir` that Quark's run_manifest produces).
+* `workspace` — Hyperloom attempt directory. Write artifacts only here;
+  see §1.1. `outputs.quantized_model_dir` must resolve within it.
 * `quark_root` — READ-ONLY. The Quark checkout.
 * `attempt_number` — 1 for the first attempt, ≥2 for retries.
 * `acceptable_eval_gap` — float | "see SKILL.md" sentinel. Resolution
@@ -166,7 +200,7 @@ phase chain after the fix.
 | `intent_parse_failed` (#8) | Re-read user prompt; if missing required field (model path / target dtype / output dir), make a best-effort default and continue. Cap self-correction at 2 tries. |
 | `analysis_artifact_invalid_or_missing` (#10) | Re-invoke `quark-torch-ptq` Step 1. |
 | `plan_artifact_invalid_or_missing` (#11) | Re-invoke `quark-torch-ptq` Step 2. |
-| `manifest_artifact_invalid_or_missing` (#12) | Re-invoke `quark-torch-ptq` Step 3. |
+| `manifest_artifact_invalid_or_missing` (#12) | If `quantized_model_dir` resolved outside `<workspace>`, rewrite it to a relative path under `<workspace>` then re-invoke Step 3 (and re-export if weights were written elsewhere). Otherwise re-invoke `quark-torch-ptq` Step 3. |
 | `must_have_config_missing_or_invalid` (#14) | `cp <source_model>/config.json <quantized_model_dir>/`; if vLLM-required keys (`model_type`, `architectures`) are absent, copy them from source's config. Re-run validator Step 3. |
 | `must_have_tokenizer_missing` (#15) | `cp <source_model>/tokenizer*` to `<quantized_model_dir>/`. Re-run validator Step 1. |
 | `must_validate_config_mismatch` (#17) | Diff config.json source vs quantized after stripping `quantization_config`. Copy the missing/diverged business-field values from source into quantized. Re-run validator Step 3. |
@@ -275,7 +309,8 @@ You may write any of these files; the Python runner reads them:
 Before the SDK session ends, verify every MUST-have is on disk:
 
 * `run_manifest.yaml` parses; `outputs.quantized_model_dir` resolves to an
-  existing directory.
+  existing directory within `<workspace>` (no `../`, no outside absolute
+  path, no escaping symlink). See §1.1.
 * That directory contains `config.json`, at least one `*.safetensors` /
   `*.bin`, and at least one tokenizer file (`tokenizer.json` /
   `tokenizer_config.json` / `tokenizer.model` / `vocab.json`).

--- a/src/hyperloom/agents/quantization/driver/assessment.py
+++ b/src/hyperloom/agents/quantization/driver/assessment.py
@@ -10,7 +10,8 @@ Classification precedence (first match wins):
   1. Hard SDK-level signatures in ``sdk_error`` mapping to bootstrap-class
      outcomes, decisive even if some artifacts exist.
   2. Explicit ``blocked.md`` outcome marker (``outcome_id: <id>``) when it is
-     a known ``OutcomeId``.
+     a known failure/ask ``OutcomeId`` (success tags such as
+     ``eval_gap_accepted`` are ignored so they cannot skip MUST-have checks).
   3. Phase-aware artifact gaps under the recorded ``last_phase``.
   4. MUST-have model files on the quantized directory.
   5. Validator step results (FAIL > SKIPPED > absent step heading).
@@ -38,11 +39,17 @@ from .outcomes import (
     MUST_HAVE_RECOVERS_THAT_FAIL_WITHOUT_ARTIFACT,
     OutcomeId,
     SUCCESS_TAGS,
+    UNCLASSIFIED_FAILURE,
 )
 from .result_collector import CollectedArtifacts, collect_artifacts
 
 
 _BLOCKED_OUTCOME_RE = re.compile(r"(?:^|\n)\s*outcome_id\s*:\s*([A-Za-z_][A-Za-z0-9_]*)", re.IGNORECASE)
+
+#: ``blocked.md`` may only stop the run on a failure/ask id. Success tags
+#: (``eval_gap_accepted``) and other non-blocked vocabulary must not short-
+#: circuit MUST-have / validator checks.
+_BLOCKED_MD_OUTCOMES: frozenset[OutcomeId] = AUTO_FAIL | ASK | AUTO_RECOVER | frozenset({UNCLASSIFIED_FAILURE})
 
 _GAP_NARRATIVE_EPSILON = 1e-4  # gaps smaller than this are clean success
 
@@ -168,9 +175,12 @@ def _parse_blocked_outcome(text: str | None) -> OutcomeId | None:
         return None
     raw = m.group(1).lower()
     try:
-        return OutcomeId(raw)
+        oid = OutcomeId(raw)
     except ValueError:
         return None
+    if oid not in _BLOCKED_MD_OUTCOMES:
+        return None
+    return oid
 
 
 def _classify_eval_outcome(

--- a/src/hyperloom/agents/quantization/driver/assessment.py
+++ b/src/hyperloom/agents/quantization/driver/assessment.py
@@ -39,17 +39,11 @@ from .outcomes import (
     MUST_HAVE_RECOVERS_THAT_FAIL_WITHOUT_ARTIFACT,
     OutcomeId,
     SUCCESS_TAGS,
-    UNCLASSIFIED_FAILURE,
 )
 from .result_collector import CollectedArtifacts, collect_artifacts
 
 
 _BLOCKED_OUTCOME_RE = re.compile(r"(?:^|\n)\s*outcome_id\s*:\s*([A-Za-z_][A-Za-z0-9_]*)", re.IGNORECASE)
-
-#: ``blocked.md`` may only stop the run on a failure/ask id. Success tags
-#: (``eval_gap_accepted``) and other non-blocked vocabulary must not short-
-#: circuit MUST-have / validator checks.
-_BLOCKED_MD_OUTCOMES: frozenset[OutcomeId] = AUTO_FAIL | ASK | AUTO_RECOVER | frozenset({UNCLASSIFIED_FAILURE})
 
 _GAP_NARRATIVE_EPSILON = 1e-4  # gaps smaller than this are clean success
 
@@ -178,7 +172,7 @@ def _parse_blocked_outcome(text: str | None) -> OutcomeId | None:
         oid = OutcomeId(raw)
     except ValueError:
         return None
-    if oid not in _BLOCKED_MD_OUTCOMES:
+    if oid in SUCCESS_TAGS:
         return None
     return oid
 

--- a/src/hyperloom/agents/quantization/driver/result_collector.py
+++ b/src/hyperloom/agents/quantization/driver/result_collector.py
@@ -205,10 +205,16 @@ def _resolve_quantized_dir(workspace: Path) -> tuple[Path | None, bool, str | No
     if not raw_path:
         return None, True, "missing_outputs_quantized_model_dir"
 
-    path = Path(str(raw_path))
-    if not path.is_absolute():
-        # Manifest paths are relative to workspace.
-        path = (workspace / path).resolve()
+    try:
+        ws = workspace.resolve()
+        path = Path(str(raw_path))
+        path = path.resolve() if path.is_absolute() else (ws / path).resolve()
+    except (OSError, RuntimeError) as exc:
+        return None, True, f"quantized_model_dir_unresolvable:{exc}"
+    try:
+        path.relative_to(ws)
+    except ValueError:
+        return None, True, "quantized_model_dir_outside_workspace"
     return path, True, None
 
 

--- a/src/hyperloom/agents/quantization/driver/runner.py
+++ b/src/hyperloom/agents/quantization/driver/runner.py
@@ -10,9 +10,12 @@ this module just plumbs run context into a templated prompt for the SDK.
 
 from __future__ import annotations
 
+import atexit
 import os
+import shutil
 import tempfile
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterable
 
@@ -24,7 +27,6 @@ DEFAULT_ALLOWED_TOOLS = ["Read", "Write", "Edit", "Bash"]
 DEFAULT_MAX_TURNS = 240  # Quark workflow has 4 STOPs + validator + eval
 
 SKILL_RELATIVE_PATH = "SKILL.md"
-QUARK_PY310_COMPAT_DIR = ".hyperloom_quark_py310_compat"
 QUARK_PY310_SITE_CUSTOMIZE = """\
 import datetime as _datetime
 import typing as _typing
@@ -93,6 +95,16 @@ def resolve_skill_path(package_root: Path | None = None) -> Path:
     return root / SKILL_RELATIVE_PATH
 
 
+def _cleanup_quark_py310_compat(compat_dir: Path) -> None:
+    """Remove the process-level compatibility shim."""
+    try:
+        compat_dir.chmod(0o755)
+        shutil.rmtree(compat_dir)
+    except OSError:
+        pass
+
+
+@lru_cache(maxsize=1)
 def _prepare_quark_py310_compat() -> Path:
     """Create a workspace-external Python 3.10 compatibility shim for Quark 0.12.
 
@@ -106,6 +118,7 @@ def _prepare_quark_py310_compat() -> Path:
     sitecustomize.write_text(QUARK_PY310_SITE_CUSTOMIZE, encoding="utf-8")
     sitecustomize.chmod(0o444)
     compat_dir.chmod(0o555)
+    atexit.register(_cleanup_quark_py310_compat, compat_dir)
     return compat_dir
 
 

--- a/src/hyperloom/agents/quantization/driver/runner.py
+++ b/src/hyperloom/agents/quantization/driver/runner.py
@@ -2,7 +2,7 @@
 
 Keyword-only public API with injection seams (``sdk_query_factory`` /
 ``sdk_options_cls``) so tests don't need the SDK installed. Runs with
-``cwd = quark_root`` (graceful fallback for older SDK builds), stores SDK
+``cwd = workspace`` (graceful fallback for older SDK builds), stores SDK
 errors on the result rather than raising, and routes output through a single
 ``log`` callable. The agent leans on ``SKILL.md`` as the runtime contract;
 this module just plumbs run context into a templated prompt for the SDK.
@@ -11,6 +11,7 @@ this module just plumbs run context into a templated prompt for the SDK.
 from __future__ import annotations
 
 import os
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterable
@@ -92,15 +93,19 @@ def resolve_skill_path(package_root: Path | None = None) -> Path:
     return root / SKILL_RELATIVE_PATH
 
 
-def _prepare_quark_py310_compat(workspace: Path) -> Path:
-    """Create a workspace-local Python 3.10 compatibility shim for Quark 0.12.
+def _prepare_quark_py310_compat() -> Path:
+    """Create a workspace-external Python 3.10 compatibility shim for Quark 0.12.
 
     Quark 0.12 uses Python 3.11 symbols (``typing.Self`` and ``datetime.UTC``);
     inject them via ``sitecustomize`` without modifying the Quark checkout.
+    The directory is created outside the agent workspace and made read-only so
+    a Write/Edit hallucination cannot replace the shim.
     """
-    compat_dir = workspace / QUARK_PY310_COMPAT_DIR
-    compat_dir.mkdir(parents=True, exist_ok=True)
-    (compat_dir / "sitecustomize.py").write_text(QUARK_PY310_SITE_CUSTOMIZE, encoding="utf-8")
+    compat_dir = Path(tempfile.mkdtemp(prefix="hyperloom_quark_py310_"))
+    sitecustomize = compat_dir / "sitecustomize.py"
+    sitecustomize.write_text(QUARK_PY310_SITE_CUSTOMIZE, encoding="utf-8")
+    sitecustomize.chmod(0o444)
+    compat_dir.chmod(0o555)
     return compat_dir
 
 
@@ -109,11 +114,11 @@ def _prepend_pythonpath(path: Path, current: str | None) -> str:
     return prefix if not current else prefix + os.pathsep + current
 
 
-def _quark_py310_compat_env(workspace: Path, base_env: dict[str, str] | None = None) -> dict[str, str]:
+def _quark_py310_compat_env(base_env: dict[str, str] | None = None) -> dict[str, str]:
     """Return child-process env exposing Quark's Python 3.10 shim."""
 
     env = dict(os.environ if base_env is None else base_env)
-    compat_dir = _prepare_quark_py310_compat(workspace)
+    compat_dir = _prepare_quark_py310_compat()
     env["PYTHONPATH"] = _prepend_pythonpath(compat_dir, env.get("PYTHONPATH"))
     env["PIP_IGNORE_REQUIRES_PYTHON"] = "1"
     return env
@@ -278,12 +283,12 @@ async def run_one_attempt(
         "system_prompt": system_prompt,
         "allowed_tools": DEFAULT_ALLOWED_TOOLS if allowed_tools is None else allowed_tools,
         "stderr": (lambda line: log(f"[claude-sdk] {line.rstrip()}")) if log else None,
-        "env": _quark_py310_compat_env(workspace),
+        "env": _quark_py310_compat_env(),
     }
     kwargs["env"].update(sdk_env_overlay(component="quantization", operation="quantize_attempt"))
     if model:
         kwargs["model"] = model
-    kwargs["cwd"] = str(quark_root)
+    kwargs["cwd"] = str(workspace)
 
     try:
         options = sdk_options_cls(**kwargs)

--- a/src/hyperloom/agents/quantization/driver/runner.py
+++ b/src/hyperloom/agents/quantization/driver/runner.py
@@ -199,7 +199,7 @@ Read and follow the FULL runtime contract in this skill file:
 {skill_path}
 
 ## Run context (passed in via prompt; SKILL.md tells you what to do with these)
-- Workspace (write all your artifacts here): {workspace}
+- Workspace (WRITE only here; quantized_model_dir must resolve inside this path after Path.resolve(); see SKILL.md §1.1): {workspace}
 - Quark project root (READ-ONLY; never edit files under this path): {quark_root}
 - Attempt number: {attempt_number}
 - Acceptable eval gap: {threshold_str}

--- a/src/hyperloom/agents/quantization/driver/runner.py
+++ b/src/hyperloom/agents/quantization/driver/runner.py
@@ -101,6 +101,7 @@ def _cleanup_quark_py310_compat(compat_dir: Path) -> None:
         compat_dir.chmod(0o755)
         shutil.rmtree(compat_dir)
     except OSError:
+        # Interpreter-exit cleanup; a leftover temp shim must not raise.
         pass
 
 

--- a/src/hyperloom/agents/quantization/tests/test_assessment.py
+++ b/src/hyperloom/agents/quantization/tests/test_assessment.py
@@ -25,6 +25,7 @@ def test_parse_blocked_outcome() -> None:
     assert A._parse_blocked_outcome(None) is None
     assert A._parse_blocked_outcome("nothing here") is None
     assert A._parse_blocked_outcome("outcome_id: eval_oom") == OutcomeId.eval_oom
+    assert A._parse_blocked_outcome("outcome_id: eval_gap_accepted") is None
     assert A._parse_blocked_outcome("outcome_id: not_a_real_outcome") is None
 
 

--- a/src/hyperloom/agents/quantization/tests/test_assessment_branches_unit.py
+++ b/src/hyperloom/agents/quantization/tests/test_assessment_branches_unit.py
@@ -25,6 +25,7 @@ def test_parse_blocked_outcome() -> None:
     assert A._parse_blocked_outcome(None) is None
     assert A._parse_blocked_outcome("nothing here") is None
     assert A._parse_blocked_outcome("outcome_id: eval_oom") == OutcomeId.eval_oom
+    assert A._parse_blocked_outcome("outcome_id: eval_gap_accepted") is None
     assert A._parse_blocked_outcome("outcome_id: not_a_real_outcome") is None
 
 

--- a/src/hyperloom/agents/quantization/tests/test_assessment_classifier.py
+++ b/src/hyperloom/agents/quantization/tests/test_assessment_classifier.py
@@ -82,7 +82,7 @@ def test_blocked_md_eval_gap_accepted_does_not_bypass(build_workspace):
 
 def test_blocked_md_accepts_every_known_non_success_outcome():
     """New known failures are blocked unless explicitly classified as success."""
-    for outcome in OutcomeId:
+    for outcome in list(OutcomeId):
         parsed = _parse_blocked_outcome(f"outcome_id: {outcome.value}\n")
         assert parsed is (None if outcome in SUCCESS_TAGS else outcome)
 

--- a/src/hyperloom/agents/quantization/tests/test_assessment_classifier.py
+++ b/src/hyperloom/agents/quantization/tests/test_assessment_classifier.py
@@ -65,6 +65,16 @@ def test_blocked_md_invalid_outcome_id_ignored(build_workspace):
     assert classify_attempt(ws) is None  # successful artifacts
 
 
+def test_blocked_md_eval_gap_accepted_does_not_bypass(build_workspace):
+    ws = build_workspace(
+        blocked_md="outcome_id: eval_gap_accepted\n",
+        include_quantized_dir=False,
+        include_validation_report=False,
+        include_eval_report=False,
+    )
+    assert classify_attempt(ws) != OutcomeId.eval_gap_accepted
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # phase-aware artifact gaps
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/hyperloom/agents/quantization/tests/test_assessment_classifier.py
+++ b/src/hyperloom/agents/quantization/tests/test_assessment_classifier.py
@@ -6,8 +6,13 @@ covers them via the sdk_error pattern path or the blocked.md outcome-id parser.
 
 from __future__ import annotations
 
-from hyperloom.agents.quantization.driver.assessment import build_assessment, classify_attempt, derive_status
-from hyperloom.agents.quantization.driver.outcomes import OutcomeId
+from hyperloom.agents.quantization.driver.assessment import (
+    _parse_blocked_outcome,
+    build_assessment,
+    classify_attempt,
+    derive_status,
+)
+from hyperloom.agents.quantization.driver.outcomes import SUCCESS_TAGS, OutcomeId
 from hyperloom.agents.quantization.driver.result_collector import collect_artifacts
 
 
@@ -73,6 +78,13 @@ def test_blocked_md_eval_gap_accepted_does_not_bypass(build_workspace):
         include_eval_report=False,
     )
     assert classify_attempt(ws) != OutcomeId.eval_gap_accepted
+
+
+def test_blocked_md_accepts_every_known_non_success_outcome():
+    """New known failures are blocked unless explicitly classified as success."""
+    for outcome in OutcomeId:
+        parsed = _parse_blocked_outcome(f"outcome_id: {outcome.value}\n")
+        assert parsed is (None if outcome in SUCCESS_TAGS else outcome)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/hyperloom/agents/quantization/tests/test_result_collector.py
+++ b/src/hyperloom/agents/quantization/tests/test_result_collector.py
@@ -132,3 +132,31 @@ def test_quantized_dir_resolved_relative(tmp_path):
     assert art.quantized_model_dir is not None
     assert art.quantized_model_dir.name == "out"
     assert art.has_weights
+
+
+def test_quantized_dir_absolute_outside_workspace(tmp_path):
+    pytest.importorskip("yaml")
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (ws / "run_manifest.yaml").write_text(
+        f"outputs:\n  quantized_model_dir: {outside}\n",
+        encoding="utf-8",
+    )
+    art = collect_artifacts(ws)
+    assert art.quantized_model_dir is None
+    assert art.manifest_parse_error == "quantized_model_dir_outside_workspace"
+
+
+def test_quantized_dir_relative_escape(tmp_path):
+    pytest.importorskip("yaml")
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "run_manifest.yaml").write_text(
+        "outputs:\n  quantized_model_dir: ../evil\n",
+        encoding="utf-8",
+    )
+    art = collect_artifacts(ws)
+    assert art.quantized_model_dir is None
+    assert art.manifest_parse_error == "quantized_model_dir_outside_workspace"

--- a/src/hyperloom/agents/quantization/tests/test_result_collector.py
+++ b/src/hyperloom/agents/quantization/tests/test_result_collector.py
@@ -160,3 +160,18 @@ def test_quantized_dir_relative_escape(tmp_path):
     art = collect_artifacts(ws)
     assert art.quantized_model_dir is None
     assert art.manifest_parse_error == "quantized_model_dir_outside_workspace"
+
+
+def test_quantized_dir_symlink_escape(tmp_path):
+    pytest.importorskip("yaml")
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (ws / "out").symlink_to(outside, target_is_directory=True)
+    (ws / "run_manifest.yaml").write_text("outputs:\n  quantized_model_dir: out\n", encoding="utf-8")
+
+    art = collect_artifacts(ws)
+
+    assert art.quantized_model_dir is None
+    assert art.manifest_parse_error == "quantized_model_dir_outside_workspace"

--- a/src/hyperloom/agents/quantization/tests/test_runner.py
+++ b/src/hyperloom/agents/quantization/tests/test_runner.py
@@ -6,6 +6,7 @@ Uses ``FakeSDK`` / ``FakeOptions`` from conftest to bypass the real SDK.
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -148,22 +149,23 @@ async def test_run_one_attempt_invokes_sdk_with_prompt(tmp_path, fake_sdk, fake_
 
 
 @pytest.mark.asyncio
-async def test_run_one_attempt_sets_cwd_to_quark_root(tmp_path, fake_sdk, fake_options_cls):
+async def test_run_one_attempt_sets_cwd_to_workspace(tmp_path, fake_sdk, fake_options_cls):
     skill = tmp_path / "SKILL.md"
     skill.write_text("x", encoding="utf-8")
     qr = tmp_path / "qr"
     qr.mkdir()
+    ws = tmp_path / "ws"
 
     await run_one_attempt(
         user_prompt="x",
-        workspace=tmp_path / "ws",
+        workspace=ws,
         quark_root=qr,
         skill_path=skill,
         sdk_query_factory=fake_sdk,
         sdk_options_cls=fake_options_cls,
     )
     options = fake_sdk.received_options[0]
-    assert options.kwargs.get("cwd") == str(qr)
+    assert options.kwargs.get("cwd") == str(ws)
     assert options.kwargs.get("allowed_tools") == DEFAULT_ALLOWED_TOOLS
 
 
@@ -185,15 +187,19 @@ async def test_run_one_attempt_passes_quark_py310_env_to_sdk_options(tmp_path, f
         sdk_options_cls=fake_options_cls,
     )
 
-    compat_dir = tmp_path / "ws" / ".hyperloom_quark_py310_compat"
-    sitecustomize = compat_dir / "sitecustomize.py"
     env = fake_sdk.received_options[0].kwargs["env"]
+    pythonpath = env["PYTHONPATH"]
+    compat_dir = Path(pythonpath.split(os.pathsep)[0])
+    sitecustomize = compat_dir / "sitecustomize.py"
+    ws = tmp_path / "ws"
     assert sitecustomize.is_file()
+    assert not str(compat_dir).startswith(str(ws.resolve()))
     assert "typing.Self" in sitecustomize.read_text(encoding="utf-8")
-    assert env["PYTHONPATH"] == f"{compat_dir}{os.pathsep}/existing/pythonpath"
+    assert env["PYTHONPATH"].startswith(str(compat_dir))
     assert env["PIP_IGNORE_REQUIRES_PYTHON"] == "1"
     assert os.environ["PYTHONPATH"] == "/existing/pythonpath"
     assert "PIP_IGNORE_REQUIRES_PYTHON" not in os.environ
+    assert (sitecustomize.stat().st_mode & 0o222) == 0
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/agents/quantization/tests/test_runner.py
+++ b/src/hyperloom/agents/quantization/tests/test_runner.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from hyperloom.agents.quantization.driver import runner as runner_module
 from hyperloom.agents.quantization.driver.runner import (
     DEFAULT_ALLOWED_TOOLS,
     AttemptResult,
@@ -34,6 +35,16 @@ def test_resolve_skill_path_respects_override(tmp_path):
     (tmp_path / "SKILL.md").write_text("x", encoding="utf-8")
     p = resolve_skill_path(package_root=tmp_path)
     assert p == tmp_path / "SKILL.md"
+
+
+def test_quark_py310_compat_dir_is_process_singleton():
+    """Repeated attempts reuse one read-only compatibility directory."""
+    first = runner_module._prepare_quark_py310_compat()
+    second = runner_module._prepare_quark_py310_compat()
+
+    assert first == second
+    assert first.is_dir()
+    assert (first.stat().st_mode & 0o222) == 0
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/hyperloom/common/env_safety.py
+++ b/src/hyperloom/common/env_safety.py
@@ -82,25 +82,38 @@ BENCHMARK_SECRET_ENV_NAMES: frozenset[str] = frozenset(
 _SECRET_REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (
         re.compile(
-            r"(?i)\b(authorization\s*:\s*(?:(?:bearer|basic)\s+)?)"
+            r"(?i)\b(authorization\s*:\s*)"
+            r"(?:(?P<authorization_scheme>[A-Za-z][A-Za-z0-9._~+/-]*[ \t]+)"
+            r"(?=[^\s,;'\"\\]+))?"
             r"[^\s,;'\"\\]+"
         ),
-        r"\1[REDACTED]",
+        r"\1\g<authorization_scheme>[REDACTED]",
     ),
-    (re.compile(r"(?i)(bearer\s+)[A-Za-z0-9\-_.=]{8,}"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]{8,}"), r"\1[REDACTED]"),
     (re.compile(r"\b((?:ak|sk|pk)-(?:lf-)?)[A-Za-z0-9\-_]{6,}"), r"\1[REDACTED]"),
-    (re.compile(r"\b(gh[pousr]_|github_pat_)[A-Za-z0-9_]{10,}"), r"\1[REDACTED]"),
+    (re.compile(r"\b(gh[pousr]_)[A-Za-z0-9_]{3,}"), r"\1[REDACTED]"),
+    (re.compile(r"\b(github_pat_)[A-Za-z0-9_]{10,}"), r"\1[REDACTED]"),
     # AWS access-key id and compact JWT. Same two shapes the specialist
     # transcript redactor already matches; kept here so a command that
     # carries either form is masked whether it went through an assignment
     # or not.
     (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "[REDACTED]"),
     (re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"), "[REDACTED]"),
-    (re.compile(r"(?i)(ocp-apim-subscription-key\s*:\s*)\S+"), r"\1[REDACTED]"),
+    (
+        re.compile(r"(?i)(ocp-apim-subscription-key\s*:\s*)[^\s,;'\"\\]+"),
+        r"\1[REDACTED]",
+    ),
+    (
+        re.compile(r"(?i)(?<![A-Z0-9_./-])(authorization\s*=\s*)[^\s,;'\"\\]+"),
+        r"\1[REDACTED]",
+    ),
     (
         re.compile(
             r"(?i)\b([A-Z0-9_]*CUSTOM_HEADERS\s*[=:]\s*)"
-            r"(\\?[\"'])?(?:[^\s,;'\"\\]+:[ \t]*)?[^\s,;'\"\\]+"
+            r"(\\?[\"'])?"
+            r"(?:[A-Z0-9_-]+:[ \t]*[^\r\n,;'\"\\]+"
+            r"(?:,[ \t]*[A-Z0-9_-]+:[ \t]*[^\r\n,;'\"\\]+)*|"
+            r"[^\s,;'\"\\]+)"
         ),
         r"\1\2[REDACTED]",
     ),
@@ -124,9 +137,11 @@ _SECRET_REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     # quoting stays balanced) while ``PASSWORD=C:\foo`` is still masked whole.
     (
         re.compile(
-            r"(?i)\b([A-Z0-9_]*"
-            r"(?:(?:API_?KEY|SECRET|PASSWORD|CREDENTIAL|HEADERS)[A-Z0-9_]*|"
-            r"AUTH(?:_[A-Z0-9]+)?|TOKEN(?:_\d+)?)"
+            r"(?i)(?<![A-Z0-9_./-])("
+            r"(?:[A-Z0-9_]*(?:API_?KEY|SECRET|PASSWORD|CREDENTIAL|HEADERS)[A-Z0-9_]*|"
+            r"AUTH(?:_[A-Z0-9_]+)?|"
+            r"[A-Z0-9_]+_AUTH(?:ORIZATION)?(?:_[A-Z0-9_]+)?|"
+            r"(?:[A-Z0-9_]+_)?TOKEN(?:_\d+)?)"
             r"\s*[=:]\s*)"
             r"(\\?[\"'])?(?:\\(?![\"'])|[^\s,;'\"\\])+"
         ),

--- a/src/hyperloom/common/env_safety.py
+++ b/src/hyperloom/common/env_safety.py
@@ -82,7 +82,7 @@ BENCHMARK_SECRET_ENV_NAMES: frozenset[str] = frozenset(
 _SECRET_REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (
         re.compile(
-            r"(?i)\b(authorization\s*:\s*)(?:(?:bearer|basic)\s+)?"
+            r"(?i)\b(authorization\s*:\s*(?:(?:bearer|basic)\s+)?)"
             r"[^\s,;'\"\\]+"
         ),
         r"\1[REDACTED]",
@@ -115,16 +115,18 @@ _SECRET_REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     # for IZER / TOKENS still left ``tokenized_requests`` and
     # ``stop_token_ids`` matching — TOKEN is a generic word in this stack,
     # and a half-redacted list (``stop_token_ids=[REDACTED], 154827]``) is
-    # worse than leaving the knob readable. ``API_KEY`` / ``SECRET`` /
-    # ``PASSWORD`` / ``CREDENTIAL`` still allow trailing name characters, so
-    # ``AWS_SECRET_ACCESS_KEY`` is unchanged. A backslash is only excluded
-    # from the value when it precedes a quote, so a JSON-escaped closer is
-    # left in place (the quoting stays balanced) while ``PASSWORD=C:\foo``
-    # is still masked whole.
+    # worse than leaving the knob readable. ``AUTH`` is the same kind of
+    # suffix (``AUTH_KEY``) so ``Unauthorized:`` is not treated as a secret
+    # assignment. ``API_KEY`` / ``SECRET`` / ``PASSWORD`` / ``CREDENTIAL``
+    # still allow trailing name characters, so ``AWS_SECRET_ACCESS_KEY`` is
+    # unchanged. A backslash is only excluded from the value when it
+    # precedes a quote, so a JSON-escaped closer is left in place (the
+    # quoting stays balanced) while ``PASSWORD=C:\foo`` is still masked whole.
     (
         re.compile(
             r"(?i)\b([A-Z0-9_]*"
-            r"(?:(?:API_?KEY|AUTH|SECRET|PASSWORD|CREDENTIAL|HEADERS)[A-Z0-9_]*|TOKEN(?:_\d+)?)"
+            r"(?:(?:API_?KEY|SECRET|PASSWORD|CREDENTIAL|HEADERS)[A-Z0-9_]*|"
+            r"AUTH(?:_[A-Z0-9]+)?|TOKEN(?:_\d+)?)"
             r"\s*[=:]\s*)"
             r"(\\?[\"'])?(?:\\(?![\"'])|[^\s,;'\"\\])+"
         ),

--- a/src/hyperloom/common/env_safety.py
+++ b/src/hyperloom/common/env_safety.py
@@ -80,6 +80,13 @@ BENCHMARK_SECRET_ENV_NAMES: frozenset[str] = frozenset(
 )
 
 _SECRET_REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(
+            r"(?i)\b(authorization\s*:\s*)(?:(?:bearer|basic)\s+)?"
+            r"[^\s,;'\"\\]+"
+        ),
+        r"\1[REDACTED]",
+    ),
     (re.compile(r"(?i)(bearer\s+)[A-Za-z0-9\-_.=]{8,}"), r"\1[REDACTED]"),
     (re.compile(r"\b((?:ak|sk|pk)-(?:lf-)?)[A-Za-z0-9\-_]{6,}"), r"\1[REDACTED]"),
     (re.compile(r"\b(gh[pousr]_|github_pat_)[A-Za-z0-9_]{10,}"), r"\1[REDACTED]"),
@@ -91,8 +98,11 @@ _SECRET_REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"), "[REDACTED]"),
     (re.compile(r"(?i)(ocp-apim-subscription-key\s*:\s*)\S+"), r"\1[REDACTED]"),
     (
-        re.compile(r"(?i)\b([A-Z0-9_]*CUSTOM_HEADERS\s*[=:]\s*)(\S.*?)(?=\s+[A-Z][A-Z0-9_]*=|\s*$)"),
-        r"\1[REDACTED]",
+        re.compile(
+            r"(?i)\b([A-Z0-9_]*CUSTOM_HEADERS\s*[=:]\s*)"
+            r"(\\?[\"'])?(?:[^\s,;'\"\\]+:[ \t]*)?[^\s,;'\"\\]+"
+        ),
+        r"\1\2[REDACTED]",
     ),
     # Shell commands quote the value (``PASSWORD="x"``), and a command that has
     # been through ``json.dumps`` carries an escaped quote (``PASSWORD=\"x\"``).
@@ -114,7 +124,7 @@ _SECRET_REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (
         re.compile(
             r"(?i)\b([A-Z0-9_]*"
-            r"(?:(?:API_?KEY|SECRET|PASSWORD|CREDENTIAL|HEADERS)[A-Z0-9_]*|TOKEN(?:_\d+)?)"
+            r"(?:(?:API_?KEY|AUTH|SECRET|PASSWORD|CREDENTIAL|HEADERS)[A-Z0-9_]*|TOKEN(?:_\d+)?)"
             r"\s*[=:]\s*)"
             r"(\\?[\"'])?(?:\\(?![\"'])|[^\s,;'\"\\])+"
         ),
@@ -427,25 +437,33 @@ def redact_secret_values(text: str) -> str:
 
 
 def redact_file_in_place(path: os.PathLike[str] | str, *, mode: int = 0o600) -> None:
-    """Rewrite ``path`` with :func:`redact_secret_values` and restrict mode.
+    """Stream-redact ``path`` with :func:`redact_secret_values` and restrict mode.
 
     Missing files and I/O errors are ignored so a logging path cannot fail a run.
     """
     from pathlib import Path
 
     target = Path(path)
+    tmp = target.with_name(target.name + ".redacting")
+    changed = False
     try:
-        text = target.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return
-    redacted = redact_secret_values(text)
-    try:
-        if redacted != text:
-            tmp = target.with_name(target.name + ".redacting")
-            tmp.write_text(redacted, encoding="utf-8")
+        with target.open("r", encoding="utf-8", errors="replace") as source:
+            with tmp.open("w", encoding="utf-8") as destination:
+                for line in source:
+                    redacted = redact_secret_values(line)
+                    changed = changed or redacted != line
+                    destination.write(redacted)
+        if changed:
+            tmp.chmod(mode)
             tmp.replace(target)
+        else:
+            tmp.unlink()
         target.chmod(mode)
     except OSError:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
         return
 
 

--- a/src/hyperloom/common/env_safety.py
+++ b/src/hyperloom/common/env_safety.py
@@ -71,6 +71,9 @@ BENCHMARK_SECRET_ENV_NAMES: frozenset[str] = frozenset(
         "LLM_PROXY_API_KEY",
         "OPENAI_API_KEY",
         "OPENAI_CUSTOM_HEADERS",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
         # Legacy: not consumed anymore, still scrubbed if present.
         "SAFE_API_KEY",
     }
@@ -86,6 +89,11 @@ _SECRET_REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     # or not.
     (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "[REDACTED]"),
     (re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"), "[REDACTED]"),
+    (re.compile(r"(?i)(ocp-apim-subscription-key\s*:\s*)\S+"), r"\1[REDACTED]"),
+    (
+        re.compile(r"(?i)\b([A-Z0-9_]*CUSTOM_HEADERS\s*[=:]\s*)(\S.*?)(?=\s+[A-Z][A-Z0-9_]*=|\s*$)"),
+        r"\1[REDACTED]",
+    ),
     # Shell commands quote the value (``PASSWORD="x"``), and a command that has
     # been through ``json.dumps`` carries an escaped quote (``PASSWORD=\"x\"``).
     # The opening quote is matched separately and re-emitted so the mask keeps
@@ -106,7 +114,7 @@ _SECRET_REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (
         re.compile(
             r"(?i)\b([A-Z0-9_]*"
-            r"(?:(?:API_?KEY|SECRET|PASSWORD|CREDENTIAL)[A-Z0-9_]*|TOKEN(?:_\d+)?)"
+            r"(?:(?:API_?KEY|SECRET|PASSWORD|CREDENTIAL|HEADERS)[A-Z0-9_]*|TOKEN(?:_\d+)?)"
             r"\s*[=:]\s*)"
             r"(\\?[\"'])?(?:\\(?![\"'])|[^\s,;'\"\\])+"
         ),
@@ -418,6 +426,29 @@ def redact_secret_values(text: str) -> str:
     return out
 
 
+def redact_file_in_place(path: os.PathLike[str] | str, *, mode: int = 0o600) -> None:
+    """Rewrite ``path`` with :func:`redact_secret_values` and restrict mode.
+
+    Missing files and I/O errors are ignored so a logging path cannot fail a run.
+    """
+    from pathlib import Path
+
+    target = Path(path)
+    try:
+        text = target.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return
+    redacted = redact_secret_values(text)
+    try:
+        if redacted != text:
+            tmp = target.with_name(target.name + ".redacting")
+            tmp.write_text(redacted, encoding="utf-8")
+            tmp.replace(target)
+        target.chmod(mode)
+    except OSError:
+        return
+
+
 __all__ = [
     "BENCHMARK_SECRET_ENV_NAMES",
     "BLOCKED_CHILD_ENV_NAMES",
@@ -433,6 +464,7 @@ __all__ = [
     "is_allowed_variant_env_key",
     "is_python_package_root",
     "is_secret_shaped_env_name",
+    "redact_file_in_place",
     "redact_secret_values",
     "scrub_benchmark_process_env",
     "scrub_child_process_env",

--- a/src/hyperloom/common/env_safety.py
+++ b/src/hyperloom/common/env_safety.py
@@ -480,6 +480,7 @@ def redact_file_in_place(path: os.PathLike[str] | str, *, mode: int = 0o600) -> 
         try:
             tmp.unlink(missing_ok=True)
         except OSError:
+            # The temp file is already gone or unreachable; nothing left to clean.
             pass
         return
 

--- a/src/hyperloom/inference_optimizer/tests/test_env_safety.py
+++ b/src/hyperloom/inference_optimizer/tests/test_env_safety.py
@@ -196,7 +196,12 @@ def test_redact_secret_values_masks_assignments_and_bearer_tokens():
     (
         "Authorization: abcdef1234567890",
         "authorization: Basic YWJjOmRlZg==",
+        "Authorization: Token abc123def456",
+        "Authorization: AWS4-HMAC-SHA256 Credential=abc123def456",
         "AUTH_KEY=supersecret",
+        "AUTHORIZATION=supersecretvalue",
+        "X_AUTHORIZATION=supersecretvalue",
+        "PROXY_AUTHORIZATION: abc12345678",
     ),
 )
 def test_redact_secret_values_masks_authorization_forms(text):
@@ -220,6 +225,18 @@ def test_redact_secret_values_spares_unauthorized_status_text():
     text = "401 Unauthorized: invalid API key"
 
     assert common_env_safety.redact_secret_values(text) == text
+
+
+def test_redact_secret_values_masks_base64_bearer_token():
+    """Bearer token characters include the standard base64 alphabet."""
+    out = common_env_safety.redact_secret_values("Bearer abc+def/ghi=jkl")
+
+    assert out == "Bearer [REDACTED]"
+
+
+def test_redact_secret_values_masks_short_legacy_github_token_shape():
+    """Legacy runner coverage masks gh-prefixed token-shaped values."""
+    assert common_env_safety.redact_secret_values("ghp_abc") == "ghp_[REDACTED]"
 
 
 def test_redact_secret_values_masks_quoted_assignments():
@@ -297,3 +314,19 @@ def test_redact_secret_values_masks_spaced_custom_header_before_newline():
 
     assert "deadbeefsecret" not in out
     assert out.endswith("next line\n")
+
+
+def test_redact_secret_values_masks_every_custom_header():
+    """Comma-separated custom headers are redacted as one bounded value."""
+    text = "ANTHROPIC_CUSTOM_HEADERS=k1: v1,k2: secret2"
+
+    assert common_env_safety.redact_secret_values(text) == "ANTHROPIC_CUSTOM_HEADERS=[REDACTED]"
+
+
+def test_redact_secret_values_preserves_json_around_ocp_header():
+    """OCP header redaction stops at the enclosing JSON delimiters."""
+    text = '{"h":"Ocp-Apim-Subscription-Key: deadbeefsecret", "ok":true}'
+
+    out = common_env_safety.redact_secret_values(text)
+
+    assert json.loads(out) == {"h": "Ocp-Apim-Subscription-Key: [REDACTED]", "ok": True}

--- a/src/hyperloom/inference_optimizer/tests/test_env_safety.py
+++ b/src/hyperloom/inference_optimizer/tests/test_env_safety.py
@@ -212,7 +212,14 @@ def test_redact_secret_values_preserves_json_around_authorization():
 
     out = common_env_safety.redact_secret_values(text)
 
-    assert json.loads(out) == {"header": "Authorization: [REDACTED]", "ok": True}
+    assert json.loads(out) == {"header": "Authorization: Basic [REDACTED]", "ok": True}
+
+
+def test_redact_secret_values_spares_unauthorized_status_text():
+    """AUTH is a suffix, so HTTP Unauthorized text is not an assignment."""
+    text = "401 Unauthorized: invalid API key"
+
+    assert common_env_safety.redact_secret_values(text) == text
 
 
 def test_redact_secret_values_masks_quoted_assignments():

--- a/src/hyperloom/inference_optimizer/tests/test_env_safety.py
+++ b/src/hyperloom/inference_optimizer/tests/test_env_safety.py
@@ -13,6 +13,8 @@ placed into the forward dict, so they are not SSH-forwarded to inference pods.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from hyperloom.inference_optimizer.multi_node._internal import env_safety
@@ -189,6 +191,30 @@ def test_redact_secret_values_masks_assignments_and_bearer_tokens():
     assert redacted.count("[REDACTED]") == 2
 
 
+@pytest.mark.parametrize(
+    "text",
+    (
+        "Authorization: abcdef1234567890",
+        "authorization: Basic YWJjOmRlZg==",
+        "AUTH_KEY=supersecret",
+    ),
+)
+def test_redact_secret_values_masks_authorization_forms(text):
+    """Authorization headers and AUTH assignments are masked."""
+    redacted = common_env_safety.redact_secret_values(text)
+
+    assert redacted.endswith("[REDACTED]")
+
+
+def test_redact_secret_values_preserves_json_around_authorization():
+    """Authorization redaction must stop at the enclosing JSON quote."""
+    text = '{"header": "Authorization: Basic YWJjOmRlZg==", "ok": true}'
+
+    out = common_env_safety.redact_secret_values(text)
+
+    assert json.loads(out) == {"header": "Authorization: [REDACTED]", "ok": True}
+
+
 def test_redact_secret_values_masks_quoted_assignments():
     """A quoted value is the common shape: shells quote it, json.dumps escapes it."""
     double = common_env_safety.redact_secret_values('export MYAPP_PASSWORD="hunter2"')
@@ -245,3 +271,22 @@ def test_redact_secret_values_masks_custom_headers_assignment():
     out = common_env_safety.redact_secret_values(text)
     assert "deadbeefsecret" not in out
     assert "ANTHROPIC_CUSTOM_HEADERS=" in out
+
+
+def test_redact_secret_values_preserves_json_around_custom_headers():
+    """A custom-header assignment must not consume adjacent JSON fields."""
+    text = '{"a": ["OPENAI_CUSTOM_HEADERS=h"], "b": "run with FOO=1"}'
+
+    out = common_env_safety.redact_secret_values(text)
+
+    assert json.loads(out) == {"a": ["OPENAI_CUSTOM_HEADERS=[REDACTED]"], "b": "run with FOO=1"}
+
+
+def test_redact_secret_values_masks_spaced_custom_header_before_newline():
+    """A custom-header value containing a space is masked on non-final lines."""
+    text = "ANTHROPIC_CUSTOM_HEADERS=x-key: deadbeefsecret\nnext line\n"
+
+    out = common_env_safety.redact_secret_values(text)
+
+    assert "deadbeefsecret" not in out
+    assert out.endswith("next line\n")

--- a/src/hyperloom/inference_optimizer/tests/test_env_safety.py
+++ b/src/hyperloom/inference_optimizer/tests/test_env_safety.py
@@ -238,3 +238,10 @@ def test_redact_secret_values_masks_aws_key_and_jwt_shapes():
     assert access_id not in redacted
     assert jwt not in redacted
     assert redacted.count("[REDACTED]") == 2
+
+
+def test_redact_secret_values_masks_custom_headers_assignment():
+    text = "ANTHROPIC_CUSTOM_HEADERS=Ocp-Apim-Subscription-Key: deadbeefsecret"
+    out = common_env_safety.redact_secret_values(text)
+    assert "deadbeefsecret" not in out
+    assert "ANTHROPIC_CUSTOM_HEADERS=" in out

--- a/src/hyperloom/inference_optimizer/tests/test_env_safety.py
+++ b/src/hyperloom/inference_optimizer/tests/test_env_safety.py
@@ -197,7 +197,7 @@ def test_redact_secret_values_masks_assignments_and_bearer_tokens():
         "Authorization: abcdef1234567890",
         "authorization: Basic YWJjOmRlZg==",
         "Authorization: Token abc123def456",
-        "Authorization: AWS4-HMAC-SHA256 Credential=abc123def456",
+        "Authorization: AWS4-HMAC-SHA256 Credential=EXAMPLEEXAMPLE",
         "AUTH_KEY=supersecret",
         "AUTHORIZATION=supersecretvalue",
         "X_AUTHORIZATION=supersecretvalue",

--- a/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
@@ -708,6 +708,11 @@ class TestRocmHipSourceRoots:
         """aiter stays in the default allowlist too."""
         assert any("/aiter/" in r for r in fp._DEFAULT_SOURCE_ROOTS)
 
+    def test_rocm_write_filter_allows_source_not_runtime(self):
+        assert fp.is_rocm_hip_writable_path("/opt/rocm/include/hip/hip_runtime.h") is True
+        assert fp.is_rocm_hip_writable_path("/opt/rocm/lib/libhip_hcc.so") is False
+        assert fp.is_rocm_hip_writable_path("/sgl-workspace/vllm/foo.py") is True
+
 
 # Source-root resolution + prompt injection
 def test_resolve_source_file_allowlist_unions_env_override(monkeypatch):

--- a/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
+++ b/src/hyperloom/inference_optimizer/tests/test_framework_paths_units.py
@@ -713,6 +713,13 @@ class TestRocmHipSourceRoots:
         assert fp.is_rocm_hip_writable_path("/opt/rocm/lib/libhip_hcc.so") is False
         assert fp.is_rocm_hip_writable_path("/sgl-workspace/vllm/foo.py") is True
 
+    def test_rocm_write_filter_checks_resolved_symlink_suffix(self, tmp_path):
+        """A source-looking symlink to a runtime object remains read-only."""
+        link = tmp_path / "patch_me.py"
+        link.symlink_to("/opt/rocm/lib/libamdhip64.so")
+
+        assert fp.is_rocm_hip_writable_path(str(link)) is False
+
 
 # Source-root resolution + prompt injection
 def test_resolve_source_file_allowlist_unions_env_override(monkeypatch):

--- a/src/hyperloom/inference_optimizer/tests/test_integrate_patch_artifacts_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_integrate_patch_artifacts_unit.py
@@ -244,6 +244,25 @@ def test_resolve_artifact_target_absolute_outside_allowlist_rejected(tmp_path, m
     assert ip._resolve_artifact_target("/etc/passwd") is None
 
 
+def test_resolve_artifact_target_rejects_rocm_runtime_object(tmp_path, monkeypatch):
+    rocm = tmp_path / "opt" / "rocm"
+    (rocm / "lib").mkdir(parents=True)
+    (rocm / "include").mkdir()
+    so_path = rocm / "lib" / "libhip_hcc.so"
+    hdr_path = rocm / "include" / "hip_runtime.h"
+    so_path.write_bytes(b"x")
+    hdr_path.write_text("typedef int hipError_t;\n", encoding="utf-8")
+    monkeypatch.setattr(ip, "resolve_source_file_allowlist", lambda: [str(rocm)])
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.framework.paths._ROCM_HIP_SOURCE_ROOTS",
+        (str(rocm) + "/",),
+    )
+    assert ip._resolve_artifact_target(str(so_path)) is None
+    out = ip._resolve_artifact_target(str(hdr_path))
+    assert out is not None
+    assert out[0] == hdr_path.resolve()
+
+
 def test_resolve_artifact_target_relative_still_works(tmp_path, monkeypatch):
     """Relative targets keep resolving under an allowlisted root."""
     fw = tmp_path / "aiter"

--- a/src/hyperloom/inference_optimizer/tests/test_integrate_patch_localize.py
+++ b/src/hyperloom/inference_optimizer/tests/test_integrate_patch_localize.py
@@ -171,3 +171,13 @@ def test_empty_allowlist_still_uses_framework_root(tmp_path):
     )
     assert "ok.py" not in outside
     assert "/etc/passwd" in outside
+
+
+def test_localization_rejects_rocm_runtime_objects(tmp_path):
+    outside = ip._localization_paths_outside_allowlist(
+        ["/opt/rocm/lib/libhip_hcc.so", "/opt/rocm/include/hip/hip_runtime.h"],
+        None,
+        ["/opt/rocm/"],
+    )
+    assert "/opt/rocm/lib/libhip_hcc.so" in outside
+    assert "/opt/rocm/include/hip/hip_runtime.h" not in outside

--- a/src/hyperloom/inference_optimizer/tests/test_langfuse_emitter.py
+++ b/src/hyperloom/inference_optimizer/tests/test_langfuse_emitter.py
@@ -300,6 +300,7 @@ def test_redact_env_keeps_names_redacts_secret_values():
     snap = lfmap.redact_env(
         {
             "PATH": "/usr/bin",
+            "ROCM_PATH": "/opt/rocm/bin:/usr/local/auth:/usr/bin",
             "HF_TOKEN": "hf_xxx",
             "AWS_SECRET_ACCESS_KEY": "abc",
             "DB_PASSWORD": "pw",
@@ -307,6 +308,7 @@ def test_redact_env_keeps_names_redacts_secret_values():
         }
     )
     assert snap["PATH"] == "/usr/bin"
+    assert snap["ROCM_PATH"] == "/opt/rocm/bin:/usr/local/auth:/usr/bin"
     assert snap["PLAIN"] == "value"
     assert snap["HF_TOKEN"] == "***redacted***"
     assert snap["AWS_SECRET_ACCESS_KEY"] == "***redacted***"
@@ -325,8 +327,8 @@ def test_redact_env_redacts_custom_headers_and_value_shaped_secrets():
     assert snap["ANTHROPIC_CUSTOM_HEADERS"] == "***redacted***"
     assert snap["OPENAI_CUSTOM_HEADERS"] == "***redacted***"
     assert snap["HARMLESS"] == "ok"
-    assert snap["GATEWAY_HDR"] == "***redacted***"
-    assert "deadbeefsecret" not in snap.values()
+    assert snap["GATEWAY_HDR"] == "Ocp-Apim-Subscription-Key: [REDACTED]"
+    assert "anothersecretvalue" not in snap["GATEWAY_HDR"]
 
 
 def test_session_start_is_idempotent(tmp_path, monkeypatch):

--- a/src/hyperloom/inference_optimizer/tests/test_langfuse_emitter.py
+++ b/src/hyperloom/inference_optimizer/tests/test_langfuse_emitter.py
@@ -313,6 +313,22 @@ def test_redact_env_keeps_names_redacts_secret_values():
     assert snap["DB_PASSWORD"] == "***redacted***"
 
 
+def test_redact_env_redacts_custom_headers_and_value_shaped_secrets():
+    snap = lfmap.redact_env(
+        {
+            "ANTHROPIC_CUSTOM_HEADERS": "Ocp-Apim-Subscription-Key: deadbeefsecret",
+            "OPENAI_CUSTOM_HEADERS": "Authorization: Bearer abcdefghijklmnop",
+            "HARMLESS": "ok",
+            "GATEWAY_HDR": "Ocp-Apim-Subscription-Key: anothersecretvalue",
+        }
+    )
+    assert snap["ANTHROPIC_CUSTOM_HEADERS"] == "***redacted***"
+    assert snap["OPENAI_CUSTOM_HEADERS"] == "***redacted***"
+    assert snap["HARMLESS"] == "ok"
+    assert snap["GATEWAY_HDR"] == "***redacted***"
+    assert "deadbeefsecret" not in snap.values()
+
+
 def test_session_start_is_idempotent(tmp_path, monkeypatch):
     _enable_env(monkeypatch)
     client = _FakeClient()

--- a/src/hyperloom/inference_optimizer/tests/test_patch_source_pr.py
+++ b/src/hyperloom/inference_optimizer/tests/test_patch_source_pr.py
@@ -151,6 +151,27 @@ def test_materialize_refuses_to_bench_when_every_explicit_patch_is_missing(tmp_p
     assert out.failure["error_class"] == "explicit_patches_missing"
 
 
+def test_fetch_diff_to_path_passes_max_filesize(tmp_path: Path, monkeypatch):
+    dest = tmp_path / "out.patch"
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append(list(cmd))
+        dest.write_text(_VALID_PATCH, encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.actions.executors._patch_source_pr.subprocess.run",
+        fake_run,
+    )
+    from hyperloom.orchestrator.actions.executors._patch_source_pr import DEFAULT_DIFF_MAX_BYTES
+
+    ok, err = _fetch_diff_to_path("https://example.test/pr.diff", dest, timeout_sec=5.0)
+    assert ok, err
+    assert "--max-filesize" in captured[0]
+    assert str(DEFAULT_DIFF_MAX_BYTES) in captured[0]
+
+
 def test_materialize_reports_no_patch_when_candidate_carries_no_source(tmp_path: Path):
     out = materialize_candidate_patches(
         candidate={},

--- a/src/hyperloom/inference_optimizer/tests/test_policy_gate.py
+++ b/src/hyperloom/inference_optimizer/tests/test_policy_gate.py
@@ -176,6 +176,21 @@ def test_rocm_runtime_write_denied(tmp_path: Path) -> None:
     assert exc.value.rule == "rocm_runtime_write_denied"
 
 
+def test_rocm_runtime_filter_does_not_apply_to_read_path_fields(tmp_path: Path, monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    from hyperloom.inference_optimizer.protocol.intent import IntentType
+
+    g = PolicyGate(role_registry=default_role_registry(), session_dir=tmp_path, strict_paths=True)
+    monkeypatch.setattr(g, "_path_under_session", lambda _path: True)
+
+    g._validate_payload_paths(
+        SimpleNamespace(name="kernel"),
+        IntentType.DELEGATE,
+        {"trace_input": "/opt/rocm/lib/runtime.trace.json"},
+    )
+
+
 # -- _check_freeform_task_description -------------------------------------
 def test_freeform_description_empty() -> None:
     with pytest.raises(PolicyDenied) as exc:

--- a/src/hyperloom/inference_optimizer/tests/test_policy_gate.py
+++ b/src/hyperloom/inference_optimizer/tests/test_policy_gate.py
@@ -157,6 +157,25 @@ def test_path_in_trace_allowlist(monkeypatch) -> None:
     assert g._path_in_trace_allowlist("/shared/profileX/run.json.gz") is False
 
 
+def test_rocm_runtime_write_denied(tmp_path: Path) -> None:
+    from types import SimpleNamespace
+
+    from hyperloom.inference_optimizer.protocol.intent import IntentType
+
+    g = PolicyGate(
+        role_registry=default_role_registry(),
+        session_dir=tmp_path,
+        strict_paths=True,
+    )
+    with pytest.raises(PolicyDenied) as exc:
+        g._validate_payload_paths(
+            SimpleNamespace(name="kernel"),
+            IntentType.DELEGATE,
+            {"target_file": "/opt/rocm/lib/libhip_hcc.so"},
+        )
+    assert exc.value.rule == "rocm_runtime_write_denied"
+
+
 # -- _check_freeform_task_description -------------------------------------
 def test_freeform_description_empty() -> None:
     with pytest.raises(PolicyDenied) as exc:

--- a/src/hyperloom/inference_optimizer/tests/test_recover_executor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_recover_executor.py
@@ -200,12 +200,33 @@ async def test_sigkill_fallthrough_when_pid_still_alive(tmp_path, monkeypatch):
 
     monkeypatch.setattr(exe, "_send_signal", _send)
     monkeypatch.setattr(exe, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(exe, "_pid_cmdline", lambda pid: "EngineCore worker")
     monkeypatch.setattr(recmod.time, "sleep", lambda _s: None)
 
     out = await exe(_ctx(workspace, params={"force_gpu_cleanup": True}))
     assert (7777, signal.SIGTERM) in sent
     assert (7777, signal.SIGKILL) in sent
     assert out["killed_pids"][0]["signal"] == "KILL"
+
+
+def test_sigkill_skips_pid_reused_after_sigterm(monkeypatch):
+    """The KILL phase revalidates ownership after its grace period."""
+    exe = RecoverExecutor()
+    monkeypatch.setattr(
+        exe,
+        "_discover_stale_pids",
+        lambda: [{"pid": 7777, "cmd": "EngineCore worker", "pattern": "EngineCore"}],
+    )
+    sent: list[tuple[int, signal.Signals]] = []
+    monkeypatch.setattr(exe, "_send_signal", lambda pid, sig: sent.append((pid, sig)) or True)
+    monkeypatch.setattr(exe, "_pid_alive", lambda _pid: True)
+    monkeypatch.setattr(exe, "_pid_cmdline", lambda _pid: "python unrelated.py")
+    monkeypatch.setattr(recmod.time, "sleep", lambda _s: None)
+
+    out = exe._kill_stale_owners()
+
+    assert sent == [(7777, signal.SIGTERM)]
+    assert out[0]["signal"] == "TERM"
 
 
 # Soft-cleanup failure path: leaked VRAM after kills -> needs_review.
@@ -666,6 +687,22 @@ class TestParseRocmSmiCsvEdgeCases:
 
 
 class TestKillStaleOwnersNoneSignalled:
+    def test_unrecognized_pidfile_owner_is_not_signalled(self, monkeypatch):
+        """A recycled PID with an unrelated cmdline is ignored."""
+        exe = RecoverExecutor()
+        monkeypatch.setattr(
+            exe,
+            "_discover_stale_pids",
+            lambda: [{"pid": 111, "cmd": "python unrelated.py", "pattern": "session_pidfile"}],
+        )
+        monkeypatch.setattr(
+            exe,
+            "_send_signal",
+            lambda _pid, _sig: pytest.fail("unrecognized owner must not be signalled"),
+        )
+
+        assert exe._kill_stale_owners() == []
+
     def test_all_sigterm_fail_returns_empty(self, monkeypatch):
         """If every SIGTERM fails to deliver, no wait/KILL and returns []."""
         exe = RecoverExecutor()

--- a/src/hyperloom/inference_optimizer/tests/test_recover_executor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_recover_executor.py
@@ -489,53 +489,31 @@ class TestSendAndAlive:
 
 
 class TestDiscoverStalePids:
-    def test_no_pgrep_returns_empty(self, monkeypatch):
-        monkeypatch.setattr(
-            "hyperloom.orchestrator.actions.executors.recover.shutil.which",
-            lambda name: None,
-        )
+    def test_no_session_dir_returns_empty(self):
         assert RecoverExecutor()._discover_stale_pids() == []
 
-    def test_parses_pgrep_output(self, monkeypatch):
-        monkeypatch.setattr(
-            "hyperloom.orchestrator.actions.executors.recover.shutil.which",
-            lambda name: "/usr/bin/pgrep",
-        )
-        scripted = {
-            "sglang.launch_server": "12345 python sglang.launch_server --port 8000",
-            "vllm.entrypoints": "12347 python vllm.entrypoints.api_server\n0 invalid",
-            "EngineCore": "",
-        }
-
-        def fake_run(cmd, *args, **kwargs):
-            pattern = cmd[-1]
-            output = scripted.get(pattern, "")
-            rc = 0 if output else 1
-            return _ProcResult(returncode=rc, stdout=output)
-
-        monkeypatch.setattr(
-            "hyperloom.orchestrator.actions.executors.recover.subprocess.run",
-            fake_run,
-        )
+    def test_parses_session_pidfiles(self, tmp_path):
+        runs = tmp_path / "runs" / "baseline"
+        runs.mkdir(parents=True)
+        (runs / "sglang_8000.pid").write_text("12345 12345\n", encoding="utf-8")
+        (runs / "vllm_8001.pid").write_text("12347\n", encoding="utf-8")
+        (runs / "empty.pid").write_text("\n", encoding="utf-8")
+        (runs / "bad.pid").write_text("notapid rest\n", encoding="utf-8")
         ex = RecoverExecutor()
-        ex.OWNER_PATTERNS = ("sglang.launch_server", "vllm.entrypoints", "EngineCore")
+        ex._active_session_dir = tmp_path
         out = ex._discover_stale_pids()
         pids = sorted(o["pid"] for o in out)
         assert pids == [12345, 12347]
+        assert all(o["pattern"] == "session_pidfile" for o in out)
 
-    def test_skips_own_pid(self, monkeypatch):
-        monkeypatch.setattr(
-            "hyperloom.orchestrator.actions.executors.recover.shutil.which",
-            lambda name: "/usr/bin/pgrep",
-        )
+    def test_skips_own_pid(self, tmp_path):
+        runs = tmp_path / "runs"
+        runs.mkdir()
         own_pid = os.getpid()
-        output = f"{own_pid} sglang.launch_server self\n12000 sglang.launch_server other"
-        monkeypatch.setattr(
-            "hyperloom.orchestrator.actions.executors.recover.subprocess.run",
-            lambda *a, **k: _ProcResult(returncode=0, stdout=output),
-        )
+        (runs / "self.pid").write_text(f"{own_pid}\n", encoding="utf-8")
+        (runs / "other.pid").write_text("12000\n", encoding="utf-8")
         ex = RecoverExecutor()
-        ex.OWNER_PATTERNS = ("sglang.launch_server",)
+        ex._active_session_dir = tmp_path
         out = ex._discover_stale_pids()
         assert [o["pid"] for o in out] == [12000]
 
@@ -713,72 +691,20 @@ class TestKillStaleOwnersNoneSignalled:
 
 
 class TestDiscoverStalePidsBranches:
-    def test_pgrep_timeout_is_skipped(self, monkeypatch):
-        """A pgrep TimeoutExpired for a pattern is logged and skipped."""
-        monkeypatch.setattr(recmod.shutil, "which", lambda name: "/usr/bin/pgrep")
-
-        def _boom(cmd, *a, **k):
-            raise subprocess.TimeoutExpired(cmd=cmd, timeout=3.0)
-
-        monkeypatch.setattr(recmod.subprocess, "run", _boom)
+    def test_missing_runs_dir_returns_empty(self, tmp_path):
         ex = RecoverExecutor()
-        ex.OWNER_PATTERNS = ("sglang.launch_server",)
+        ex._active_session_dir = tmp_path
         assert ex._discover_stale_pids() == []
 
-    def test_nonzero_nonone_returncode_is_skipped(self, monkeypatch):
-        """pgrep exit code not in (0, 1) is treated as an error and skipped."""
-        monkeypatch.setattr(recmod.shutil, "which", lambda name: "/usr/bin/pgrep")
-        monkeypatch.setattr(
-            recmod.subprocess,
-            "run",
-            lambda *a, **k: _ProcResult(returncode=2, stdout="9999 sglang.launch_server x"),
-        )
+    def test_duplicate_pid_is_deduped(self, tmp_path):
+        runs = tmp_path / "runs"
+        runs.mkdir()
+        (runs / "a.pid").write_text("5001 5001\n", encoding="utf-8")
+        (runs / "b.pid").write_text("5001\n", encoding="utf-8")
         ex = RecoverExecutor()
-        ex.OWNER_PATTERNS = ("sglang.launch_server",)
-        assert ex._discover_stale_pids() == []
-
-    def test_blank_and_single_token_lines_skipped(self, monkeypatch):
-        """Blank lines and single-token lines (no cmd) are skipped."""
-        monkeypatch.setattr(recmod.shutil, "which", lambda name: "/usr/bin/pgrep")
-        # Leading blank line, a single-token line (only pid), then a good match.
-        out = "\n   \n12345\n5001 sglang.launch_server --port 8000\n"
-        monkeypatch.setattr(
-            recmod.subprocess,
-            "run",
-            lambda *a, **k: _ProcResult(returncode=0, stdout=out),
-        )
-        ex = RecoverExecutor()
-        ex.OWNER_PATTERNS = ("sglang.launch_server",)
+        ex._active_session_dir = tmp_path
         found = ex._discover_stale_pids()
         assert [o["pid"] for o in found] == [5001]
-
-    def test_non_integer_pid_token_skipped(self, monkeypatch):
-        """A non-integer pid field is skipped."""
-        monkeypatch.setattr(recmod.shutil, "which", lambda name: "/usr/bin/pgrep")
-        out = "notapid sglang.launch_server foo\n7000 sglang.launch_server bar\n"
-        monkeypatch.setattr(
-            recmod.subprocess,
-            "run",
-            lambda *a, **k: _ProcResult(returncode=0, stdout=out),
-        )
-        ex = RecoverExecutor()
-        ex.OWNER_PATTERNS = ("sglang.launch_server",)
-        found = ex._discover_stale_pids()
-        assert [o["pid"] for o in found] == [7000]
-
-    def test_pattern_not_in_cmd_is_skipped(self, monkeypatch):
-        """Defence-in-depth substring check drops permissive-regex false positives."""
-        monkeypatch.setattr(recmod.shutil, "which", lambda name: "/usr/bin/pgrep")
-        # pgrep returns a row whose cmd does NOT literally contain the pattern.
-        out = "8000 python some_other_process --flag\n"
-        monkeypatch.setattr(
-            recmod.subprocess,
-            "run",
-            lambda *a, **k: _ProcResult(returncode=0, stdout=out),
-        )
-        ex = RecoverExecutor()
-        ex.OWNER_PATTERNS = ("sglang.launch_server",)
-        assert ex._discover_stale_pids() == []
 
 
 class TestPidAliveTrue:

--- a/src/hyperloom/inference_optimizer/tests/test_recover_executor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_recover_executor.py
@@ -687,6 +687,31 @@ class TestParseRocmSmiCsvEdgeCases:
 
 
 class TestKillStaleOwnersNoneSignalled:
+    def test_recorded_process_group_is_signalled(self, monkeypatch):
+        """A lifecycle pidfile entry reaps the full server process group."""
+        exe = RecoverExecutor()
+        monkeypatch.setattr(
+            exe,
+            "_discover_stale_pids",
+            lambda: [
+                {
+                    "pid": 111,
+                    "pgid": 222,
+                    "cmd": "python -m vllm.entrypoints.openai.api_server",
+                    "pattern": "session_pidfile",
+                }
+            ],
+        )
+        sent: list[tuple[int, signal.Signals]] = []
+        monkeypatch.setattr(exe, "_send_group_signal", lambda pgid, sig: sent.append((pgid, sig)) or True)
+        monkeypatch.setattr(exe, "_process_group_alive", lambda _pgid: False)
+        monkeypatch.setattr(recmod.time, "sleep", lambda _s: None)
+
+        out = exe._kill_stale_owners()
+
+        assert sent == [(222, signal.SIGTERM)]
+        assert out[0]["signal"] == "TERM"
+
     def test_unrecognized_pidfile_owner_is_not_signalled(self, monkeypatch):
         """A recycled PID with an unrelated cmdline is ignored."""
         exe = RecoverExecutor()
@@ -742,6 +767,17 @@ class TestDiscoverStalePidsBranches:
         ex._active_session_dir = tmp_path
         found = ex._discover_stale_pids()
         assert [o["pid"] for o in found] == [5001]
+
+    def test_dead_pidfile_is_removed_during_cleanup(self, tmp_path):
+        runs = tmp_path / "runs"
+        runs.mkdir()
+        pid_file = runs / "dead.pid"
+        pid_file.write_text("2147483646 2147483646\n", encoding="utf-8")
+        ex = RecoverExecutor()
+        ex._active_session_dir = tmp_path
+
+        assert ex._kill_stale_owners() == []
+        assert not pid_file.exists()
 
 
 class TestPidAliveTrue:

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_runner_helpers_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_runner_helpers_unit.py
@@ -56,6 +56,19 @@ def test_safe_redact_bare_gateway_token_shapes():
     assert out.count("[REDACTED]") == 3
 
 
+def test_safe_redact_aws_and_custom_headers():
+    line = (
+        "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY "
+        "AWS_SESSION_TOKEN=FwoGZXIvYXdzEHsaDNEXAMPLETOKEN "
+        "ANTHROPIC_CUSTOM_HEADERS=Ocp-Apim-Subscription-Key: deadbeefsecret"
+    )
+    out = sr._safe_redact(line)
+    assert "wJalrXUtnFEMI" not in out
+    assert "FwoGZXIvYXdzEHsaDNEXAMPLETOKEN" not in out
+    assert "deadbeefsecret" not in out
+    assert "[REDACTED]" in out
+
+
 def test_extra_focus_tags(monkeypatch):
     monkeypatch.setattr(sr, "normalize_dispatch_tags", lambda params: ["anchor", "extra1", "extra2", ""])
     domain = SimpleNamespace(kb_anchor="anchor")

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_runner_helpers_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_runner_helpers_unit.py
@@ -36,6 +36,7 @@ def test_safe_redact():
     assert "GITHUB_TOKEN=[REDACTED]" in out
     assert "redact_me" not in out
     assert "redact_me_too" not in out
+    assert "[REDACTED]]" not in out
     assert sr._safe_redact("plain line") == "plain line"
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_trace_utils.py
+++ b/src/hyperloom/inference_optimizer/tests/test_trace_utils.py
@@ -286,6 +286,12 @@ def test_redact_secrets_strips_bearer_and_env_shapes():
     assert "abcd1234efgh" not in out
 
 
+def test_redact_secrets_masks_custom_headers():
+    out = ct.redact_secrets("ANTHROPIC_CUSTOM_HEADERS=Ocp-Apim-Subscription-Key: deadbeefsecret")
+    assert "deadbeefsecret" not in out
+    assert "[REDACTED]" in out
+
+
 def test_coerce_text_none_and_non_str():
     assert ct._coerce_text(None) == ""
     assert ct._coerce_text(123) == "123"

--- a/src/hyperloom/orchestrator/actions/executors/_patch_source_pr.py
+++ b/src/hyperloom/orchestrator/actions/executors/_patch_source_pr.py
@@ -30,6 +30,8 @@ log = logging.getLogger(__name__)
 #: Timeout for fetching a served diff. The worktree route is given four times
 #: this, because it clones and diffs rather than downloading one file.
 DEFAULT_DIFF_FETCH_TIMEOUT_SEC: float = 30.0
+#: Cap on a downloaded unified-diff body (bytes). Larger payloads are refused.
+DEFAULT_DIFF_MAX_BYTES: int = 32 * 1024 * 1024
 
 
 def _git_head_sha(framework_root: Path) -> tuple[str | None, str]:
@@ -123,6 +125,8 @@ def _fetch_diff_to_path(
         "2",
         "--max-time",
         str(int(timeout_sec)),
+        "--max-filesize",
+        str(DEFAULT_DIFF_MAX_BYTES),
         "-o",
         str(dest),
         diff_url,
@@ -141,6 +145,9 @@ def _fetch_diff_to_path(
         return False, (cp.stderr or "").strip()
     if not dest.exists() or dest.stat().st_size == 0:
         return False, "curl wrote empty / missing file"
+    if dest.stat().st_size > DEFAULT_DIFF_MAX_BYTES:
+        dest.unlink(missing_ok=True)
+        return False, "diff exceeds max bytes"
     return True, ""
 
 

--- a/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
+++ b/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
@@ -30,6 +30,7 @@ from hyperloom.common.timeutil import now_iso
 from hyperloom.inference_optimizer.gpu_types import amd_gpu_dispatch_identity
 from hyperloom.inference_optimizer.session.session_paths import runs_dir
 from ...framework.paths import (
+    is_rocm_hip_writable_path,
     resolve_session_framework_root,
     resolve_source_file_allowlist,
     resolved_within,
@@ -735,7 +736,7 @@ def _localization_paths_outside_allowlist(
             continue
         base = framework_root if framework_root is not None else Path("/")
         cand = (base / rel_s).resolve() if not Path(rel_s).is_absolute() else Path(rel_s).resolve()
-        if not any(_is_within(cand, root) for root in roots):
+        if not any(_is_within(cand, root) for root in roots) or not is_rocm_hip_writable_path(str(cand)):
             outside.append(rel_s)
     return outside
 
@@ -1389,20 +1390,20 @@ def _resolve_artifact_target(rel_target: str) -> tuple[Path, str, Path] | None:
     if Path(rel).is_absolute():
         cand = Path(rel).resolve()
         for root in roots:
-            if _is_within(cand, root):
+            if _is_within(cand, root) and is_rocm_hip_writable_path(str(cand)):
                 return cand, cand.relative_to(root).as_posix(), root
         return None
     # Prefer a root whose tree already holds the target's parent dir.
     for root in roots:
         cand = (root / rel).resolve()
-        if not _is_within(cand, root):
+        if not _is_within(cand, root) or not is_rocm_hip_writable_path(str(cand)):
             continue
         if cand.parent.is_dir():
             return cand, cand.relative_to(root).as_posix(), root
     # Fall back to the first root that keeps the path contained.
     for root in roots:
         cand = (root / rel).resolve()
-        if _is_within(cand, root):
+        if _is_within(cand, root) and is_rocm_hip_writable_path(str(cand)):
             return cand, cand.relative_to(root).as_posix(), root
     return None
 

--- a/src/hyperloom/orchestrator/actions/executors/recover.py
+++ b/src/hyperloom/orchestrator/actions/executors/recover.py
@@ -7,8 +7,9 @@ Counterpart of the Robustness ``gpu_memory_leaked`` signal: when a crashed
 server leaves the ROCm KFD tables attributing VRAM to dead PIDs, every
 subsequent server start aborts on insufficient free memory. Invoked via
 ``delegate{action_name="recover", ...}`` (Robustness-only by PolicyGate)
-for a soft cleanup: ``pgrep`` stale owners, SIGTERM, wait
-``SERVER_KILL_WAIT_S``, SIGKILL survivors.
+for a soft cleanup: SIGTERM then SIGKILL owners recorded in this session's
+pidfiles, wait ``SERVER_KILL_WAIT_S``, SIGKILL survivors. Co-located
+sessions and host-wide ``pgrep`` matches are never signalled.
 
 We deliberately do NOT reload amdgpu, reset the GPU, restart the pod/Ray
 head, or touch persistent runtime config (would kill the optimizer, need
@@ -131,6 +132,7 @@ class RecoverExecutor:
         reason = str(params.get("reason", ""))
         force_cleanup = bool(params.get("force_gpu_cleanup", False))
         workspace = self._workspace_dir(ctx)
+        self._active_session_dir = self._session_dir(ctx)
 
         log.info(
             "recover_executor: start reason=%r force=%s",
@@ -219,6 +221,23 @@ class RecoverExecutor:
             return None
         try:
             return Path(ws)
+        except (TypeError, ValueError):
+            return None
+
+    def _session_dir(self, ctx: RunnerContext) -> Path | None:
+        """Resolve the session directory that owns recover pidfiles.
+
+        Args:
+            ctx (RunnerContext): The action runner context.
+
+        Returns:
+            Path | None: The session path, or ``None`` when none is configured.
+        """
+        sd = (ctx.extra or {}).get("session_dir")
+        if not sd:
+            return None
+        try:
+            return Path(sd)
         except (TypeError, ValueError):
             return None
 
@@ -355,9 +374,9 @@ class RecoverExecutor:
             isinstance(snap.get("free_mb"), (int, float)) and snap["free_mb"] >= self.FREE_MB_HEALTHY for snap in gpus
         )
 
-    # soft cleanup — pgrep + kill loop
+    # soft cleanup — session pidfiles + kill loop
     def _kill_stale_owners(self) -> list[dict[str, Any]]:
-        """SIGTERM then SIGKILL stale owners matching :data:`OWNER_PATTERNS`.
+        """SIGTERM then SIGKILL owners recorded in this session's pidfiles.
 
         Returns one record per signalled PID (cmdline at discovery + final
         signal name ``"TERM"`` / ``"KILL"``).
@@ -384,51 +403,47 @@ class RecoverExecutor:
                 entry["signal"] = "KILL"
         return killed
 
+    @staticmethod
+    def _pid_cmdline(pid: int) -> str:
+        """Best-effort cmdline from ``/proc``; empty when the pid is gone."""
+        try:
+            raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+        except OSError:
+            return ""
+        return raw.replace(b"\x00", b" ").decode("utf-8", "replace").strip()
+
     def _discover_stale_pids(self) -> list[dict[str, Any]]:
-        """Run ``pgrep -a -f -- <pattern>`` per owner pattern (matches the
-        full cmdline) and return unique PID records, excluding our own PID.
+        """Return unique PIDs from this session's ``runs/**/*.pid`` files.
+
+        Host-wide ``pgrep`` is not used: only processes this session recorded
+        are candidates. Missing ``session_dir`` yields an empty list.
 
         Returns:
-            Unique PID records matching the owner patterns, or ``[]`` when
-            ``pgrep`` is unavailable or nothing matched.
+            Unique PID records from session pidfiles, excluding our own PID.
         """
-        if not shutil.which("pgrep"):
-            log.warning("recover_executor: pgrep not on PATH; skipping kill stage")
+        session_dir = getattr(self, "_active_session_dir", None)
+        if session_dir is None:
+            return []
+        runs = Path(session_dir) / "runs"
+        if not runs.is_dir():
             return []
         own_pid = os.getpid()
         seen: dict[int, dict[str, Any]] = {}
-        for pattern in self.OWNER_PATTERNS:
+        for pid_file in sorted(runs.rglob("*.pid")):
             try:
-                proc = subprocess.run(
-                    ["pgrep", "-a", "-f", "--", pattern],
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                    timeout=3.0,
-                )
-            except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
-                log.warning("recover_executor: pgrep(%r) failed: %s", pattern, exc)
+                parts = pid_file.read_text(encoding="utf-8").split()
+            except OSError:
                 continue
-            if proc.returncode not in (0, 1):  # 1 = no matches
+            if not parts:
                 continue
-            for line in proc.stdout.splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                parts = line.split(None, 1)
-                if len(parts) < 2:
-                    continue
-                try:
-                    pid = int(parts[0])
-                except ValueError:
-                    continue
-                cmd = parts[1]
-                if pid == own_pid:
-                    continue
-                # Confirm the pattern via plain substring (pgrep's regex is permissive).
-                if pattern not in cmd:
-                    continue
-                seen[pid] = {"pid": pid, "cmd": cmd, "pattern": pattern}
+            try:
+                pid = int(parts[0])
+            except ValueError:
+                continue
+            if pid == own_pid:
+                continue
+            cmd = self._pid_cmdline(pid) or str(pid_file)
+            seen[pid] = {"pid": pid, "cmd": cmd, "pattern": "session_pidfile"}
         return list(seen.values())
 
     def _send_signal(self, pid: int, sig: signal.Signals) -> bool:

--- a/src/hyperloom/orchestrator/actions/executors/recover.py
+++ b/src/hyperloom/orchestrator/actions/executors/recover.py
@@ -47,6 +47,7 @@ from pathlib import Path
 from typing import Any
 
 from ...loop.sub_agent_runner import RunnerContext
+from ._server_lifecycle import _pid_cmdline as _shared_pid_cmdline
 
 
 log = logging.getLogger(__name__)
@@ -111,6 +112,7 @@ class RecoverExecutor:
     FREE_MB_HEALTHY: float = 500.0
     # Owner patterns enforced by ``_kill_stale_owners``.
     OWNER_PATTERNS: tuple[str, ...] = _OWNER_PATTERNS
+    _pid_cmdline = staticmethod(_shared_pid_cmdline)
 
     async def __call__(self, ctx: RunnerContext) -> dict[str, Any]:
         """Run the GPU recovery sequence and report the outcome.
@@ -397,9 +399,16 @@ class RecoverExecutor:
                     "recover_executor: pid %d is not a recognized session owner; not signalling",
                     pid,
                 )
+                self._remove_finished_pidfile(entry)
                 continue
             entry["pattern"] = pattern
-            if self._send_signal(pid, signal.SIGTERM):
+            pgid = entry.get("pgid")
+            sent = (
+                self._send_group_signal(int(pgid), signal.SIGTERM) or self._send_signal(pid, signal.SIGTERM)
+                if isinstance(pgid, int)
+                else self._send_signal(pid, signal.SIGTERM)
+            )
+            if sent:
                 entry["signal"] = "TERM"
                 killed.append(entry)
         if not killed:
@@ -408,20 +417,89 @@ class RecoverExecutor:
         time.sleep(self.SERVER_KILL_WAIT_S)
         for entry in killed:
             pid = entry["pid"]
-            current_cmd = self._pid_cmdline(pid)
-            still_owned = any(marker in current_cmd for marker in self.OWNER_PATTERNS)
-            if self._pid_alive(pid) and still_owned and self._send_signal(pid, signal.SIGKILL):
+            pgid = entry.get("pgid")
+            if isinstance(pgid, int):
+                still_owned = bool(self._process_group_owner_cmd(pgid))
+                alive = self._process_group_alive(pgid)
+                if alive and still_owned:
+                    sent = self._send_group_signal(pgid, signal.SIGKILL)
+                else:
+                    current_cmd = self._pid_cmdline(pid)
+                    pid_owned = any(marker in current_cmd for marker in self.OWNER_PATTERNS)
+                    sent = self._pid_alive(pid) and pid_owned and self._send_signal(pid, signal.SIGKILL)
+            else:
+                current_cmd = self._pid_cmdline(pid)
+                still_owned = any(marker in current_cmd for marker in self.OWNER_PATTERNS)
+                sent = self._pid_alive(pid) and still_owned and self._send_signal(pid, signal.SIGKILL)
+            if sent:
                 entry["signal"] = "KILL"
+            self._remove_finished_pidfile(entry, force=bool(sent))
         return killed
 
-    @staticmethod
-    def _pid_cmdline(pid: int) -> str:
-        """Best-effort cmdline from ``/proc``; empty when the pid is gone."""
+    def _send_group_signal(self, pgid: int, sig: signal.Signals) -> bool:
+        """Signal an owned process group without touching our own group."""
+        if os.name != "posix" or pgid <= 0 or pgid == os.getpgrp():
+            return False
         try:
-            raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+            os.killpg(pgid, sig)
+            return True
+        except ProcessLookupError:
+            return False
+        except OSError as exc:
+            log.warning("recover_executor: cannot signal pgid=%d sig=%s: %s", pgid, sig.name, exc)
+            return False
+
+    @staticmethod
+    def _process_group_alive(pgid: int) -> bool:
+        """Return whether a POSIX process group still has members."""
+        if os.name != "posix":
+            return False
+        try:
+            os.killpg(pgid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+
+    def _process_group_owner_cmd(self, pgid: int) -> str:
+        """Return a recognized owner cmdline from ``pgid``, if one exists."""
+        try:
+            entries = list(Path("/proc").iterdir())
         except OSError:
             return ""
-        return raw.replace(b"\x00", b" ").decode("utf-8", "replace").strip()
+        for entry in entries:
+            if not entry.name.isdigit():
+                continue
+            try:
+                stat = (entry / "stat").read_text(encoding="utf-8")
+                entry_pgid = int(stat.rsplit(")", 1)[1].split()[2])
+            except (IndexError, OSError, ValueError):
+                continue
+            if entry_pgid != pgid:
+                continue
+            cmd = self._pid_cmdline(int(entry.name))
+            if any(marker in cmd for marker in self.OWNER_PATTERNS):
+                return cmd
+        return ""
+
+    def _remove_finished_pidfile(self, entry: dict[str, Any], *, force: bool = False) -> None:
+        """Remove a pidfile after its recorded process group has exited."""
+        pid_file = entry.get("pid_file")
+        if not isinstance(pid_file, str):
+            return
+        pgid = entry.get("pgid")
+        alive = self._pid_alive(entry["pid"])
+        if isinstance(pgid, int):
+            alive = alive or self._process_group_alive(pgid)
+        if alive and not force:
+            return
+        path = Path(pid_file)
+        for candidate in (path, path.with_suffix(".json")):
+            try:
+                candidate.unlink()
+            except OSError:
+                pass
 
     def _discover_stale_pids(self) -> list[dict[str, Any]]:
         """Return unique PIDs from this session's ``runs/**/*.pid`` files.
@@ -453,8 +531,20 @@ class RecoverExecutor:
                 continue
             if pid == own_pid:
                 continue
-            cmd = self._pid_cmdline(pid) or str(pid_file)
-            seen[pid] = {"pid": pid, "cmd": cmd, "pattern": "session_pidfile"}
+            try:
+                pgid = int(parts[1]) if len(parts) > 1 else pid
+            except ValueError:
+                pgid = pid
+            cmd = self._pid_cmdline(pid)
+            if not cmd and pgid != own_pid:
+                cmd = self._process_group_owner_cmd(pgid)
+            seen[pid] = {
+                "pid": pid,
+                "pgid": pgid,
+                "pid_file": str(pid_file),
+                "cmd": cmd,
+                "pattern": "session_pidfile",
+            }
         return list(seen.values())
 
     def _send_signal(self, pid: int, sig: signal.Signals) -> bool:

--- a/src/hyperloom/orchestrator/actions/executors/recover.py
+++ b/src/hyperloom/orchestrator/actions/executors/recover.py
@@ -390,6 +390,15 @@ class RecoverExecutor:
         killed: list[dict[str, Any]] = []
         for entry in candidates:
             pid = entry["pid"]
+            cmd = str(entry.get("cmd", ""))
+            pattern = next((marker for marker in self.OWNER_PATTERNS if marker in cmd), None)
+            if pattern is None:
+                log.warning(
+                    "recover_executor: pid %d is not a recognized session owner; not signalling",
+                    pid,
+                )
+                continue
+            entry["pattern"] = pattern
             if self._send_signal(pid, signal.SIGTERM):
                 entry["signal"] = "TERM"
                 killed.append(entry)
@@ -399,7 +408,9 @@ class RecoverExecutor:
         time.sleep(self.SERVER_KILL_WAIT_S)
         for entry in killed:
             pid = entry["pid"]
-            if self._pid_alive(pid) and self._send_signal(pid, signal.SIGKILL):
+            current_cmd = self._pid_cmdline(pid)
+            still_owned = any(marker in current_cmd for marker in self.OWNER_PATTERNS)
+            if self._pid_alive(pid) and still_owned and self._send_signal(pid, signal.SIGKILL):
                 entry["signal"] = "KILL"
         return killed
 

--- a/src/hyperloom/orchestrator/actions/executors/recover.py
+++ b/src/hyperloom/orchestrator/actions/executors/recover.py
@@ -499,6 +499,7 @@ class RecoverExecutor:
             try:
                 candidate.unlink()
             except OSError:
+                # Best-effort cleanup: an absent or locked pidfile is not an error.
                 pass
 
     def _discover_stale_pids(self) -> list[dict[str, Any]]:

--- a/src/hyperloom/orchestrator/framework/paths.py
+++ b/src/hyperloom/orchestrator/framework/paths.py
@@ -108,6 +108,56 @@ def resolve_rocm_hip_source_roots() -> tuple[str, ...]:
     return _ROCM_HIP_SOURCE_ROOTS
 
 
+#: File types an enablement patch may write under the ROCm/HIP roots.
+#: Runtime objects (``.so``, binaries) stay readable via the source allowlist
+#: but are not writable through localization or artifact install.
+_ROCM_HIP_WRITE_SUFFIXES: frozenset[str] = frozenset(
+    {
+        ".c",
+        ".cc",
+        ".cpp",
+        ".cxx",
+        ".cu",
+        ".cuh",
+        ".h",
+        ".hh",
+        ".hpp",
+        ".hxx",
+        ".hip",
+        ".cl",
+        ".cmake",
+        ".txt",
+        ".in",
+        ".py",
+        ".s",
+        ".S",
+        ".asm",
+        ".inc",
+        ".inl",
+    }
+)
+_ROCM_HIP_WRITE_NAMES: frozenset[str] = frozenset({"cmakelists.txt", "makefile"})
+
+
+def is_rocm_hip_path(value: str) -> bool:
+    """True when ``value`` resolves under a ROCm/HIP source root."""
+    return any(resolved_within(value, root) for root in resolve_rocm_hip_source_roots())
+
+
+def is_rocm_hip_writable_path(value: str) -> bool:
+    """True when ``value`` may be written (not a ROCm runtime object).
+
+    Non-ROCm paths return True so callers can AND this with their own
+    allowlist. Paths under ``/opt/rocm/`` must be source/header/CMake files.
+    """
+    if not is_rocm_hip_path(value):
+        return True
+    path = Path(str(value))
+    if path.name.lower() in _ROCM_HIP_WRITE_NAMES:
+        return True
+    return path.suffix.lower() in _ROCM_HIP_WRITE_SUFFIXES
+
+
 # FlyDSL checkout roots. Env overrides come first, then the image defaults.
 _FLYDSL_ROOT_ENV_KEYS: tuple[str, ...] = ("DSL2_ROOT", "FLYDSL_ROOT")
 _FLYDSL_DEFAULT_ROOTS: tuple[str, ...] = ("/opt/flydsl/", "/sgl-workspace/flydsl/")
@@ -736,6 +786,8 @@ __all__ = [
     "resolve_kernel_search_roots",
     "resolve_patch_target_roots",
     "resolve_rocm_hip_source_roots",
+    "is_rocm_hip_path",
+    "is_rocm_hip_writable_path",
     "resolve_session_framework_root",
     "resolve_source_file_allowlist",
     "resolved_within",

--- a/src/hyperloom/orchestrator/framework/paths.py
+++ b/src/hyperloom/orchestrator/framework/paths.py
@@ -130,7 +130,6 @@ _ROCM_HIP_WRITE_SUFFIXES: frozenset[str] = frozenset(
         ".in",
         ".py",
         ".s",
-        ".S",
         ".asm",
         ".inc",
         ".inl",

--- a/src/hyperloom/orchestrator/framework/paths.py
+++ b/src/hyperloom/orchestrator/framework/paths.py
@@ -152,7 +152,10 @@ def is_rocm_hip_writable_path(value: str) -> bool:
     """
     if not is_rocm_hip_path(value):
         return True
-    path = Path(str(value))
+    try:
+        path = Path(str(value)).resolve()
+    except (OSError, RuntimeError):
+        return False
     if path.name.lower() in _ROCM_HIP_WRITE_NAMES:
         return True
     return path.suffix.lower() in _ROCM_HIP_WRITE_SUFFIXES

--- a/src/hyperloom/orchestrator/policy/gate.py
+++ b/src/hyperloom/orchestrator/policy/gate.py
@@ -436,6 +436,9 @@ PATH_LIKE_FIELDS: frozenset[str] = frozenset(
 # scopes outside the session directory. Real-path containment prevents escapes.
 SOURCE_LIKE_FIELDS: frozenset[str] = frozenset({"source_file", "framework_source_root"})
 
+# Payload fields that name files modified by patch/install actions.
+ROCM_WRITE_PATH_FIELDS: frozenset[str] = frozenset({"patch_path", "target_file", "resolved_patch_targets"})
+
 # Coordinator-owned warm replay may deploy a KB patch into the active framework
 # checkout.  The exception is intentionally narrower than SOURCE_LIKE_FIELDS:
 # only target_file values paired with a patch downloaded into this session's
@@ -1992,7 +1995,7 @@ class PolicyGate:
                 )
             if key not in PATH_LIKE_FIELDS:
                 return
-            if not is_rocm_hip_writable_path(node):
+            if key in ROCM_WRITE_PATH_FIELDS and not is_rocm_hip_writable_path(node):
                 raise PolicyDenied(
                     f"role={role.name!r} {intent_type.value} payload field "
                     f"{key!r}={node!r} is a ROCm runtime path, not HIP source",
@@ -2255,6 +2258,7 @@ __all__ = [
     "REQUEST_ROUTING",
     "REVIEW_VERDICTS",
     "REVIEW_VERDICT_SOURCE_ALLOWLIST",
+    "ROCM_WRITE_PATH_FIELDS",
     "ROBUSTNESS_ONLY_INTENTS",
     "ROBUSTNESS_ONLY_SOURCE_ALLOWLIST",
     "TRACE_PATH_LIKE_FIELDS",

--- a/src/hyperloom/orchestrator/policy/gate.py
+++ b/src/hyperloom/orchestrator/policy/gate.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
 
 from ..framework.paths import (
+    is_rocm_hip_writable_path,
     resolve_session_framework_root,
     resolve_source_file_allowlist,
     resolved_within,
@@ -1991,6 +1992,13 @@ class PolicyGate:
                 )
             if key not in PATH_LIKE_FIELDS:
                 return
+            if not is_rocm_hip_writable_path(node):
+                raise PolicyDenied(
+                    f"role={role.name!r} {intent_type.value} payload field "
+                    f"{key!r}={node!r} is a ROCm runtime path, not HIP source",
+                    rule="rocm_runtime_write_denied",
+                    hint="ROCm writes are limited to source, header, and CMake files",
+                )
             if not self._path_under_session(node):
                 if key in {"target_file", "resolved_patch_targets"} and trusted_framework_targets:
                     try:

--- a/src/hyperloom/orchestrator/specialists/runner.py
+++ b/src/hyperloom/orchestrator/specialists/runner.py
@@ -138,7 +138,8 @@ _SECRET_ENV_NAMES: tuple[str, ...] = tuple(
 _SECRET_ASSIGNMENT_RE = re.compile(
     r"(?P<key>\b(?:"
     + "|".join(re.escape(name) for name in _SECRET_ENV_NAMES)
-    + r")\b)(?P<sep>\s*(?:=|:)\s*)(?P<quote>['\"]?)(?P<value>[^\s,'\"\]}]+)(?P=quote)",
+    + r")\b)(?P<sep>\s*(?:=|:)\s*)(?P<quote>['\"]?)(?!\[REDACTED\])"
+    + r"(?P<value>[^\s,'\"\]}]+)(?P=quote)",
     re.IGNORECASE,
 )
 
@@ -250,7 +251,7 @@ def _safe_redact(s: str) -> str:
         lambda m: f"{m.group('key')}{m.group('sep')}{m.group('quote')}[REDACTED]{m.group('quote')}",
         out,
     )
-    return redact_secret_values(out)
+    return out
 
 
 def _redact_transcript_value(value: Any) -> Any:

--- a/src/hyperloom/orchestrator/specialists/runner.py
+++ b/src/hyperloom/orchestrator/specialists/runner.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from hyperloom.common import io as _common_io
+from hyperloom.common.env_safety import BENCHMARK_SECRET_ENV_NAMES, redact_secret_values
 from hyperloom.common.timeutil import now_iso
 
 from hyperloom.inference_optimizer.session.session_paths import runs_dir, specialist_intel_path
@@ -109,34 +110,36 @@ SPECIALIST_TOOL_DENYLIST: frozenset[str] = frozenset(
 _now_iso = now_iso
 
 
-_SECRET_ENV_NAMES: tuple[str, ...] = (
-    "ANTHROPIC_API_KEY",
-    "CLAW_API_KEY",
-    "GITHUB_TOKEN",
-    "HF_TOKEN",
-    "HF_TOKEN_2",
-    "HYPERLOOM_GIT_TOKEN",
-    "HYPERLOOM_PR_CI_GH_TOKEN",
-    "LLM_API_KEY",
-    "OPENAI_API_KEY",
-    # Legacy: not consumed anymore, still redacted if present.
-    "SAFE_API_KEY",
+_SECRET_ENV_NAMES: tuple[str, ...] = tuple(
+    sorted(
+        {
+            *BENCHMARK_SECRET_ENV_NAMES,
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_AUTH_TOKEN",
+            "ANTHROPIC_CUSTOM_HEADERS",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "CLAW_API_KEY",
+            "GITHUB_TOKEN",
+            "HF_TOKEN",
+            "HF_TOKEN_2",
+            "HYPERLOOM_GIT_TOKEN",
+            "HYPERLOOM_PR_CI_GH_TOKEN",
+            "LLM_API_KEY",
+            "LLM_GATEWAY_KEY",
+            "OPENAI_API_KEY",
+            "OPENAI_CUSTOM_HEADERS",
+            "SAFE_API_KEY",
+        }
+    )
 )
 _SECRET_ASSIGNMENT_RE = re.compile(
     r"(?P<key>\b(?:"
     + "|".join(re.escape(name) for name in _SECRET_ENV_NAMES)
     + r")\b)(?P<sep>\s*(?:=|:)\s*)(?P<quote>['\"]?)(?P<value>[^\s,'\"\]}]+)(?P=quote)",
     re.IGNORECASE,
-)
-_AUTHORIZATION_RE = re.compile(r"(?i)\b(?P<prefix>authorization\s*:\s*(?:bearer\s+)?)(?P<value>[A-Za-z0-9._~+/=-]+)")
-_BEARER_RE = re.compile(r"(?i)\b(?P<prefix>bearer\s+)(?P<value>[A-Za-z0-9._~+/=-]+)")
-_TOKEN_VALUE_RES = (
-    # Keep in sync with env_safety.redact_secret_values().
-    re.compile(r"\b(?:ak|pk|sk)-[A-Za-z0-9_-]{3,}\b"),
-    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{3,}\b"),
-    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{10,}\b"),
-    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
-    re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"),
 )
 
 
@@ -242,15 +245,12 @@ def _safe_redact(s: str) -> str:
         str: The line with recognised secret values replaced by
             ``[REDACTED]``.
     """
+    out = redact_secret_values(s)
     out = _SECRET_ASSIGNMENT_RE.sub(
         lambda m: f"{m.group('key')}{m.group('sep')}{m.group('quote')}[REDACTED]{m.group('quote')}",
-        s,
+        out,
     )
-    out = _AUTHORIZATION_RE.sub(lambda m: f"{m.group('prefix')}[REDACTED]", out)
-    out = _BEARER_RE.sub(lambda m: f"{m.group('prefix')}[REDACTED]", out)
-    for token_re in _TOKEN_VALUE_RES:
-        out = token_re.sub("[REDACTED]", out)
-    return out
+    return redact_secret_values(out)
 
 
 def _redact_transcript_value(value: Any) -> Any:
@@ -815,7 +815,7 @@ class SpecialistRunner:
                         "turn": turn,
                         "ts": ts,
                         "tool": str(call.get("tool") or "tool"),
-                        "query": call.get("query"),
+                        "query": _redact_transcript_value(call.get("query")),
                     }
                     f.write(json.dumps(row, sort_keys=True) + "\n")
         except Exception:  # noqa: BLE001 — trace must never break the run

--- a/src/hyperloom/orchestrator/specialists/subprocess_.py
+++ b/src/hyperloom/orchestrator/specialists/subprocess_.py
@@ -1059,6 +1059,8 @@ class SpecialistSubprocessDispatcher:
             try:
                 process_log.chmod(0o600)
             except OSError:
+                # Tightening the mode is advisory; the run continues on filesystems
+                # that reject chmod.
                 pass
             stdin_fh: Any = None
             try:

--- a/src/hyperloom/orchestrator/specialists/subprocess_.py
+++ b/src/hyperloom/orchestrator/specialists/subprocess_.py
@@ -1111,8 +1111,10 @@ class SpecialistSubprocessDispatcher:
         finally:
             if log_fh is not None:
                 log_fh.close()
-            await asyncio.to_thread(redact_file_in_place, process_log, mode=0o600)
-            clear_wall_budget_extension(task_id)
+            try:
+                await asyncio.to_thread(redact_file_in_place, process_log, mode=0o600)
+            finally:
+                clear_wall_budget_extension(task_id)
 
         # Patches: harvest from the worktree via git diff first; fall back to disk scan.
         patches, collected_patch_roots = self._collect_patches(worktree, workspace, worktree_base)

--- a/src/hyperloom/orchestrator/specialists/subprocess_.py
+++ b/src/hyperloom/orchestrator/specialists/subprocess_.py
@@ -47,6 +47,7 @@ from hyperloom.common.env import is_truthy
 from hyperloom.common.llm_attribution import inject_env as inject_attribution_env
 from hyperloom.common.env_safety import (
     BLOCKED_CHILD_ENV_NAMES,
+    redact_file_in_place,
     scrub_child_process_env,
     valid_env_key,
 )
@@ -1055,6 +1056,10 @@ class SpecialistSubprocessDispatcher:
         else:
             proc_started = time.monotonic()
             log_fh = process_log.open("w", encoding="utf-8")
+            try:
+                process_log.chmod(0o600)
+            except OSError:
+                pass
             stdin_fh: Any = None
             try:
                 stdin_fh = prompt_file.open("rb")
@@ -1106,6 +1111,7 @@ class SpecialistSubprocessDispatcher:
         finally:
             if log_fh is not None:
                 log_fh.close()
+            redact_file_in_place(process_log, mode=0o600)
             clear_wall_budget_extension(task_id)
 
         # Patches: harvest from the worktree via git diff first; fall back to disk scan.

--- a/src/hyperloom/orchestrator/specialists/subprocess_.py
+++ b/src/hyperloom/orchestrator/specialists/subprocess_.py
@@ -1111,7 +1111,7 @@ class SpecialistSubprocessDispatcher:
         finally:
             if log_fh is not None:
                 log_fh.close()
-            redact_file_in_place(process_log, mode=0o600)
+            await asyncio.to_thread(redact_file_in_place, process_log, mode=0o600)
             clear_wall_budget_extension(task_id)
 
         # Patches: harvest from the worktree via git diff first; fall back to disk scan.

--- a/src/hyperloom/orchestrator/trace/conversation_trace.py
+++ b/src/hyperloom/orchestrator/trace/conversation_trace.py
@@ -23,10 +23,11 @@ Design contract:
 from __future__ import annotations
 
 import logging
-import re
 from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any
+
+from hyperloom.common.env_safety import redact_secret_values
 
 from hyperloom.common.io import append_jsonl
 from hyperloom.common.timeutil import now_iso
@@ -65,48 +66,15 @@ class ConversationRowError(ValueError):
     """Raised when a conversation row violates the closed schema."""
 
 
-# Secret redaction. Each pattern keeps a leading "label" group and replaces the
-# trailing secret value with a placeholder. Ordered most-specific first.
-_REDACT_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
-    # Authorization: Bearer <token>
-    (re.compile(r"(?i)(bearer\s+)[A-Za-z0-9\-_.=]{8,}"), r"\1[REDACTED]"),
-    # Provider key prefixes: ak-, sk-, pk-, sk-lf-, pk-lf- ...
-    (re.compile(r"\b((?:ak|sk|pk)-(?:lf-)?)[A-Za-z0-9\-_]{6,}"), r"\1[REDACTED]"),
-    # GitHub tokens: ghp_, gho_, ghs_, ghr_, github_pat_
-    (re.compile(r"\b(gh[pousr]_|github_pat_)[A-Za-z0-9_]{10,}"), r"\1[REDACTED]"),
-    # KEY=value / TOKEN=value / SECRET=value / PASSWORD=value (env shape)
-    (
-        re.compile(
-            r"(?i)\b([A-Z0-9_]*"
-            r"(?:API_?KEY|TOKEN|SECRET|PASSWORD|AUTH|CREDENTIAL)"
-            r"[A-Z0-9_]*\s*[=:]\s*)"
-            r"[^\s,;'\"]+"
-        ),
-        r"\1[REDACTED]",
-    ),
-)
-
-
 def redact_secrets(text: str) -> str:
     """Strip obvious secret *values* from ``text`` before it hits disk.
 
-    Conservative and idempotent: the label / prefix is preserved so the
-    redacted line still reads sensibly, only the secret material is
-    replaced with ``[REDACTED]``. Returns ``text`` unchanged when it
-    carries no recognizable secret shape.
-
-    Args:
-        text: Raw text that may embed secret values.
-
-    Returns:
-        The text with recognizable secret values replaced by ``[REDACTED]``.
+    Delegates to :func:`hyperloom.common.env_safety.redact_secret_values` so
+    conversations, transcripts, and Langfuse snapshots share one rule set.
     """
     if not text:
         return text
-    out = text
-    for pattern, repl in _REDACT_PATTERNS:
-        out = pattern.sub(repl, out)
-    return out
+    return redact_secret_values(text)
 
 
 # microseconds + ``+00:00`` (canonical helper; kept importable for callers).

--- a/src/hyperloom/orchestrator/trace/langfuse_mapping.py
+++ b/src/hyperloom/orchestrator/trace/langfuse_mapping.py
@@ -25,6 +25,8 @@ from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from hyperloom.common.env_safety import BENCHMARK_SECRET_ENV_NAMES, is_secret_shaped_env_name, redact_secret_values
+
 UNPHASED = "(unphased)"
 UNKNOWN_AGENT = "(unknown)"
 
@@ -55,6 +57,8 @@ _SENSITIVE_ENV_MARKERS: tuple[str, ...] = (
     "SECRET_KEY",
     "AUTH",
     "SIGNATURE",
+    "HEADERS",
+    "CUSTOM_HEADERS",
 )
 _REDACTED = "***redacted***"
 
@@ -374,8 +378,9 @@ def redact_env(environ: Mapping[str, str]) -> dict[str, str]:
     """Snapshot the process environment with secret values redacted.
 
     Keeps every variable name but replaces the value of anything whose name
-    looks like a credential (see :data:`_SENSITIVE_ENV_MARKERS`) with a
-    placeholder, so session_start never ships secrets to Langfuse.
+    looks like a credential (see :data:`_SENSITIVE_ENV_MARKERS` and
+    :data:`BENCHMARK_SECRET_ENV_NAMES`) or whose value matches a known secret
+    shape with a placeholder, so session_start never ships secrets to Langfuse.
 
     Args:
         environ: The process environment mapping (e.g. ``os.environ``).
@@ -386,7 +391,13 @@ def redact_env(environ: Mapping[str, str]) -> dict[str, str]:
     out: dict[str, str] = {}
     for key, value in environ.items():
         upper = key.upper()
-        if any(marker in upper for marker in _SENSITIVE_ENV_MARKERS):
+        if (
+            upper in BENCHMARK_SECRET_ENV_NAMES
+            or is_secret_shaped_env_name(upper)
+            or any(marker in upper for marker in _SENSITIVE_ENV_MARKERS)
+        ):
+            out[key] = _REDACTED
+        elif value and redact_secret_values(value) != value:
             out[key] = _REDACTED
         else:
             out[key] = value

--- a/src/hyperloom/orchestrator/trace/langfuse_mapping.py
+++ b/src/hyperloom/orchestrator/trace/langfuse_mapping.py
@@ -397,10 +397,8 @@ def redact_env(environ: Mapping[str, str]) -> dict[str, str]:
             or any(marker in upper for marker in _SENSITIVE_ENV_MARKERS)
         ):
             out[key] = _REDACTED
-        elif value and redact_secret_values(value) != value:
-            out[key] = _REDACTED
         else:
-            out[key] = value
+            out[key] = redact_secret_values(value) if value else value
     return out
 
 


### PR DESCRIPTION
## Summary
- Redact secrets in Langfuse env snapshots, transcripts, process.log, and intel records.
- Keep quantization sitecustomize outside the workspace, pin SDK cwd to workspace, and reject quantized_model_dir paths that escape it.
- Cap kernel trace aggregation, harden grep/literal_eval/recover/PR download, and deny writes of ROCm runtime objects under /opt/rocm/.

## Test plan
- [ ] Confirm Langfuse session_start and specialist process.log do not persist API keys or custom headers.
- [ ] Run quantization unit tests for sitecustomize location, blocked.md outcomes, and workspace-bounded quantized_model_dir.
- [ ] Run recover, policy-gate, kernel trace, and patch-source-pr tests covering pidfile-only kill, ROCm write filter, and curl max-filesize.


Made with [Cursor](https://cursor.com)