### PR TITLE
fix(agentx): isolate aiperf in a compatible Python environment

### DIFF
--- a/src/hyperloom/inference_optimizer/agentx/preflight.py
+++ b/src/hyperloom/inference_optimizer/agentx/preflight.py
@@ -34,11 +34,32 @@ class AgentXPreflightError(RuntimeError):
         self.repairable = repairable
 
 
+def _aiperf_state_dir(env: Mapping[str, str]) -> Path:
+    state = env.get("HYPERLOOM_STATE_DIR")
+    if not state:
+        home = env.get("HOME")
+        if not home:
+            if os.name == "posix":
+                import pwd
+
+                home = pwd.getpwuid(os.getuid()).pw_dir
+            else:
+                home = str(Path.home())
+        state = str(Path(home) / ".hyperloom")
+    path = Path(state)
+    if not path.is_absolute():
+        raise AgentXPreflightError(f"HYPERLOOM_STATE_DIR must be an absolute path: {state}")
+    return path
+
+
 def resolve_aiperf_bin(env: Mapping[str, str]) -> Optional[str]:
-    """Return ``AIPERF_BIN`` (operator override) else a PATH lookup else None."""
+    """Return the explicit override, managed CLI, or a PATH lookup, in that order."""
     override = (env.get("AIPERF_BIN") or "").strip()
     if override:
         return override
+    managed = _aiperf_state_dir(env) / "aiperf-venv" / "bin" / "aiperf"
+    if managed.is_file() and os.access(managed, os.X_OK):
+        return str(managed)
     # Resolve against the SAME PATH the benchmark subprocess will use (the child
     # env), not this process's os.environ, so preflight probes the binary that
     # actually runs. Falls back to os.environ PATH when env has none.
@@ -61,13 +82,29 @@ _ALLOWLIST_SNIPPET = (
 )
 
 
-def _default_probe(aiperf_bin: str) -> str:
+def _is_managed_aiperf(aiperf_bin: str, env: Mapping[str, str]) -> bool:
+    if (env.get("AIPERF_BIN") or "").strip():
+        return False
+    managed = _aiperf_state_dir(env) / "aiperf-venv" / "bin" / "aiperf"
+    return Path(aiperf_bin).resolve() == managed.resolve()
+
+
+def _probe_env(aiperf_bin: str, env: Mapping[str, str]) -> dict[str, str]:
+    child_env = dict(env)
+    if _is_managed_aiperf(aiperf_bin, env):
+        for key in ("PYTHONHOME", "PYTHONPATH", "PYTHONUSERBASE", "PYTHONPLATLIBDIR", "__PYVENV_LAUNCHER__"):
+            child_env.pop(key, None)
+    return child_env
+
+
+def _default_probe(aiperf_bin: str, *, env: Optional[Mapping[str, str]] = None) -> str:
     """Run ``aiperf profile --help`` and return combined stdout+stderr."""
     out = subprocess.run(
         [aiperf_bin, "profile", "--help"],
         capture_output=True,
         text=True,
         timeout=60,
+        env=_probe_env(aiperf_bin, os.environ if env is None else env),
     )
     return (out.stdout or "") + (out.stderr or "")
 
@@ -75,9 +112,8 @@ def _default_probe(aiperf_bin: str) -> str:
 def _interpreters_for(aiperf_bin: str) -> list[str]:
     """Interpreters that might have the probed aiperf importable.
 
-    install.sh pips aiperf into Hyperloom's own environment, so ``sys.executable``
-    is the usual hit; an ``AIPERF_BIN`` pointing at another venv is served by the
-    python sitting next to it.
+    The managed CLI uses the python next to it. ``sys.executable`` remains a
+    fallback for legacy installs and operator-provided wrappers.
     """
     import sys
 
@@ -85,7 +121,7 @@ def _interpreters_for(aiperf_bin: str) -> list[str]:
     return [str(sibling), sys.executable]
 
 
-def _default_loader_probe(aiperf_bin: str) -> Optional[list[str]]:
+def _default_loader_probe(aiperf_bin: str, *, env: Optional[Mapping[str, str]] = None) -> Optional[list[str]]:
     """Return the scenario's loader allowlist, or None if it cannot be read.
 
     Read from the *scenario registry* of the aiperf that will actually run, not
@@ -94,21 +130,22 @@ def _default_loader_probe(aiperf_bin: str) -> Optional[list[str]]:
     """
     import json
 
-    for interp in _interpreters_for(aiperf_bin):
+    runtime_env = os.environ if env is None else env
+    sibling_env = _probe_env(aiperf_bin, runtime_env)
+    interpreters = _interpreters_for(aiperf_bin)
+    if _is_managed_aiperf(aiperf_bin, runtime_env):
+        interpreters = interpreters[:1]
+    for index, interp in enumerate(interpreters):
         try:
             out = subprocess.run(
                 [interp, "-c", _ALLOWLIST_SNIPPET],
                 capture_output=True,
                 text=True,
                 timeout=60,
+                env=sibling_env if index == 0 else dict(runtime_env),
             )
-        # SubprocessError as well as OSError: subprocess.run(timeout=...) raises
-        # TimeoutExpired, which descends from SubprocessError, not OSError. Left
-        # uncaught it escapes check_aiperf_capability entirely -- turning the
-        # documented "degrade to the flag probe with a warning" into a hard
-        # preflight failure, on the one input (a hung interpreter) the timeout
-        # exists to handle. The sibling probes in cli/preflight.py already catch
-        # both.
+        # Timeouts are unreadable probes too: managed installs need repair;
+        # legacy layouts may still use the host interpreter or flag fallback.
         except (OSError, subprocess.SubprocessError):
             continue
         if out.returncode != 0:
@@ -147,9 +184,9 @@ def check_aiperf_capability(
     recipes do) lands in the stale build's allowlist and would otherwise replay
     it under the wrong invariants and stamp the result submittable.
 
-    Falls back to the flag probe, loudly, when the allowlist cannot be read at
-    all -- refusing outright would break setups that work today over what may be
-    nothing worse than an unusual install layout.
+    Managed installs must expose the allowlist through their own interpreter.
+    Legacy layouts and explicit overrides may fall back to the flag probe,
+    loudly, when the allowlist cannot be read at all.
 
     Args:
         aiperf_bin: Resolved aiperf path (None/empty means "not found").
