### PR TITLE
fix(server_patcher): stop crashing on a namespace-package sglang install

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_server_patcher_sglang_namespace_package.py
+++ b/src/hyperloom/inference_optimizer/tests/test_server_patcher_sglang_namespace_package.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""SGLang plan discovery must fail-soft, not crash, on a namespace-package install.
+
+A PEP 420 namespace-package ``sglang`` install (``sglang.__file__ is None``,
+resolved only via ``sglang.__path__``) used to make ``_discover_sglang_plan`` /
+``_discover_sglang_ck_plan`` raise ``TypeError`` from ``Path(sglang.__file__)``
+instead of returning ``None`` like every other fail-soft condition in this
+module. That breaks the documented contract of
+``ensure_sglang_patched_for_tracelens`` / ``ensure_sglang_patched_for_ck_blockscale``
+("any failure returns False") and crashes the profile run that calls them.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from hyperloom.orchestrator.actions.executors import _server_patcher as sp
+
+
+def _fake_sglang_namespace_package(tmp_path: Path, *, version: str = "0.5.11") -> ModuleType:
+    """Build a fake ``sglang`` module that mimics a namespace-package install.
+
+    ``__file__`` is ``None`` (the actual PEP 420 shape); only ``__path__``
+    resolves to the package directory.
+    """
+    pkg_dir = tmp_path / "site-packages" / "sglang"
+    (pkg_dir / "srt").mkdir(parents=True)
+    fake = ModuleType("sglang")
+    fake.__file__ = None  # type: ignore[assignment]
+    fake.__path__ = [str(pkg_dir)]  # type: ignore[attr-defined]
+    fake.__version__ = version
+    return fake
+
+
+def _tracelens_root_with_sglang_patches(tmp_path: Path, *, version_subdir: str = "sglang_0_5_11") -> Path:
+    tracelens_root = tmp_path / "tracelens"
+    patches_dir = tracelens_root / "examples" / "custom_workflows" / "inference_analysis" / "sglang_roofline_patches" / version_subdir
+    patches_dir.mkdir(parents=True)
+    (patches_dir / "0001-annotations.patch").write_text(
+        "--- a/python/sglang/srt/managers/scheduler.py\n"
+        "+++ b/python/sglang/srt/managers/scheduler.py\n",
+        encoding="utf-8",
+    )
+    return tracelens_root
+
+
+def test_sglang_package_dir_falls_back_to_path_when_file_is_none(tmp_path: Path) -> None:
+    fake = _fake_sglang_namespace_package(tmp_path)
+
+    resolved = sp._sglang_package_dir(fake)
+
+    assert resolved == Path(fake.__path__[0]).resolve()
+
+
+def test_sglang_package_dir_is_none_without_file_or_path() -> None:
+    fake = ModuleType("sglang")
+    fake.__file__ = None  # type: ignore[assignment]
+    fake.__path__ = []  # type: ignore[attr-defined]
+
+    assert sp._sglang_package_dir(fake) is None
+
+
+def test_discover_sglang_plan_does_not_crash_on_namespace_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reproduces the TypeError this test guards against (pre-fix: crash)."""
+    fake = _fake_sglang_namespace_package(tmp_path)
+    monkeypatch.setitem(sys.modules, "sglang", fake)
+    tracelens_root = _tracelens_root_with_sglang_patches(tmp_path)
+
+    # Must not raise TypeError("... not NoneType ...") from Path(sglang.__file__).
+    plan = sp._discover_sglang_plan(tracelens_root)
+
+    assert plan is not None
+    assert plan.framework == "sglang"
+    assert plan.version == "0.5.11"
+    assert plan.apply_root == Path(fake.__path__[0]).resolve()
+
+
+def test_discover_sglang_ck_plan_does_not_crash_on_namespace_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = _fake_sglang_namespace_package(tmp_path)
+    monkeypatch.setitem(sys.modules, "sglang", fake)
+    # The CK plan requires the patch TARGET file to already exist (the patch
+    # edits it in place rather than creating it).
+    pkg_dir = Path(fake.__path__[0])
+    fp8_utils = pkg_dir / "srt" / "layers" / "quantization" / "fp8_utils.py"
+    fp8_utils.parent.mkdir(parents=True)
+    fp8_utils.write_text("", encoding="utf-8")
+    serving_patches_root = tmp_path / "kernelforge" / "serving_patches"
+    ck_patches_dir = serving_patches_root / "sglang" / "sglang_0_5_11"
+    ck_patches_dir.mkdir(parents=True)
+    (ck_patches_dir / "0001-ck-blockscale.patch").write_text(
+        "--- a/python/sglang/srt/layers/quantization/fp8_utils.py\n"
+        "+++ b/python/sglang/srt/layers/quantization/fp8_utils.py\n",
+        encoding="utf-8",
+    )
+
+    plan = sp._discover_sglang_ck_plan(serving_patches_root.parent)
+
+    assert plan is not None
+    assert plan.framework == "sglang-ck"
+    assert plan.apply_root == Path(fake.__path__[0]).resolve()
+
+
+def test_discover_sglang_plan_still_works_for_a_regular_file_backed_install(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression guard: the common (non-namespace) install path is unchanged."""
+    pkg_dir = tmp_path / "site-packages" / "sglang"
+    (pkg_dir / "srt").mkdir(parents=True)
+    init_file = pkg_dir / "__init__.py"
+    init_file.write_text("", encoding="utf-8")
+    fake = ModuleType("sglang")
+    fake.__file__ = str(init_file)  # type: ignore[assignment]
+    fake.__version__ = "0.5.11"
+    monkeypatch.setitem(sys.modules, "sglang", fake)
+    tracelens_root = _tracelens_root_with_sglang_patches(tmp_path)
+
+    plan = sp._discover_sglang_plan(tracelens_root)
+
+    assert plan is not None
+    # Wheel layout: apply_root is the sglang package dir itself, strip=3.
+    assert plan.apply_root == pkg_dir.resolve()
+    assert plan.apply_strip == 3

