### PR TITLE
fix(teardown): reach the server our own wrapper setsid-ed away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **Teardown reaches the server its own wrapper `setsid`-ed away.**
+  `kill_my_spawned_server` signals one process group: the wrapper's. Magpie's
+  wrappers `setsid` the serving process, which is exactly what moves it out of
+  that group — the wrapper then exits, the server reparents to init, and every
+  rank it spawned keeps its GPUs. This is the teardown used wherever
+  server_lifecycle does not apply, which includes every profile round, since
+  reuse is ineligible once `torch_profiler` is on. Measured on MI355X: a
+  torn-down ATOM server left eight per-rank workers alive holding 2,188,381 MiB;
+  signalling the escaped group freed all of it.<br/>
+  Escaped groups are now enumerated *before* anything is signalled, because the
+  link that attributes them to this run — the wrapper still being their parent —
+  disappears the moment the wrapper dies. Attribution is by descent from our own
+  wrapper rather than by cmdline: a framework this repository has not heard of is
+  still ours, and the per-rank workers of the ATOM build measured here carry no
+  identifying argv at all (`multiprocessing.spawn` children, indistinguishable
+  from any other Python process by name). Nothing outside the tree we launched is
+  ever signalled.
+
 - **SWEEP is one concurrency sweep, and it produces the chart a submission is
   read on.** The workload sweep over `(CONC, ISL, OSL)` is deleted. Two of its
   three axes carried nothing under an agentic replay — request shapes come from

--- a/src/hyperloom/inference_optimizer/tests/test_kill_spawned_server.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kill_spawned_server.py
@@ -96,6 +96,79 @@ def test_kill_my_spawned_server_sigterm_then_sigkill_for_ignorer():
     assert elapsed < 5.0, f"kill_my_spawned_server hung for {elapsed:.2f}s"
 
 