@@ -158,8 +195,9 @@ def check_aiperf_capability(
         probe: Injectable help-text probe, used for the fallback path.
         loader_probe: Injectable allowlist probe; returns the scenario's
             permitted loaders, or None when they cannot be determined.
-        env: Environment the benchmark will run with; read for an operator
-            corpus pin. Defaults to the current process environment.
+        env: Environment the benchmark will run with, including any corpus pin.
+            Managed CLI probes isolate Python paths in a child copy only.
+            Defaults to the current process environment.
     """
     if not aiperf_bin:
         raise AgentXPreflightError(
@@ -174,7 +212,7 @@ def check_aiperf_capability(
         runtime_env.get("WEKA_LOADER_OVERRIDE") or ""
     ).strip()
 
-    loaders = (loader_probe or _default_loader_probe)(aiperf_bin)
+    loaders = loader_probe(aiperf_bin) if loader_probe else _default_loader_probe(aiperf_bin, env=runtime_env)
     if loaders is not None:
         # Two distinct questions, and only asking the second one leaves the
         # silent path open. Measured: with WEKA_LOADER_OVERRIDE pointing at an
@@ -210,6 +248,13 @@ def check_aiperf_capability(
             return
 
     if loaders is None:
+        if _is_managed_aiperf(aiperf_bin, runtime_env):
+            raise AgentXPreflightError(
+                f"managed aiperf at {aiperf_bin!r} could not read its {SCENARIO_NAME!r} "
+                "loader allowlist using its own Python interpreter; reinstall the pinned "
+                "build via install.sh.",
+                repairable=True,
+            )
         # Allowlist unreadable: fall back to the old flag probe, and say that the
         # real check did not run so a stale build is not silently blessed.
         print(
@@ -227,9 +272,8 @@ def check_aiperf_capability(
             file=sys.stderr,
         )
 
-    probe = probe or _default_probe
     try:
-        help_text = probe(aiperf_bin)
+        help_text = probe(aiperf_bin) if probe else _default_probe(aiperf_bin, env=runtime_env)
     except Exception as exc:  # noqa: BLE001 — surface as a structured preflight error
         # Repairable like its siblings: a half-installed aiperf whose ``--help``
         # cannot even be read is exactly what reinstalling the pin fixes, and

--- a/src/hyperloom/inference_optimizer/agentx/repair.py
+++ b/src/hyperloom/inference_optimizer/agentx/repair.py
@@ -35,6 +35,8 @@ import subprocess
 from pathlib import Path
 from typing import Mapping, Optional
 
+from hyperloom.inference_optimizer.agentx.preflight import AgentXPreflightError, _aiperf_state_dir
+
 log = logging.getLogger(__name__)
 
 #: Entry point ``install.sh`` exposes for "run ensure_aiperf and nothing else".
@@ -118,15 +120,12 @@ def _install_aiperf(*, env: Optional[Mapping[str, str]], timeout_sec: int) -> Op
     # the installer's own log says why it ran, and so a future refactor that
     # re-routes this through the ordinary gate keeps working.
     child_env["INSTALL_AIPERF"] = "1"
-    # The installer runs under ``set -u`` and expands ``${HOME}`` for its state
-    # dir. The benchmark child env this inherits does not always carry HOME, and
-    # the resulting "HOME: unbound variable" reads like a packaging bug rather
-    # than a missing variable, so supply this process's own.
+    # Freeze the preflight's destination before supplying a HOME for subprocesses.
+    try:
+        child_env["HYPERLOOM_STATE_DIR"] = str(_aiperf_state_dir(child_env))
+    except (AgentXPreflightError, KeyError, OSError, RuntimeError) as exc:
+        return f"could not resolve the aiperf state directory: {exc}"
     if not child_env.get("HOME"):
-        # setdefault would leave an empty-string HOME in place, and the
-        # installer expands ${HOME}/.hyperloom into an unwritable
-        # /.hyperloom -- the stamp write then fails and every later
-        # provision redoes the install this one was supposed to record.
         child_env["HOME"] = os.path.expanduser("~")
 
     log.warning(

--- a/src/hyperloom/inference_optimizer/assets/agentx/aiperf_client.sh
+++ b/src/hyperloom/inference_optimizer/assets/agentx/aiperf_client.sh
@@ -64,6 +64,32 @@ PORT="${PORT:-8000}"
 # and the mapped result records no concurrency at all, so the mismatch would be
 # invisible afterwards. The switch always projects CONC; if it ever stops, say so.
 : "${CONC:?CONC required (the AgentX switch projects it from the benchmark config)}"
+
+# Match preflight's override -> managed CLI -> PATH order without changing PATH.
+_aiperf_override="${AIPERF_BIN:-}"
+_aiperf_override="${_aiperf_override#"${_aiperf_override%%[![:space:]]*}"}"
+_aiperf_override="${_aiperf_override%"${_aiperf_override##*[![:space:]]}"}"
+AIPERF_CMD=("${_aiperf_override:-aiperf}")
+if [ -z "$_aiperf_override" ]; then
+  _aiperf_state="${HYPERLOOM_STATE_DIR:-}"
+  if [ -z "$_aiperf_state" ]; then
+    _aiperf_home="${HOME:-}"
+    if [ -z "$_aiperf_home" ]; then
+      _aiperf_home="$(env -u __PYVENV_LAUNCHER__ "${PYTHON:-python3}" -I -c 'import os, pwd; print(pwd.getpwuid(os.getuid()).pw_dir)')"
+    fi
+    _aiperf_state="${_aiperf_home}/.hyperloom"
+  fi
+  case "$_aiperf_state" in
+    /*) ;;
+    *) log "ERROR: HYPERLOOM_STATE_DIR must be an absolute path: $_aiperf_state"; exit 2 ;;
+  esac
+  _aiperf_managed="${_aiperf_state}/aiperf-venv/bin/aiperf"
+  if [ -f "$_aiperf_managed" ] && [ -x "$_aiperf_managed" ]; then
+    # Only the independent client interpreter is isolated, not server/mapper Python.
+    AIPERF_CMD=(env -u PYTHONHOME -u PYTHONPATH -u PYTHONUSERBASE -u PYTHONPLATLIBDIR -u __PYVENV_LAUNCHER__ "$_aiperf_managed")
+  fi
+fi
+
 RESULT_DIR="${RESULT_DIR:-$(pwd)}"
 RESULT_FILENAME="${RESULT_FILENAME:-inferencex_result}"
 ART="${RESULT_DIR}/aiperf_artifacts"
@@ -355,8 +381,6 @@ export AIPERF_UI_REALTIME_METRICS_ENABLED="${AGENTX_REALTIME_METRICS:-true}"
 _mmap_default="${HF_HUB_CACHE:-${HOME:-/tmp}/.cache/huggingface/hub}/aiperf_dataset_mmap"
 export AIPERF_DATASET_MMAP_CACHE_DIR="${AGENTX_MMAP_CACHE_DIR:-$_mmap_default}"
 
-AIPERF="${AIPERF_BIN:-aiperf}"
-
 # Abort the run once the error rate exceeds this ratio. aiperf's own default is
 # None, i.e. the check is DISABLED -- without the flag a run whose requests
 # mostly 4xx still exits 0 and is mapped as a normal measurement, because
@@ -476,7 +500,7 @@ log "aiperf model=${SERVE_MODEL} corpus=${DS} entries=${NENT} conc=${CONC} durat
 #   --max-context-length omitted (see the replay-context note above).
 AIPERF_PROGRESS_ARGS=()
 run_aiperf() {
-  "$AIPERF" profile \
+  "${AIPERF_CMD[@]}" profile \
     --scenario inferencex-agentx-mvp \
     --url "http://localhost:${PORT}" \
     --endpoint /v1/chat/completions \

--- a/src/hyperloom/inference_optimizer/assets/install.sh
+++ b/src/hyperloom/inference_optimizer/assets/install.sh
@@ -617,6 +617,7 @@ resolve_python() {
   # Bare-image bootstrap (Debian/Ubuntu only). Skipped silently when
   # apt-get is missing (RHEL/Alpine/etc.) or the operator opted out.
   if command -v apt-get >/dev/null 2>&1 \
+      && [ "${ONLY_AIPERF:-0}" -eq 0 ] \
       && [ "$DRY_RUN" -eq 0 ] && [ "$CHECK_ONLY" -eq 0 ] \
       && [ -z "${INFERENCE_OPTIMIZER_SKIP_APT_BOOTSTRAP:-}" ]; then
     log "no python3 found; attempting bare-image apt bootstrap " \
@@ -751,7 +752,7 @@ fi
 # in pip 23.0.1; older pips reject it as an unknown option, so we probe
 # `pip install --break-system-packages --help` before adopting it.
 PIP_EXTRA=()
-if "$PYTHON" - <<'PY' 2>/dev/null
+if [ "$ONLY_AIPERF" -eq 0 ] && "$PYTHON" - <<'PY' 2>/dev/null
 import sys
 raise SystemExit(0 if sys.prefix == sys.base_prefix else 1)
 PY
@@ -1192,81 +1193,175 @@ PY
 }
 
 # --- 2a. aiperf (AgentX benchmark client) ---
-# Installs the pinned aiperf. Reached from the gate at the call site on either
-# branch -- a default provision pre-warms it when this build ships the AgentX
-# client, and an explicit INSTALL_AIPERF / HYPERLOOM_AGENTX / --only-aiperf
-# demands it. Skipped when the operator points AIPERF_BIN at their own build.
-#
-# Failure handling is asymmetric by design, keyed on $AIPERF_REQUIRED:
-#   * pre-warm (nobody asked)  -> WARN. The install is speculative: nothing has
-#     said this box will run AgentX, so an interpreter below the pin's floor or
-#     an unreachable index must not fail a provision that was never going to use
-#     it. The runtime preflight repairs and, failing that, stops the run.
-#   * explicit request         -> FATAL. A dependency the caller asked for by
-#     name, with a pin this repository owns, must not end up absent with only a
-#     warning in a log nobody reads. Measured: the fail-soft warn let a
-#     provisioning run report success while leaving the box unable to run AgentX
-#     at all, and the gap surfaced hours later as a benchmark failure that was
-#     then handed to an enablement specialist as if it were a framework bug.
-#
-# So the synthetic path can still be provisioned on a box that cannot host
-# aiperf -- what it no longer does is skip the install merely because nobody
-# happened to export a runtime mode flag while provisioning.
+# The client owns a separate Python environment; never pip into the GPU stack.
+_aiperf_clean_env() (
+  unset PYTHONHOME PYTHONPATH PYTHONUSERBASE PYTHONPLATLIBDIR __PYVENV_LAUNCHER__ VIRTUAL_ENV CONDA_PREFIX
+  unset PIP_TARGET PIP_PREFIX PIP_ROOT PIP_USER
+  unset UV_PYTHON UV_SYSTEM_PYTHON UV_TARGET UV_PREFIX UV_PROJECT_ENVIRONMENT
+  unset UV_MANAGED_PYTHON UV_NO_MANAGED_PYTHON UV_PYTHON_PREFERENCE
+  "$@"
+)
+
+_aiperf_check_owned_dir() {
+  local dir="$1" marker="$1/.hyperloom-${1##*/}"
+  if [ -e "$dir" ] || [ -L "$dir" ]; then
+    if [ -L "$dir" ] || [ ! -d "$dir" ] || [ ! -f "$marker" ] || [ -L "$marker" ] \
+        || [ "$(cat "$marker")" != hyperloom-aiperf-v1 ]; then
+      warn "refusing to modify unowned aiperf directory: $dir"
+      return 1
+    fi
+  fi
+  return 0
+}
+
+_aiperf_healthy() {
+  local venv="$1" help_text ref="$AIPERF_REF"
+  # A package-spec override chooses its own source; the default must match our pin.
+  [ "$AIPERF_PACKAGE_SPEC" = "aiperf @ git+${AIPERF_REPO}@${AIPERF_REF}" ] || ref=""
+  [ -x "$venv/bin/python" ] && [ -x "$venv/bin/aiperf" ] || return 1
+  _aiperf_clean_env timeout 60 "$venv/bin/python" -I - "$ref" <<'PY' >/dev/null 2>&1 || return 1
+import json
+import re
+import sys
+from importlib.metadata import PackageNotFoundError, distribution
+try:
+    source = json.loads(distribution("aiperf").read_text("direct_url.json") or "{}")
+except (PackageNotFoundError, ValueError, OSError):
+    raise SystemExit(1)
+vcs = source.get("vcs_info", {})
+ref = sys.argv[1]
+if not ref:
+    matches = True
+elif re.fullmatch(r"[0-9a-fA-F]{7,40}", ref):
+    matches = (vcs.get("commit_id") or "").lower().startswith(ref.lower())
+else:
+    matches = vcs.get("requested_revision") == ref
+raise SystemExit(0 if matches and (3, 11) <= sys.version_info[:2] < (3, 14) else 1)
+PY
+  help_text="$(_aiperf_clean_env timeout 60 "$venv/bin/aiperf" profile --help)" || return 1
+  case "$help_text" in *weka-trace*--scenario*|*--scenario*weka-trace*) ;; *) return 1 ;; esac
+  [[ "$help_text" == *--benchmark-duration* ]]
+}
+
+_aiperf_uv() (
+  local no_index="${PIP_NO_INDEX:-}"
+  # uv does not read pip's network environment variables.
+  if [ -n "${PIP_INDEX_URL:-}" ] && [ -z "${UV_DEFAULT_INDEX:-}${UV_INDEX_URL:-}" ]; then
+    export UV_DEFAULT_INDEX="$PIP_INDEX_URL"
+  fi
+  if [ -n "${PIP_EXTRA_INDEX_URL:-}" ] && [ -z "${UV_INDEX:-}${UV_EXTRA_INDEX_URL:-}" ]; then
+    export UV_EXTRA_INDEX_URL="$PIP_EXTRA_INDEX_URL"
+  fi
+  if [ -n "${PIP_FIND_LINKS:-}" ] && [ -z "${UV_FIND_LINKS:-}" ]; then
+    export UV_FIND_LINKS="$PIP_FIND_LINKS"
+  fi
+  if [ "${1:-} ${2:-}" = "pip install" ]; then
+    case "${no_index,,}" in 1|true|yes|on) set -- "$@" --no-index ;; esac
+  fi
+  _aiperf_clean_env env \
+    UV_PYTHON_INSTALL_DIR="$state/aiperf-python" \
+    UV_PYTHON_BIN_DIR="$state/aiperf-python-bin" \
+    UV_CACHE_DIR="$state/aiperf-cache" \
+    "$uv" --no-config "$@"
+)
+
+_install_aiperf() (
+  local state="${HYPERLOOM_STATE_DIR:-}" home="${HOME:-}" venv stamp install_id uv tools candidate aiperf_python=""
+  local offline="${UV_OFFLINE:-}"
+  if [ -z "$state" ]; then
+    if [ -z "$home" ]; then
+      home="$(_aiperf_clean_env "$PYTHON" -I -c 'import os, pwd; print(pwd.getpwuid(os.getuid()).pw_dir)')" || return 1
+    fi
+    state="${home}/.hyperloom"
+  fi
+  case "$state" in /*) ;; *) warn "HYPERLOOM_STATE_DIR must be an absolute path: $state"; return 1 ;; esac
+  venv="$state/aiperf-venv"
+  stamp="$state/aiperf_installed_ref"
+  install_id="$(printf '%s\n%s' "$AIPERF_REF" "$AIPERF_PACKAGE_SPEC")"
+  tools="$state/aiperf-tools"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "would install ${AIPERF_PACKAGE_SPEC} into ${venv} using Python >=3.11,<3.14 (managed 3.11 if needed)"
+    return 0
+  fi
+  if [ "$CHECK_ONLY" -eq 1 ]; then
+    if _aiperf_healthy "$venv"; then log "aiperf ready: $venv/bin/aiperf"; else warn "aiperf missing or unhealthy at $venv (check-only)"; fi
+    return 0
+  fi
+
+  # The checkout lock is acquired by the caller, before this shared state lock.
+  mkdir -p "$state" || return 1
+  exec 8>"$state/aiperf-install.lock" || return 1
+  if command -v flock >/dev/null 2>&1; then
+    flock 8 || return 1
+  else
+    warn "flock not available; concurrent aiperf installs may race"
+  fi
+  if [ "$(cat "$stamp" 2>/dev/null)" = "$install_id" ] && _aiperf_healthy "$venv"; then
+    log "aiperf at $venv/bin/aiperf is healthy at ref ${AIPERF_REF:0:8}; skipping install"
+    return 0
+  fi
+  _aiperf_check_owned_dir "$venv" || return 1
+  rm -f -- "$stamp" || return 1
+
+  uv="$(command -v uv 2>/dev/null || true)"
+  if [ -z "$uv" ]; then
+    _aiperf_check_owned_dir "$tools" || return 1
+    uv="$tools/bin/uv"
+    if [ ! -x "$uv" ]; then
+      case "${offline,,}" in
+        1|true|yes|on) warn "aiperf: UV_OFFLINE forbids bootstrapping uv with pip; provide uv on PATH"; return 1 ;;
+      esac
+      if ! _aiperf_clean_env "$PYTHON" -I -m pip --version >/dev/null 2>&1; then
+        warn "aiperf needs uv, but uv and pip in $PYTHON are unavailable; install uv on PATH or provide AIPERF_BIN"
+        return 1
+      fi
+      mkdir -p "$tools" || return 1
+      printf '%s\n' hyperloom-aiperf-v1 > "$tools/.hyperloom-aiperf-tools" || return 1
+      log "installing private uv==0.12.3 into $tools"
+      _aiperf_clean_env env PIP_REQUIRE_VIRTUALENV=false "$PYTHON" -I -m pip install --disable-pip-version-check \
+        --no-cache-dir --no-deps --only-binary=:all: --upgrade --target "$tools" uv==0.12.3 \
+        || { warn "aiperf: private uv bootstrap failed; check the pip/download error above"; return 1; }
+    fi
+  fi
+  for candidate in "$PYTHON" python3.11 python3.12 python3.13; do
+    if [ "$candidate" != "$PYTHON" ]; then
+      candidate="$(command -v "$candidate" 2>/dev/null)" || continue
+    fi
+    if _aiperf_clean_env "$candidate" -I -c 'import sys; sys.exit(not ((3, 11) <= sys.version_info[:2] < (3, 14)))'; then
+      aiperf_python="$candidate"
+      break
+    fi
+  done
+  if [ -z "$aiperf_python" ]; then
+    log "aiperf requires Python >=3.11,<3.14; preparing private managed Python 3.11"
+    _aiperf_uv python install --no-bin 3.11 \
+      || { warn "aiperf: managed Python 3.11 download failed; check network access and the uv error above"; return 1; }
+    aiperf_python="$(_aiperf_uv python find --managed-python --no-python-downloads 3.11)" || return 1
+  fi
+
+  # Only an environment bearing our marker can be removed, including partial builds.
+  if [ -d "$venv" ]; then rm -rf -- "$venv" || return 1; fi
+  mkdir -p "$venv" || return 1
+  printf '%s\n' hyperloom-aiperf-v1 > "$venv/.hyperloom-aiperf-venv" || return 1
+  _aiperf_uv venv --allow-existing --python "$aiperf_python" "$venv" || return 1
+  log "installing aiperf (AgentX) into $venv: ${AIPERF_PACKAGE_SPEC}"
+  _aiperf_uv pip install --python "$venv/bin/python" "$AIPERF_PACKAGE_SPEC" || return 1
+  _aiperf_healthy "$venv" || { warn "aiperf installed but failed its pinned-build health check at $venv"; return 1; }
+  printf '%s\n' "$install_id" > "$stamp" || return 1
+  log "aiperf installed OK: $venv/bin/aiperf"
+)
+
 ensure_aiperf() {
   if [ -n "${AIPERF_BIN:-}" ]; then
     log "AIPERF_BIN set (${AIPERF_BIN}); skipping aiperf install"
     return 0
   fi
-  if [ "$CHECK_ONLY" -eq 1 ]; then
-    if command -v aiperf >/dev/null 2>&1; then log "aiperf on PATH"; else warn "aiperf not found (check-only)"; fi
+  if _install_aiperf; then
     return 0
-  fi
-  if [ "$DRY_RUN" -eq 1 ]; then
-    log "would pip install aiperf (AgentX): ${AIPERF_PACKAGE_SPEC}"
-    return 0
-  fi
-  # Presence is not enough. Measured: the previous pin (aiperf 0.8.0) carries
-  # weka-trace, --scenario and --benchmark-duration, and defines a scenario by
-  # the same name -- but with different invariants and an allowlist that predates
-  # the current corpus. A presence-only skip therefore left every already
-  # provisioned box on the old build after a pin bump, silently, while the
-  # preflight's own advice ("install via install.sh") pointed back at this no-op.
-  # Record what we installed and reinstall when it no longer matches.
-  local stamp="${HYPERLOOM_STATE_DIR:-${HOME}/.hyperloom}/aiperf_installed_ref"
-  local -a pip_args=("${PIP_EXTRA[@]}")
-  if command -v aiperf >/dev/null 2>&1; then
-    if [ "$(cat "$stamp" 2>/dev/null)" = "$AIPERF_REF" ]; then
-      log "aiperf on PATH is the pinned ref ${AIPERF_REF:0:8}; skipping install"
-      return 0
-    fi
-    if [ "$AIPERF_REQUIRED" -ne 1 ]; then
-      # Pre-warm, and something is already on PATH. --force-reinstall below
-      # rebuilds aiperf's whole dependency tree (deliberately NOT --no-deps),
-      # which on a shared venv can move packages this box actually runs on --
-      # and nothing has said this box will run AgentX at all. Leave it: the
-      # runtime preflight sees the stale ref, and its repair asks for the
-      # upgrade by name, which does reach the branch below.
-      log "aiperf on PATH is not the pinned ref ${AIPERF_REF:0:8} (recorded: $(cat "$stamp" 2>/dev/null || echo none)); leaving it alone on a pre-warm -- the runtime repair upgrades it if AgentX is actually used"
-      return 0
-    fi
-    log "aiperf on PATH is not the pinned ref ${AIPERF_REF:0:8} (recorded: $(cat "$stamp" 2>/dev/null || echo none)); reinstalling"
-    # Deliberately NOT --no-deps: a newer aiperf may need dependencies the old
-    # one did not, and installing the package without them is a worse failure
-    # than the stale build we are replacing.
-    pip_args+=(--force-reinstall)
-  fi
-  log "installing aiperf (AgentX): ${AIPERF_PACKAGE_SPEC}"
-  if "$PYTHON" -m pip install --quiet "${pip_args[@]}" "$AIPERF_PACKAGE_SPEC"; then
-    log "aiperf installed OK"
-    # Stamp only after a success, so a failed upgrade retries next run instead
-    # of recording a ref that is not what is on disk. Best-effort: an unwritable
-    # state dir costs a redundant reinstall, never a wrong skip.
-    mkdir -p "$(dirname "$stamp")" 2>/dev/null && printf '%s\n' "$AIPERF_REF" > "$stamp" 2>/dev/null || \
-      warn "could not record the installed aiperf ref at ${stamp}; the next run will reinstall"
   elif [ "$AIPERF_REQUIRED" -eq 1 ]; then
-    die "aiperf install failed (${AIPERF_PACKAGE_SPEC}). AgentX was explicitly requested (INSTALL_AIPERF / HYPERLOOM_AGENTX / --only-aiperf), and aiperf is the AgentX benchmark client -- there is no usable AgentX install without it. Fix the failure above, or point AIPERF_BIN at an existing pinned build."
+    die "aiperf install failed (${AIPERF_PACKAGE_SPEC}); AgentX was explicitly requested. Fix the error above or provide AIPERF_BIN."
   else
-    warn "aiperf install failed (${AIPERF_PACKAGE_SPEC}); AgentX mode (HYPERLOOM_AGENTX) stays unavailable until aiperf is installed or AIPERF_BIN is set. Default synthetic path is unaffected."
+    warn "aiperf install failed (${AIPERF_PACKAGE_SPEC}); AgentX remains unavailable. Default synthetic path is unaffected."
   fi
 }
 
@@ -1726,15 +1821,7 @@ chain_kernel_agent() {
 }
 
 # --- targeted entry point: aiperf only -------------------------------------
-# Placed after every function definition (so ensure_aiperf exists) and before
-# the first heavy step. Everything ensure_aiperf reads is resolved by here:
-# $PYTHON (resolve_python), $PIP_EXTRA, $AIPERF_PACKAGE_SPEC, $AIPERF_REQUIRED
-# and the state dir. Other top-level statements do run between those and this
-# line -- directory setup, dependency-list arrays -- but ensure_aiperf reads
-# none of them, so the short-circuit drops nothing it depends on.
-#
-# The lock is taken for the same reason a full install takes it: two sessions on
-# one node must not pip into the same interpreter concurrently.
+# Both entry points acquire the checkout lock before the aiperf state lock.
 if [ "$ONLY_AIPERF" -eq 1 ]; then
   log "--only-aiperf: installing just the pinned AgentX client"
   acquire_install_lock

--- a/src/hyperloom/inference_optimizer/tests/test_agentx_preflight.py
+++ b/src/hyperloom/inference_optimizer/tests/test_agentx_preflight.py
@@ -4,7 +4,7 @@
 """AgentX preflight: AIPERF_BIN resolution + capability (weka-trace) check.
 
 Contract:
-- ``resolve_aiperf_bin`` prefers ``AIPERF_BIN`` env, else PATH lookup, else None.
+- ``resolve_aiperf_bin`` prefers ``AIPERF_BIN``, then the managed CLI, then PATH.
 - ``check_aiperf_capability`` raises ``AgentXPreflightError`` when the binary is
   missing OR lacks the AgentX (weka-trace) capability. It verifies *capability*,
   not mere existence. The probe is injectable so the check is testable offline.
@@ -12,7 +12,16 @@ Contract:
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
+
+from hyperloom.inference_optimizer.agentx import preflight as pf
 
 from hyperloom.inference_optimizer.agentx.preflight import (
     AgentXPreflightError,
@@ -25,15 +34,93 @@ def test_resolve_prefers_env():
     assert resolve_aiperf_bin({"AIPERF_BIN": "/venv/bin/aiperf"}) == "/venv/bin/aiperf"
 
 
-def test_resolve_none_when_absent(monkeypatch):
+def _managed_cli(state: Path) -> Path:
+    cli = state / "aiperf-venv" / "bin" / "aiperf"
+    cli.parent.mkdir(parents=True)
+    cli.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    cli.chmod(0o755)
+    return cli
+
+
+@pytest.mark.parametrize("override", ["", " \t\n"])
+def test_resolve_managed_before_broken_path_aiperf(tmp_path, monkeypatch, override):
+    cli = _managed_cli(tmp_path / "home" / ".hyperloom")
+    monkeypatch.setattr(pf.shutil, "which", lambda *_a, **_k: "/broken/bin/aiperf")
+    env = {"HOME": str(tmp_path / "home"), "AIPERF_BIN": override, "PATH": "/broken/bin"}
+    original = dict(env)
+    assert resolve_aiperf_bin(env) == str(cli)
+    assert env == original
+
+
+def test_resolve_managed_custom_state_outranks_home(tmp_path):
+    cli = _managed_cli(tmp_path / "custom state")
+    _managed_cli(tmp_path / "home" / ".hyperloom")
+    assert resolve_aiperf_bin(
+        {"HYPERLOOM_STATE_DIR": str(tmp_path / "custom state"), "HOME": str(tmp_path / "home")}
+    ) == str(cli)
+
+
+def test_resolve_managed_empty_state_uses_home(tmp_path):
+    cli = _managed_cli(tmp_path / ".hyperloom")
+    assert resolve_aiperf_bin({"HYPERLOOM_STATE_DIR": "", "HOME": str(tmp_path)}) == str(cli)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX user database")
+@pytest.mark.parametrize("home", [None, ""])
+def test_resolve_managed_missing_home_uses_system_user(tmp_path, monkeypatch, home):
+    import pwd
+
+    cli = _managed_cli(tmp_path / "system-home" / ".hyperloom")
+    monkeypatch.setenv("HOME", str(tmp_path / "unrelated-parent-home"))
+    seen = []
+
+    def _getpwuid(uid):
+        seen.append(uid)
+        return SimpleNamespace(pw_dir=str(tmp_path / "system-home"))
+
+    monkeypatch.setattr(pwd, "getpwuid", _getpwuid)
+    env = {"HOME": home} if home is not None else {}
+    assert resolve_aiperf_bin(env) == str(cli)
+    assert seen == [os.getuid()]
+
+
+@pytest.mark.parametrize("env", [{"HYPERLOOM_STATE_DIR": "relative"}, {"HOME": "relative-home"}])
+def test_resolve_rejects_relative_state(env):
+    with pytest.raises(AgentXPreflightError, match="HYPERLOOM_STATE_DIR.*absolute") as exc:
+        resolve_aiperf_bin(env)
+    assert not exc.value.repairable
+
+
+def test_resolve_override_outranks_managed_and_invalid_state(tmp_path):
+    _managed_cli(tmp_path)
+    for state in (str(tmp_path), "relative"):
+        env = {"HYPERLOOM_STATE_DIR": state, "AIPERF_BIN": " \t/external/bin/aiperf\n"}
+        assert resolve_aiperf_bin(env) == "/external/bin/aiperf"
+
+
+@pytest.mark.parametrize("candidate_kind", ["directory", "not-executable"])
+def test_resolve_unusable_managed_falls_back_to_path(tmp_path, monkeypatch, candidate_kind):
+    cli = _managed_cli(tmp_path)
+    if candidate_kind == "directory":
+        cli.unlink()
+        cli.mkdir()
+    else:
+        if os.name != "posix":
+            pytest.skip("POSIX executable permissions")
+        cli.chmod(0o644)
+    monkeypatch.setattr(pf.shutil, "which", lambda *_a, **_k: "/fallback/aiperf")
+    assert resolve_aiperf_bin({"HYPERLOOM_STATE_DIR": str(tmp_path)}) == "/fallback/aiperf"
+
+
+def test_resolve_none_when_absent(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "hyperloom.inference_optimizer.agentx.preflight.shutil.which",
         lambda _n, path=None: None,
     )
-    assert resolve_aiperf_bin({}) is None
+    assert resolve_aiperf_bin({"HOME": str(tmp_path)}) is None
 
 
-def test_resolve_path_lookup_returns_which(monkeypatch):
+def test_resolve_path_lookup_returns_which(monkeypatch, tmp_path):
     seen = {}
 
     def _which(name, path=None):
@@ -43,7 +130,7 @@ def test_resolve_path_lookup_returns_which(monkeypatch):
 
     monkeypatch.setattr("hyperloom.inference_optimizer.agentx.preflight.shutil.which", _which)
     # No AIPERF_BIN override -> falls back to which(), honoring the passed env PATH.
-    assert resolve_aiperf_bin({"PATH": "/opt/venv/bin"}) == "/opt/venv/bin/aiperf"
+    assert resolve_aiperf_bin({"HOME": str(tmp_path), "PATH": "/opt/venv/bin"}) == "/opt/venv/bin/aiperf"
     assert seen == {"name": "aiperf", "path": "/opt/venv/bin"}
 
 
@@ -242,6 +329,139 @@ def test_loader_probe_survives_a_hung_interpreter(monkeypatch):
 
     monkeypatch.setattr(pf.subprocess, "run", _hang)
     assert pf._default_loader_probe("/venv/bin/aiperf") is None
+
+
+@pytest.mark.parametrize("external_override", [False, True])
+def test_default_probes_scope_python_environment_to_managed_cli(tmp_path, monkeypatch, external_override):
+    cli = _managed_cli(tmp_path)
+    for key in ("PYTHONHOME", "PYTHONPATH", "PYTHONUSERBASE", "PYTHONPLATLIBDIR", "__PYVENV_LAUNCHER__"):
+        monkeypatch.setenv(key, "parent-pollution")
+    monkeypatch.setenv("HYPERLOOM_STATE_DIR", str(tmp_path))
+    monkeypatch.delenv("AIPERF_BIN", raising=False)
+    if external_override:
+        monkeypatch.setenv("AIPERF_BIN", str(cli))
+    original = dict(os.environ)
+    calls = []
+
+    def _run(argv, **kwargs):
+        calls.append((argv, kwargs.get("env")))
+        stdout = _CAPABLE_HELP if "profile" in argv else json.dumps(_NEW)
+        return subprocess.CompletedProcess(argv, 0, stdout, "")
+
+    monkeypatch.setattr(pf.subprocess, "run", _run)
+    check_aiperf_capability(str(cli), env=os.environ, require_progress_api=True)
+    assert calls[0][0][0] == str(cli.resolve().parent / "python")
+    assert calls[1][0] == [str(cli), "profile", "--help"]
+    for _, child_env in calls:
+        assert child_env is not None
+        assert child_env["PATH"] == original["PATH"]
+        assert child_env.get("AIPERF_BIN") == original.get("AIPERF_BIN")
+        for key in ("PYTHONHOME", "PYTHONPATH", "PYTHONUSERBASE", "PYTHONPLATLIBDIR", "__PYVENV_LAUNCHER__"):
+            assert child_env.get(key) == (original[key] if external_override else None)
+    assert dict(os.environ) == original
+
+
+@pytest.mark.parametrize("install_kind", ["legacy", "explicit"])
+def test_loader_fallback_keeps_runtime_pythonpath(tmp_path, monkeypatch, install_kind):
+    cli = _managed_cli(tmp_path)
+    env = {"HYPERLOOM_STATE_DIR": str(tmp_path / "other-state"), "PYTHONPATH": "/host/packages"}
+    if install_kind == "explicit":
+        env.update(HYPERLOOM_STATE_DIR=str(tmp_path), AIPERF_BIN=str(cli))
+    calls = []
+
+    def _run(argv, **kwargs):
+        calls.append((argv, kwargs.get("env")))
+        return subprocess.CompletedProcess(argv, 1 if len(calls) == 1 else 0, json.dumps(_NEW), "")
+
+    monkeypatch.setattr(pf.subprocess, "run", _run)
+    check_aiperf_capability(str(cli), env=env)
+    assert len(calls) == 2
+    assert calls[0][1] == env
+    assert calls[1][0][0] == sys.executable
+    assert "-I" not in calls[1][0]
+    assert calls[1][1] == env
+
+
+@pytest.mark.parametrize("failure", ["missing", "timeout", "nonzero", "empty", "invalid-json", "not-a-list"])
+def test_managed_loader_failure_cannot_be_blessed_by_host_python(tmp_path, monkeypatch, failure):
+    cli = _managed_cli(tmp_path)
+    env = {"HYPERLOOM_STATE_DIR": str(tmp_path), "PYTHONPATH": "/host/packages"}
+    before = dict(env)
+    sibling = str(cli.resolve().parent / "python")
+    calls = []
+
+    def _run(argv, **kwargs):
+        calls.append(argv)
+        if argv[0] == sibling:
+            if failure == "missing":
+                raise FileNotFoundError(sibling)
+            if failure == "timeout":
+                raise subprocess.TimeoutExpired(argv, 60)
+            stdout = {"empty": "", "invalid-json": "broken import", "not-a-list": "{}"}.get(failure, json.dumps(_NEW))
+            return subprocess.CompletedProcess(argv, 1 if failure == "nonzero" else 0, stdout, "")
+        return subprocess.CompletedProcess(argv, 0, json.dumps(_NEW), "")
+
+    monkeypatch.setattr(pf.subprocess, "run", _run)
+    with pytest.raises(AgentXPreflightError, match="managed.*loader allowlist") as exc:
+        check_aiperf_capability(str(cli), env=env, probe=lambda _bin: _CAPABLE_HELP)
+    assert exc.value.repairable is True
+    assert [argv[0] for argv in calls] == [sibling]
+    assert env == before
+
+
+def test_managed_unreadable_allowlist_does_not_degrade_to_flag_probe(tmp_path):
+    cli = _managed_cli(tmp_path)
+    help_calls = []
+
+    def _probe(aiperf_bin):
+        help_calls.append(aiperf_bin)
+        return _CAPABLE_HELP
+
+    with pytest.raises(AgentXPreflightError, match="managed.*loader allowlist") as exc:
+        check_aiperf_capability(
+            str(cli),
+            env={"HYPERLOOM_STATE_DIR": str(tmp_path)},
+            loader_probe=lambda _bin: None,
+            probe=_probe,
+        )
+    assert exc.value.repairable is True
+    assert help_calls == []
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX venv CLI shebang")
+def test_managed_sibling_python_ignores_host_packages(tmp_path, monkeypatch):
+    venv = tmp_path / "state" / "aiperf-venv"
+    subprocess.run([sys.executable, "-I", "-m", "venv", "--without-pip", str(venv)], check=True, capture_output=True)
+    python = venv / "bin" / "python"
+    purelib = Path(
+        subprocess.check_output(
+            [str(python), "-I", "-c", "import sysconfig; print(sysconfig.get_path('purelib'))"], text=True
+        ).strip()
+    )
+    poison = tmp_path / "host-python310-packages"
+    for root, loaders in ((purelib, _NEW), (poison, _OLD)):
+        package = root / "aiperf" / "common"
+        package.mkdir(parents=True)
+        (package.parent / "__init__.py").write_text("", encoding="utf-8")
+        (package / "__init__.py").write_text("", encoding="utf-8")
+        (package / "scenario.py").write_text(
+            f"from types import SimpleNamespace\ndef get_scenario(name):\n    return SimpleNamespace(require_loader={loaders!r})\n",
+            encoding="utf-8",
+        )
+    cli = python.with_name("aiperf")
+    cli.write_text(
+        f"#!{python}\nfrom aiperf.common.scenario import get_scenario\n"
+        f"assert get_scenario('test').require_loader == {_NEW!r}\nprint({_CAPABLE_HELP!r})\n",
+        encoding="utf-8",
+    )
+    cli.chmod(0o755)
+    monkeypatch.setenv("PYTHONPATH", str(poison))
+    env = dict(os.environ, HYPERLOOM_STATE_DIR=str(venv.parent), AIPERF_BIN="")
+    env.update(PYTHONHOME="/missing-python-home", PYTHONUSERBASE=str(poison), PYTHONPLATLIBDIR="missing-lib")
+    before = dict(env)
+    check_aiperf_capability(str(cli), env=env, require_progress_api=True)
+    assert env == before
+    assert os.environ["PYTHONPATH"] == str(poison)
 
 
 def test_hung_interpreter_reaches_the_flag_fallback(monkeypatch, capsys):

--- a/src/hyperloom/inference_optimizer/tests/test_agentx_repair.py
+++ b/src/hyperloom/inference_optimizer/tests/test_agentx_repair.py
@@ -15,7 +15,10 @@ re-derived by an LLM specialist.
 from __future__ import annotations
 
 import os
+import shlex
+import shutil
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -639,3 +642,555 @@ def test_an_unreadable_config_is_left_to_magpie(tmp_path, monkeypatch):
 
     assert runtime.maybe_prepare_agentx(env={}, inferencex_path=str(tmp_path), config_path=bad) is False
     assert called["deploy"] is False
+
+
+# Run the real installer block with shell executables, not the host's Python/uv.
+_FAKE_PYTHON = r"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'python|%s' "$0" >> "$FAKE_CALLS"
+printf '|%s' "$@" >> "$FAKE_CALLS"
+printf '\n' >> "$FAKE_CALLS"
+if [ "${1:-}" = -I ]; then shift; fi
+case "${1:-}" in
+  -c)
+    case "$2" in
+      *version_info*)
+        version="$(cat "$0.version")"
+        case "$version" in 3.11|3.12|3.13) exit 0 ;; *) exit 1 ;; esac ;;
+      *expanduser*|*getpwuid*) printf '%s\n' "$FAKE_USER_HOME"; exit 0 ;;
+    esac ;;
+  -)
+    source="$(cat)"
+    case "$source" in
+      *sys.base_prefix*) exit "$FAKE_PRIMARY_VENV" ;;
+      *direct_url*)
+        printf 'metadata|direct_url\n' >> "$FAKE_CALLS"
+        root="${0%/bin/python}"
+        test -f "$root/healthy" && { [ -z "${2:-}" ] || test "$(cat "$root/installed-ref")" = "$2"; }
+        exit $? ;;
+    esac ;;
+  -m)
+    [ "$2" = pip ] || exit 71
+    [ "$FAKE_PIP" = 1 ] || { printf 'ERROR: No module named pip\n' >&2; exit 72; }
+    case "$3" in
+      --version) printf 'pip 22.0 from primary\n'; exit 0 ;;
+      install)
+        for name in PIP_CONFIG_FILE PIP_INDEX_URL PIP_EXTRA_INDEX_URL PIP_NO_INDEX PIP_FIND_LINKS; do
+          printf 'pip-policy|%s|%s\n' "$name" "${!name:-}" >> "$FAKE_CALLS"
+        done
+        target=''
+        while [ "$#" -gt 0 ]; do
+          case "$1" in --target) target="$2"; shift ;; esac
+          shift
+        done
+        [ -n "$target" ] || { printf 'ERROR: refused to modify primary Python\n' >&2; exit 73; }
+        [ "$FAKE_FAILURE" != bootstrap ] || { printf 'ERROR: uv wheel download blocked\n' >&2; exit 74; }
+        mkdir -p "$target/bin"
+        cp "$FAKE_ROOT/fake-uv" "$target/bin/uv"
+        exit 0 ;;
+    esac ;;
+esac
+printf 'ERROR: unexpected Python invocation\n' >&2
+exit 75
+"""
+
+_FAKE_UV = r"""#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-}" = --no-config ] || { printf 'ERROR: uv config files were not disabled\n' >&2; exit 79; }
+shift
+printf 'uv' >> "$FAKE_CALLS"
+printf '|%s' "$@" >> "$FAKE_CALLS"
+printf '\n' >> "$FAKE_CALLS"
+for name in UV_OFFLINE UV_PYTHON_DOWNLOADS UV_PYTHON_INSTALL_MIRROR UV_DEFAULT_INDEX UV_INDEX_URL UV_INDEX UV_EXTRA_INDEX_URL UV_FIND_LINKS SSL_CERT_FILE HTTPS_PROXY; do
+  printf 'uv-policy|%s|%s\n' "$name" "${!name:-}" >> "$FAKE_CALLS"
+done
+for name in PYTHONHOME PYTHONPATH PYTHONUSERBASE PYTHONPLATLIBDIR __PYVENV_LAUNCHER__ PIP_TARGET PIP_PREFIX PIP_ROOT PIP_USER UV_SYSTEM_PYTHON UV_PYTHON UV_TARGET UV_PREFIX UV_PROJECT_ENVIRONMENT UV_MANAGED_PYTHON UV_NO_MANAGED_PYTHON UV_PYTHON_PREFERENCE; do
+  [ -z "${!name:-}" ] || { printf 'ERROR: leaked %s\n' "$name" >&2; exit 80; }
+done
+printf 'uv-env|%s|%s|%s\n' "${UV_PYTHON_INSTALL_DIR:-}" "${UV_PYTHON_BIN_DIR:-}" "${UV_CACHE_DIR:-}" >> "$FAKE_CALLS"
+case "$1 $2" in
+  'python install')
+    [ "$FAKE_FAILURE" != download ] || { printf 'ERROR: managed Python download blocked\n' >&2; exit 81; }
+    mkdir -p "$UV_PYTHON_INSTALL_DIR/cpython/bin"
+    cp "$FAKE_ROOT/fake-python" "$UV_PYTHON_INSTALL_DIR/cpython/bin/python"
+    printf '3.11\n' > "$UV_PYTHON_INSTALL_DIR/cpython/bin/python.version" ;;
+  'python find') printf '%s\n' "$UV_PYTHON_INSTALL_DIR/cpython/bin/python" ;;
+  'venv '*)
+    target="${!#}"
+    mkdir -p "$target/bin"
+    [ "$FAKE_FAILURE" != venv ] || { printf 'ERROR: venv creation failed\n' >&2; exit 82; }
+    cp "$FAKE_ROOT/fake-python" "$target/bin/python"
+    printf '3.11\n' > "$target/bin/python.version" ;;
+  'pip install')
+    if [ "$FAKE_FAILURE" = slow ]; then
+      touch "$FAKE_ROOT/install-started"
+      sleep 1
+    fi
+    [ "$FAKE_FAILURE" != install ] || { printf 'ERROR: aiperf download blocked\n' >&2; exit 83; }
+    target=''
+    while [ "$#" -gt 0 ]; do
+      case "$1" in --python) target="$2"; shift ;; esac
+      shift
+    done
+    [ -n "$target" ] || exit 84
+    root="${target%/bin/python}"
+    cp "$FAKE_ROOT/fake-aiperf" "$root/bin/aiperf"
+    printf '%s\n' "$FAKE_REF" > "$root/installed-ref"
+    if [ "$FAKE_FAILURE" = metadata ]; then printf 'no-vcs\n' > "$root/installed-ref"; fi
+    touch "$root/healthy" ;;
+  *) printf 'ERROR: unexpected uv invocation\n' >&2; exit 85 ;;
+esac
+"""
+
+_FAKE_AIPERF = r"""#!/usr/bin/env bash
+set -euo pipefail
+printf 'aiperf|%s|%s\n' "$0" "$*" >> "$FAKE_CALLS"
+[ -z "${PYTHONHOME:-}${PYTHONPATH:-}" ] || exit 86
+[ ! -f "${0%/bin/aiperf}/broken-cli" ] || exit 87
+printf 'weka-trace --scenario --benchmark-duration --api-host --api-port\n'
+"""
+
+
+@pytest.fixture
+def isolated_aiperf(tmp_path):
+    """A shell-only fixture safe on Windows and Linux, with no network access."""
+    for name, body in (("fake-python", _FAKE_PYTHON), ("fake-uv", _FAKE_UV), ("fake-aiperf", _FAKE_AIPERF)):
+        path = tmp_path / name
+        path.write_text(body, encoding="utf-8", newline="\n")
+        path.chmod(0o755)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    primary = bin_dir / "primary"
+    primary.write_text(_FAKE_PYTHON, encoding="utf-8", newline="\n")
+    primary.chmod(0o755)
+    (bin_dir / "primary.version").write_text("3.10", encoding="utf-8")
+
+    def run(
+        *,
+        primary_version="3.10",
+        primary_venv=False,
+        candidates=None,
+        uv_on_path=True,
+        pip=True,
+        failure="",
+        required=True,
+        mode="",
+        override=False,
+        state='"$PWD/state with spaces"',
+        home='"$PWD/home"',
+        polluted=False,
+        package_spec=None,
+        policy=None,
+        real_flock=False,
+        prepare_only=False,
+    ):
+        (bin_dir / "primary.version").write_text(primary_version, encoding="utf-8")
+        for version, actual in (candidates or {}).items():
+            candidate = bin_dir / f"python{version}"
+            candidate.write_text(_FAKE_PYTHON, encoding="utf-8", newline="\n")
+            candidate.chmod(0o755)
+            (bin_dir / f"python{version}.version").write_text(actual, encoding="utf-8")
+        uv_path = bin_dir / "uv"
+        if uv_on_path:
+            uv_path.write_text(_FAKE_UV, encoding="utf-8", newline="\n")
+            uv_path.chmod(0o755)
+        else:
+            uv_path.unlink(missing_ok=True)
+        text = repair.install_script_path().read_text(encoding="utf-8")
+        pip_gate = text[text.index("PIP_EXTRA=()") : text.index("# --- 1. inference_optimizer")]
+        block = text[text.index("# --- 2a. aiperf") : text.index("# --- 2b. Atomic-write")]
+        polluted_vars = (
+            "PYTHONHOME PYTHONPATH PYTHONUSERBASE PYTHONPLATLIBDIR __PYVENV_LAUNCHER__ "
+            "PIP_TARGET PIP_PREFIX PIP_ROOT PIP_USER UV_SYSTEM_PYTHON UV_PYTHON "
+            "UV_TARGET UV_PREFIX UV_PROJECT_ENVIRONMENT UV_CONFIG_FILE "
+            "UV_MANAGED_PYTHON UV_NO_MANAGED_PYTHON UV_PYTHON_PREFERENCE"
+        )
+        policy_vars = (
+            "UV_OFFLINE UV_PYTHON_DOWNLOADS UV_PYTHON_INSTALL_MIRROR UV_DEFAULT_INDEX UV_INDEX_URL "
+            "UV_INDEX UV_EXTRA_INDEX_URL UV_FIND_LINKS SSL_CERT_FILE HTTPS_PROXY PIP_CONFIG_FILE "
+            "PIP_INDEX_URL PIP_EXTRA_INDEX_URL PIP_NO_INDEX PIP_FIND_LINKS"
+        )
+        runner = tmp_path / "isolated-install.sh"
+        runner.write_text(
+            "\n".join(
+                [
+                    "#!/usr/bin/env bash",
+                    "set -euo pipefail",
+                    f"unset {polluted_vars} {policy_vars}",
+                    'export FAKE_ROOT="$PWD" FAKE_CALLS="${FAKE_CALLS:-$PWD/calls}" FAKE_USER_HOME="$PWD/fallback-home"',
+                    ': > "$FAKE_CALLS"',
+                    f"export FAKE_PIP={int(pip)} FAKE_FAILURE='{failure}' FAKE_REF=754356e9a39acc6cc6afb242d123bb57c3fb6f75",
+                    f"export FAKE_PRIMARY_VENV={int(primary_venv)}",
+                    'PYTHON="$PWD/bin/primary"',
+                    f"export HYPERLOOM_STATE_DIR={state}",
+                    f"export HOME={home}" if home is not None else "unset HOME",
+                    f"ONLY_AIPERF=1; AIPERF_REQUIRED={int(required)}",
+                    f"DRY_RUN={int(mode == 'dry')}; CHECK_ONLY={int(mode == 'check')}",
+                    'AIPERF_REF="$FAKE_REF"; AIPERF_REPO="https://example.test/aiperf.git"',
+                    f"AIPERF_PACKAGE_SPEC='{package_spec}'"
+                    if package_spec
+                    else 'AIPERF_PACKAGE_SPEC="aiperf @ git+${AIPERF_REPO}@$AIPERF_REF"',
+                    'AIPERF_BIN="/operator/aiperf"' if override else "unset AIPERF_BIN",
+                    'log() { printf "%s\\n" "$*"; }',
+                    'warn() { printf "%s\\n" "$*" >&2; }',
+                    'die() { warn "$*"; exit 99; }',
+                    # Hide host candidates without hiding the shell's core utilities.
+                    'command() { if [ "${1:-}" = -v ]; then case "$2" in uv|python3.11|python3.12|python3.13|aiperf) '
+                    '[ -x "$PWD/bin/$2" ] || return 1; printf "%s\\n" "$PWD/bin/$2"; return ;; esac; fi; builtin command "$@"; }',
+                    ":" if real_flock else 'flock() { printf "flock|%s\\n" "$*" >> "$FAKE_CALLS"; }',
+                    pip_gate,
+                    f"export {' '.join(name + '=polluted' for name in polluted_vars.split())}" if polluted else ":",
+                    *[f"export {name}={shlex.quote(value)}" for name, value in (policy or {}).items()],
+                    block,
+                    "ensure_aiperf",
+                    '[ "$PYTHON" = "$PWD/bin/primary" ]',
+                    '[ "${PYTHONHOME:-}" = polluted ]' if polluted else ":",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        if prepare_only:
+            return runner
+        proc = _bash(runner)
+        return proc, (tmp_path / "calls").read_text(encoding="utf-8")
+
+    return run
+
+
+def _assert_isolated_success(tmp_path, proc, calls):
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    state = tmp_path / "state with spaces"
+    assert (state / "aiperf-venv/bin/aiperf").is_file()
+    stamp = (state / "aiperf_installed_ref").read_text().splitlines()
+    assert stamp == [
+        "754356e9a39acc6cc6afb242d123bb57c3fb6f75",
+        "aiperf @ git+https://example.test/aiperf.git@754356e9a39acc6cc6afb242d123bb57c3fb6f75",
+    ]
+    installs = [line for line in calls.splitlines() if line.startswith("uv|pip|install|")]
+    assert len(installs) == 1, calls
+    assert "/aiperf-venv/bin/python" in installs[0]
+    assert "--no-deps" not in installs[0]
+    assert "--seed" not in calls and "ensurepip" not in calls
+    assert "--break-system-packages" not in calls
+
+
+@pytest.mark.parametrize("primary_venv", [False, True])
+def test_isolated_aiperf_uses_managed_python_for_310(tmp_path, isolated_aiperf, primary_venv):
+    proc, calls = isolated_aiperf(primary_venv=primary_venv)
+    _assert_isolated_success(tmp_path, proc, calls)
+    assert "uv|python|install|" in calls and "|3.11" in calls
+    assert "uv|python|find|" in calls
+    assert "/aiperf-python/" in calls
+    assert "/aiperf-python-bin|" in calls and "/aiperf-cache" in calls
+
+
+@pytest.mark.parametrize("version", ["3.11", "3.12", "3.13"])
+def test_isolated_aiperf_reuses_compatible_primary(tmp_path, isolated_aiperf, version):
+    proc, calls = isolated_aiperf(primary_version=version)
+    _assert_isolated_success(tmp_path, proc, calls)
+    assert "uv|python|install" not in calls
+    assert any("/bin/primary" in line for line in calls.splitlines() if line.startswith("uv|venv|"))
+
+
+def test_isolated_aiperf_validates_path_candidate_versions(tmp_path, isolated_aiperf):
+    proc, calls = isolated_aiperf(primary_version="3.14", candidates={"3.11": "3.10", "3.12": "3.12"})
+    _assert_isolated_success(tmp_path, proc, calls)
+    assert "uv|python|install" not in calls
+    assert any("/bin/python3.12" in line for line in calls.splitlines() if line.startswith("uv|venv|"))
+
+
+def test_isolated_aiperf_bootstraps_uv_privately_without_ensurepip(tmp_path, isolated_aiperf):
+    proc, calls = isolated_aiperf(uv_on_path=False)
+    _assert_isolated_success(tmp_path, proc, calls)
+    bootstraps = [line for line in calls.splitlines() if "|-m|pip|install|" in line]
+    assert len(bootstraps) == 1
+    assert "--target|" in bootstraps[0] and "/aiperf-tools|" in bootstraps[0]
+    assert "uv==0.12.3" in bootstraps[0]
+    assert (tmp_path / "state with spaces/aiperf-tools/bin/uv").is_file()
+
+
+@pytest.mark.parametrize("required", [True, False])
+@pytest.mark.parametrize("failure", ["bootstrap", "download", "venv", "install"])
+def test_isolated_aiperf_failure_has_no_success_stamp(tmp_path, isolated_aiperf, required, failure):
+    proc, calls = isolated_aiperf(uv_on_path=failure != "bootstrap", failure=failure, required=required)
+    assert (proc.returncode != 0) is required, proc.stdout + proc.stderr
+    assert "ERROR:" in proc.stderr
+    assert "aiperf" in proc.stderr.lower()
+    assert not (tmp_path / "state with spaces/aiperf_installed_ref").exists()
+    assert "ensurepip" not in calls
+
+
+def test_isolated_aiperf_missing_pip_does_not_bootstrap_system(tmp_path, isolated_aiperf):
+    proc, calls = isolated_aiperf(uv_on_path=False, pip=False)
+    assert proc.returncode != 0
+    assert "pip" in proc.stderr and "uv" in proc.stderr
+    assert "ensurepip" not in calls and "apt-get" not in calls
+    assert not (tmp_path / "state with spaces/aiperf_installed_ref").exists()
+
+
+def test_isolated_aiperf_path_uv_does_not_need_primary_pip(tmp_path, isolated_aiperf):
+    proc, calls = isolated_aiperf(pip=False)
+    _assert_isolated_success(tmp_path, proc, calls)
+    assert "|-m|pip|" not in calls
+
+
+def test_isolated_aiperf_same_pin_is_healthy_before_skip(tmp_path, isolated_aiperf):
+    first, calls = isolated_aiperf()
+    _assert_isolated_success(tmp_path, first, calls)
+    second, calls = isolated_aiperf(pip=False, uv_on_path=False)
+    assert second.returncode == 0, second.stderr
+    assert "uv|" not in calls and "|-m|pip|" not in calls
+    assert "aiperf|" in calls and "profile --help" in calls
+    assert "direct_url" in calls
+
+
+@pytest.mark.parametrize("broken", ["healthy", "bin/python", "bin/aiperf", "installed-ref", "broken-cli"])
+def test_isolated_aiperf_repairs_broken_same_pin(tmp_path, isolated_aiperf, broken):
+    first, calls = isolated_aiperf()
+    _assert_isolated_success(tmp_path, first, calls)
+    target = tmp_path / "state with spaces/aiperf-venv" / broken
+    if broken == "broken-cli":
+        target.touch()
+    else:
+        target.unlink()
+    second, calls = isolated_aiperf()
+    _assert_isolated_success(tmp_path, second, calls)
+
+
+def test_isolated_aiperf_failed_repair_removes_stale_stamp(tmp_path, isolated_aiperf):
+    first, calls = isolated_aiperf()
+    _assert_isolated_success(tmp_path, first, calls)
+    (tmp_path / "state with spaces/aiperf-venv/healthy").unlink()
+    second, _ = isolated_aiperf(failure="install")
+    assert second.returncode != 0
+    assert not (tmp_path / "state with spaces/aiperf_installed_ref").exists()
+
+
+def test_isolated_aiperf_leaves_unknown_venv_untouched(tmp_path, isolated_aiperf):
+    unknown = tmp_path / "state with spaces/aiperf-venv"
+    unknown.mkdir(parents=True)
+    sentinel = unknown / "operator-data"
+    sentinel.write_text("keep", encoding="utf-8")
+    proc, calls = isolated_aiperf()
+    assert proc.returncode != 0
+    assert "refus" in proc.stderr.lower() and "aiperf-venv" in proc.stderr
+    assert sentinel.read_text() == "keep"
+    assert "uv|venv|" not in calls
+
+
+@pytest.mark.parametrize("mode,override", [("dry", False), ("check", False), ("", True)])
+def test_isolated_aiperf_readonly_and_override_do_not_install(tmp_path, isolated_aiperf, mode, override):
+    proc, calls = isolated_aiperf(mode=mode, override=override, pip=False, uv_on_path=False)
+    assert proc.returncode == 0, proc.stderr
+    assert "uv|" not in calls and "|-m|pip|" not in calls
+    assert not (tmp_path / "state with spaces").exists()
+
+
+def test_isolated_aiperf_rejects_relative_state(tmp_path, isolated_aiperf):
+    proc, calls = isolated_aiperf(state="relative-state")
+    assert proc.returncode != 0
+    assert "absolute" in proc.stderr and "HYPERLOOM_STATE_DIR" in proc.stderr
+    assert not (tmp_path / "relative-state").exists()
+    assert "uv|" not in calls
+
+
+@pytest.mark.parametrize("home", ['""', None])
+def test_isolated_aiperf_empty_or_missing_home_uses_user_home(tmp_path, isolated_aiperf, home):
+    proc, _ = isolated_aiperf(state='""', home=home)
+    assert proc.returncode == 0, proc.stderr
+    assert (tmp_path / "fallback-home/.hyperloom/aiperf-venv/bin/aiperf").is_file()
+
+
+def test_isolated_aiperf_cleans_child_environment_only(tmp_path, isolated_aiperf):
+    proc, calls = isolated_aiperf(polluted=True)
+    _assert_isolated_success(tmp_path, proc, calls)
+
+
+def test_isolated_aiperf_does_not_trust_old_path_binary(tmp_path, isolated_aiperf):
+    stale = tmp_path / "bin/aiperf"
+    stale.write_text('#!/usr/bin/env bash\nprintf "stale PATH aiperf invoked\\n" >&2\nexit 0\n', encoding="utf-8")
+    stale.chmod(0o755)
+    proc, calls = isolated_aiperf(required=False)
+    _assert_isolated_success(tmp_path, proc, calls)
+    assert "stale PATH aiperf invoked" not in proc.stderr
+
+
+def test_isolated_aiperf_preserves_package_spec_override(tmp_path, isolated_aiperf):
+    spec = "aiperf @ https://example.test/custom.whl"
+    first, calls = isolated_aiperf(package_spec=spec, failure="metadata")
+    assert first.returncode == 0, first.stderr
+    assert spec in calls
+    second, calls = isolated_aiperf(package_spec=spec, failure="metadata")
+    assert second.returncode == 0, second.stderr
+    assert "uv|pip|install" not in calls
+    changed, calls = isolated_aiperf(package_spec="aiperf @ https://example.test/other.whl", failure="metadata")
+    assert changed.returncode == 0, changed.stderr
+    assert "uv|pip|install" in calls
+
+
+def test_isolated_aiperf_default_source_requires_real_pin(tmp_path, isolated_aiperf):
+    proc, _ = isolated_aiperf(failure="metadata")
+    assert proc.returncode != 0
+    assert not (tmp_path / "state with spaces/aiperf_installed_ref").exists()
+
+
+@pytest.mark.parametrize("layout", ["unknown", "symlink", "owned-symlink", "unknown-uv"])
+def test_isolated_aiperf_rejects_unowned_tools(tmp_path, isolated_aiperf, layout):
+    tools = tmp_path / "state with spaces/aiperf-tools"
+    tools.parent.mkdir()
+    target = tmp_path / "external" if "symlink" in layout else tools
+    (target / "bin").mkdir(parents=True)
+    sentinel = target / "bin/keep-me"
+    sentinel.write_text("operator data", encoding="utf-8")
+    if layout == "owned-symlink":
+        (target / ".hyperloom-aiperf-tools").write_text("hyperloom-aiperf-v1\n", encoding="utf-8")
+    if "symlink" in layout:
+        if os.name != "posix":
+            pytest.skip("requires POSIX symlinks")
+        tools.symlink_to(target, target_is_directory=True)
+    if layout == "unknown-uv":
+        (target / "bin/uv").write_text(_FAKE_UV, encoding="utf-8", newline="\n")
+        (target / "bin/uv").chmod(0o755)
+    before = sorted(path.relative_to(target).as_posix() for path in target.rglob("*"))
+    proc, calls = isolated_aiperf(uv_on_path=False)
+    assert proc.returncode != 0, proc.stdout + proc.stderr
+    assert "refus" in proc.stderr.lower() and "aiperf-tools" in proc.stderr
+    assert "|-m|pip|install|" not in calls and "uv|" not in calls
+    assert sentinel.read_text() == "operator data"
+    assert sorted(path.relative_to(target).as_posix() for path in target.rglob("*")) == before
+
+
+def test_isolated_aiperf_retries_owned_tools_bootstrap(tmp_path, isolated_aiperf):
+    failed, _ = isolated_aiperf(uv_on_path=False, failure="bootstrap")
+    assert failed.returncode != 0
+    assert (tmp_path / "state with spaces/aiperf-tools/.hyperloom-aiperf-tools").is_file()
+    retried, calls = isolated_aiperf(uv_on_path=False)
+    _assert_isolated_success(tmp_path, retried, calls)
+
+
+def test_isolated_aiperf_preserves_network_policy(tmp_path, isolated_aiperf):
+    policy = {
+        "UV_OFFLINE": "true",
+        "UV_PYTHON_DOWNLOADS": "never",
+        "UV_PYTHON_INSTALL_MIRROR": "https://python.example.test",
+        "UV_DEFAULT_INDEX": "https://packages.example.test/simple",
+        "UV_EXTRA_INDEX_URL": "https://extra.example.test/simple",
+        "SSL_CERT_FILE": "/etc/company-ca.pem",
+        "HTTPS_PROXY": "http://proxy.example.test:8080",
+    }
+    proc, calls = isolated_aiperf(policy=policy, primary_version="3.12")
+    _assert_isolated_success(tmp_path, proc, calls)
+    for name, value in policy.items():
+        assert f"uv-policy|{name}|{value}\n" in calls
+
+
+def test_isolated_aiperf_bootstrap_preserves_pip_config(tmp_path, isolated_aiperf):
+    policy = {"PIP_CONFIG_FILE": "/etc/company-pip.conf", "PIP_INDEX_URL": "https://packages.example.test/simple"}
+    proc, calls = isolated_aiperf(policy=policy, uv_on_path=False)
+    _assert_isolated_success(tmp_path, proc, calls)
+    for name, value in policy.items():
+        assert f"pip-policy|{name}|{value}\n" in calls
+
+
+@pytest.mark.parametrize("offline", ["true", "1"])
+def test_isolated_aiperf_offline_cannot_bootstrap_uv(tmp_path, isolated_aiperf, offline):
+    proc, calls = isolated_aiperf(policy={"UV_OFFLINE": offline}, uv_on_path=False)
+    assert proc.returncode != 0, proc.stdout + proc.stderr
+    assert "UV_OFFLINE" in proc.stderr
+    assert "|-m|pip|install|" not in calls
+    assert not (tmp_path / "state with spaces/aiperf_installed_ref").exists()
+
+
+@pytest.mark.parametrize(
+    "uv_indexes", [{}, {"UV_DEFAULT_INDEX": "https://uv.test/simple", "UV_INDEX": "https://extra-uv.test"}]
+)
+def test_isolated_aiperf_maps_pip_network_env_without_overriding_uv(tmp_path, isolated_aiperf, uv_indexes):
+    pip_policy = {
+        "PIP_INDEX_URL": "https://pip.test/simple",
+        "PIP_EXTRA_INDEX_URL": "https://extra-pip.test/simple",
+        "PIP_FIND_LINKS": "/company/wheelhouse",
+    }
+    proc, calls = isolated_aiperf(policy={**pip_policy, **uv_indexes})
+    _assert_isolated_success(tmp_path, proc, calls)
+    assert f"uv-policy|UV_DEFAULT_INDEX|{uv_indexes.get('UV_DEFAULT_INDEX', pip_policy['PIP_INDEX_URL'])}\n" in calls
+    if uv_indexes:
+        assert f"uv-policy|UV_INDEX|{uv_indexes['UV_INDEX']}\n" in calls
+        assert "uv-policy|UV_EXTRA_INDEX_URL|\n" in calls
+    else:
+        assert f"uv-policy|UV_EXTRA_INDEX_URL|{pip_policy['PIP_EXTRA_INDEX_URL']}\n" in calls
+    assert "uv-policy|UV_FIND_LINKS|/company/wheelhouse\n" in calls
+
+
+@pytest.mark.parametrize("no_index", ["1", "true", "false", ""])
+def test_isolated_aiperf_maps_pip_no_index_to_cli_only(tmp_path, isolated_aiperf, no_index):
+    proc, calls = isolated_aiperf(policy={"PIP_NO_INDEX": no_index})
+    _assert_isolated_success(tmp_path, proc, calls)
+    installs = [line for line in calls.splitlines() if line.startswith("uv|pip|install|")]
+    assert ("--no-index" in installs[0].split("|")) is (no_index in {"1", "true"})
+    assert all("--no-index" not in line for line in calls.splitlines() if line.startswith("uv|python|"))
+
+
+@pytest.mark.parametrize("home", [None, ""])
+def test_repair_state_resolution_precedes_parent_home_fallback(tmp_path, monkeypatch, home):
+    from hyperloom.inference_optimizer.agentx import preflight
+
+    child_env = {"PATH": "/usr/bin"}
+    if home is not None:
+        child_env["HOME"] = home
+    user_home = tmp_path / "user-home"
+    monkeypatch.setenv("HOME", str(tmp_path / "parent-home"))
+    if os.name == "posix":
+        import pwd
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(pwd, "getpwuid", lambda uid: SimpleNamespace(pw_dir=str(user_home)))
+    else:
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: user_home))
+    # The installer must target the state directory the preflight will re-check.
+    expected = preflight._aiperf_state_dir(child_env)
+    seen = {}
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kw: (seen.update(kw["env"]), subprocess.CompletedProcess(cmd, 0, "", ""))[1],
+    )
+    assert repair.ensure_aiperf_installed(env=child_env) is None
+    assert preflight._aiperf_state_dir(seen) == expected
+    assert seen.get("HYPERLOOM_STATE_DIR") == str(expected)
+    assert child_env.get("HOME") == home
+
+
+@pytest.mark.skipif(os.name != "posix" or not shutil.which("flock"), reason="requires POSIX flock")
+def test_isolated_aiperf_real_flock_serializes_shared_state(tmp_path, isolated_aiperf):
+    runner = isolated_aiperf(primary_version="3.12", failure="slow", real_flock=True, prepare_only=True)
+    processes = []
+    try:
+        for index in range(2):
+            processes.append(
+                subprocess.Popen(
+                    ["bash", runner.name],
+                    cwd=tmp_path,
+                    env={**os.environ, "FAKE_CALLS": str(tmp_path / f"calls-{index}")},
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+            )
+            if index == 0:
+                deadline = time.monotonic() + 10
+                while not (tmp_path / "install-started").exists():
+                    assert processes[0].poll() is None, "first installer exited before reaching installation"
+                    assert time.monotonic() < deadline, "first installer never reached installation"
+                    time.sleep(0.01)
+        outputs = [process.communicate(timeout=20) for process in processes]
+        assert all(process.returncode == 0 for process in processes), outputs
+        calls = "".join((tmp_path / f"calls-{index}").read_text() for index in range(2))
+        _assert_isolated_success(tmp_path, processes[0], calls)
+        assert "skipping install" in outputs[1][0], outputs
+    finally:
+        for process in processes:
+            if process.poll() is None:
+                process.kill()
+                process.communicate()

--- a/src/hyperloom/inference_optimizer/tests/test_aiperf_client_sh.py
+++ b/src/hyperloom/inference_optimizer/tests/test_aiperf_client_sh.py
@@ -13,9 +13,11 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import stat
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -41,6 +43,11 @@ def _fake_builtin(write_pid: bool) -> str:
         "{\n"
         '  echo "VLLM_HTTP_TIMEOUT_KEEP_ALIVE=${VLLM_HTTP_TIMEOUT_KEEP_ALIVE:-UNSET}"\n'
         '  echo "SGLANG_TIMEOUT_KEEP_ALIVE=${SGLANG_TIMEOUT_KEEP_ALIVE:-UNSET}"\n'
+        '  echo "PATH=$PATH"\n'
+        '  echo "PYTHON=${PYTHON:-UNSET}"\n'
+        '  echo "PYTHONPATH=${PYTHONPATH:-UNSET}"\n'
+        '  echo "PYTHONHOME=${PYTHONHOME:-UNSET}"\n'
+        '  echo "PYTHONUSERBASE=${PYTHONUSERBASE:-UNSET}"\n'
         '} > "${AGENTX_TEST_SERVER_MARKER:-/dev/null}"\n'
     )
     return "#!/usr/bin/env bash\nset -e\n" + dump + pid_line + "exit 0\n"
@@ -61,6 +68,14 @@ mkdir -p "$art"
 echo '{"output_token_throughput":{"avg":1.0},"request_count":{"avg":1}}' > "$art/profile_export_aiperf.json"
 printf '%s\n' "$@" > "$art/aiperf_args.txt"
 {
+  echo "CLI=$0"
+  echo "PATH=$PATH"
+  echo "PYTHON=${PYTHON:-UNSET}"
+  echo "PYTHONPATH=${PYTHONPATH:-UNSET}"
+  echo "PYTHONHOME=${PYTHONHOME:-UNSET}"
+  echo "PYTHONUSERBASE=${PYTHONUSERBASE:-UNSET}"
+  echo "PYTHONPLATLIBDIR=${PYTHONPLATLIBDIR:-UNSET}"
+  echo "__PYVENV_LAUNCHER__=${__PYVENV_LAUNCHER__:-UNSET}"
   echo "AIPERF_BIN=${AIPERF_BIN:-UNSET}"
   echo "AIPERF_FOO=${AIPERF_FOO:-UNSET}"
   echo "AIPERF_DATASET_CONFIGURATION_TIMEOUT=${AIPERF_DATASET_CONFIGURATION_TIMEOUT:-UNSET}"
@@ -176,6 +191,7 @@ def _run(bench, bind, res, tmp_path, **extra_env):
         AGENTX_TEST_MARKER=str(tmp_path / "marker.txt"),
     )
     env.update(extra_env)
+    env = {key: value for key, value in env.items() if value is not None}
     return subprocess.run(
         ["bash", str(bench / "aiperf_client.sh")],
         env=env,
@@ -189,6 +205,147 @@ def test_happy_path_writes_result(tmp_path):
     bench, bind, res = _sandbox(tmp_path)
     r = _run(bench, bind, res, tmp_path)
     assert r.returncode == 0, r.stderr
+    assert (res / "inferencex_result.json").exists()
+
+
+def _managed_aiperf(state: Path) -> Path:
+    cli = state / "aiperf-venv" / "bin" / "aiperf"
+    cli.parent.mkdir(parents=True)
+    _write_exec(cli, _FAKE_AIPERF)
+    return cli
+
+
+@pytest.mark.parametrize("custom_state", [False, True])
+def test_managed_client_outranks_broken_path_without_changing_parent_env(tmp_path, custom_state):
+    bench, bind, res = _sandbox(tmp_path)
+    home = tmp_path / "home"
+    state = tmp_path / "custom state" if custom_state else home / ".hyperloom"
+    cli = _managed_aiperf(state)
+    _write_exec(bind / "aiperf", "#!/bin/sh\nexit 91\n")
+    before = dict(os.environ)
+    r = _run(
+        bench,
+        bind,
+        res,
+        tmp_path,
+        AIPERF_BIN=" \t\n",
+        HOME=str(home),
+        HYPERLOOM_STATE_DIR=str(state) if custom_state else "",
+        AGENTX_TEST_SERVER_MARKER=str(tmp_path / "server.txt"),
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+    client = _server_env(tmp_path, tmp_path / "marker.txt")
+    server = _server_env(tmp_path, tmp_path / "server.txt")
+    assert client["CLI"] == str(cli)
+    assert client["PATH"] == server["PATH"] == f"{bind}:{before.get('PATH', '')}"
+    assert client["PYTHON"] == server["PYTHON"] == before.get("PYTHON", "UNSET")
+    assert dict(os.environ) == before
+
+
+@pytest.mark.parametrize("home", [None, ""])
+def test_managed_client_missing_home_uses_isolated_system_user_lookup(tmp_path, home):
+    bench, bind, res = _sandbox(tmp_path)
+    cli = _managed_aiperf(tmp_path / "system-home" / ".hyperloom")
+    user_python = bind / "user-python"
+    _write_exec(
+        user_python,
+        f'#!/bin/sh\n[ "$1" = "-I" ] || exit 88\nprintf \'%s\\n\' {shlex.quote(str(tmp_path / "system-home"))}\n',
+    )
+    _write_exec(bind / "aiperf", "#!/bin/sh\nexit 91\n")
+    r = _run(bench, bind, res, tmp_path, AIPERF_BIN=None, HOME=home, HYPERLOOM_STATE_DIR="", PYTHON=str(user_python))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert _server_env(tmp_path, tmp_path / "marker.txt")["CLI"] == str(cli)
+
+
+@pytest.mark.parametrize(
+    "state_env", [{"HYPERLOOM_STATE_DIR": "relative"}, {"HOME": "relative-home", "HYPERLOOM_STATE_DIR": ""}]
+)
+def test_client_rejects_relative_state(tmp_path, state_env):
+    bench, bind, res = _sandbox(tmp_path)
+    r = _run(bench, bind, res, tmp_path, AIPERF_BIN="", **state_env)
+    assert r.returncode == 2, r.stdout + r.stderr
+    assert "HYPERLOOM_STATE_DIR must be an absolute path" in r.stdout + r.stderr
+    assert not (tmp_path / "marker.txt").exists()
+
+
+@pytest.mark.parametrize("candidate_kind", ["missing", "directory", "not-executable"])
+def test_managed_client_unusable_falls_back_to_path(tmp_path, candidate_kind):
+    bench, bind, res = _sandbox(tmp_path)
+    state = tmp_path / "state"
+    if candidate_kind != "missing":
+        cli = _managed_aiperf(state)
+        if candidate_kind == "directory":
+            cli.unlink()
+            cli.mkdir()
+        else:
+            cli.chmod(0o644)
+    r = _run(bench, bind, res, tmp_path, AIPERF_BIN=None, HYPERLOOM_STATE_DIR=str(state))
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert _server_env(tmp_path, tmp_path / "marker.txt")["CLI"] == str(bind / "aiperf")
+
+
+@pytest.mark.parametrize("broken_override", [False, True])
+def test_managed_client_explicit_override_wins_and_keeps_pythonpath(tmp_path, broken_override):
+    bench, bind, res = _sandbox(tmp_path)
+    _managed_aiperf(tmp_path / "state")
+    override = bind / "operator-aiperf"
+    _write_exec(override, "#!/bin/sh\nexit 79\n" if broken_override else _FAKE_AIPERF)
+    r = _run(
+        bench,
+        bind,
+        res,
+        tmp_path,
+        AIPERF_BIN=f" \t{override}\n",
+        HYPERLOOM_STATE_DIR=str(tmp_path / "state"),
+        PYTHONPATH="/operator/python-packages",
+    )
+    assert r.returncode == (79 if broken_override else 0), r.stdout + r.stderr
+    if not broken_override:
+        client = _server_env(tmp_path, tmp_path / "marker.txt")
+        assert client["CLI"] == str(override)
+        assert client["PYTHONPATH"] == "/operator/python-packages"
+    else:
+        assert not (res / "inferencex_result.json").exists()
+
+
+@pytest.mark.parametrize("profile", [False, True])
+def test_managed_client_sanitizes_only_aiperf_python_environment(tmp_path, profile):
+    bench, bind, res = _sandbox(tmp_path)
+    cli = _managed_aiperf(tmp_path / "state")
+    _write_exec(
+        bind / "python3",
+        '#!/bin/sh\nprintf "%s\\n" "${PYTHONPATH:-UNSET}" >> "$AGENTX_TEST_PYTHON_MARKER"\n'
+        "exec env -u PYTHONHOME -u PYTHONPATH -u PYTHONUSERBASE -u PYTHONPLATLIBDIR -u __PYVENV_LAUNCHER__ "
+        f'{shlex.quote(sys.executable)} "$@"\n',
+    )
+    pollution = {
+        "PYTHONHOME": "/host/python310",
+        "PYTHONPATH": "/host/python310/site-packages",
+        "PYTHONUSERBASE": "/host/user-packages",
+        "PYTHONPLATLIBDIR": "host-lib",
+        "__PYVENV_LAUNCHER__": "/host/python310/bin/python",
+    }
+    run = _run_profile if profile else _run
+    r = run(
+        bench,
+        bind,
+        res,
+        tmp_path,
+        AIPERF_BIN="",
+        HYPERLOOM_STATE_DIR=str(tmp_path / "state"),
+        AGENTX_TEST_SERVER_MARKER=str(tmp_path / "server.txt"),
+        AGENTX_TEST_PYTHON_MARKER=str(tmp_path / "python.txt"),
+        **pollution,
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+    client = _server_env(tmp_path, tmp_path / "marker.txt")
+    server = _server_env(tmp_path, tmp_path / "server.txt")
+    assert client["CLI"] == str(cli)
+    for key in pollution:
+        assert client[key] == "UNSET"
+    for key in ("PYTHONHOME", "PYTHONPATH", "PYTHONUSERBASE"):
+        assert server[key] == pollution[key]
+    assert set((tmp_path / "python.txt").read_text().splitlines()) == {pollution["PYTHONPATH"]}
     assert (res / "inferencex_result.json").exists()
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_concurrent_dispatch.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_concurrent_dispatch.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -66,17 +67,32 @@ async def _build_coord_with_capacity(
 class _ConcurrencyProbe:
     """Captures per-task entry/exit times to detect actual parallelism."""
 
-    def __init__(self, sleep_seconds: float = 0.2):
+    def __init__(
+        self, sleep_seconds: float = 0.2, *, expected_concurrency: int | None = None, wait_timeout: float = 10.0
+    ):
         self.sleep_seconds = sleep_seconds
+        self.expected_concurrency = expected_concurrency
+        self.wait_timeout = wait_timeout
         self.entries: list[tuple[str, float]] = []
         self.exits: list[tuple[str, float]] = []
         self.gpu_ids_by_task: dict[str, list[int]] = {}
         self._lock = asyncio.Lock()
+        self._wave_ready = asyncio.Event()
+        self._wave_entries = 0
 
     async def __call__(self, ctx) -> dict:
         async with self._lock:
             self.entries.append((ctx.task.task_id, time.monotonic()))
             self.gpu_ids_by_task[ctx.task.task_id] = list((ctx.extra or {}).get("gpu_ids") or [])
+            wave_ready = self._wave_ready
+            if self.expected_concurrency is not None:
+                self._wave_entries += 1
+                if self._wave_entries == self.expected_concurrency:
+                    wave_ready.set()
+                    self._wave_ready = asyncio.Event()
+                    self._wave_entries = 0
+        if self.expected_concurrency is not None:
+            await asyncio.wait_for(wave_ready.wait(), timeout=self.wait_timeout)
         await asyncio.sleep(self.sleep_seconds)
         async with self._lock:
             self.exits.append((ctx.task.task_id, time.monotonic()))
@@ -122,11 +138,64 @@ def _max_concurrent(entries: list[tuple[str, float]], exits: list[tuple[str, flo
 
 
 @pytest.mark.asyncio
-async def test_dispatcher_runs_four_specialists_concurrently(tmp_path: Path):
+@pytest.mark.parametrize("participants, capacity", [(3, 3), (4, 1)], ids=["missing-participant", "serial"])
+async def test_concurrency_probe_rejects_insufficient_concurrency(participants: int, capacity: int):
+    probe = _ConcurrencyProbe(sleep_seconds=0, expected_concurrency=4, wait_timeout=0.05)
+    slots = asyncio.Semaphore(capacity)
+
+    async def _run(index):
+        async with slots:
+            ctx = SimpleNamespace(task=SimpleNamespace(task_id=str(index), params={}), extra={})
+            return await probe(ctx)
+
+    tasks = [asyncio.create_task(_run(i)) for i in range(participants)]
+    try:
+        results = await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), timeout=10)
+        assert sum(isinstance(result, asyncio.TimeoutError) for result in results) == 3
+        assert len(probe.entries) == participants
+        assert len(probe.exits) == participants - 3
+    finally:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_concurrency_probe_requires_a_fresh_second_wave():
+    probe = _ConcurrencyProbe(sleep_seconds=0.01, expected_concurrency=2)
+    contexts = [SimpleNamespace(task=SimpleNamespace(task_id=str(i), params={}), extra={}) for i in range(4)]
+    tasks = [asyncio.create_task(probe(ctx)) for ctx in contexts[:2]]
+    try:
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=10)
+        tasks.append(asyncio.create_task(probe(contexts[2])))
+        await asyncio.sleep(0.4)
+        assert len(probe.exits) == 2
+        tasks.append(asyncio.create_task(probe(contexts[3])))
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=10)
+        assert len(probe.entries) == len(probe.exits) == 4
+    finally:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("late_entry_delay", [0.0, 0.4], ids=["default", "staggered"])
+async def test_dispatcher_runs_four_specialists_concurrently(tmp_path: Path, late_entry_delay: float):
     """capacity=4 with 4 queued specialists runs all 4 in one pump (peak concurrency 4)."""
     coord = await _build_coord_with_capacity(tmp_path, capacity=4)
-    probe = _ConcurrencyProbe(sleep_seconds=0.3)
-    coord.sub.register_executor("specialist", probe)
+    probe = _ConcurrencyProbe(sleep_seconds=0.3, expected_concurrency=4)
+    first_entry = asyncio.Event()
+
+    async def _staggered_probe(ctx):
+        if ctx.task.params["gap_canonical_id"] == "gap.test.3":
+            await first_entry.wait()
+            await asyncio.sleep(late_entry_delay)
+        else:
+            first_entry.set()
+        return await probe(ctx)
+
+    coord.sub.register_executor("specialist", _staggered_probe)
 
     for i in range(4):
         await coord.tasks.create_or_return_existing(
@@ -162,7 +231,7 @@ async def test_dispatcher_caps_concurrency_at_capacity_when_more_queued(
     concurrency 2 (the lane-capacity invariant), re-dispatching as a slot frees.
     """
     coord = await _build_coord_with_capacity(tmp_path, capacity=2)
