### PR TITLE
[FEAT] KernelForge: trace-driven nominator behind KERNELFORGE_NOMINATOR=trace

### DIFF
--- a/src/kernelforge/nomination/__init__.py
+++ b/src/kernelforge/nomination/__init__.py
@@ -1,0 +1,397 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Consumer half of the nomination contract.
+
+Mirrors ``hyperloom.orchestrator.kernel.nomination_request`` field for field.
+The two halves are deliberately separate modules rather than a shared import:
+forge stays independently importable, and ``PROTOCOL_VERSION`` is what keeps
+them honest. Bump both together.
+
+The seam a real implementation replaces is :func:`nominate`; everything else
+here is shell -- read, validate, delegate, assemble.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+#: Must equal the producer's value. A mismatch stops the run rather than
+#: risking a partially understood request.
+PROTOCOL_VERSION = 1
+
+#: Must equal the producer's ``candidate_manifest.MANIFEST_VERSION``; an absent
+#: version is a skew too. No compatibility path, so both halves move together.
+MANIFEST_VERSION = 2
+
+#: Every field a candidate row must carry. A row missing one comes from a
+#: producer this build does not understand, so the gap is refused, not guessed.
+_REQUIRED_CANDIDATE_FIELDS = ("kernel_name", "gpu_pct", "source_file", "reason_class", "attempts", "rejected")
+
+#: Mirrors ``kernel_source_contract.KNOWN_REASON_CLASSES`` as a literal so forge
+#: stays independently importable; ``MANIFEST_VERSION`` keeps the two in step.
+KNOWN_REASON_CLASSES = frozenset(
+    {
+        "resolved",
+        "launch_api_only",
+        "vendor_binary",
+        "dispatch_shim",
+        "non_patchable_name",
+        "not_rewritable_verdict",
+        "source_not_resolved",
+        "unknown",
+    }
+)
+
+LANE_REWRITE = "rewrite"
+LANE_FUSION = "fusion"
+LANE_GEMM = "gemm"
+
+KNOWN_LANES = frozenset({LANE_REWRITE, LANE_FUSION, LANE_GEMM})
+
+#: The complete set of keys a request may carry. Anything outside this set is a
+#: field Hyperloom wrote that this build does not understand -- silently dropping
+#: it hides a version skew (a producer that thinks a field is honoured when it is
+#: not), so an unknown key stops the run rather than being swallowed.
+_KNOWN_REQUEST_KEYS = frozenset(
+    {
+        "protocol_version",
+        "lane",
+        "trace_path",
+        "candidates_path",
+        "lane_budget_sec",
+        "max_kernels",
+        "trace_captured_after",
+    }
+)
+
+
+class NominationError(RuntimeError):
+    """A malformed request or an unreadable candidate list stops the run."""
+
+
+@dataclass(frozen=True)
+class NominationRequest:
+    """One lane's brief, as read off disk."""
+
+    lane: str
+    trace_path: str
+    candidates_path: str
+    lane_budget_sec: int
+    max_kernels: int
+    trace_captured_after: str = ""
+
+
+@dataclass(frozen=True)
+class Target:
+    """One kernel a nominator picked, plus the budget it was given."""
+
+    kernel_name: str
+    source_file: str
+    budget_sec: int
+    gpu_pct: float = 0.0
+    reason: str = ""
+
+
+@dataclass
+class NominationSummary:
+    """Counts that make "how many hot kernels did we rescue" answerable.
+
+    Deliberately counts only -- no per-kernel detail, so this stays inside the
+    "forge does not report what it looked at and skipped" decision.
+    """
+
+    candidates_seen: int = 0
+    resolved: int = 0
+    selected: int = 0
+
+    def to_dict(self) -> dict[str, int]:
+        return asdict(self)
+
+
+@dataclass
+class Candidate:
+    """One row of the hot-kernel list, reduced to what a nominator needs."""
+
+    kernel_name: str
+    source_file: str = ""
+    gpu_pct: float = 0.0
+    reason_class: str = ""
+    attempts: int = 0
+    rejected: bool = False
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_resolved(self) -> bool:
+        """A row without a source file cannot be handed to a campaign as-is."""
+        return bool(self.source_file)
+
+
+def read_request(path: str | Path) -> NominationRequest:
+    """Read and validate a nomination request written by Hyperloom.
+
+    Args:
+        path: Path to the request JSON.
+
+    Returns:
+        The parsed request.
+
+    Raises:
+        NominationError: On unreadable JSON, an unknown protocol version, an
+            unknown lane, an unknown request field, or a non-positive budget or
+            ceiling.
+    """
+    payload = _load_json(path, what="nomination request")
+    if not isinstance(payload, dict):
+        raise NominationError(f"nomination request must be a JSON object: {path}")
+    unknown = set(payload) - _KNOWN_REQUEST_KEYS
+    if unknown:
+        raise NominationError(f"unknown nomination request field(s): {sorted(unknown)}")
+    version = payload.get("protocol_version")
+    if version != PROTOCOL_VERSION:
+        raise NominationError(f"unsupported nomination protocol {version!r}; this build speaks {PROTOCOL_VERSION}")
+    lane = str(payload.get("lane") or "")
+    if lane not in KNOWN_LANES:
+        raise NominationError(f"unknown lane {lane!r}; expected one of {sorted(KNOWN_LANES)}")
+    return NominationRequest(
+        lane=lane,
+        trace_path=str(payload.get("trace_path") or ""),
+        candidates_path=str(payload.get("candidates_path") or ""),
+        lane_budget_sec=_positive_int(payload.get("lane_budget_sec"), field_name="lane_budget_sec"),
+        max_kernels=_positive_int(payload.get("max_kernels"), field_name="max_kernels"),
+        trace_captured_after=str(payload.get("trace_captured_after") or ""),
+    )
+
+
+def read_candidates(path: str | Path) -> list[Candidate]:
+    """Read the hot-kernel list, keeping unresolved rows.
+
+    Unresolved rows are the whole point of handing the full list over: a
+    nominator that never sees them cannot rescue them.
+
+    Args:
+        path: Path to the candidate list JSON.
+
+    Returns:
+        Candidates in file order; ranking is the nominator's business.
+
+    Raises:
+        NominationError: On unreadable JSON, a manifest version this build does
+            not know, a missing ``hot_kernels`` array, a row that is not an
+            object, a row missing a required field, or a ``reason_class`` outside
+            the known set. A dropped row would hide the same producer/consumer
+            skew an unknown request field does.
+    """
+    payload = _load_json(path, what="candidate list")
+    if not isinstance(payload, dict):
+        raise NominationError(f"candidate list must be a JSON object: {path}")
+    version = payload.get("manifest_version")
+    if version != MANIFEST_VERSION:
+        raise NominationError(f"unsupported candidate manifest {version!r}; this build speaks {MANIFEST_VERSION}")
+    rows = payload.get("hot_kernels")
+    if not isinstance(rows, list):
+        raise NominationError(f"candidate list has no hot_kernels array: {path}")
+    candidates: list[Candidate] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise NominationError(f"candidate row {index} is not a JSON object: {path}")
+        missing = [field_name for field_name in _REQUIRED_CANDIDATE_FIELDS if field_name not in row]
+        if missing:
+            raise NominationError(f"candidate row {index} is missing required field(s) {missing}: {path}")
+        reason_class = str(row.get("reason_class") or "").strip()
+        if reason_class not in KNOWN_REASON_CLASSES:
+            raise NominationError(
+                f"candidate row {index} has unknown reason_class {reason_class!r}; "
+                f"this build knows {sorted(KNOWN_REASON_CLASSES)}: {path}"
+            )
+        name = str(row.get("kernel_name") or "").strip()
+        if not name:
+            raise NominationError(f"candidate row {index} has no kernel name: {path}")
+        candidates.append(
+            Candidate(
+                kernel_name=name,
+                source_file=str(row.get("source_file") or "").strip(),
+                gpu_pct=_finite_float(row.get("gpu_pct")),
+                reason_class=reason_class,
+                attempts=max(0, _int_or_zero(row.get("attempts"))),
+                rejected=bool(row.get("rejected")),
+                raw=row,
+            )
+        )
+    return candidates
+
+
+def nominate(request: NominationRequest, candidates: list[Candidate]) -> list[Target]:
+    """Pick the kernels to optimize and split the budget across them.
+
+    **This is the seam.** :mod:`kernelforge.nomination.trace_nominator` is the
+    real implementation: it ranks on the trace's per-kernel shares, resolves
+    rows the producer could not, and splits the budget in proportion to
+    measured GPU share.
+
+    The placeholder in :mod:`kernelforge.nomination.stub` remains the fallback
+    for the case the real nominator is built to handle and cannot: no row
+    survives trace ranking and source resolution. Falling through to the
+    already-resolved rows there is strictly better than returning nothing,
+    since an empty nomination ends the lane.
+
+    Args:
+        request: The lane brief, including budget and ceiling.
+        candidates: Rows from :func:`read_candidates`.
+
+    Returns:
+        At most ``request.max_kernels`` targets, strongest first.
+    """
+    if _selected_nominator() == "trace":
+        from kernelforge.nomination.trace_nominator import nominate_from_trace
+
+        targets = nominate_from_trace(request, candidates)
+        if targets:
+            return targets
+
+    from kernelforge.nomination.stub import nominate_from_candidates
+
+    return nominate_from_candidates(request, candidates)
+
+
+#: Nominator implementations selectable through ``KERNELFORGE_NOMINATOR``.
+KNOWN_NOMINATORS = frozenset({"stub", "trace"})
+
+
+def _selected_nominator() -> str:
+    """Which nominator to use; the placeholder stays the default.
+
+    Opt-in rather than opt-out on purpose. The stub's behaviour -- skip every
+    unresolved row, split the budget evenly -- is what the shell's tests assert
+    and what any existing caller already gets. A trace nominator deliberately
+    contradicts the first half of that (rescuing unresolved rows is its whole
+    point), so making it the default would silently change what a run does.
+    An unrecognised value falls back to the stub instead of raising: a typo in
+    an env var should not end a campaign that would otherwise have run.
+    """
+    import os
+
+    choice = (os.environ.get("KERNELFORGE_NOMINATOR") or "stub").strip().lower()
+    return choice if choice in KNOWN_NOMINATORS else "stub"
+
+
+def summarize(candidates: list[Candidate], targets: list[Target]) -> NominationSummary:
+    """Count what was seen, what was resolvable, and what was picked."""
+    return NominationSummary(
+        candidates_seen=len(candidates),
+        resolved=sum(1 for candidate in candidates if candidate.is_resolved),
+        selected=len(targets),
+    )
+
+
+@dataclass(frozen=True)
+class Resolution:
+    """Everything one nomination pass decided, ready for the CLI to act on."""
+
+    request: NominationRequest
+    targets: tuple[Target, ...]
+    summary: NominationSummary
+
+
+def resolve(nomination_input: str | Path) -> Resolution:
+    """Read the brief, rank the candidates, and pick targets.
+
+    Args:
+        nomination_input: Path to the nomination request JSON.
+
+    Returns:
+        The request, the chosen targets, and the counts to report.
+
+    Raises:
+        NominationError: On a malformed request or candidate list.
+    """
+    request = read_request(nomination_input)
+    candidates = read_candidates(request.candidates_path)
+    targets = nominate(request, candidates)
+    return Resolution(
+        request=request,
+        targets=tuple(targets),
+        summary=summarize(candidates, targets),
+    )
+
+
+def patch_entry(
+    target: Target,
+    *,
+    patch_path: str,
+    base_commit: str = "",
+    micro_speedup: float = 0.0,
+    kernel_repo: str = "",
+    snapshot_dir: str = "",
+) -> dict[str, Any]:
+    """Build one result-envelope entry for a target that produced a patch.
+
+    Field names mirror ``hyperloom.orchestrator.kernel.nomination_result``; the
+    three the consumer requires are the kernel name, the patch path, and the
+    target file.
+
+    Args:
+        target: The nominated target this patch came from.
+        patch_path: Path to the published patch.
+        base_commit: Commit the patch is diffed against.
+        micro_speedup: Forge's own measurement, used only as a queue tiebreaker.
+        kernel_repo: Repo root, required for a multi-file patch.
+        snapshot_dir: Snapshot dir, which enables atomic multi-file apply.
+
+    Returns:
+        The entry mapping.
+    """
+    entry: dict[str, Any] = {
+        "kernel_name": target.kernel_name,
+        "patch_path": str(patch_path),
+        "target_file": target.source_file,
+        "micro_speedup": float(micro_speedup or 0.0),
+    }
+    for key, value in (
+        ("base_commit", base_commit),
+        ("kernel_repo", kernel_repo),
+        ("snapshot_dir", snapshot_dir),
+    ):
+        if str(value or "").strip():
+            entry[key] = str(value)
+    return entry
+
+
+def _load_json(path: str | Path, *, what: str) -> Any:
+    """Read JSON, turning every failure into one contract error."""
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise NominationError(f"could not read {what} {path}: {error}") from error
+
+
+def _positive_int(value: Any, *, field_name: str) -> int:
+    """Coerce to a positive int; anything else is a contract violation."""
+    try:
+        number = int(value)
+    except (TypeError, ValueError) as error:
+        raise NominationError(f"{field_name} must be an integer, got {value!r}") from error
+    if number <= 0:
+        raise NominationError(f"{field_name} must be positive, got {number}")
+    return number
+
+
+def _finite_float(value: Any) -> float:
+    """Non-finite or non-numeric shares rank as zero rather than crashing."""
+    import math
+
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0.0
+    number = float(value)
+    return number if math.isfinite(number) else 0.0
+
+
+def _int_or_zero(value: Any) -> int:
+    """Missing counters mean zero; a bad counter must not stop nomination."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0

--- a/src/kernelforge/nomination/stub.py
+++ b/src/kernelforge/nomination/stub.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Placeholder nominator, kept in its own file so it can be replaced wholesale.
+
+It exists to make the contract runnable end to end, not to be good at picking
+kernels: it trusts Hyperloom's already-resolved rows and never looks at the
+trace. A real nominator parses the trace, resolves the rows Hyperloom could not,
+and splits the budget on evidence rather than evenly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kernelforge.nomination import Candidate, NominationRequest, Target
+
+
+def nominate_from_candidates(
+    request: NominationRequest,
+    candidates: list[Candidate],
+) -> list[Target]:
+    """Take the hottest already-resolved, unrejected rows and split the budget evenly.
+
+    Args:
+        request: The lane brief, for the budget and the ceiling.
+        candidates: Rows from the hot-kernel list.
+
+    Returns:
+        At most ``request.max_kernels`` targets, hottest first. Empty when no row
+        is eligible, which is a valid outcome and not an error.
+    """
+    from kernelforge.nomination import Target
+
+    eligible = [candidate for candidate in candidates if candidate.is_resolved and not candidate.rejected]
+    eligible.sort(key=lambda candidate: candidate.gpu_pct, reverse=True)
+    picked = eligible[: request.max_kernels]
+    if not picked:
+        return []
+    share = request.lane_budget_sec // len(picked)
+    return [
+        Target(
+            kernel_name=candidate.kernel_name,
+            source_file=candidate.source_file,
+            budget_sec=share,
+            gpu_pct=candidate.gpu_pct,
+            reason="placeholder nominator: hottest resolved candidate",
+        )
+        for candidate in picked
+    ]

--- a/src/kernelforge/nomination/trace_nominator.py
+++ b/src/kernelforge/nomination/trace_nominator.py
@@ -1,0 +1,268 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Trace-driven nominator: the three things the placeholder does not do.
+
+``nomination.stub`` exists to make the contract runnable, and says so: it
+"trusts Hyperloom's already-resolved rows and never looks at the trace". That
+is enough for a demo and not enough for a serving target, because on a real
+decode trace the rows that matter most are frequently the *unresolved* ones --
+a hot AITER kernel arrives as a mangled HIP symbol with no ``source_file``, and
+the placeholder drops it silently by way of ``is_resolved``.
+
+This module adds, in order:
+
+1. **Trace evidence.** ``gpu_pct`` on an incoming row is whatever the producer
+   measured, which may be a whole-run average. When ``request.trace_path``
+   points at a candidate manifest carrying per-kernel shares, those shares
+   replace the row's, so ranking reflects the profiled window rather than the
+   run that happened to contain it.
+2. **Source resolution.** An unresolved row is searched for across configured
+   source roots and promoted to ``resolved`` when exactly one plausible home is
+   found. This is the "rescue" the placeholder's docstring points at.
+3. **Evidence-weighted budget.** The placeholder splits the lane budget evenly.
+   Here it is split in proportion to measured GPU share, subject to a floor, so
+   a 30%-of-GPU kernel is not given the same wall clock as a 3% one.
+
+Ranking stays a pure function of the inputs: same manifest and same roots give
+the same targets, because a nominator that reorders between runs makes a
+campaign impossible to reproduce.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from kernelforge.nomination import Candidate, NominationRequest, Target
+
+#: Rows below this share are not worth a session: even a perfect rewrite of a
+#: 1%-of-GPU kernel cannot move an end-to-end latency target.
+MIN_GPU_PCT = 1.0
+
+#: No target gets less than this, regardless of proportional split -- a session
+#: too short to finish a measure/keep cycle produces nothing at all.
+MIN_BUDGET_SEC = 600
+
+#: Where to look for a kernel's implementation, in priority order. Overridable
+#: with KERNELFORGE_SOURCE_ROOTS (os.pathsep-separated) so a deployment can
+#: point at its own checkouts without a code change.
+DEFAULT_SOURCE_ROOTS: tuple[str, ...] = (
+    "/forge/aiter-amd",
+    "/work/aiter-amd",
+    "/opt/rocm/share/aiter",
+)
+
+#: Extensions worth searching. A kernel lives in one of these or is vendor
+#: binary, in which case no amount of grepping will resolve it.
+SOURCE_SUFFIXES = frozenset({".py", ".hip", ".cu", ".cuh", ".cpp", ".h", ".hpp", ".cc"})
+
+#: Directories that never contain editable kernel source.
+SKIP_DIRS = frozenset({".git", "build", "__pycache__", "third_party", "dist", ".pytest_cache"})
+
+
+def source_roots() -> tuple[Path, ...]:
+    """Resolve the search roots, honouring the env override."""
+    raw = os.environ.get("KERNELFORGE_SOURCE_ROOTS", "")
+    names = [part for part in raw.split(os.pathsep) if part.strip()] if raw else list(DEFAULT_SOURCE_ROOTS)
+    return tuple(Path(name) for name in names if Path(name).is_dir())
+
+
+def _identifier_candidates(kernel_name: str) -> list[str]:
+    """Reduce a device symbol to identifiers worth grepping for.
+
+    HIP kernel names arrive templated and mangled
+    (``void aiter::fmoe_kernel<...>(...)``). The searchable part is the bare
+    identifier, so template arguments, namespaces, arguments and the leading
+    return type are stripped, longest first.
+    """
+    name = kernel_name.strip()
+    name = re.sub(r"\(.*$", "", name)  # drop argument list
+    name = re.sub(r"<.*$", "", name)  # drop template arguments
+    name = name.split("::")[-1]  # drop namespaces
+    name = re.sub(r"^\s*(void|int|float|bool)\s+", "", name)
+    name = name.strip()
+    out: list[str] = []
+    if len(name) >= 4 and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+        out.append(name)
+        # Torch/aiter wrappers often expose the kernel without its
+        # _kernel/_impl suffix; try that too, but never a fragment so short it
+        # would match half the tree.
+        trimmed = re.sub(r"_(kernel|impl|launcher|fwd|bwd)$", "", name)
+        if trimmed != name and len(trimmed) >= 6:
+            out.append(trimmed)
+    return out
+
+
+def _definition_pattern(identifier: str) -> re.Pattern[bytes]:
+    """Match a *definition* of ``identifier``, not a mention of it.
+
+    Substring matching is not good enough and actively dangerous here: a bare
+    ``in path.read_bytes()`` test resolves a name like ``blind`` to whatever
+    file happens to contain those five letters, and a campaign then spends its
+    whole budget editing an unrelated file. So the identifier has to appear in
+    a position that can only be a definition:
+
+    - ``def name(``                         -- python / triton
+    - ``__global__ ... name(``              -- HIP / CUDA device entry
+    - ``void|static|inline|auto name(``     -- C++ host or device function
+    - ``template<...> ... name(``           -- templated kernel
+    - ``name = triton.jit`` / ``@triton.jit`` decorated defs are covered by
+      the ``def`` form.
+    """
+    name = re.escape(identifier).encode("utf-8")
+    return re.compile(
+        rb"(?:^|\n)\s*(?:"
+        rb"def\s+" + name + rb"\s*\("
+        rb"|(?:template\s*<[^\n>]*>\s*)?(?:__global__|__device__|__launch_bounds__\([^\n)]*\))"
+        rb"[^\n;{]*?\b" + name + rb"\s*\("
+        rb"|(?:static\s+|inline\s+|extern\s+\"C\"\s+)*"
+        rb"(?:void|auto|int|float|bool|__half|hipError_t)\s+\**" + name + rb"\s*\("
+        rb")",
+        re.MULTILINE,
+    )
+
+
+def resolve_source(kernel_name: str, roots: tuple[Path, ...]) -> tuple[str, str]:
+    """Find the file that *defines* ``kernel_name``.
+
+    Returns:
+        ``(source_file, reason_class)``. ``source_file`` is empty when no
+        definition site could be identified, and ``reason_class`` then says
+        which way it failed so the caller can report it rather than guess.
+    """
+    identifiers = _identifier_candidates(kernel_name)
+    if not identifiers:
+        return "", "non_patchable_name"
+    for identifier in identifiers:
+        pattern = _definition_pattern(identifier)
+        needle = identifier.encode("utf-8")
+        hits: list[Path] = []
+        for root in roots:
+            for path in root.rglob("*"):
+                if not path.is_file() or path.suffix not in SOURCE_SUFFIXES:
+                    continue
+                if SKIP_DIRS & set(path.parts):
+                    continue
+                try:
+                    blob = path.read_bytes()
+                except OSError:
+                    continue
+                # Cheap reject before the regex: most files do not mention it.
+                if needle not in blob:
+                    continue
+                if pattern.search(blob):
+                    hits.append(path)
+            if hits:
+                break
+        if len(hits) == 1:
+            return str(hits[0]), "resolved"
+        if len(hits) > 1:
+            # Several definition sites (a header plus its .hip, or an arch
+            # fan-out). Prefer a file whose stem is the identifier, else the
+            # shallowest path, so the choice is deterministic.
+            exact = [p for p in hits if p.stem == identifier]
+            if len(exact) == 1:
+                return str(exact[0]), "resolved"
+            shallow = sorted(hits, key=lambda p: (len(p.parts), str(p)))
+            return str(shallow[0]), "resolved"
+    return "", "source_not_resolved"
+
+
+def _trace_shares(trace_path: str) -> dict[str, float]:
+    """Read per-kernel GPU shares from the trace artifact, if it carries them.
+
+    Accepts a candidate manifest (the shape ``analyze_trace.py`` writes) and
+    returns an empty mapping for anything else -- a raw chrome trace is not
+    parsed here, because ranking must not depend on re-deriving numbers the
+    producer already measured.
+    """
+    if not trace_path:
+        return {}
+    path = Path(trace_path)
+    if not path.is_file():
+        return {}
+    try:
+        payload: Any = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    rows = payload.get("hot_kernels")
+    if not isinstance(rows, list):
+        return {}
+    shares: dict[str, float] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("kernel_name") or "").strip()
+        try:
+            pct = float(row.get("gpu_pct"))
+        except (TypeError, ValueError):
+            continue
+        if name:
+            shares[name] = pct
+    return shares
+
+
+def nominate_from_trace(
+    request: NominationRequest,
+    candidates: list[Candidate],
+) -> list[Target]:
+    """Rank on trace evidence, rescue unresolved rows, split budget by share.
+
+    Args:
+        request: The lane brief, for the trace path, budget and ceiling.
+        candidates: Rows from :func:`kernelforge.nomination.read_candidates`.
+
+    Returns:
+        At most ``request.max_kernels`` targets, strongest first. Empty when
+        nothing clears :data:`MIN_GPU_PCT`, which is a valid outcome: it says
+        this trace has no kernel worth a session.
+    """
+    from kernelforge.nomination import Target
+
+    shares = _trace_shares(request.trace_path)
+    roots = source_roots()
+
+    ranked: list[tuple[float, Candidate, str, str]] = []
+    for candidate in candidates:
+        if candidate.rejected:
+            continue
+        pct = shares.get(candidate.kernel_name, candidate.gpu_pct)
+        if pct < MIN_GPU_PCT:
+            continue
+        source_file, reason_class = candidate.source_file, candidate.reason_class
+        if not source_file:
+            source_file, reason_class = resolve_source(candidate.kernel_name, roots)
+        if not source_file:
+            continue
+        ranked.append((pct, candidate, source_file, reason_class))
+
+    # Sort by measured share, then by name so ties are stable across runs.
+    ranked.sort(key=lambda row: (-row[0], row[1].kernel_name))
+    picked = ranked[: request.max_kernels]
+    if not picked:
+        return []
+
+    total = sum(row[0] for row in picked) or 1.0
+    targets: list[Target] = []
+    for pct, candidate, source_file, reason_class in picked:
+        budget = int(request.lane_budget_sec * (pct / total))
+        targets.append(
+            Target(
+                kernel_name=candidate.kernel_name,
+                source_file=source_file,
+                budget_sec=max(MIN_BUDGET_SEC, budget),
+                gpu_pct=pct,
+                reason=(
+                    f"trace nominator: {pct:.2f}% of profiled GPU time"
+                    + ("" if reason_class == candidate.reason_class else f"; rescued via {reason_class}")
+                ),
+            )
+        )
+    return targets

--- a/src/kernelforge/tests/test_nomination_trace.py
+++ b/src/kernelforge/tests/test_nomination_trace.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""The trace nominator: trace-ranked, definition-resolved, share-weighted.
+
+The three behaviours here are the ones the placeholder in ``nomination.stub``
+explicitly does not have, so each is pinned against the stub's opposite.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kernelforge import nomination as nom
+from kernelforge.nomination import trace_nominator as tn
+
+
+def _write(path: Path, payload: object) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _request(tmp_path: Path, **overrides: object) -> nom.NominationRequest:
+    payload: dict[str, object] = {
+        "protocol_version": nom.PROTOCOL_VERSION,
+        "lane": nom.LANE_REWRITE,
+        "trace_path": "",
+        "candidates_path": "/tmp/kernel_candidates.json",
+        "lane_budget_sec": 6000,
+        "max_kernels": 2,
+        "trace_captured_after": "abc1234",
+    }
+    payload.update(overrides)
+    return nom.read_request(_write(tmp_path / "req.json", payload))
+
+
+def _candidates(tmp_path: Path, rows: list[dict[str, object]]) -> list[nom.Candidate]:
+    payload = {"manifest_version": nom.MANIFEST_VERSION, "hot_kernels": rows}
+    return nom.read_candidates(_write(tmp_path / "cand.json", payload))
+
+
+def _row(name: str, **overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "kernel_name": name,
+        "source_file": f"/repo/{name}.py",
+        "gpu_pct": 1.0,
+        "reason_class": "resolved",
+        "attempts": 0,
+        "rejected": False,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_trace_shares_override_the_row(tmp_path: Path) -> None:
+    """A row's own gpu_pct may be a whole-run average; the window wins."""
+    trace = _write(
+        tmp_path / "trace.json",
+        {
+            "manifest_version": 2,
+            "hot_kernels": [
+                {"kernel_name": "cold_in_row", "gpu_pct": 40.0},
+                {"kernel_name": "hot_in_row", "gpu_pct": 2.0},
+            ],
+        },
+    )
+    request = _request(tmp_path, trace_path=str(trace))
+    candidates = _candidates(
+        tmp_path,
+        [_row("hot_in_row", gpu_pct=90.0), _row("cold_in_row", gpu_pct=3.0)],
+    )
+    targets = tn.nominate_from_trace(request, candidates)
+    # Ranked by the trace (40 vs 2), not by the rows (90 vs 3).
+    assert [t.kernel_name for t in targets] == ["cold_in_row", "hot_in_row"]
+
+
+def test_budget_is_split_by_share_not_evenly(tmp_path: Path) -> None:
+    trace = _write(
+        tmp_path / "trace.json",
+        {
+            "manifest_version": 2,
+            "hot_kernels": [
+                {"kernel_name": "big", "gpu_pct": 75.0},
+                {"kernel_name": "small", "gpu_pct": 25.0},
+            ],
+        },
+    )
+    request = _request(tmp_path, trace_path=str(trace), lane_budget_sec=8000)
+    targets = tn.nominate_from_trace(request, _candidates(tmp_path, [_row("big"), _row("small")]))
+    budgets = {t.kernel_name: t.budget_sec for t in targets}
+    assert budgets["big"] == 6000
+    assert budgets["small"] == 2000
+
+
+def test_budget_never_falls_below_the_floor(tmp_path: Path) -> None:
+    """A session too short to finish a measure/keep cycle produces nothing."""
+    trace = _write(
+        tmp_path / "trace.json",
+        {
+            "manifest_version": 2,
+            "hot_kernels": [
+                {"kernel_name": "dominant", "gpu_pct": 99.0},
+                {"kernel_name": "marginal", "gpu_pct": 1.5},
+            ],
+        },
+    )
+    request = _request(tmp_path, trace_path=str(trace), lane_budget_sec=1000)
+    targets = tn.nominate_from_trace(request, _candidates(tmp_path, [_row("dominant"), _row("marginal")]))
+    assert all(t.budget_sec >= tn.MIN_BUDGET_SEC for t in targets)
+
+
+def test_rows_below_the_floor_are_dropped(tmp_path: Path) -> None:
+    """Perfecting a 1%-of-GPU kernel cannot move an end-to-end target."""
+    request = _request(tmp_path)
+    targets = tn.nominate_from_trace(request, _candidates(tmp_path, [_row("tiny", gpu_pct=0.4)]))
+    assert targets == []
+
+
+def test_rejected_rows_stay_rejected(tmp_path: Path) -> None:
+    request = _request(tmp_path)
+    targets = tn.nominate_from_trace(request, _candidates(tmp_path, [_row("banned", gpu_pct=99.0, rejected=True)]))
+    assert targets == []
+
+
+def test_unresolved_row_is_rescued_from_a_definition_site(tmp_path: Path) -> None:
+    """The rescue the stub cannot do: promote a row that has no source_file."""
+    root = tmp_path / "aiter"
+    (root / "csrc").mkdir(parents=True)
+    (root / "csrc" / "fmoe.hip").write_text(
+        "__global__ void fmoe_stage1_kernel(const float* x) { }\n", encoding="utf-8"
+    )
+    monkey = str(root)
+    request = _request(tmp_path)
+    candidates = _candidates(
+        tmp_path, [_row("fmoe_stage1_kernel", source_file="", reason_class="source_not_resolved", gpu_pct=30.0)]
+    )
+    import os
+
+    os.environ["KERNELFORGE_SOURCE_ROOTS"] = monkey
+    try:
+        targets = tn.nominate_from_trace(request, candidates)
+    finally:
+        del os.environ["KERNELFORGE_SOURCE_ROOTS"]
+    assert len(targets) == 1
+    assert targets[0].source_file.endswith("csrc/fmoe.hip")
+    assert "rescued" in targets[0].reason
+
+
+def test_a_mere_mention_does_not_resolve(tmp_path: Path) -> None:
+    """The bug this guards: substring matching resolved 'blind' to any file."""
+    root = tmp_path / "aiter"
+    root.mkdir()
+    (root / "notes.py").write_text("# we should test the blind case and blind_spot handling\n", encoding="utf-8")
+    import os
+
+    os.environ["KERNELFORGE_SOURCE_ROOTS"] = str(root)
+    try:
+        source_file, reason = tn.resolve_source("blind", (root,))
+    finally:
+        del os.environ["KERNELFORGE_SOURCE_ROOTS"]
+    assert source_file == ""
+    assert reason == "source_not_resolved"
+
+
+def test_templated_mangled_symbol_reduces_to_its_identifier(tmp_path: Path) -> None:
+    got = tn._identifier_candidates("void aiter::fmoe_kernel<128, true>(float const*, int)")
+    assert got[0] == "fmoe_kernel"
+    assert "fmoe" in got or len(got) == 1
+
+
+def test_seam_defaults_to_stub_and_is_opt_in(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Flipping the default would silently change what an existing run does."""
+    monkeypatch.delenv("KERNELFORGE_NOMINATOR", raising=False)
+    assert nom._selected_nominator() == "stub"
+    monkeypatch.setenv("KERNELFORGE_NOMINATOR", "trace")
+    assert nom._selected_nominator() == "trace"
+    monkeypatch.setenv("KERNELFORGE_NOMINATOR", "typo")
+    assert nom._selected_nominator() == "stub"


### PR DESCRIPTION
- **Description: what and why**

`kernelforge/nomination` ships a documented stub seam. It only accepts rows that are already source-resolved, ranks them on whatever `gpu_pct` the candidate list was authored with, and splits the campaign budget evenly across whatever survives. That is fine as a placeholder and wrong as a nominator: the thing that knows what is hot is the profiler, not the candidate list.

This adds a nominator driven by real trace evidence, with three capabilities:

1. **Trace evidence overrides the row.** Per-kernel GPU shares are read from the profiler output, so the trace decides what is hot rather than the authored `gpu_pct`.
2. **Unresolved rows get rescued.** A row with no `source_file` is searched across the configured roots by *definition site* — a regex over `__global__`, `def`, and templated/static declarations — instead of by substring. Substring matching is actively wrong here: it resolves a kernel named `blind` to any file that happens to contain those five letters in a comment. There is a test for exactly that false positive.
3. **Budget follows share.** The campaign budget is split in proportion to each target's measured GPU share, with a floor, so a 9% kernel is not handed the same wall clock as a 0.5% one.

**Backward compatibility is the design constraint here, not an afterthought.** 48 shell tests encode the stub's semantics as a contract, including "skip unresolved rows" — which is the exact behaviour capability 2 inverts. So the new nominator is:

- opt-in behind `KERNELFORGE_NOMINATOR=trace`,
- defaulting to `stub`,
- and falling back to the stub when it nominates nothing, because an empty nomination ends the lane and falling through to the already-resolved rows is strictly better than returning nothing.

- **Linked issue(s): close/fix refs**

None. Raised from a KernelForge campaign on DeepSeek-V4-Pro-0813 decode; happy to file a tracking issue if you would prefer one.

- **Tests: added/updated? commands run?**

9 new tests in `src/kernelforge/tests/test_nomination_trace.py`, covering: trace override of the row's `gpu_pct`, share-weighted budget split, the budget floor, rejection handling, definition-site resolution, the substring false positive, mangled-symbol reduction, and the `KERNELFORGE_NOMINATOR` env gate.

```
pytest src/kernelforge/tests -m "not critic_agent_e2e and not robustness_agent_e2e and not targeted_build_e2e"
ruff check src/kernelforge
ruff format --check src/kernelforge
```

Result against `main` (9ae79d6) on the same machine and interpreter:

| | passed | failed |
|---|---|---|
| `main` | 3594 | 28 |
| this branch | 3603 | 28 |

`+9 passed, +0 failed` — the 9 new tests, no regressions. The 28 failures are pre-existing on `main` and environmental: they are `test_forge_loop_resume.py` cases that need an LLM provider extra (`AgentProviderUnavailableError: no Agent provider is available; install the 'claude' or 'codex' extra`), which is not installed in this sandbox. They fail identically with and without the patch.

`ruff check` and `ruff format --check` both clean.

- **Breaking changes: yes/no (details if yes)**

No. Default behaviour is byte-for-byte the stub. The new path is only reachable with `KERNELFORGE_NOMINATOR=trace` set, and even then it falls back to the stub if it nominates nothing.
