### PR TITLE
fix(sbd-v6): name the copies an enablement round left in the archive

### DIFF
--- a/src/hyperloom/inference_optimizer/breakdown/recorder/enablement_event.py
+++ b/src/hyperloom/inference_optimizer/breakdown/recorder/enablement_event.py
@@ -32,6 +32,8 @@ from .event_fields import (
     now_iso_seconds as _now,
     text_or_none as _text_or_none,
 )
+from hyperloom.orchestrator.delivery.archive import ROLE_LAUNCH_CONFIG
+
 from .event_ids import event_id
 from .event_rows import rows_for_event, sort_rows, wire_rows
 from .event_sink import EventSink, make_sink
@@ -249,6 +251,39 @@ def record_dispatch(
         note_failure(section="enablement_event", error=exc, detail="enablement event: dispatch record failed")
 
 
+def record_archive(*, task_id: str, attempt: int, files: Sequence[Mapping[str, str]]) -> None:
+    """Record which of a round's deliverables the archive took. Never raises.
+
+    Its own entry point rather than a field of the settle: the copies exist
+    only once ``snapshot_round`` has run, and only the coordinator ever sees
+    them. Nothing in the round's own result can stand in -- ``patches_applied``
+    names workspace originals the package does not hold, and cannot say whether
+    the size ceiling kept a copy at all.
+
+    Upserts onto the row the dispatch opened, so it wants the same
+    ``(task_id, attempt)``.
+    """
+    try:
+        sink = _sink()
+        if sink is None:
+            return
+        _open()
+        archived = _archived_files(files)
+        sink.record(
+            SECTION_ATTEMPT,
+            {
+                "attempt": int(attempt or 0),
+                "task_id": str(task_id or ""),
+                "files": archived,
+                "accepted_config_path": _text_or_none(_archived_path(archived, ROLE_LAUNCH_CONFIG)),
+            },
+            row_type="attempt",
+            natural_ids=_row_id(task_id, attempt),
+        )
+    except Exception as exc:  # noqa: BLE001
+        note_failure(section="enablement_event", error=exc, detail="enablement event: archive record failed")
+
+
 def record_round(
     *,
     task_id: str,
@@ -264,6 +299,9 @@ def record_round(
     dispatched opens its own row here, being still a round the lane spent.
     ``validation_pending`` means an eval-origin KEEP opened a revalidation
     window instead of landing.
+
+    What the archive took is :func:`record_archive`'s to write, not a field of
+    the verdict.
     """
     try:
         sink = _sink()
@@ -291,7 +329,6 @@ def record_round(
             "patches_dropped_by_grounding": [str(d) for d in _as_list(res.get("patches_dropped_by_grounding"))[:8]],
             "patches_span_multiple_roots": bool(res.get("patches_span_multiple_roots")),
             "framework_root": _text_or_none(res.get("framework_root")),
-            "accepted_config_path": _text_or_none(res.get("enablement_accepted_config_path")),
             "effective_config": _config_row(res.get("enablement_effective_config")),
             "stack_action": _stack_action_row(res.get("enablement_kept_stack_action")),
             "runtime": _runtime_row(res.get("enablement_active_runtime")),
@@ -660,6 +697,21 @@ def _artifact_row(artifact: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _archived_files(files: Sequence[Mapping[str, str]]) -> list[dict[str, str]]:
+    """Project the copies a round's archive holds, path and role as recorded."""
+    return [
+        {"path": str(f.get("path") or ""), "role": str(f.get("role") or "")} for f in files if isinstance(f, Mapping)
+    ]
+
+
+def _archived_path(files: Sequence[Mapping[str, str]], role: str) -> str:
+    """Return the archived path recorded for a single-valued role, or ``""``."""
+    return next(
+        (str(f.get("path") or "") for f in files if isinstance(f, Mapping) and str(f.get("role") or "") == role),
+        "",
+    )
+
+
 def _config_row(config: Any) -> dict[str, Any] | None:
     """Project the env/arg layers a bench ran with."""
     row = _as_dict(config)
@@ -732,6 +784,7 @@ __all__ = [
     "assemble_enablement_ext",
     "enablement_event_id",
     "finish",
+    "record_archive",
     "record_build",
     "record_dispatch",
     "record_human_review",

--- a/src/hyperloom/inference_optimizer/breakdown/schema.py
+++ b/src/hyperloom/inference_optimizer/breakdown/schema.py
@@ -620,6 +620,17 @@ class V6ConcSweepExt(TypedDict, total=False):
     superseded_sweeps: list[str]
 
 
+class V6ArchivedFile(TypedDict, total=False):
+    """One copy an enablement round's archive holds, and what it is.
+
+    ``role`` is a ``delivery.archive.ROLE_*`` value. It distinguishes a patch
+    the round applied from one it refused, which the round's own result cannot.
+    """
+
+    path: str
+    role: str
+
+
 class V6EnablementAttempt(TypedDict, total=False):
     """One authoring round of the enablement lane, keyed by its specialist.
 
@@ -633,7 +644,18 @@ class V6EnablementAttempt(TypedDict, total=False):
     ``next_launch_log_excerpt`` is what its patch uncovered underneath, which
     is the gap the *next* round will be pointed at. The projection kept one
     ``launch_log`` for the whole lane and every advance overwrote it, so the
-    export published the newest gap as the reason the lane had opened."""
+    export published the newest gap as the reason the lane had opened.
+
+    ``files`` and ``accepted_config_path`` are session-relative and name only
+    copies the round's archive took, which is a weaker claim than "fetchable":
+    ``reports/enablement/**`` is packaged outside ``RESERVED_PATHS``, so a
+    session that hit the file or byte cap ships a truncated package and a
+    consumer must tolerate a miss. ``patches_applied`` and
+    ``artifacts_applied[].target`` are the workspace originals the round
+    reported, which are never packaged -- they are identity, not a way to
+    fetch. Note the asymmetry with ``V6EnablementResult.accepted_config_path``,
+    which stays absolute because the revalidation baseline opens that one
+    directly."""
 
     attempt: int
     task_id: str
@@ -654,6 +676,7 @@ class V6EnablementAttempt(TypedDict, total=False):
     patches_dropped_by_grounding: list[str]
     patches_span_multiple_roots: bool
     framework_root: str | None
+    files: list[V6ArchivedFile]
     accepted_config_path: str | None
     effective_config: dict[str, Any] | None
     stack_action: dict[str, Any] | None
@@ -1754,6 +1777,7 @@ __all__ = [
     "SCHEMA_VERSION",
     "SCHEMA_VERSION_V6",
     "SessionBreakdown",
+    "V6ArchivedFile",
     "V6BaselineProgress",
     "V6Close",
     "V6CloseRobustness",

--- a/src/hyperloom/inference_optimizer/tests/conftest.py
+++ b/src/hyperloom/inference_optimizer/tests/conftest.py
@@ -25,6 +25,24 @@ def _isolate_session_layout_env(monkeypatch, tmp_path_factory):
     monkeypatch.delenv("INFERENCE_OPTIMIZER_NODES", raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _restore_recording_session_binding():
+    """Undo any recording-session binding a test leaves behind.
+
+    ``Coordinator.__init__`` binds the session and drops the token, so a test
+    that constructs one leaves every later test in the worker running with a
+    session bound. Restoring a token is the only way back -- no public call
+    unbinds to "nothing" -- hence the reach for the module's ContextVar.
+    """
+    from hyperloom.inference_optimizer.session import session_binding
+
+    token = session_binding._CURRENT_SESSION.set(session_binding._CURRENT_SESSION.get())
+    try:
+        yield
+    finally:
+        session_binding._CURRENT_SESSION.reset(token)
+
+
 def _bootstrap_kernel_agent_env() -> None:
     """Point HYPERLOOM_KERNEL_AGENT_ROOT at the in-repo kernel-agent checkout."""
     if os.environ.get("HYPERLOOM_KERNEL_AGENT_ROOT"):

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_v6_enablement_timeline.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_v6_enablement_timeline.py
@@ -500,6 +500,7 @@ def test_nothing_recorded_outside_a_session_raises(tmp_path, monkeypatch):
     )
     _boot_trigger()
     enablement_event.record_dispatch(task_id="spec-1", attempt=1)
+    enablement_event.record_archive(task_id="spec-1", attempt=1, files=[{"path": "p", "role": "patch"}])
     enablement_event.record_round(task_id="spec-1", attempt=1, result={}, stall_streak=0, succeeded=False)
     enablement_event.record_build(task_id="build-1", entry={"ok": True})
     enablement_event.record_revalidation(generation=1)
@@ -513,3 +514,52 @@ def test_a_malformed_result_does_not_cost_the_round_its_row(_bound_session):
     enablement_event.record_round(task_id="spec-1", attempt=1, result=None, stall_streak=0, succeeded=False)
 
     assert _ext(_bound_session)["attempts"]["count"] == 1
+
+
+def test_the_archive_merges_onto_the_round_the_dispatch_opened(_bound_session):
+    _boot_trigger()
+    enablement_event.record_dispatch(task_id="spec-1", attempt=1)
+    enablement_event.record_archive(
+        task_id="spec-1",
+        attempt=1,
+        files=[
+            {"path": "reports/enablement/spec-1/patches/moe.diff", "role": "patch"},
+            {"path": "reports/enablement/spec-1/launch_config.yaml", "role": "launch_config"},
+            {"path": "reports/enablement/spec-1/server.log", "role": "server_log"},
+        ],
+    )
+    enablement_event.record_round(
+        task_id="spec-1",
+        attempt=1,
+        result=_kept(enablement_accepted_config_path="/s/runs/integrate_patch/spec-1/integrate_patch.with_envs.yaml"),
+        stall_streak=0,
+        succeeded=True,
+    )
+
+    rows = _ext(_bound_session)["attempts"]["rows"]
+    assert len(rows) == 1
+    assert rows[0]["files"] == [
+        {"path": "reports/enablement/spec-1/patches/moe.diff", "role": "patch"},
+        {"path": "reports/enablement/spec-1/launch_config.yaml", "role": "launch_config"},
+        {"path": "reports/enablement/spec-1/server.log", "role": "server_log"},
+    ]
+    # Read out of the manifest, so it cannot name a copy the manifest lacks.
+    assert rows[0]["accepted_config_path"] == "reports/enablement/spec-1/launch_config.yaml"
+    # The round's own paths stay, as identity rather than as a way to fetch.
+    assert rows[0]["patches_applied"] == ["/s/patches/moe.diff"]
+
+
+def test_a_copy_the_archive_refused_is_named_nowhere(_bound_session):
+    _boot_trigger()
+    enablement_event.record_archive(task_id="spec-1", attempt=1, files=[])
+    enablement_event.record_round(
+        task_id="spec-1",
+        attempt=1,
+        result=_kept(enablement_accepted_config_path="/s/runs/integrate_patch/spec-1/integrate_patch.with_envs.yaml"),
+        stall_streak=0,
+        succeeded=True,
+    )
+
+    row = _ext(_bound_session)["attempts"]["rows"][0]
+    assert row["files"] == []
+    assert row["accepted_config_path"] is None

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_v6_enablement_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_v6_enablement_wiring.py
@@ -363,6 +363,54 @@ async def test_an_eval_origin_keep_does_not_close_the_lane(_bound_session):
     assert row["status"] == "kept"
     assert row["validation_pending"] is True
     assert row["landed"] is False
+    # Nothing was there to copy, so the row names nothing rather than the
+    # ``runs/`` path the round reported.
+    assert row["files"] == []
+    assert row["accepted_config_path"] is None
+
+
+@pytest.mark.asyncio
+async def test_the_rearm_hands_the_round_its_archive(_bound_session):
+    lane = _lane(_bound_session)
+    lane.shared_state.enablement.last_specialist_task_id = "spec-1"
+    config = _bound_session / "runs" / "integrate_patch" / "spec-1" / "integrate_patch.with_envs.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("tp: 8\n", encoding="utf-8")
+
+    await lane._maybe_rearm_enablement(
+        {
+            "enablement": True,
+            "status": "kept",
+            "specialist_task_id": "spec-1",
+            "enablement_accepted_config_path": str(config),
+        }
+    )
+
+    rows = _ext()["attempts"]["rows"]
+    # The archive and the verdict are two calls on one tick, onto one row.
+    assert len(rows) == 1
+    assert {"path": "reports/enablement/spec-1/launch_config.yaml", "role": "launch_config"} in rows[0]["files"]
+    assert rows[0]["accepted_config_path"] == "reports/enablement/spec-1/launch_config.yaml"
+    assert rows[0]["status"] == "kept"
+
+
+@pytest.mark.asyncio
+async def test_a_snapshot_that_raised_leaves_the_row_silent(_bound_session, monkeypatch):
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.enablement.lane.snapshot_round",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("no space left on device")),
+    )
+    lane = _lane(_bound_session)
+    lane.shared_state.enablement.last_specialist_task_id = "spec-1"
+
+    await lane._maybe_rearm_enablement({"enablement": True, "status": "reverted", "specialist_task_id": "spec-1"})
+
+    # Absent, not empty: an archive that blew up did not establish that
+    # nothing landed. The round is still ruled.
+    row = _ext()["attempts"]["rows"][0]
+    assert "files" not in row
+    assert "accepted_config_path" not in row
+    assert row["status"] == "reverted"
 
 
 @pytest.mark.asyncio

--- a/src/hyperloom/orchestrator/enablement/lane.py
+++ b/src/hyperloom/orchestrator/enablement/lane.py
@@ -627,10 +627,21 @@ class EnablementLane(CoordinatorCollaborator):
         res_fw_root = str(res.get("framework_root") or "").strip()
         if res_fw_root:
             state.enablement.framework_root = res_fw_root
+        # The ordinal the dispatch filed this round under, read before the
+        # settle scores it, so every row of this round meets on the same number.
+        attempt = await self.rounds.consecutive_stalled() + 1
         setting_script = ""
         archive = RoundArchive(self.session_dir)
         try:
             archive = snapshot_round(self.session_dir, res)
+            # Where the copies come into being, and from the archive rather
+            # than from ``res``. Inside the try so that a snapshot which raised
+            # leaves the row silent instead of claiming nothing landed.
+            enablement_event.record_archive(
+                task_id=_round_task_id(state, res),
+                attempt=attempt,
+                files=archive.to_list(),
+            )
             if status in ("kept", "advanced"):
                 setting_script = write_setting_script(
                     self.session_dir,
@@ -650,9 +661,6 @@ class EnablementLane(CoordinatorCollaborator):
         archived_config = archive.path_for(ROLE_LAUNCH_CONFIG)
         if status == "kept" and archived_config:
             state.enablement.accepted_config_path = str(Path(self.session_dir) / archived_config)
-        # The ordinal the dispatch filed this round under, read before the
-        # settle scores it, so the two rows meet on the same number.
-        attempt = await self.rounds.consecutive_stalled() + 1
         # A rearm always ends the round; only a KEEP booted and was graded, and
         # an advance is the ledger's record that the cap must not charge it.
         is_advanced = status == "advanced" or bool(res.get("advanced"))
@@ -705,6 +713,15 @@ class EnablementLane(CoordinatorCollaborator):
                 log.exception("ENABLEMENT %s (%s) failed", pump.__name__, caller)
 
 
+def _round_task_id(state: Any, res: dict[str, Any]) -> str:
+    """The specialist task id every row of one round is keyed by.
+
+    A phase-synthesised rearm carries no id of its own, so the in-flight one
+    the dispatch filed stands in.
+    """
+    return str(res.get("specialist_task_id") or "").strip() or str(state.enablement.last_specialist_task_id or "")
+
+
 def _record_enablement_round(
     state: Any,
     res: dict[str, Any],
@@ -723,10 +740,9 @@ def _record_enablement_round(
     dispatch filed it under.
     """
     lane = state.enablement
-    round_tid = str(res.get("specialist_task_id") or "").strip() or str(lane.last_specialist_task_id or "")
     succeeded = bool(lane.succeeded)
     enablement_event.record_round(
-        task_id=round_tid,
+        task_id=_round_task_id(state, res),
         attempt=int(attempt or 0),
         result=res,
         stall_streak=int(stall_streak or 0),


### PR DESCRIPTION
## What

**An enablement attempt row names files a reader cannot fetch.**
`patches_applied` and `accepted_config_path` are the round's own paths —
workspace originals under `runs/`. `session_package.py`'s `PACKAGE_GLOBS` takes
all of `reports/enablement/**` and only a narrow allow-list under `runs/`,
which patches and materialized configs are not on. Running that matcher
directly confirms it: `runs/specialist/<tid>/patches/001_fix.patch` and
`runs/integrate_patch/<tid>/integrate_patch.with_envs.yaml` are both **not
packaged**.

**`accepted_config_path` is the dangling pointer
[#1394](https://github.com/AMD-AGI/Hyperloom/pull/1394) fixed**, re-recorded a
layer down. That fix holds where it was applied — `lane.py` overrides
`state.enablement.accepted_config_path` with the archived copy, so
`ext.result.accepted_config_path` resolves — but the per-attempt row takes
`res["enablement_accepted_config_path"]`, which is
`bench_result["materialized_config"]`, the value from before the archive ran.

## How

`snapshot_round` already returns a `RoundArchive` that records only copies that
landed. A new `record_archive` writes what it holds onto the row the dispatch
opened — `files` with its roles, and `accepted_config_path` read out of that
same manifest so the two cannot disagree.

It is its own entry point rather than a field of `record_round`. That call is
the verdict projection, built from the round's own `res`; which copies exist is
a fact only the coordinator has and only once the snapshot has run, so it is
recorded where it comes into being, on the same tick, keyed by the
`(task_id, attempt)` the dispatch already filed. The recorder is not put inside
`snapshot_round` itself: that helper is copy and IO, has no attempt key, and
should not reach for the SBD. `lane.py` still reads
`archive.path_for(ROLE_LAUNCH_CONFIG)` to re-point
`state.enablement.accepted_config_path`, which is control plane rather than
observability.

The call sits inside the archive block's `try`, so a snapshot that raised
leaves both fields **absent** rather than asserting an empty manifest — it did
not establish that nothing landed, and `null`/absent is what this layer
reserves for a fact that was not produced. The round is still ruled either way.

## Notes

**The roles are what the round's own result cannot supply.** A patch the round
applied and one it refused are archived apart — `ROLE_PATCH` against
`ROLE_PATCH_EVIDENCE` — and nothing in `res` distinguishes them, so without the
manifest a consumer cannot tell which patch to replay and cannot enumerate the
refused ones at all, their names appearing nowhere else on the event. The
archive's 2 MiB ceiling is the other half: it silently declines a copy it
cannot take, which is what makes "the round reported this patch" and "the
archive holds it" two different facts.

**A list of `{path, role}` rather than the keyed `artifacts` dict** the other
event types use (`conc_sweep_event`, `framework_event`, `close_out`). Those
hold one file per name; four of the archive's roles repeat — `ROLE_PATCH` by
design — so a keyed map cannot express this. `files` rather than `artifacts`
because `artifacts_applied` already sits on the same row meaning something
else: whole files installed into the framework tree.

**The workspace paths stay**, as identity rather than as a way to fetch. A
patch name joins a round to its `files` entry, and an artifact's target is the
position a replay installs to. The schema docstring says which of the two each
field is, and flags the deliberate asymmetry with
`ext.result.accepted_config_path`, which stays absolute because the
revalidation baseline opens that one directly.

**`files` names copies the archive took, which is weaker than "fetchable".**
`reports/enablement/**` is packaged outside `RESERVED_PATHS`, so a session that
hit the file or byte cap ships a truncated package and a consumer has to
tolerate a miss. The schema docstring says so rather than promising more than
the packer does. Moving these under the reserved partition would be a separate
call, and a bigger one than this PR should make.

**One distinction is given up.** A config that existed but whose copy the
archive declined now reads, at row level, like no config at all.
`ext.result.accepted_config_path` still separates the two, keeping the `runs/`
original in that case.

**`accepted_config_path` changes meaning** from an absolute `runs/` path to a
session-relative archived one.
[#1455](https://github.com/AMD-AGI/Hyperloom/pull/1455) merged this week, so no
production payload carries the old form.

**The first commit is independent** and fixes a pre-existing leak:
`Coordinator.__init__` binds the recording session and drops the token, so any
test constructing one leaves the rest of the worker with a session bound. Only
*sync* construction leaks — `pytest.mark.asyncio` runs the coroutine in a Task
that gets a copy of the context — which is why it has stayed latent under
alphabetical collection order. Happy to split it out.

## Test plan

- [x] `pytest test_sbd_v6_enablement_timeline.py test_sbd_v6_enablement_wiring.py
      test_enablement_artifacts.py` — 88 passed
- [x] `pytest` over `-k "enablement or sbd_v6 or breakdown or recorder or
      coordinator or integrate_patch"` — 1848 passed
- [x] Full `inference_optimizer` + `phases` suites against `main`: identical
      failure set, all pre-existing
- [x] Each fix verified to fail its test when reverted, including deleting the
      `record_archive` call in `lane.py`, which two wiring tests catch
- [x] Leak reproduced on `main` before the fixture and green after
- [x] `ruff check` / `ruff format --check` clean; `mypy` reports nothing new on
      the changed modules

New coverage: the archive and the verdict are two calls on one tick and land on
one row, not two; a copy the archive declined is named nowhere rather than named
and dangling; a snapshot that raised leaves the row silent rather than claiming
an empty manifest, and the round is still ruled; the round's workspace originals
survive as identity; and in `test_sbd_v6_enablement_wiring.py`, which exists so
that a call site quietly not making a call fails there, the real rearm records
the archive it took.

_Made with Cursor_