-    probe = _ConcurrencyProbe(sleep_seconds=0.3)
+    probe = _ConcurrencyProbe(sleep_seconds=0.3, expected_concurrency=2)
     coord.sub.register_executor("specialist", probe)
 
     for i in range(4):


### PR DESCRIPTION
## Description: what and why

AgentX dispatches #55042 and #55047 stopped at the first baseline preflight because the sandbox installer selected Python 3.10.12, while the pinned aiperf revision requires Python >=3.11,<3.14. The existing automatic repair correctly ran `install.sh --only-aiperf`, but retried the same incompatible interpreter.

This change supplies the client with its own compatible environment instead of upgrading the sandbox GPU stack or downgrading the pinned client.

### Scope

Four implementation files and three existing test files; no new service, feature flag, model-server configuration, or aiperf revision change.

- **Installer:** install aiperf into `${HYPERLOOM_STATE_DIR:-$HOME/.hyperloom}/aiperf-venv`. Reuse an available Python 3.11–3.13 interpreter, or provision private managed Python 3.11 through uv. If uv is absent, bootstrap pinned uv 0.12.3 into a private tools directory with `pip --target`.
- **Preflight and client:** consistently resolve explicit `AIPERF_BIN`, then the managed CLI, then PATH. Keep Python-path isolation local to managed client/probe subprocesses; do not activate the venv or change the primary interpreter, parent PATH, server environment, or GPU packages.
- **Runtime repair:** keep installation and post-repair lookup on the same state directory, including missing/empty HOME. A broken managed interpreter cannot be declared healthy by importing aiperf from the host Python.
- **Install safety and reuse:** protect unknown directories and symlinks, serialize shared-state installation, validate the recorded pin/spec against the actual environment, and reuse healthy installs. Preserve explicit overrides, dry/check modes, pre-warm versus required-install error handling, and network/index/mirror/offline environment policy.

