### PR TITLE
fix(ci): stop the e2e dispatcher shadowing the platform orchestration model

### DIFF
--- a/.github/scripts/ci-e2e-dispatch.sh
+++ b/.github/scripts/ci-e2e-dispatch.sh
@@ -12,8 +12,6 @@
 #   E2E_INFRA_TYPE    infra type for the submission    (required)
 #   MODEL             HF repo id                       (default Qwen/Qwen3-0.6B)
 #   MODEL_CLASS       dense|moe_mla|moe_swa|moe_mla_nsa|"" (default dense; "" -> auto-infer)
-#   CI_E2E_CLAUDE_MODEL orchestration model             (default claude-opus-5)
-#   CI_E2E_ALLOW_CUSTOM_ORCH_MODEL allow a non-standard explicit model override
 #   GPUS              physical GPUs per replica        (default 1)
 #   TP                tensor-parallel degree           (default 1)
 #   MAX_HOURS         optimizer time budget (hours)    (default 0.5)
@@ -43,17 +41,6 @@ set -euo pipefail
 
 MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
 MODEL_CLASS="${MODEL_CLASS:-dense}"
-if [ -n "${CI_E2E_CLAUDE_MODEL:-}" ]; then
-  _CI_E2E_MODEL_WAS_EXPLICIT=1
-else
-  _CI_E2E_MODEL_WAS_EXPLICIT=0
-fi
-CI_E2E_CLAUDE_MODEL="${CI_E2E_CLAUDE_MODEL:-claude-opus-5}"
-CI_E2E_ALLOW_CUSTOM_ORCH_MODEL="${CI_E2E_ALLOW_CUSTOM_ORCH_MODEL:-${_CI_E2E_MODEL_WAS_EXPLICIT}}"
-case "$CI_E2E_ALLOW_CUSTOM_ORCH_MODEL" in
-  0|1) ;;
-  *) echo "CI_E2E_ALLOW_CUSTOM_ORCH_MODEL must be 0 or 1" >&2; exit 2 ;;
-esac
 GPUS="${GPUS:-1}"
 TP="${TP:-1}"
 MAX_HOURS="${MAX_HOURS:-0.5}"