+def test_kill_my_spawned_server_reaps_a_server_the_child_setsid_ed(tmp_path):
+    """A server moved out of the wrapper's process group by ``setsid`` is reaped.
+
+    Magpie's wrappers ``setsid`` the serving process, which is precisely what
+    takes it out of the one process group this helper signals. The wrapper then
+    exits, the server reparents to init, and every rank it spawned keeps its
+    GPUs. Measured on MI355X: a torn-down ATOM server left eight per-rank workers
+    alive holding 2,188,381 MiB.
+    """
+    marker = "atom.entrypoints.openai_server"
+    info = tmp_path / "server.pid"
+    wrapper_script = tmp_path / "wrapper.py"
+    wrapper_script.write_text(
+        "\n".join(
+            [
+                "import subprocess, sys, time",
+                # setsid equivalent: the server gets its own session, so its pgid
+                # is no longer the wrapper's.
+                "p = subprocess.Popen(",
+                "    [sys.executable, '-c', 'import sys, time; _ = sys.argv[1]; time.sleep(120)', sys.argv[2]],",
+                "    start_new_session=True,",
+                ")",
+                "open(sys.argv[1], 'w').write(str(p.pid))",
+                "time.sleep(120)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    proc = subprocess.Popen(
+        [sys.executable, str(wrapper_script), str(info), marker],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        **new_session_kwargs(),
+    )
+    server_pid: int | None = None
+    try:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if info.exists():
+                txt = info.read_text(encoding="utf-8").strip()
+                if txt:
+                    server_pid = int(txt)
+                    break
+            time.sleep(0.05)
+        assert server_pid is not None, "wrapper never wrote the server pid"
+
+        # It really did escape: a different process group from the one signalled.
+        assert os.getpgid(server_pid) != os.getpgid(proc.pid)
+
+        kill_my_spawned_server(proc, grace_seconds=1.5)
+
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            try:
+                os.kill(server_pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.05)
+        with pytest.raises(ProcessLookupError):
+            os.kill(server_pid, 0)
+    finally:
+        for pid in (server_pid, proc.pid):
+            if pid is not None:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except OSError:
+                    pass
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+
+
 def test_kill_my_spawned_server_reaps_grandchildren():
     """A child that spawns a grandchild leaves no surviving descendant after the helper returns."""
     proc = subprocess.Popen(

--- a/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
+++ b/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
@@ -123,6 +123,76 @@ def _signal_group(pgid: int, sig: int) -> None:
         )
 
 
+def _descendant_pgids(root_pid: int, root_pgid: int) -> list[int]:
+    """Process groups spawned under ``root_pid`` that are not ``root_pgid``.
+
+    Magpie's wrappers ``setsid`` the serving process, which is exactly what moves
+    it out of the one group :func:`kill_my_spawned_server` signals. The wrapper
+    then exits, the server reparents to init, and its per-rank workers keep their
+    GPUs. Measured on MI355X: a torn-down ATOM server left eight workers alive
+    holding 2,188,381 MiB.
+
+    Descent is the attribution: anything below our own wrapper was spawned by the
+    run we are tearing down, whatever it happens to be called. That is why this
+    does not match on cmdline -- a framework we have not heard of is still ours,
+    and this ATOM build's per-rank workers carry no identifying argv at all.
+
+    Callers MUST read this BEFORE signalling: ``setsid`` breaks the process group
+    but the escaped leader stays the wrapper's child until the wrapper dies, so
+    the link that attributes it to us exists only until then.
+
+    Args:
+        root_pid: Pid of the wrapper we launched.
+        root_pgid: The process group the caller is about to signal.
+
+    Returns:
+        Distinct pgids below ``root_pid``, excluding ``root_pgid`` and our own.
+        Empty on non-POSIX or when ``/proc`` cannot be read.
+    """
+    if os.name != "posix":
+        return []
+    children: dict[int, list[int]] = {}
+    pgid_of: dict[int, int] = {}
+    try:
+        entries = [e.name for e in Path("/proc").iterdir() if e.name.isdigit()]
+    except OSError:
+        return []
+    for name in entries:
+        pid = int(name)
+        try:
+            stat = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+            after_comm = stat.rsplit(")", 1)[1].split()
+            ppid, pgid = int(after_comm[1]), int(after_comm[2])
+        except (IndexError, OSError, ValueError):
+            continue
+        children.setdefault(ppid, []).append(pid)
+        pgid_of[pid] = pgid
+
+    try:
+        own_pgid = os.getpgid(0)
+    except OSError:
+        own_pgid = -1
+
+    seen: set[int] = set()
+    frontier = [root_pid]
+    # Bounded walk: a benchmark tree is wrapper -> server -> ranks, and a cycle in
+    # /proc would otherwise be unbounded.
+    for _ in range(8):
+        nxt = [c for pid in frontier for c in children.get(pid, ()) if c not in seen]
+        if not nxt:
+            break
+        seen.update(nxt)
+        frontier = nxt
+
+    found: list[int] = []
+    for pid in seen:
+        pgid = pgid_of.get(pid, 0)
+        if pgid in (0, root_pgid, own_pgid) or pgid in found:
+            continue
+        found.append(pgid)
+    return found
+
+
 def kill_my_spawned_server(
     proc: subprocess.Popen | None,
     *,
@@ -186,16 +256,31 @@ def kill_my_spawned_server(
         )
         return
 
+    # Read the escaped groups BEFORE signalling: the link that attributes them to
+    # this run is the wrapper still being their parent, and it is about to die.
+    escaped = _descendant_pgids(proc.pid, pgid)
+    if escaped:
+        log.info(
+            "_subprocess_kill: wrapper pgid=%d also spawned setsid'd group(s) %s; reaping them alongside it",
+            pgid,
+            escaped,
+        )
+
     _signal_group(pgid, signal.SIGTERM)
+    for escaped_pgid in escaped:
+        _signal_group(escaped_pgid, signal.SIGTERM)
 
     deadline = time.monotonic() + grace_seconds
     while time.monotonic() < deadline:
-        if not _process_group_alive(pgid):
+        if not _process_group_alive(pgid) and not any(_process_group_alive(g) for g in escaped):
             break
         time.sleep(0.05)
 
     if _process_group_alive(pgid):
         _signal_group(pgid, signal.SIGKILL)
+    for escaped_pgid in escaped:
+        if _process_group_alive(escaped_pgid):
+            _signal_group(escaped_pgid, signal.SIGKILL)
 
     try:
         proc.wait(timeout=_REAP_COLLECT_SECONDS)


### PR DESCRIPTION
## What

`kill_my_spawned_server` signals one process group: the wrapper's. Magpie's wrappers `setsid` the serving process, which is exactly what moves it out of that group. The wrapper then exits, the server reparents to init, and every rank it spawned keeps its GPUs.

This is the teardown used wherever `server_lifecycle` does not apply — which includes **every profile round**, since reuse is ineligible once `torch_profiler` is on.

## Evidence

Measured on MI355X with the real Magpie wrapper and a real ATOM server:

```
before teardown : 10 processes, 647,204 MiB
killpg(wrapper_pgid, SIGTERM) → SIGKILL
after teardown  : 10/10 alive, 647,206 MiB unchanged
                  leader ppid 2502 → 1, whole tree in pgid 2519
```

And inside a live optimisation run, on the profile round:

```
pid=298494  ppid=1  pgid=298317      8 workers, 2,188,381 MiB held, leader gone
```

Signalling the escaped group freed all of it.

## Approach

Escaped groups are enumerated **before** anything is signalled. The link that attributes them to this run — the wrapper still being their parent — disappears the moment the wrapper dies, so reading it afterwards is too late.

Attribution is **by descent from our own wrapper, not by cmdline**. Two reasons:

- A framework this repository has not heard of is still ours if our wrapper spawned it.
- The per-rank workers of the ATOM build measured here carry no identifying argv at all — they are `multiprocessing.spawn` children, indistinguishable by name from any other Python process. Ten processes in that tree, and only the leader mentions `atom`.

Nothing outside the tree we launched is ever signalled; our own process group is excluded explicitly, and the walk is depth-bounded.

## Tests

`test_kill_my_spawned_server_reaps_a_server_the_child_setsid_ed` — a wrapper `setsid`s a server into its own group; after teardown the server must be gone. Asserts the escape actually happened (`getpgid(server) != getpgid(wrapper)`) so the test cannot pass vacuously.

On the parent commit: `Failed: DID NOT RAISE ProcessLookupError` — the escaped server survives.

Verified on MI355X (Linux):

```
test_kill_spawned_server.py                          52 passed
every test file importing _subprocess_kill (10)      608 passed, 1 failed
ruff check / ruff format --check                     clean
```

The one failure, `test_grid_runner.py::TestSessionBudgetWarmupRounds::test_the_budget_is_re_checked_after_the_uncapped_server_restart`, is **pre-existing**: it fails identically with the changed file reverted to `main`.

## Relationship to #1416

Independent and non-overlapping. #1416 teaches the *lifecycle* teardown and `recover` to recognise an ATOM server by name; this teaches the *non-lifecycle* teardown to follow its own wrapper's descendants regardless of name. Different files, different paths, either can merge first.

## Deliberately not in scope

- The duplicated marker lists in `_server_lifecycle` and `recover` (adding a framework means editing both).
- The "pid reuse" wording both refusal messages use for what is really an unrecognised framework.
- A leaked group whose leader has already exited: `_process_group_looks_like_server` still cannot attribute it, because nothing left in the group carries a matching cmdline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