## Linked issues

Follow-up to #1387. No separate issue is closed by this PR.

## Tests

Regressions were demonstrated failing before the corresponding fixes.

### Focused Linux regression suite

```bash
python -m pytest -o addopts= \
  src/hyperloom/inference_optimizer/tests/test_agentx_repair.py \
  src/hyperloom/inference_optimizer/tests/test_agentx_preflight.py \
  src/hyperloom/inference_optimizer/tests/test_aiperf_client_sh.py \
  src/hyperloom/inference_optimizer/tests/test_setup_cli.py \
  src/hyperloom/inference_optimizer/tests/test_agentx_runtime.py -q
```

**311 passed** in 375.16 seconds. The isolated test environment reported one `asyncio_mode` configuration warning because plugin autoload was disabled; these selected tests do not require async execution. Local and Linux-tested versions of all seven changed files were matched by SHA256 after LF normalization.

### Real isolated installation checks

- Original full installer with an actual Python 3.10.12 caller: reproduced the exact Requires-Python failure, exit 1.
- Real installer block with only Python 3.10 discoverable and uv absent from PATH: bootstrapped private uv, downloaded Python 3.11.15, and installed aiperf 0.12.0 from the unchanged commit `754356e9a39acc6cc6afb242d123bb57c3fb6f75`; exit 0. A second invocation reused the healthy installation. The primary Python version and package inventory remained unchanged.
- Full `--only-aiperf` entry point with a Python 3.10 caller and an existing compatible Python 3.12: installed into the dedicated venv and reused it on the second invocation.
- Actual runtime repair from Python 3.10, starting without aiperf: installer, managed-path re-resolution, capability/progress preflight, and second-call reuse passed. Parent and caller-supplied environments remained unchanged.
- Managed Python 3.11 preflight also passed with deliberately conflicting host `PYTHONPATH` entries.
- Real disposable-directory checks confirmed rejection of a tools-root symlink and refusal to bootstrap over the network under `UV_OFFLINE`.