@@ -220,15 +207,11 @@ body="$(jq -n \
   --arg knowledge_mode "$KNOWLEDGE_STORE_MODE" \
   --arg kb_store_url "${KB_STORE_URL:-}" \
   --arg kb_store_token "${KB_STORE_TOKEN:-}" \
-  --arg claude_model "$CI_E2E_CLAUDE_MODEL" \
-  --arg allow_custom_orch_model "$CI_E2E_ALLOW_CUSTOM_ORCH_MODEL" \
   --argjson gpus "$GPUS" --argjson params "$params" \
   '{name:$name, infra_type:$itype, kind:"hyperloom", replicas:1,
     gpu_per_replica:$gpus,
     template:{params:$params, env:
-      ({HL_CI_E2E:"1", KNOWLEDGE_STORE_MODE:$knowledge_mode,
-        CLAUDE_MODEL:$claude_model,
-        INFERENCE_OPTIMIZER_ALLOW_CUSTOM_ORCH_MODEL:$allow_custom_orch_model}
+      ({HL_CI_E2E:"1", KNOWLEDGE_STORE_MODE:$knowledge_mode}
        + (if $knowledge_mode == "remote"
           then {KB_STORE_URL:$kb_store_url, KB_STORE_TOKEN:$kb_store_token}
           else {}


### PR DESCRIPTION
## Summary

Remove `CLAUDE_MODEL` and `INFERENCE_OPTIMIZER_ALLOW_CUSTOM_ORCH_MODEL` from the run-submission `template.env` in `.github/scripts/ci-e2e-dispatch.sh`. The file is now byte-identical to its pre-#1401 state (blob `dbc5103a9` -> `09acdcabd`).

## The regression

#1401 ("remove dead compatibility and fallback paths") is a dead-code removal PR, but it also carried a CI fix: commit `b068183a9` "pin a supported e2e orchestration model". That commit injected two keys into the submission body:

```
template.env = { HL_CI_E2E, KNOWLEDGE_STORE_MODE,
                 CLAUDE_MODEL: "${CI_E2E_CLAUDE_MODEL:-claude-opus-5}",
                 INFERENCE_OPTIMIZER_ALLOW_CUSTOM_ORCH_MODEL: <derived> }
```

The `:-` guard looks like it respects existing configuration, but it only reads `CI_E2E_CLAUDE_MODEL` from the **GitHub runner** process, and `ci-e2e.yml` never passes that variable. So the default always won, and `CI_E2E_ALLOW_CUSTOM_ORCH_MODEL` -- derived from whether the model was set explicitly -- was always `"0"`.

`template.env` outranks the platform configuration, so since 2026-09-04 every PR `ci-e2e/run` has ignored the platform's `CLAUDE_MODEL` and run `claude-opus-5` under the strict AMD allowlist.

Reproducing the body construction with the exact env `ci-e2e.yml` provides:

| | `template.env` |
|---|---|
| `main` | `CLAUDE_MODEL=claude-opus-5`, `INFERENCE_OPTIMIZER_ALLOW_CUSTOM_ORCH_MODEL=0`, `HL_CI_E2E=1`, `KNOWLEDGE_STORE_MODE=local` |
| this PR | `HL_CI_E2E=1`, `KNOWLEDGE_STORE_MODE=local` |

## Why the pin is not needed

The failure it was fixing was real -- three consecutive runs died with `exited with code 2 ... custom orchestration model support enabled`, the preflight gate refusing an orchestration model the gateway no longer served:

| time (UTC) | event |
|---|---|
| 09-03 15:40 / 09-04 03:11 / 09-04 04:03 | `ci-e2e/run` fails on the model gate |
| **09-04 05:18** | **platform configuration corrected to a model the gateway serves** |
| 09-04 06:36 | `b068183a9` pins `claude-opus-5` + literal `INFERENCE_OPTIMIZER_ALLOW_CUSTOM_ORCH_MODEL:"0"` |
| 09-04 08:38 | `CI_E2E_*` escape hatches added on review |
| 09-04 09:04 | merged |

The root cause was already fixed 78 minutes before the pin landed. The pin has only ever masked a solved problem while silently overriding a deliberately configured model.

## Why both keys, not just `CLAUDE_MODEL`

Removing only `CLAUDE_MODEL` would be worse than the current bug. `_CI_E2E_MODEL_WAS_EXPLICIT` is always 0, so the allowlist switch would stay `"0"` and keep the strict AMD allowlist active; a platform model outside `claude-opus-5/4-8/4-7/4-6` would then fail preflight with `exit 2` instead of merely running the wrong model -- turning "wrong model" into "run refuses to start".

The two variables are orthogonal knobs (which model vs. whether non-allowlist models are permitted). Deriving one from the other was the design error; both go.

## Follow-up, deliberately not done here

No replacement pin is added. The platform configuration is the single source of truth; a second override path in the dispatch script would just recreate the conflict. If a pinned model is ever genuinely required, `pre-release-e2e-test.yml` already has the right pattern -- `CLAUDE_MODEL: ${{ vars.PRE_E2E_CLAUDE_MODEL }}`, an explicit repo variable with no default baked into the script.

## Validation

- `bash -n` clean.
- Blob hash returns to the pre-#1401 pre-image, so the change is a byte-exact revert of that hunk.
- Body construction replayed with `ci-e2e.yml`'s env; `template.env` output shown in the table above.
- The currently configured platform model is present in the gateway `/models` catalog, so with the allowlist switch unset the catalog probe passes. This PR's own `ci-e2e/run` is the end-to-end proof: its preflight should log `Claude model ... confirmed in gateway catalog` with the platform-configured model rather than `claude-opus-5`.