--- a/src/hyperloom/orchestrator/actions/executors/_server_patcher.py
+++ b/src/hyperloom/orchestrator/actions/executors/_server_patcher.py
@@ -25,7 +25,7 @@ import subprocess
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Sequence
+from typing import Any, Callable, Sequence
 
 from ._file_lock import best_effort_file_lock
 
@@ -704,6 +704,14 @@ def _discover_sglang_plan(arg: Path | str | None) -> _PatchPlan | None:
 
     version = (getattr(sglang, "__version__", "") or "").strip()
 
+    sglang_pkg = _sglang_package_dir(sglang)
+    if sglang_pkg is None:
+        log.warning(
+            "_server_patcher: cannot locate sglang install root (no "
+            "__file__ and no __path__ entries); skip patch"
+        )
+        return None
+
     # Resolve the patches dir before the version check so the gate can consult
     # the TraceLens-shipped manifest.
     patches_root = _patch_tree(tracelens_root, "sglang_roofline_patches")
@@ -745,18 +753,13 @@ def _discover_sglang_plan(arg: Path | str | None) -> _PatchPlan | None:
         return None
 
     # Support both editable and wheel layouts (see _resolve_sglang_apply_root).
-    sglang_module = Path(sglang.__file__).resolve()
-    apply_resolution = _resolve_sglang_apply_root(sglang_module)
-    if apply_resolution is None:
-        return None
-    apply_root, apply_strip = apply_resolution
+    apply_root, apply_strip = _resolve_sglang_apply_root(sglang_pkg)
 
     filtered_patches: list[Path] = list(patches)
 
     # Sentinel: the kernel_shape_profiler patch creates a new file at
     # ``sglang/srt/utils/kernel_shape_profiler.py`` in both layouts.
-    sentinel = sglang_module.parent / "srt" / "utils" / "kernel_shape_profiler.py"
-    sglang_pkg = sglang_module.parent
+    sentinel = sglang_pkg / "srt" / "utils" / "kernel_shape_profiler.py"
     # Also verify the annotation pipeline so a partial apply (main sentinel
     # present but annotations missing) is still detected: scheduler callback ->
     # profiler_manager toggle -> io_struct request fields -> step-span
@@ -788,31 +791,53 @@ def _discover_sglang_plan(arg: Path | str | None) -> _PatchPlan | None:
     )
 
 
-def _resolve_sglang_apply_root(sglang_module: Path) -> tuple[Path, int] | None:
-    """Pick ``(apply_root, strip_count)`` for the active SGLang install.
+def _sglang_package_dir(sglang_module: Any) -> Path | None:
+    """Resolve the installed ``sglang`` package directory.
 
-    Editable (``<repo>/python/sglang/``): ``(repo_root, 1)``. Wheel
-    (``site-packages/sglang/`` with no ``python/`` parent):
-    ``(<site-packages>/sglang, 3)``. Anything else: ``None`` (fail-soft).
+    Prefers ``__file__``'s parent (the common case: a regular package whose
+    ``__init__.py`` sits directly in the package directory). Falls back to
+    ``__path__[0]`` when ``__file__`` is ``None`` -- the shape of a PEP 420
+    namespace-package install, which some pip/conda layouts produce for
+    ``sglang``. ``__path__`` is always present on an importable package
+    (namespace or regular) and already points at the package directory
+    itself, so no further ``.parent`` walk is needed for that branch.
 
     Args:
-        sglang_module: Resolved path to the imported ``sglang`` package file.
+        sglang_module: The imported ``sglang`` module object.
 
     Returns:
-        An ``(apply_root, strip_count)`` tuple, or ``None`` when the install
-        layout is unrecognized.
+        The resolved package directory, or ``None`` when neither
+        ``__file__`` nor ``__path__`` resolves to anything (an install this
+        module has no way to locate).
     """
-    if sglang_module.parent.parent.name == "python":
-        return sglang_module.parent.parent.parent, 1
-    sglang_dir = sglang_module.parent
-    if sglang_dir.name == "sglang":
-        return sglang_dir, 3
-    log.info(
-        "_server_patcher: SGLang install at %s has unexpected layout (parent dir name=%r); skip patching",
-        sglang_module,
-        sglang_dir.name,
-    )
+    file_attr = getattr(sglang_module, "__file__", None)
+    if file_attr:
+        return Path(file_attr).resolve().parent
+    search_path = list(getattr(sglang_module, "__path__", []) or [])
+    if search_path:
+        return Path(search_path[0]).resolve()
     return None
+
+
+def _resolve_sglang_apply_root(sglang_pkg: Path) -> tuple[Path, int]:
+    """Pick ``(apply_root, strip_count)`` for the active SGLang install.
+
+    Editable (``<repo>/python/sglang/``): ``(repo_root, 1)``. Wheel /
+    namespace-package (``site-packages/sglang/`` with no ``python/``
+    parent): ``(sglang_pkg, 3)``.
+
+    Args:
+        sglang_pkg: The resolved ``sglang`` package directory (see
+            :func:`_sglang_package_dir`).
+
+    Returns:
+        An ``(apply_root, strip_count)`` tuple. Always resolvable given a
+        genuine package directory; the caller fail-softs earlier, when
+        :func:`_sglang_package_dir` cannot locate one at all.
+    """
+    if sglang_pkg.parent.name == "python":
+        return sglang_pkg.parent.parent, 1
+    return sglang_pkg, 3
 
 
 # CK fp8 block-scale routing markers added to ``fp8_utils.py`` by the
@@ -931,6 +956,14 @@ def _discover_sglang_ck_plan(arg: Path | str | None) -> _PatchPlan | None:
 
     version = (getattr(sglang, "__version__", "") or "").strip()
 
+    sglang_pkg = _sglang_package_dir(sglang)
+    if sglang_pkg is None:
+        log.warning(
+            "_server_patcher: cannot locate sglang install root (no "
+            "__file__ and no __path__ entries); skip CK block-scale patch"
+        )
+        return None
+
     # KernelForge layout: ``serving_patches/sglang/`` holds the per-version
     # subdirs plus the SUPPORTED_VERSIONS manifest.
     patches_root = serving_patches_root / "sglang"
@@ -972,15 +1005,11 @@ def _discover_sglang_ck_plan(arg: Path | str | None) -> _PatchPlan | None:
         )
         return None
 
-    sglang_module = Path(sglang.__file__).resolve()
-    apply_resolution = _resolve_sglang_apply_root(sglang_module)
-    if apply_resolution is None:
-        return None
-    apply_root, apply_strip = apply_resolution
+    apply_root, apply_strip = _resolve_sglang_apply_root(sglang_pkg)
 
     # Sentinel: the patch edits
     # ``sglang/srt/layers/quantization/fp8_utils.py`` in place (both layouts).
-    sentinel = sglang_module.parent / "srt" / "layers" / "quantization" / "fp8_utils.py"
+    sentinel = sglang_pkg / "srt" / "layers" / "quantization" / "fp8_utils.py"
     if not sentinel.is_file():
         log.warning(
             "_server_patcher: SGLang install layout unexpected (no %s); skip CK block-scale patch",


### PR DESCRIPTION
## Problem

`_discover_sglang_plan` / `_discover_sglang_ck_plan` in `_server_patcher.py` (the TraceLens roofline patcher and the KernelForge fp8 block-scale CK patcher) resolve the installed SGLang package root via:

```python
sglang_module = Path(sglang.__file__).resolve()
```

On a PEP 420 namespace-package SGLang install, `sglang.__file__` is `None`, so this raises `TypeError: argument should be a str or an os.PathLike object ... not 'NoneType'` instead of failing soft. This breaks the documented contract of `ensure_sglang_patched_for_tracelens()` / `ensure_sglang_patched_for_ck_blockscale()` ('any failure returns False') and crashes the profile run that calls them.

## Fix

Add `_sglang_package_dir()` to resolve the package directory from `__file__` when available, falling back to `__path__[0]` (always present on an importable package, namespace or regular, and already the package directory itself). `_resolve_sglang_apply_root()` now takes the resolved package directory instead of a file path, so it always returns a plan (removing a redundant `None` branch). Both discover functions now fail soft with a warning instead of raising when neither `__file__` nor `__path__` resolves anything.

Added `test_server_patcher_sglang_namespace_package.py`: reproduces the original crash, verifies the fail-soft path, and guards the common (non-namespace) editable/wheel install path is unchanged.