### Static checks and limits

- Targeted Ruff lint/format, `bash -n` for both changed shell scripts, and `git diff --check` passed.
- ShellCheck passed for the complete client script and the changed installer block. Whole-installer ShellCheck remains blocked by a pre-existing malformed directive at baseline line 1081 (`# shellcheck disable=SC2086 -- ...`); it was not changed here.
- No GPU baseline, complete optimization run, or end-to-end run in the exact incident image was performed. The real checks above exercise installation, CLI capability checks, and runtime repair without starting a model server.

## Breaking changes

No public API or benchmark-scenario changes. Automatic installs now use a dedicated environment rather than the primary Python environment, and the managed CLI takes precedence over a legacy PATH entry. Explicit `AIPERF_BIN` retains precedence and remains operator-managed. A custom `HYPERLOOM_STATE_DIR` must be absolute.

When the necessary interpreter/packages are not already available and downloads are disallowed or unreachable, the installer reports the failure; it does not bypass offline policy or replace the system interpreter.

## PR addresses a single concern

Yes: provide and consistently use a compatible, isolated aiperf environment for AgentX. Directory protection, environment handling, and tests support that same installation boundary.

## Upstream root cause / ticket

Not an upstream component defect. The pinned client legitimately requires Python >=3.11; Hyperloom must provide a compatible client environment while retaining its supported Python 3.10 sandbox stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)