### PR TITLE
[FIX] KernelForge: exempt the loop's own aiter cache from the workspace guard

### DIFF
--- a/src/kernelforge/orchestrator/agent.py
+++ b/src/kernelforge/orchestrator/agent.py
@@ -45,6 +45,40 @@ _REPO_EXTRA_PROTECTED_GLOBS = [
     "conftest.py",
 ]
 
+# Untracked paths written by the tooling rather than by the agent, declared so a
+# turn is not rejected for them. Deliberately per-path: an undeclared stray file
+# is still a violation, which is why this is not ``allow_untracked``.
+#
+# Exported as a constant so the guard's behaviour can be tested against the list
+# that actually ships rather than against a copy of it.
+TOOL_OWNED_UNTRACKED_GLOBS = [
+    # The profiler writes where it is run. Both forms must reach any depth: it
+    # runs in ``run_cwd``, the kernel file's parent, while the guard reports
+    # paths relative to the git toplevel. ``fnmatch`` crosses "/", so
+    # ``*_results.db`` already does; ``.rocprofv3/`` has to be spelled twice.
+    ".rocprofv3/*",
+    "*/.rocprofv3/*",
+    "*_results.db",
+    # The loop's own aiter cache, for the same reason and with the same remedy.
+    # ``allow_dirty_baseline`` forgives the shards present when a turn begins,
+    # but a candidate that triggers a JIT build creates new ones *during* the
+    # turn -- ``<experiments-dir>/aiter_cache/sources/<hash>/...``,
+    # ``.forge_cache_owner.json``, ``flydsl_cache/launch_*`` -- which land among
+    # the untracked and get the turn rejected for files the framework wrote.
+    #
+    # This is not hypothetical: a candidate measured at 1.027x, which the
+    # in-session gate had already ALLOWed as correct and faster, was reverted as
+    # a "Protected integrity violation" and -- never having been committed --
+    # could not be recovered afterwards.
+    #
+    # ``configure_aiter_cache_isolation`` roots the tree at
+    # ``experiments_dir / "aiter_cache"``, so the directory name is fixed even
+    # though ``--experiments-dir`` is not; matching on it covers every placement
+    # inside the workspace.
+    "aiter_cache/*",
+    "*/aiter_cache/*",
+]
+
 # task_type values that mean "a full source tree, not a self-contained snippet".
 _REPO_TASK_TYPES = {"repository", "image_kernel"}
 
@@ -679,16 +713,7 @@ Make your change(s) now.
             # rather than for anything it did. Named rather than forgiven
             # wholesale (``allow_untracked``), so every path nobody declared is
             # still refused.
-            ignored_untracked_globs=[
-                # Both entries must reach any depth: the profiler runs in
-                # ``run_cwd``, which is the kernel file's parent (see above),
-                # while the guard reports paths relative to the git toplevel.
-                # ``fnmatch`` crosses "/", so the ``*_results.db`` form already
-                # does; ``.rocprofv3/`` has to be spelled out twice.
-                ".rocprofv3/*",
-                "*/.rocprofv3/*",
-                "*_results.db",
-            ],
+            ignored_untracked_globs=list(TOOL_OWNED_UNTRACKED_GLOBS),
             protected_paths=list(extra_protected_paths or []),
             hooks=(gate.make_agent_hooks(stop_check=gate_stop_check) if gate is not None else None),
             mcp_servers=pr_mcp_servers,

--- a/src/kernelforge/tests/test_aiter_cache.py
+++ b/src/kernelforge/tests/test_aiter_cache.py
@@ -368,6 +368,111 @@ def test_profiler_droppings_do_not_fail_a_session(tmp_path):
         run([]).verify()  # undeclared -> still refused
 
 
