### PR TITLE
Preserve environment values in the GEAK handoff

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_geak_handoff_env.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_handoff_env.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+"""The GEAK handoff's shell environment preserves current-best values."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from pathlib import Path
+
+import pytest
+
+from hyperloom.orchestrator.loop.coordinator import Coordinator
+from hyperloom.orchestrator.state.shared_state import SharedState
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", ["two words", '{"key": "a b", "eq": "a=b"}', "user's config", r"a\b", "", "plain"])
+async def test_handoff_preserves_environment_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    expected = {"SGLANG_USE_AITER": "1", "CUSTOM_CONFIG": value}
+    coord = Coordinator.__new__(Coordinator)
+    coord.session_dir = tmp_path
+    coord.shared_state = SharedState(
+        model_path="/models/example",
+        current_best={"extra_envs": expected, "optimization_stack": []},
+    )
+    coord.phase_kernel._record_geak_kernel_journey = lambda _result: None
+    monkeypatch.setenv("FRAMEWORK", "sglang")
+
+    def stop_after_handoff(_name: str) -> Path:
+        raise RuntimeError("stop after handoff write")
+
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.kernel.request_handlers._kernel_agent_tool_path",
+        stop_after_handoff,
+    )
+    await coord._run_geak_kernel_phase(from_phase="KERNEL")
+
+    handoff = json.loads((tmp_path / "geak" / "handoff.json").read_text(encoding="utf-8"))
+    assert handoff["baseline_env_spec"]["config"]["extra_envs"] == expected
+    assert dict(token.split("=", 1) for token in shlex.split(handoff["accepted_env"])) == expected

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -10,6 +10,7 @@ import json
 import logging as _logging
 import math
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -877,7 +878,7 @@ class KernelPhase(PhaseHandler):
         spec_config = env_spec.get("config") if isinstance(env_spec.get("config"), Mapping) else {}
         accepted_flags = str(spec_config.get("extra_server_args") or cb.get("extra_server_args") or "")
         extra_envs = spec_config.get("extra_envs") or cb.get("extra_envs") or {}
-        accepted_env = " ".join(f"{k}={v}" for k, v in dict(extra_envs).items())
+        accepted_env = shlex.join(f"{k}={v}" for k, v in dict(extra_envs).items())
         state_measurement = getattr(state, "current_best_measurement", None)
         measurement = (
             state_measurement


### PR DESCRIPTION
The GEAK handoff's `accepted_env` string could split values containing spaces, misread apostrophes, or remove backslashes even though the parallel `extra_envs` mapping held the original value. Serialize complete `KEY=value` tokens with `shlex.join`; plain and empty values retain their existing meaning.

- Description: one serialization change plus a regression invoking the real handoff writer for spaces, JSON/equals, apostrophes, backslashes, empty values, and plain values.
- Linked issue: fixes #1429.
- Tests: the regression gives **4 failures and 2 passes on main**, and all six pass with the correction. Focused handoff/identity/fidelity/GPU-pin/gain tests: **126 passed**. Full suite with two workers: **20,654 passed, 43 skipped, 8 xfailed**, plus 15 passing subtests. Whole-repository Ruff check/format, REUSE, and whitespace checks passed. Advisory Mypy produced identical baseline and candidate diagnostics, with no new findings.
- Breaking changes: no; the handoff fields and schema are unchanged.
- Single concern: yes, lossless producer serialization.
- Upstream root cause: this defect is in Hyperloom. The independent GEAK JSON-environment normalization defect is handled separately.

The two-repository audit runs the actual handoff producer, resolver, argument mapper, and measurement-protocol mapper without launching the external runner. With the separate GEAK environment correction and #452, all six argv/state cases and all six environment cases pass, including composition with #437. No GPU performance or historical funnel recovery is claimed.