+def test_aiter_cache_droppings_do_not_fail_a_session(tmp_path):
+    """The loop's own JIT cache must not be read as the agent's doing.
+
+    ``configure_aiter_cache_isolation`` roots its tree at
+    ``<experiments-dir>/aiter_cache``, and the shipped AITER example puts
+    ``--experiments-dir`` inside the workspace. A candidate that triggers a JIT
+    build therefore creates untracked files mid-turn. Without a declaration the
+    turn is rejected for files the framework wrote -- which is not theoretical:
+    a 1.027x candidate the in-session gate had already ALLOWed as correct and
+    faster was reverted as a "Protected integrity violation", and having never
+    been committed it could not be recovered from git afterwards.
+
+    Asserted against the list that actually ships, not a copy of it, so a future
+    edit to the globs cannot pass this test while breaking the real run.
+    """
+    import subprocess
+
+    from kernelforge.agent_backends.base import AgentRunSpec
+    from kernelforge.agent_backends.workspace_guard import (
+        WorkspaceGuard,
+        WorkspaceSafetyError,
+    )
+    from kernelforge.orchestrator.agent import TOOL_OWNED_UNTRACKED_GLOBS
+
+    ws = tmp_path / "ws"
+    (ws / "csrc").mkdir(parents=True)
+    (ws / "csrc" / "k.cu").write_text("// kernel\n", encoding="utf-8")
+    for cmd in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "t@t"],
+        ["git", "config", "user.name", "t"],
+        ["git", "add", "-A"],
+        ["git", "commit", "-q", "-m", "base"],
+    ):
+        subprocess.run(cmd, cwd=ws, check=True, capture_output=True)
+
+    # The exact shapes observed in the campaign that lost the candidate.
+    shard = "forge_experiments/aiter_cache/sources/d7287ba5e00fb3a3529d082a"
+
+    def run(globs):
+        spec = AgentRunSpec(
+            system_prompt="",
+            user_prompt="",
+            cwd=str(ws),
+            target_files=[str(ws / "csrc" / "k.cu")],
+            ignored_untracked_globs=list(globs),
+        )
+        guard = WorkspaceGuard(spec, dirty_baseline_default=True)
+        guard.prepare()
+        (ws / shard / "flydsl_cache").mkdir(parents=True, exist_ok=True)
+        (ws / shard / ".forge_cache_owner.json").write_text("{}", encoding="utf-8")
+        (ws / shard / "flydsl_cache" / "launch_1b1a70825d5869240ee77e954dd460a0").write_text("", encoding="utf-8")
+        return guard
+
+    run(TOOL_OWNED_UNTRACKED_GLOBS).verify()  # declared -> passes
+
+    subprocess.run(["git", "clean", "-fdq"], cwd=ws, capture_output=True)
+    with pytest.raises(WorkspaceSafetyError, match="new non-ignored files"):
+        run([]).verify()  # undeclared -> still refused
+
+
+def test_tool_owned_globs_still_refuse_an_undeclared_stray(tmp_path):
+    """The declaration stays per-path; it is not a blanket allow_untracked.
+
+    Guards the fix against being "simplified" into forgiving everything: a file
+    the agent invents next to the cache must still fail the turn.
+    """
+    import subprocess
+
+    from kernelforge.agent_backends.base import AgentRunSpec
+    from kernelforge.agent_backends.workspace_guard import (
+        WorkspaceGuard,
+        WorkspaceSafetyError,
+    )
+    from kernelforge.orchestrator.agent import TOOL_OWNED_UNTRACKED_GLOBS
+
+    ws = tmp_path / "ws"
+    (ws / "csrc").mkdir(parents=True)
+    (ws / "csrc" / "k.cu").write_text("// kernel\n", encoding="utf-8")
+    for cmd in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "t@t"],
+        ["git", "config", "user.name", "t"],
+        ["git", "add", "-A"],
+        ["git", "commit", "-q", "-m", "base"],
+    ):
+        subprocess.run(cmd, cwd=ws, check=True, capture_output=True)
+
+    spec = AgentRunSpec(
+        system_prompt="",
+        user_prompt="",
+        cwd=str(ws),
+        target_files=[str(ws / "csrc" / "k.cu")],
+        ignored_untracked_globs=list(TOOL_OWNED_UNTRACKED_GLOBS),
+    )
+    guard = WorkspaceGuard(spec, dirty_baseline_default=True)
+    guard.prepare()
+    (ws / "forge_experiments" / "aiter_cache").mkdir(parents=True, exist_ok=True)
+    (ws / "forge_experiments" / "aiter_cache" / "shard.json").write_text("{}", encoding="utf-8")
+    (ws / "smuggled_notes.txt").write_text("not the framework's", encoding="utf-8")
+
+    with pytest.raises(WorkspaceSafetyError, match="smuggled_notes.txt"):
+        guard.verify()
+
+
 def test_profiler_droppings_are_forgiven_below_the_git_toplevel(tmp_path):
     """The guard reports paths from the git toplevel; the profiler runs deeper.
 


### PR DESCRIPTION
- **Description: what and why**

**The bug.** `configure_aiter_cache_isolation` roots its cache at `<experiments-dir>/aiter_cache`, and the shipped AITER example places `--experiments-dir` *inside the workspace*. When a candidate triggers a JIT build, the cache writes new untracked files **during** the turn. The workspace guard sees new untracked paths and rejects the entire turn — for files the framework itself just wrote.

`allow_dirty_baseline=True` already forgives cache shards that exist when a turn *begins*. The gap is only the files created mid-turn.

**What it cost.** This is not hypothetical. Iteration 5 of a DeepSeek-V4-Pro-0813 campaign produced a candidate that the in-session gate explicitly passed:

```
[in-session-gate] ALLOW (correct + faster: mean case speedup mean score=1.026621x
  >= 1.015225x from scores=[1.025718, 1.026704, 1.027443]) edit=21
```

Three independent measurements, tightly clustered, all better than the candidate that was ultimately kept (1.0138x). It was then destroyed by:

```
[agent] ERROR: new non-ignored files are unsupported:
  forge_experiments/aiter_cache/sources/d7287ba5e00fb3a3529d082a/.forge_cache_owner.json,
  forge_experiments/aiter_cache/sources/d7287ba5e00fb3a3529d082a/flydsl_cache/launch_...
[REVERT] Protected integrity violation; canonical validation skipped
```

Every one of those paths was written by KernelForge. Because the revert happens *before* the candidate is committed, the source was not recoverable from git — no dangling object, no stash, and `candidates/` has archives for iterations 1–4 but none for 5. The campaign reported 1.38% when it had measured 2.66%.

**The fix.** The mechanism already existed. `spec.ignored_untracked_globs` was added for precisely this class of bug when rocprofv3 droppings failed a session; the loop's own cache was simply never added to the list. This patch:

- lifts the glob list into a module constant, `TOOL_OWNED_UNTRACKED_GLOBS`, so tests assert against the list that actually ships rather than a copy of it;
- adds `aiter_cache/*` and `*/aiter_cache/*`. The directory name is fixed by `configure_aiter_cache_isolation` even though `--experiments-dir` is not, so the two forms together cover every placement of the cache inside a workspace.

It stays a **per-path declaration, not `allow_untracked`** — an undeclared stray file is still a violation, and there is a test asserting that.

**One thing worth considering alongside this patch** (not changed here, happy to fold in if you want it): the loop prints

```
[git] 2 new file(s) outside commit_new_paths, not removed: forge_mhc_driver.py, graph_harness.py
```

on **every** iteration. Those are the protected driver and harness, which the shipped AITER example deliberately keeps untracked. The message reads like a fault report for the documented pattern.

- **Linked issue(s): close/fix refs**

None filed. This is a bug report and its fix in one; glad to split out an issue if that is preferred for tracking.

- **Tests: added/updated? commands run?**

2 new tests in `src/kernelforge/tests/test_aiter_cache.py`: one reproducing the exact untracked paths that lost the candidate (`.forge_cache_owner.json` and `flydsl_cache/launch_*` under `aiter_cache/sources/<hash>/`), and one asserting that a file smuggled in next to the cache still fails the guard.

```
pytest src/kernelforge/tests -m "not critic_agent_e2e and not robustness_agent_e2e and not targeted_build_e2e"
ruff check src/kernelforge
ruff format --check src/kernelforge
```

Result against `main` (9ae79d6) on the same machine and interpreter:

| | passed | failed |
|---|---|---|
| `main` | 3594 | 28 |
| this branch | 3596 | 28 |

`+2 passed, +0 failed`. The 28 failures are pre-existing on `main` and environmental (`test_forge_loop_resume.py` needs an LLM provider extra that is not installed in this sandbox); they fail identically with and without the patch.

`ruff check` and `ruff format --check` both clean.

- **Breaking changes: yes/no (details if yes)**

No. This widens an existing exemption list by two globs and refactors it into a named constant. A turn that passed the guard before still passes; the only turns whose outcome changes are the ones that were being rejected for the framework's own cache files.
