### PR TITLE
feat(kv): collect KV cache occupancy and pressure from the engine

### DIFF
--- a/src/hyperloom/inference_optimizer/assets/agentx/aiperf_client.sh
+++ b/src/hyperloom/inference_optimizer/assets/agentx/aiperf_client.sh
@@ -375,6 +375,11 @@ export AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES="${AGENTX_LIVE_ASSISTANT:-0}
 # measurement window then emits nothing until it ends, so a run that is merely
 # slow is indistinguishable from one that has wedged. Upstream exports it too.
 export AIPERF_UI_REALTIME_METRICS_ENABLED="${AGENTX_REALTIME_METRICS:-true}"
+
+# aiperf scrapes the engine's /metrics itself, on by default, deriving the URL from --url. Its own default cadence is
+# 333ms, which is far tighter than the KV signal needs and six times what the Hyperloom-side collector settled on;
+# widen it so the round is not paying for readings nobody reads. There is no CLI flag for this, only the env var.
+export AIPERF_SERVER_METRICS_COLLECTION_INTERVAL="${AGENTX_SERVER_METRICS_INTERVAL_S:-2.0}"
 # Content-addressed mmap cache: on a hit this skips loader + tokenizer +
 # composer entirely, turning that 4-14 min into ~0 for every run after the
 # first. Soft default -- never required, so a bare environment still works.
@@ -547,6 +552,7 @@ run_aiperf() {
     --stats-interval 30 \
     --slice-duration 1.0 \
     --no-gpu-telemetry \
+    --server-metrics-formats json csv parquet jsonl \
     ${CTX_ARGS[@]+"${CTX_ARGS[@]}"} \
     ${SMOKE_ARGS[@]+"${SMOKE_ARGS[@]}"} \
     ${AIPERF_PROGRESS_ARGS[@]+"${AIPERF_PROGRESS_ARGS[@]}"} \

--- a/src/hyperloom/inference_optimizer/assets/agentx/aiperf_client.sh
+++ b/src/hyperloom/inference_optimizer/assets/agentx/aiperf_client.sh
@@ -499,6 +499,32 @@ log "aiperf model=${SERVE_MODEL} corpus=${DS} entries=${NENT} conc=${CONC} durat
 #                        /v1/models id is more robust when a server is reused.
 #   --max-context-length omitted (see the replay-context note above).
 AIPERF_PROGRESS_ARGS=()
+AIPERF_PROGRESS_PORT=""
+PHASE_GATE="${BENCH_DIR}/aiperf_phase_gate.py"
+
+# Enable AIPerf's progress API on every round, not just trace-capture ones. It
+# is the only authoritative source of phase timing: `phases.<name>.start_ns` is
+# stamped by aiperf when the phase actually begins, whereas the human-readable
+# log line the KV collector otherwise greps for is written afterwards and read
+# on the next watchdog poll, so warmup traffic lands in the measured window.
+#
+# The endpoint costs nothing when nobody polls it, and the address is published
+# as a file because the reader -- Hyperloom's watchdog -- is a different process
+# that only sees this round's result directory.
+if [ -f "$PHASE_GATE" ]; then
+  if AIPERF_PROGRESS_PORT="$(python3 "$PHASE_GATE" pick-port)"; then
+    AIPERF_PROGRESS_ARGS=(--api-host 127.0.0.1 --api-port "$AIPERF_PROGRESS_PORT")
+    printf '{"url": "http://127.0.0.1:%s", "schema_version": 1}\n' \
+      "$AIPERF_PROGRESS_PORT" > "${ART}/progress_api.json" 2>/dev/null \
+      || log "WARN could not publish the AIPerf progress API address"
+  else
+    AIPERF_PROGRESS_PORT=""
+    log "WARN failed to allocate an AIPerf progress API port; phase timing falls back to log markers"
+  fi
+else
+  log "WARN missing AIPerf phase gate ${PHASE_GATE}; phase timing falls back to log markers"
+fi
+
 run_aiperf() {
   "${AIPERF_CMD[@]}" profile \
     --scenario inferencex-agentx-mvp \
@@ -540,12 +566,10 @@ if [ "${PROFILE:-0}" = "1" ]; then
   _require_uint AGENTX_PROFILE_WINDOW_S "$PWIN"
   : "${AGENTX_CAPTURE_ID:?AGENTX_CAPTURE_ID required for AgentX profiling}"
   : "${AGENTX_CAPTURE_STATUS_PATH:?AGENTX_CAPTURE_STATUS_PATH required for AgentX profiling}"
-  PHASE_GATE="${BENCH_DIR}/aiperf_phase_gate.py"
   PHASE_WAIT_TIMEOUT="${AGENTX_PHASE_WAIT_TIMEOUT_S:-$(( DATASET_CONFIG_TIMEOUT + WARMGRACE + DURATION ))}"
   _require_uint AGENTX_PHASE_WAIT_TIMEOUT_S "$PHASE_WAIT_TIMEOUT"
   CAPTURE_STATUS_FILE="$AGENTX_CAPTURE_STATUS_PATH"
   rm -f "$CAPTURE_STATUS_FILE"
-  AIPERF_PROGRESS_PORT=""
   PHASE_GATE_FAILURE_REASON="profiling_phase_unavailable"
   _write_profile_capture_status() {
     _status="$1"
@@ -570,15 +594,13 @@ if [ "${PROFILE:-0}" = "1" ]; then
   if [ -n "${AGENTX_PROFILE_WARMUP_S:-}" ]; then
     log "WARN AGENTX_PROFILE_WARMUP_S is ignored: profiling now starts from AIPerf's measured-phase signal"
   fi
-  if [ -f "$PHASE_GATE" ]; then
-    if AIPERF_PROGRESS_PORT="$(python3 "$PHASE_GATE" pick-port)"; then
-      AIPERF_PROGRESS_ARGS=(--api-host 127.0.0.1 --api-port "$AIPERF_PROGRESS_PORT")
-    else
-      PHASE_GATE_FAILURE_REASON="api_port_allocation_failed"
-      log "WARN failed to allocate an AIPerf progress API port; the measurement will run without trace capture"
-    fi
-  else
+  # The progress API is brought up for every round further above; capture only
+  # needs to know whether that succeeded, since it cannot gate a window without it.
+  if [ ! -f "$PHASE_GATE" ]; then
     log "WARN missing AIPerf phase gate ${PHASE_GATE}; the measurement will run without trace capture"
+  elif [ -z "$AIPERF_PROGRESS_PORT" ]; then
+    PHASE_GATE_FAILURE_REASON="api_port_allocation_failed"
+    log "WARN no AIPerf progress API port; the measurement will run without trace capture"
   fi
   # A 200 OK from /stop_profile means the tracer was TOLD to stop, not that the
   # trace is on disk. MEASURED on GLM-5.3 (sglang, TP=8, one 20s window): the

--- a/src/hyperloom/inference_optimizer/breakdown/session_package.py
+++ b/src/hyperloom/inference_optimizer/breakdown/session_package.py
@@ -70,6 +70,7 @@ PACKAGE_GLOBS: tuple[str, ...] = (
     "reports/kernel_roofline.json",
     "reports/conc_sweep_summary.json",
     "runs/**/kv_metrics.json",
+    "runs/**/agentx_timeline.jsonl",
     "reports/sbd_v6/timeline/*.json",
     "reports/sbd_v6/write_warnings.jsonl",
     "reports/trace/*.jsonl",

--- a/src/hyperloom/inference_optimizer/breakdown/session_package.py
+++ b/src/hyperloom/inference_optimizer/breakdown/session_package.py
@@ -69,6 +69,7 @@ PACKAGE_GLOBS: tuple[str, ...] = (
     "reports/kernel_optimization_summary.json",
     "reports/kernel_roofline.json",
     "reports/conc_sweep_summary.json",
+    "runs/**/kv_metrics.json",
     "reports/sbd_v6/timeline/*.json",
     "reports/sbd_v6/write_warnings.jsonl",
     "reports/trace/*.jsonl",

--- a/src/hyperloom/inference_optimizer/tests/test_agentx_timeline.py
+++ b/src/hyperloom/inference_optimizer/tests/test_agentx_timeline.py
@@ -228,8 +228,14 @@ def test_request_events_are_sampled_but_the_stream_says_so(tmp_path, monkeypatch
     assert len([e for e in events if e["event"] == "turn_start"]) == 10
 
 
-def test_rows_learn_which_trajectories_were_in_flight(tmp_path):
-    """The question this exists for: which trajectory was live when the pool spiked."""
+def test_rows_learn_how_much_was_in_flight(tmp_path):
+    """Counts on the row; the identities are the timeline's job.
+
+    Repeating the ids on every row copied the same set dozens of times over -- a
+    trajectory lasts minutes, rows are seconds apart -- and made 65% of a 4.6 MB
+    artifact that ships in the session bundle. The spans in the timeline answer
+    the same question exactly, and without a truncation cap.
+    """
     records = parse_profile_export(
         _export(
             tmp_path,
@@ -248,11 +254,33 @@ def test_rows_learn_which_trajectories_were_in_flight(tmp_path):
     annotated = correlate_rows(rows, records)
 
     assert annotated == 2
-    assert rows[0]["workload"]["in_flight"]["requests"] == 2
-    assert rows[0]["workload"]["in_flight"]["trajectory_ids"] == ["traj-1", "traj-2"]
-    assert rows[1]["workload"]["in_flight"]["trajectory_ids"] == ["traj-3"]
+    assert rows[0]["workload"]["in_flight"] == {"requests": 2, "trajectories": 2, "turns": 2}
+    assert rows[1]["workload"]["in_flight"] == {"requests": 1, "trajectories": 1, "turns": 1}
     # A window with nothing running is left alone rather than annotated with zeros.
     assert "workload" not in rows[2]
+
+
+def test_the_timeline_still_names_the_trajectories_a_row_counted(tmp_path):
+    """The join the row no longer duplicates: spans overlapping its scrape window."""
+    records = parse_profile_export(
+        _export(
+            tmp_path,
+            [
+                _record(request_id="r1", correlation="traj-1", turn=0, start_offset_ms=0, duration_ms=1000),
+                _record(request_id="r2", correlation="traj-2", turn=0, start_offset_ms=500, duration_ms=1000),
+            ],
+        )
+    )
+    row = {"scrape_start_unix": BASE + 0.6, "scrape_end_unix": BASE + 0.7}
+    correlate_rows([row], records)
+    events, _ = build_events(records)
+
+    live = {
+        e["trajectory_id"] for e in events if e["event"] == "trajectory_start" and e["ts"] <= row["scrape_end_unix"]
+    } & {e["trajectory_id"] for e in events if e["event"] == "trajectory_end" and e["ts"] >= row["scrape_start_unix"]}
+
+    assert live == {"traj-1", "traj-2"}
+    assert row["workload"]["in_flight"]["trajectories"] == len(live)
 
 
 def test_correlation_counts_a_request_that_spans_the_whole_window(tmp_path):

--- a/src/hyperloom/inference_optimizer/tests/test_agentx_timeline.py
+++ b/src/hyperloom/inference_optimizer/tests/test_agentx_timeline.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the AgentX workload timeline built from aiperf's per-request export.
+
+The record shape below is aiperf's own documented one (``docs/tutorials/working-with-profile-exports.md`` at the pinned
+commit), not one invented here: getting the field names wrong is the whole risk in reading somebody else's artifact.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hyperloom.orchestrator.actions.executors._agentx_timeline import (
+    TIMELINE_ARTIFACT_NAME,
+    build_events,
+    correlate_rows,
+    find_profile_export,
+    parse_profile_export,
+    write_timeline,
+)
+
+BASE_NS = 1_759_813_207_000_000_000
+BASE = BASE_NS / 1e9
+
+
+def _record(
+    *,
+    request_id: str,
+    correlation: str,
+    turn: int,
+    start_offset_ms: float,
+    duration_ms: float,
+    ttft_ms: float | None = 250.0,
+    conversation: str = "conv-1",
+    error: dict | None = None,
+) -> dict:
+    """One line of aiperf's ``profile_export.jsonl``, in its documented shape."""
+    start_ns = BASE_NS + int(start_offset_ms * 1e6)
+    metrics: dict = {"input_sequence_length": {"value": 550, "unit": "tokens"}}
+    if ttft_ms is not None:
+        metrics["time_to_first_token"] = {"value": ttft_ms, "unit": "ms"}
+    return {
+        "metadata": {
+            "session_num": 45,
+            "x_request_id": request_id,
+            "x_correlation_id": correlation,
+            "conversation_id": conversation,
+            "turn_index": turn,
+            "request_start_ns": start_ns,
+            "request_ack_ns": start_ns + 100_000_000,
+            "request_end_ns": start_ns + int(duration_ms * 1e6),
+            "worker_id": "worker_359d423a",
+            "record_processor_id": "record_processor_1fa47cd7",
+            "benchmark_phase": "profiling",
+            "was_cancelled": False,
+            "cancellation_time_ns": None,
+        },
+        "metrics": metrics,
+        "error": error,
+    }
+
+
+def _export(tmp_path: Path, records: list[dict], *, nested: bool = False) -> Path:
+    """Write an export where aiperf would put it."""
+    art = tmp_path / ("benchmark_agentx_1" if nested else ".") / "aiperf_artifacts"
+    art.mkdir(parents=True, exist_ok=True)
+    path = art / "profile_export.jsonl"
+    path.write_text("".join(json.dumps(r) + "\n" for r in records), encoding="utf-8")
+    return path
+
+
+def test_export_is_found_beside_the_round(tmp_path):
+    """The same resolution the progress address and the aiperf log use."""
+    _export(tmp_path, [_record(request_id="r1", correlation="t1", turn=0, start_offset_ms=0, duration_ms=500)])
+    assert find_profile_export(tmp_path) is not None
+
+
+def test_export_is_found_in_a_nested_benchmark_directory(tmp_path):
+    """An AgentX round nests its benchmark one level below the server log."""
+    _export(
+        tmp_path,
+        [_record(request_id="r1", correlation="t1", turn=0, start_offset_ms=0, duration_ms=500)],
+        nested=True,
+    )
+    assert find_profile_export(tmp_path) is not None
+
+
+def test_absent_export_is_not_an_error(tmp_path):
+    """Every synthetic (non-AgentX) round is this case."""
+    assert find_profile_export(tmp_path) is None
+
+
+def test_records_parse_with_the_identifiers_the_hierarchy_needs(tmp_path):
+    """Trajectory, turn and request identity all come off one record."""
+    path = _export(
+        tmp_path,
+        [_record(request_id="req-a", correlation="traj-1", turn=2, start_offset_ms=1000, duration_ms=400)],
+    )
+    (record,) = parse_profile_export(path)
+
+    assert record.request_id == "req-a"
+    assert record.trajectory_id == "traj-1"
+    assert record.conversation_id == "conv-1"
+    assert record.turn_index == 2
+    assert record.start == BASE + 1.0
+    assert record.end == BASE + 1.4
+    # Derived from TTFT, not from the ack: the ack is acceptance, not the first token.
+    assert record.first_token == BASE + 1.25
+
+
+def test_a_truncated_last_line_does_not_cost_the_rest(tmp_path):
+    """The export is written as the round ends; a partial final line is normal."""
+    path = _export(tmp_path, [_record(request_id="r1", correlation="t1", turn=0, start_offset_ms=0, duration_ms=100)])
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write('{"metadata": {"x_request_id": "half')
+
+    assert len(parse_profile_export(path)) == 1
+
+
+def test_records_without_usable_times_are_dropped(tmp_path):
+    """A record that cannot be placed on the timeline is worse than absent."""
+    bad = _record(request_id="r1", correlation="t1", turn=0, start_offset_ms=0, duration_ms=100)
+    bad["metadata"]["request_start_ns"] = None
+    good = _record(request_id="r2", correlation="t1", turn=0, start_offset_ms=10, duration_ms=100)
+
+    assert [r.request_id for r in parse_profile_export(_export(tmp_path, [bad, good]))] == ["r2"]
+
+
+def test_event_stream_covers_every_layer(tmp_path):
+    """phase / trajectory / turn / request, which is the timeline that was asked for."""
+    records = parse_profile_export(
+        _export(
+            tmp_path,
+            [
+                _record(request_id="r1", correlation="traj-1", turn=0, start_offset_ms=0, duration_ms=500),
+                _record(request_id="r2", correlation="traj-1", turn=1, start_offset_ms=600, duration_ms=500),
+                _record(request_id="r3", correlation="traj-2", turn=0, start_offset_ms=200, duration_ms=900),
+            ],
+        )
+    )
+    events, summary = build_events(records, {"measured": (BASE, BASE + 2.0)})
+
+    kinds = {e["event"] for e in events}
+    assert kinds == {
+        "phase_start",
+        "phase_end",
+        "trajectory_start",
+        "trajectory_end",
+        "turn_start",
+        "turn_end",
+        "request_start",
+        "first_token",
+        "request_end",
+    }
+    assert summary["requests"] == 3
+    assert summary["trajectories"] == 2
+    assert summary["turns"] == 3
+    assert summary["request_events_complete"] is True
+    # Time-ordered, so a consumer can merge it against the KV rows in one pass.
+    assert [e["ts"] for e in events] == sorted(e["ts"] for e in events)
+
+
+def test_trajectory_span_runs_from_its_first_request_to_its_last(tmp_path):
+    """A trajectory outlives any single turn, which is the point of the layer."""
+    records = parse_profile_export(
+        _export(
+            tmp_path,
+            [
+                _record(request_id="r1", correlation="traj-1", turn=0, start_offset_ms=0, duration_ms=500),
+                _record(request_id="r2", correlation="traj-1", turn=1, start_offset_ms=2000, duration_ms=500),
+            ],
+        )
+    )
+    events, _ = build_events(records)
+    spans = {e["event"]: e["ts"] for e in events if e["event"].startswith("trajectory")}
+
+    assert spans["trajectory_start"] == BASE
+    assert spans["trajectory_end"] == BASE + 2.5
+
+
+def test_a_request_without_ttft_emits_no_first_token_event(tmp_path):
+    """A failed request has no first token, and inventing one would misdate a decode rise."""
+    records = parse_profile_export(
+        _export(
+            tmp_path,
+            [
+                _record(
+                    request_id="r1",
+                    correlation="t1",
+                    turn=0,
+                    start_offset_ms=0,
+                    duration_ms=10,
+                    ttft_ms=None,
+                    error={"code": 499, "type": "RequestCancellationError", "message": "cancelled"},
+                )
+            ],
+        )
+    )
+    events, _ = build_events(records)
+
+    assert not [e for e in events if e["event"] == "first_token"]
+    assert [e for e in events if e["event"] == "request_end"][0]["ok"] is False
+
+
+def test_request_events_are_sampled_but_the_stream_says_so(tmp_path, monkeypatch):
+    """A long high-concurrency round would otherwise outweigh the whole bundle."""
+    import hyperloom.orchestrator.actions.executors._agentx_timeline as tl
+
+    monkeypatch.setattr(tl, "_MAX_REQUEST_EVENTS", 2)
+    records = parse_profile_export(
+        _export(
+            tmp_path,
+            [
+                _record(request_id=f"r{i}", correlation="t1", turn=i, start_offset_ms=i * 10, duration_ms=5)
+                for i in range(10)
+            ],
+        )
+    )
+    events, summary = tl.build_events(records)
+
+    assert summary["requests"] == 10  # the count stays exact
+    assert summary["request_events_complete"] is False
+    assert summary["request_event_stride"] == 5
+    assert len([e for e in events if e["event"] == "request_start"]) == 2
+    # The coarse layers stay complete: they are bounded by trajectory count, not by request count.
+    assert len([e for e in events if e["event"] == "turn_start"]) == 10
+
+
+def test_rows_learn_which_trajectories_were_in_flight(tmp_path):
+    """The question this exists for: which trajectory was live when the pool spiked."""
+    records = parse_profile_export(
+        _export(
+            tmp_path,
+            [
+                _record(request_id="r1", correlation="traj-1", turn=0, start_offset_ms=0, duration_ms=1000),
+                _record(request_id="r2", correlation="traj-2", turn=0, start_offset_ms=500, duration_ms=1000),
+                _record(request_id="r3", correlation="traj-3", turn=0, start_offset_ms=5000, duration_ms=100),
+            ],
+        )
+    )
+    rows = [
+        {"scrape_start_unix": BASE + 0.6, "scrape_end_unix": BASE + 0.7},
+        {"scrape_start_unix": BASE + 5.02, "scrape_end_unix": BASE + 5.05},
+        {"scrape_start_unix": BASE + 100.0, "scrape_end_unix": BASE + 100.1},
+    ]
+    annotated = correlate_rows(rows, records)
+
+    assert annotated == 2
+    assert rows[0]["workload"]["in_flight"]["requests"] == 2
+    assert rows[0]["workload"]["in_flight"]["trajectory_ids"] == ["traj-1", "traj-2"]
+    assert rows[1]["workload"]["in_flight"]["trajectory_ids"] == ["traj-3"]
+    # A window with nothing running is left alone rather than annotated with zeros.
+    assert "workload" not in rows[2]
+
+
+def test_correlation_counts_a_request_that_spans_the_whole_window(tmp_path):
+    """A long request is in flight during a scrape it neither starts nor ends in."""
+    records = parse_profile_export(
+        _export(
+            tmp_path,
+            [_record(request_id="r1", correlation="traj-1", turn=0, start_offset_ms=0, duration_ms=60_000)],
+        )
+    )
+    rows = [{"scrape_start_unix": BASE + 30.0, "scrape_end_unix": BASE + 30.1}]
+
+    assert correlate_rows(rows, records) == 1
+    assert rows[0]["workload"]["in_flight"]["requests"] == 1
+
+
+def test_rows_without_a_scrape_window_are_skipped(tmp_path):
+    """Older rows carried only a duration; they cannot be placed on the timeline."""
+    records = parse_profile_export(
+        _export(tmp_path, [_record(request_id="r1", correlation="t1", turn=0, start_offset_ms=0, duration_ms=500)])
+    )
+    rows = [{"scrape_sec": 0.01}]
+
+    assert correlate_rows(rows, records) == 0
+    assert "workload" not in rows[0]
+
+
+def test_timeline_is_written_as_one_json_object_per_line(tmp_path):
+    """JSONL so a consumer can stream it rather than hold a long round in memory."""
+    records = parse_profile_export(
+        _export(tmp_path, [_record(request_id="r1", correlation="t1", turn=0, start_offset_ms=0, duration_ms=500)])
+    )
+    events, _ = build_events(records)
+    out = tmp_path / TIMELINE_ARTIFACT_NAME
+
+    assert write_timeline(out, events) is True
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == len(events)
+    assert all(isinstance(json.loads(line), dict) for line in lines)
+
+
+def test_artifact_is_in_the_package_globs():
+    """It lives in the round workspace, which the bundle does not otherwise reach."""
+    from hyperloom.inference_optimizer.breakdown.session_package import PACKAGE_GLOBS
+
+    assert "runs/**/agentx_timeline.jsonl" in PACKAGE_GLOBS

--- a/src/hyperloom/inference_optimizer/tests/test_aiperf_client_sh.py
+++ b/src/hyperloom/inference_optimizer/tests/test_aiperf_client_sh.py
@@ -418,6 +418,61 @@ def test_failed_request_threshold_is_passed(tmp_path):
     assert "--failed-request-threshold" in _aiperf_args(res)
 
 
+def test_progress_api_is_enabled_on_an_ordinary_measurement_round(tmp_path):
+    """Not just under PROFILE=1.
+
+    ``phases.<name>.start_ns`` is the only authoritative phase boundary; the log
+    line the KV collector otherwise greps for is written after the fact. Leaving
+    the endpoint off outside trace capture meant every measured round attributed
+    its warmup traffic by a timestamp that lagged the real transition.
+    """
+    bench, bind, res = _sandbox(tmp_path)
+    r = _run(bench, bind, res, tmp_path)
+    assert r.returncode == 0, r.stderr
+
+    argv = _aiperf_args(res).splitlines()
+    assert "--api-host" in argv
+    assert "--api-port" in argv
+    assert "19090" in argv  # the fake gate's pick-port
+
+
+def test_progress_api_address_is_published_for_the_watchdog(tmp_path):
+    """The reader is a different process and only sees this round's result dir."""
+    bench, bind, res = _sandbox(tmp_path)
+    r = _run(bench, bind, res, tmp_path)
+    assert r.returncode == 0, r.stderr
+
+    published = json.loads((res / "aiperf_artifacts" / "progress_api.json").read_text(encoding="utf-8"))
+    assert published["url"] == "http://127.0.0.1:19090"
+
+
+def test_run_survives_a_phase_gate_that_cannot_allocate_a_port(tmp_path):
+    """Phase timing is observational: losing it must not cost the measurement."""
+    bench, bind, res = _sandbox(tmp_path)
+    (bench / "aiperf_phase_gate.py").write_text(
+        "#!/usr/bin/env python3\nimport sys\nraise SystemExit(1)\n",
+        encoding="utf-8",
+    )
+    r = _run(bench, bind, res, tmp_path)
+
+    assert r.returncode == 0, r.stderr
+    assert (res / "inferencex_result.json").exists()
+    argv = _aiperf_args(res).splitlines()
+    assert "--api-host" not in argv
+    assert not (res / "aiperf_artifacts" / "progress_api.json").exists()
+
+
+def test_run_survives_a_missing_phase_gate(tmp_path):
+    """The asset can be absent on an older deployment; the round still measures."""
+    bench, bind, res = _sandbox(tmp_path)
+    (bench / "aiperf_phase_gate.py").unlink()
+    r = _run(bench, bind, res, tmp_path)
+
+    assert r.returncode == 0, r.stderr
+    assert (res / "inferencex_result.json").exists()
+    assert "--api-host" not in _aiperf_args(res).splitlines()
+
+
 # The upstream contract, flag by flag.
 _UPSTREAM_FLAGS = (
     ("--scenario", "inferencex-agentx-mvp"),

--- a/src/hyperloom/inference_optimizer/tests/test_kill_spawned_server.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kill_spawned_server.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Tests for ``_subprocess_kill.kill_my_spawned_server`` and the BaselineExecutor integration."""
+"""Tests for ``_subprocess_kill.kill_my_spawned_server`` and the BaselineExecutor integration.
+
+Covers the no-op / already-exited cases, the same-session-group refusal guard,
+SIGTERM→grace→SIGKILL ordering, and grandchild reaping.
+"""
 
 from __future__ import annotations
 
@@ -266,9 +270,8 @@ def test_run_with_session_kill_soft_deadline_does_not_fire_for_quick_child():
 
 
 def test_run_with_session_kill_eval_start_marker_retires_soft_deadline(tmp_path):
-    """Once the accuracy eval announces itself the soft deadline stops applying: the deadline bounds the throughput
-    phase, and its anchor excludes eval.
-    """
+    """Once the accuracy eval announces itself the soft deadline stops applying:
+    the deadline bounds the throughput phase, and its anchor excludes eval."""
     log_path = tmp_path / "server.log"
     log_path.write_text("Application startup complete\nHYPERLOOM_EVAL_START\n")
     start = time.monotonic()
@@ -284,7 +287,8 @@ def test_run_with_session_kill_eval_start_marker_retires_soft_deadline(tmp_path)
 
 
 def test_run_with_session_kill_soft_deadline_still_fires_without_eval_marker(tmp_path):
-    """Without the eval marker the deadline keeps its teeth — a genuinely slow throughput phase is still reaped."""
+    """Without the eval marker the deadline keeps its teeth — a genuinely slow
+    throughput phase is still reaped."""
     log_path = tmp_path / "server.log"
     log_path.write_text("Application startup complete\n")
     start = time.monotonic()
@@ -300,7 +304,12 @@ def test_run_with_session_kill_soft_deadline_still_fires_without_eval_marker(tmp
 
 
 class TestSessionDeadline:
-    """The session budget is a separate channel from the soft deadline."""
+    """The session budget is a separate channel from the soft deadline.
+
+    The soft deadline answers "is this variant abnormally slow", which is why it
+    retires when the accuracy eval starts. The session budget answers "is the run
+    out of time", which no phase boundary changes.
+    """
 
     def test_expired_session_budget_reaps_the_tree_with_its_own_sentinel(self):
         start = time.monotonic()
@@ -317,7 +326,11 @@ class TestSessionDeadline:
         assert elapsed < 10.0, f"session-deadline path took {elapsed:.2f}s"
 
     def test_eval_start_does_not_retire_the_session_budget(self, tmp_path):
-        """The marker that retires the soft deadline must not retire this one."""
+        """The marker that retires the soft deadline must not retire this one.
+
+        An accuracy eval that starts one minute before the run is out of time
+        still has to stop; this is the whole reason the two are separate channels.
+        """
         log_path = tmp_path / "server.log"
         log_path.write_text("Application startup complete\nHYPERLOOM_EVAL_START\n")
         start = time.monotonic()
@@ -354,7 +367,12 @@ class TestSessionDeadline:
 
 
 class TestAnOrchestratorCancelReachesTheChild:
-    """The last defence has to stop the child, not just the coroutine above it."""
+    """The last defence has to stop the child, not just the coroutine above it.
+
+    The executor blocks in a worker thread, so cancelling its task frees the
+    lanes and the GPU lease while the benchmark is still running. The cancel
+    scope is the channel the thread checks, at the poll it already runs.
+    """
 
     def test_a_cancel_raised_before_the_call_reaps_the_tree(self):
         scope = CancelScope()
@@ -398,7 +416,11 @@ class TestAnOrchestratorCancelReachesTheChild:
         assert "done" in (cp.stdout or "")
 
     def test_a_spent_budget_keeps_its_own_attribution(self):
-        """Both are true at once whenever the budget is what triggered the cancel."""
+        """Both are true at once whenever the budget is what triggered the cancel.
+
+        The budget is a fact about the run and the cancel is only the dispatcher
+        acting on it, so the ledger gets the cause, not the mechanism.
+        """
         scope = CancelScope()
         scope.cancel(reason="session_time_exhausted")
         with use_cancel_scope(scope):
@@ -431,7 +453,12 @@ class TestAnOrchestratorCancelReachesTheChild:
 
 
 class TestSessionDeadlineCrossesAProcessBoundary:
-    """A ``time.monotonic()`` instant is only meaningful in the process that read it."""
+    """A ``time.monotonic()`` instant is only meaningful in the process that read it.
+
+    Handing the absolute deadline to a Ray worker would name an instant on the
+    worker's own clock, whose origin is unrelated -- an immediate kill or one
+    that never fires, both silently. Only a duration survives the trip.
+    """
 
     def test_an_unbounded_budget_stays_unbounded_in_both_directions(self):
         assert session_deadline_to_remaining_sec(None) is None
@@ -475,7 +502,14 @@ def _sentinel_returncodes() -> dict[int, set[str]]:
 
 
 def test_every_sentinel_returncode_names_exactly_one_cause():
-    """A sentinel shared by two causes makes attribution a coin flip."""
+    """A sentinel shared by two causes makes attribution a coin flip.
+
+    The codes are handed out in more than one module and all arrive at their
+    consumer as a plain ``returncode``, so a new one can quietly reuse a number
+    already taken. That is how the session-budget code first landed on the Ray
+    actor-died number, which would have had every actor death read as a spent
+    budget and taught the ledger the wrong thing about both.
+    """
     assigned = _sentinel_returncodes()
 
     collisions = {code: sorted(names) for code, names in assigned.items() if len(names) > 1}
@@ -484,7 +518,14 @@ def test_every_sentinel_returncode_names_exactly_one_cause():
 
 
 def test_an_actor_timeout_is_not_recorded_as_a_failed_agentx_preflight():
-    """The two causes that share ``_run_magpie``'s return channel stay apart."""
+    """The two causes that share ``_run_magpie``'s return channel stay apart.
+
+    ``_run_magpie`` returns ``AGENTX_PREFLIGHT_RETURNCODE`` when the execution
+    boundary fails preflight and, a few lines on, whatever the serving lease's
+    actor returned -- including ``_ACTOR_TIMEOUT_RC``. Callers see one
+    ``returncode`` either way, so the two sharing a number (which they did) is
+    enough to have a hung actor blamed on a missing aiperf.
+    """
     from hyperloom.orchestrator.actions.executors import _ray_serving, _subprocess_kill
 
     assert _ray_serving._ACTOR_TIMEOUT_RC != _subprocess_kill.AGENTX_PREFLIGHT_RETURNCODE
@@ -519,7 +560,19 @@ def test_run_with_session_kill_reports_each_line_of_child_output():
 
 
 def _appends_until_stopped(path: Path, line: str, stop: threading.Event) -> threading.Thread:
-    """Start a writer that appends ``line`` to ``path`` until ``stop`` is set."""
+    """Start a writer that appends ``line`` to ``path`` until ``stop`` is set.
+
+    Stands in for a writer that is provably not the child under test: the
+    inference server, which keeps logging while its benchmark client is wedged.
+
+    Args:
+        path (Path): Log file to append to.
+        line (str): Line written each round, newline included.
+        stop (threading.Event): Set by the caller to end the writer.
+
+    Returns:
+        threading.Thread: The started daemon writer.
+    """
 
     def _write() -> None:
         with path.open("a") as fh:
@@ -550,7 +603,21 @@ def test_run_with_session_kill_reports_a_silent_child_alive_only_on_real_progres
     appended_line: str,
     reports_liveness: bool,
 ):
-    """A log that grew is not the child talking; a log that shows tokens flowing is."""
+    """A log that grew is not the child talking; a log that shows tokens flowing is.
+
+    All three lines are written by the same third party, so growth alone cannot
+    tell them apart — and one of them is the access line vLLM and sglang emit
+    per request, including the health probe the robustness agent issues on its
+    own tick. Counting those as the child's output closes a loop where the
+    monitor's probe manufactures the evidence that suppresses its own stall
+    accusation, and turns the heartbeat into the bare timer it documents itself
+    as never being. A throughput line is different in kind — whoever logged it,
+    tokens were being produced during the interval — but only if it carries a
+    rate: some vLLM builds keep printing the stats line at ``0.0 tokens/s`` on
+    an idle engine, and an engine goes idle precisely when the client that was
+    driving it wedges, so the zero-rate line is the shape this failure actually
+    takes in production.
+    """
     log_path = tmp_path / "server.log"
     log_path.write_text("Application startup complete\n")
     stop = threading.Event()
@@ -575,7 +642,13 @@ def test_run_with_session_kill_reports_a_silent_child_alive_only_on_real_progres
 
 
 def test_run_with_session_kill_reports_the_output_a_child_redirected_to_disk(tmp_path):
-    """A round whose body writes only to ``benchmark_stderr.log`` is still working."""
+    """A round whose body writes only to ``benchmark_stderr.log`` is still working.
+
+    The scriptable and bypass paths run the customer body with its stderr
+    redirected there rather than into the parent's pipe, and a long phase of one
+    — a client that logs its request counter but produces no server throughput
+    line yet — would otherwise have nothing left to report liveness with.
+    """
     bench = tmp_path / "benchmark_atom_20260731_085850"
     bench.mkdir(parents=True)
     (bench / "server.log").write_text("Application startup complete\n")
@@ -628,7 +701,8 @@ def test_run_with_session_kill_legacy_timeout_still_raises():
 
 # Server-liveness watchdog
 def test_server_log_shows_death_detects_marker(tmp_path):
-    """A ``server.log`` containing a terminal-init marker reads as dead; a healthy / missing log reads as alive."""
+    """A ``server.log`` containing a terminal-init marker reads as dead;
+    a healthy / missing log reads as alive."""
     log_path = tmp_path / "server.log"
     assert _server_log_shows_death(str(log_path)) is None  # missing → alive
     log_path.write_text("INFO loading shards 50%\nINFO graph capture\n")
@@ -653,7 +727,9 @@ def test_server_log_shows_death_detects_vllm_engine_core(tmp_path):
 
 
 def test_server_log_shows_death_detects_nested_benchmark_log(tmp_path):
-    """Magpie wrappers that ignore ``$SERVER_LOG`` write the real server log to a nested ``benchmark_<fw>_<ts>/server.log``."""
+    """Magpie wrappers that ignore ``$SERVER_LOG`` write the real server log to a
+    nested ``benchmark_<fw>_<ts>/server.log``. The watchdog must still detect the
+    crash via that nested file even when the watched ``output_dir/server.log`` is absent."""
     watched = tmp_path / "server.log"  # never written by the wrapper
     nested_dir = tmp_path / "benchmark_vllm_20260625_003729"
     nested_dir.mkdir()
@@ -669,7 +745,8 @@ def test_server_log_shows_death_detects_nested_benchmark_log(tmp_path):
 
 
 def test_server_log_death_excerpt_surfaces_nested_root_cause(tmp_path):
-    """The excerpt helper also falls back to a nested ``benchmark_*/server.log`` so the failure classifier still surfaces the real server fault."""
+    """The excerpt helper also falls back to a nested ``benchmark_*/server.log``
+    so the failure classifier still surfaces the real server fault."""
     watched = tmp_path / "server.log"
     nested_dir = tmp_path / "benchmark_vllm_20260625_003729"
     nested_dir.mkdir()
@@ -686,7 +763,8 @@ def test_server_log_death_excerpt_surfaces_nested_root_cause(tmp_path):
 
 
 def test_server_log_death_excerpt_surfaces_root_cause(tmp_path):
-    """The excerpt helper returns the engine/worker-init root-cause line (with a little context) for the failure classifier; a healthy / missing log returns ``None``."""
+    """The excerpt helper returns the engine/worker-init root-cause line (with a
+    little context) for the failure classifier; a healthy / missing log returns ``None``."""
     log_path = tmp_path / "server.log"
     assert server_log_death_excerpt(str(log_path)) is None  # missing → None
     log_path.write_text("INFO loading shards 50%\nINFO graph capture\n")
@@ -704,7 +782,12 @@ def test_server_log_death_excerpt_surfaces_root_cause(tmp_path):
 
 
 def test_server_log_death_excerpt_surfaces_config_validation_arch_miss(tmp_path):
-    """A config-validation-stage failure (brand-new checkpoint ``model_type`` unknown to the installed transformers/vLLM) dies BEFORE the engine starts and must still be surfaced as a fatal excerpt."""
+    """A config-validation-stage failure (brand-new checkpoint ``model_type``
+    unknown to the installed transformers/vLLM) dies BEFORE the engine starts and
+    must still be surfaced as a fatal excerpt. Without this the enablement failure
+    classifier only sees Magpie's ``subprocess_nonzero`` stdout tail, classifies
+    ``unknown``, and never seeds the ``pip install -U transformers`` bridge —
+    starving every enablement round of the real root cause (DeepSeek-V4 repro)."""
     from hyperloom.agents.framework.enablement import classify_failure
 
     log_path = tmp_path / "server.log"
@@ -723,15 +806,16 @@ def test_server_log_death_excerpt_surfaces_config_validation_arch_miss(tmp_path)
     excerpt = server_log_death_excerpt(str(log_path))
     assert excerpt is not None
     assert "does not recognize this architecture" in excerpt
-    # The extracted excerpt must classify as missing_model_arch (not unknown), which is what seeds the deterministic
-    # pip-install enablement bridge.
+    # The extracted excerpt must classify as missing_model_arch (not unknown),
+    # which is what seeds the deterministic pip-install enablement bridge.
     sig = classify_failure(excerpt)
     assert sig.kind == "missing_model_arch"
     assert sig.offending_symbol == "deepseek_v4"
 
 
 def test_run_with_session_kill_watchdog_reaps_hung_server(tmp_path):
-    """A child that writes a fatal server marker then hangs is reaped via the watchdog with ``SERVER_DEAD_RETURNCODE`` — well before the hard timeout."""
+    """A child that writes a fatal server marker then hangs is reaped via the
+    watchdog with ``SERVER_DEAD_RETURNCODE`` — well before the hard timeout."""
     log_path = tmp_path / "server.log"
     script = (
         "import sys, time\n"
@@ -752,7 +836,8 @@ def test_run_with_session_kill_watchdog_reaps_hung_server(tmp_path):
 
 
 def test_run_with_session_kill_watchdog_grace_lets_clean_exit_win(tmp_path):
-    """If the harness exits on its own within the grace window after emitting a marker, its real returncode wins (no spurious SERVER_DEAD)."""
+    """If the harness exits on its own within the grace window after emitting a
+    marker, its real returncode wins (no spurious SERVER_DEAD)."""
     log_path = tmp_path / "server.log"
     script = (
         "import sys, time\n"
@@ -771,7 +856,8 @@ def test_run_with_session_kill_watchdog_grace_lets_clean_exit_win(tmp_path):
 
 
 def test_run_with_session_kill_watchdog_ignores_healthy_server(tmp_path):
-    """A child with a clean server.log returns its own returncode — the watchdog must not false-positive on a healthy (or slow) server."""
+    """A child with a clean server.log returns its own returncode — the
+    watchdog must not false-positive on a healthy (or slow) server."""
     log_path = tmp_path / "server.log"
     script = (
         "import sys\n"
@@ -791,36 +877,42 @@ def test_run_with_session_kill_watchdog_ignores_healthy_server(tmp_path):
 
 # ── Detokenizer-stall watchdog ──
 def test_scan_server_log_increment_detects_ready_and_progress(tmp_path):
-    """The incremental scanner advances its offset and flags ready/progress markers only in the newly appended bytes."""
+    """The incremental scanner advances its offset and flags ready/progress
+    markers only in the newly appended bytes."""
     log_path = tmp_path / "server.log"
     log_path.write_text("INFO loading weights\nApplication startup complete\n")
-    off, ready, prog, ev = _scan_server_log_increment(str(log_path), 0)
-    assert ready is True and prog is False and ev is False and off == log_path.stat().st_size
+    first = _scan_server_log_increment(str(log_path), 0)
+    assert first.saw_ready is True
+    assert first.saw_progress is False and first.saw_eval_start is False
+    assert first.offset == log_path.stat().st_size
     # Re-scan from the advanced offset: nothing new, no re-trigger.
-    off2, ready2, prog2, ev2 = _scan_server_log_increment(str(log_path), off)
-    assert ready2 is False and prog2 is False and ev2 is False and off2 == off
+    second = _scan_server_log_increment(str(log_path), first.offset)
+    assert second.saw_ready is False and second.saw_progress is False and second.saw_eval_start is False
+    assert second.offset == first.offset
     # Append a vLLM throughput line; only the new bytes are scanned.
     with log_path.open("a") as f:
         f.write("Avg generation throughput: 123.4 tokens/s, Running: 8\n")
-    off3, ready3, prog3, ev3 = _scan_server_log_increment(str(log_path), off2)
-    assert prog3 is True and ready3 is False and ev3 is False and off3 == log_path.stat().st_size
+    third = _scan_server_log_increment(str(log_path), second.offset)
+    assert third.saw_progress is True and third.saw_ready is False and third.saw_eval_start is False
+    assert third.offset == log_path.stat().st_size
     # The eval-start marker is reported independently of ready/progress.
     with log_path.open("a") as f:
         f.write("HYPERLOOM_EVAL_START\n")
-    off4, ready4, prog4, ev4 = _scan_server_log_increment(str(log_path), off3)
-    assert ev4 is True and ready4 is False and prog4 is False and off4 == log_path.stat().st_size
-    # An idle engine keeps printing the same line with no rate on it: the value is the progress signal, not the
-    # marker.
+    fourth = _scan_server_log_increment(str(log_path), third.offset)
+    assert fourth.saw_eval_start is True and fourth.saw_ready is False and fourth.saw_progress is False
+    assert fourth.offset == log_path.stat().st_size
+    # An idle engine keeps printing the same line with no rate on it: the value
+    # is the progress signal, not the marker.
     with log_path.open("a") as f:
         f.write("Avg generation throughput: 0.0 tokens/s, Running: 0 reqs\n")
-    off5, _ready5, prog5, _ev5 = _scan_server_log_increment(str(log_path), off4)
-    assert prog5 is False and off5 == log_path.stat().st_size
+    fifth = _scan_server_log_increment(str(log_path), fourth.offset)
+    assert fifth.saw_progress is False and fifth.offset == log_path.stat().st_size
 
 
 def test_scan_logs_increment_reads_nested_stderr_for_eval_start(tmp_path):
-    """The real Magpie layout: the caller passes ``<output_dir>/server.log``, which does not exist, while the engine
-    log and the eval-start marker live in a ``benchmark_*/`` subdir -- the marker only ever reaching stderr.
-    """
+    """The real Magpie layout: the caller passes ``<output_dir>/server.log``,
+    which does not exist, while the engine log and the eval-start marker live in
+    a ``benchmark_*/`` subdir -- the marker only ever reaching stderr."""
     output_dir = tmp_path / "measure_round"
     bench = output_dir / "benchmark_atom_20260731_085850"
     bench.mkdir(parents=True)
@@ -845,7 +937,14 @@ def test_scan_logs_increment_reads_nested_stderr_for_eval_start(tmp_path):
 
 
 def test_scan_logs_increment_tells_the_childs_own_log_from_the_servers(tmp_path):
-    """Only one of the resolved logs is written by the process being waited on."""
+    """Only one of the resolved logs is written by the process being waited on.
+
+    ``server.log`` is the inference server's; ``benchmark_stderr.log`` is where
+    Magpie redirects the benchmark body's own stderr, so the parent's pipe stays
+    empty for the whole round and that file is the only place the child's own
+    output shows up. Liveness that cannot tell them apart either vouches for a
+    wedged client or leaves a working one unable to report.
+    """
     bench = tmp_path / "benchmark_atom_20260731_085850"
     bench.mkdir(parents=True)
     server_log = bench / "server.log"
@@ -868,7 +967,8 @@ def test_scan_logs_increment_tells_the_childs_own_log_from_the_servers(tmp_path)
 
 
 def test_run_with_session_kill_detok_stall_reaps_ready_but_silent_server(tmp_path):
-    """A server that reports ready then produces no generation progress is reaped with ``DETOKENIZER_STALL_RETURNCODE`` well before the hard timeout."""
+    """A server that reports ready then produces no generation progress is
+    reaped with ``DETOKENIZER_STALL_RETURNCODE`` well before the hard timeout."""
     log_path = tmp_path / "server.log"
     script = (
         "import sys, time\n"
@@ -888,7 +988,8 @@ def test_run_with_session_kill_detok_stall_reaps_ready_but_silent_server(tmp_pat
 
 
 def test_run_with_session_kill_detok_stall_not_armed_before_ready(tmp_path):
-    """A server still loading weights (no ready marker) must NOT trip the stall gate even past the grace window — slow is not stalled."""
+    """A server still loading weights (no ready marker) must NOT trip the stall
+    gate even past the grace window — slow is not stalled."""
     log_path = tmp_path / "server.log"
     script = (
         "import sys, time\n"
@@ -906,7 +1007,8 @@ def test_run_with_session_kill_detok_stall_not_armed_before_ready(tmp_path):
 
 
 def test_run_with_session_kill_detok_stall_progress_keeps_it_alive(tmp_path):
-    """Continued generation-progress lines reset the stall clock so a healthy (if slow) run finishes with its own returncode."""
+    """Continued generation-progress lines reset the stall clock so a healthy
+    (if slow) run finishes with its own returncode."""
     log_path = tmp_path / "server.log"
     script = (
         "import sys, time\n"
@@ -927,7 +1029,9 @@ def test_run_with_session_kill_detok_stall_progress_keeps_it_alive(tmp_path):
 
 
 def test_run_with_session_kill_detok_stall_compile_logs_keep_it_alive(tmp_path):
-    """A long, quiet first-request JIT/compile after ready must NOT trip the gate: ANY new log line (not just throughput) is liveness, so a huge model that logs compile progress between ready and its first token survives."""
+    """A long, quiet first-request JIT/compile after ready must NOT trip the
+    gate: ANY new log line (not just throughput) is liveness, so a huge model
+    that logs compile progress between ready and its first token survives."""
     log_path = tmp_path / "server.log"
     script = (
         "import sys, time\n"

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics.py
@@ -165,6 +165,79 @@ def test_exposition_without_kv_metrics_has_no_readings():
     assert not s.has_readings()
 
 
+def test_sharded_engine_gauges_are_maxed_not_summed():
+    """Eight ranks describe one pool from eight sides, not eight pools.
+
+    Summed, an 85%-full TP=8 pool reports an occupancy of 6.8 and eight times
+    its real capacity -- the same mistake the log path avoids by de-duplicating
+    capacity lines per rank.
+    """
+    text = "".join(
+        f'sglang:token_usage{{tp_rank="{i}"}} 0.85\nsglang:kv_used_tokens{{tp_rank="{i}"}} 27876.0\n' for i in range(8)
+    )
+    s = sample_from_families(parse_prometheus_text(text))
+
+    assert s.active_pool_usage == pytest.approx(0.85)
+    assert s.used_tokens == 27876.0
+    assert s.series_count == 8
+
+
+def test_imbalanced_ranks_report_the_most_pressured_one():
+    """The rank that will retract is the one worth reporting."""
+    text = 'sglang:token_usage{tp_rank="0"} 0.20\nsglang:token_usage{tp_rank="1"} 0.97\n'
+
+    assert sample_from_families(parse_prometheus_text(text)).active_pool_usage == pytest.approx(0.97)
+
+
+def test_capacity_prefers_the_engines_own_gauge():
+    """used + available + evictable can fall short: reserved tokens belong to
+    none of the three, so deriving understates the pool and overstates how full
+    it is."""
+    text = (
+        "sglang:max_total_num_tokens 40000.0\n"
+        "sglang:kv_used_tokens 27876.0\n"
+        "sglang:kv_available_tokens 2888.0\n"
+        "sglang:kv_evictable_tokens 2004.0\n"
+    )
+    s = sample_from_families(parse_prometheus_text(text))
+
+    assert s.capacity_tokens == 40000.0
+    assert s.capacity_derived is False
+    assert s.physical_pool_usage == pytest.approx(29880 / 40000)
+
+
+def test_derived_capacity_is_flagged_as_such():
+    s = sample_from_families(parse_prometheus_text(SGLANG_METRICS))
+
+    assert s.capacity_tokens == 32768.0
+    assert s.capacity_derived is True
+
+
+def test_other_pools_evictable_does_not_leak_into_the_main_pool_ratio():
+    """SWA and Mamba pools have their own capacities. Folding their evictable
+    tokens into a ratio whose numerator is main-pool-only mixes denominators."""
+    text = (
+        "sglang:kv_used_tokens 100.0\n"
+        "sglang:kv_available_tokens 100.0\n"
+        "sglang:kv_evictable_tokens 0.0\n"
+        "sglang:swa_evictable_tokens 500.0\n"
+        "sglang:mamba_evictable_tokens 500.0\n"
+    )
+    s = sample_from_families(parse_prometheus_text(text))
+
+    assert s.evictable_tokens == 0.0
+    assert s.capacity_tokens == 200.0
+    assert s.physical_pool_usage == pytest.approx(0.5)
+
+
+def test_prefix_cache_counters_are_read():
+    s = sample_from_families(parse_prometheus_text(VLLM_METRICS))
+    assert (s.prefix_cache_queries, s.prefix_cache_hits) == (1000.0, 529.0)
+
+    sg = sample_from_families(parse_prometheus_text(SGLANG_METRICS))
+    assert sg.cached_tokens_total == 4600439.0
+
+
 def test_canonical_label_key_is_order_independent():
     assert canonical_label_key({"b": "2", "a": "1"}) == canonical_label_key({"a": "1", "b": "2"})
     assert canonical_label_key({}) == ""

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics.py
@@ -132,8 +132,8 @@ def test_vllm_shape_and_legacy_usage_alias():
     s = sample_from_families(parse_prometheus_text(VLLM_METRICS))
     assert s.engine == "vllm"
     assert s.active_pool_usage == pytest.approx(0.969)
-    assert s.prefix_cache_queries == 1000.0
-    assert s.prefix_cache_hits == 529.0
+    assert aggregate_series(s.prefix_cache_queries) == 1000.0
+    assert aggregate_series(s.prefix_cache_hits) == 529.0
 
     legacy = sample_from_families(parse_prometheus_text("vllm:gpu_cache_usage_perc 0.5\n"))
     assert legacy.active_pool_usage == pytest.approx(0.5)
@@ -154,7 +154,7 @@ def test_prefix_cache_off_omits_cached_tokens_entirely():
     without = SGLANG_METRICS.replace("sglang:cached_tokens_total 4600439.0\n", "")
     s = sample_from_families(parse_prometheus_text(without))
 
-    assert s.cached_tokens_total is None
+    assert s.cached_tokens_total == {}
 
 
 def test_idle_zero_is_a_reading_not_an_absence():
@@ -273,10 +273,10 @@ def test_other_pools_evictable_does_not_leak_into_the_main_pool_ratio():
 
 def test_prefix_cache_counters_are_read():
     s = sample_from_families(parse_prometheus_text(VLLM_METRICS))
-    assert (s.prefix_cache_queries, s.prefix_cache_hits) == (1000.0, 529.0)
+    assert (aggregate_series(s.prefix_cache_queries), aggregate_series(s.prefix_cache_hits)) == (1000.0, 529.0)
 
     sg = sample_from_families(parse_prometheus_text(SGLANG_METRICS))
-    assert sg.cached_tokens_total == 4600439.0
+    assert aggregate_series(sg.cached_tokens_total) == 4600439.0
 
 
 def test_canonical_label_key_is_order_independent():

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics.py
@@ -294,7 +294,16 @@ def test_port_resolution_prefers_config_over_env(monkeypatch):
 
 
 def test_poller_availability_is_tristate_and_gives_up(monkeypatch):
-    """Unknown until proven; parked once an engine shows it has metrics off."""
+    """Unknown until proven; parked once an engine shows it has metrics off.
+
+    Parking now needs a clock as well as a count: three misses can happen inside
+    six seconds while a server is still binding, and giving up on that alone cost
+    a real round its whole collection.
+    """
+    import time as _time
+
+    from hyperloom.orchestrator.actions.executors._kv_metrics import _GIVE_UP_GRACE_SEC
+
     poller = KvMetricsPoller(port=1)
     assert poller.available is None
 
@@ -307,6 +316,12 @@ def test_poller_availability_is_tristate_and_gives_up(monkeypatch):
     )
     for _ in range(3):
         assert poller.fetch() is None
+
+    # Count reached, grace not: still trying.
+    assert poller.available is None
+
+    poller._first_attempt_mono = _time.monotonic() - (_GIVE_UP_GRACE_SEC + 1)
+    assert poller.fetch() is None
 
     assert poller.available is False
 

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the ``/metrics`` KV sampler.
+
+Fixtures are verbatim expositions captured off MI355X nodes, so a name or unit
+that drifts upstream fails here rather than in a breakdown three weeks later.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hyperloom.orchestrator.actions.executors._kv_metrics import (
+    DEFAULT_METRICS_PORT,
+    KvMetricsPoller,
+    canonical_label_key,
+    parse_prometheus_text,
+    resolve_metrics_port,
+    sample_from_families,
+)
+
+
+# Captured from a saturated SGLang 0.5.17 server. The two retract names differ
+# by one word and mean different things; both are here on purpose.
+SGLANG_METRICS = """\
+# HELP sglang:token_usage Pool usage.
+# TYPE sglang:token_usage gauge
+sglang:token_usage 0.85
+sglang:full_token_usage 0.8506
+sglang:swa_token_usage 0.0
+sglang:kv_used_tokens 27876.0
+sglang:kv_available_tokens 2888.0
+sglang:kv_evictable_tokens 2004.0
+sglang:swa_evictable_tokens 0.0
+sglang:mamba_evictable_tokens 0.0
+sglang:kv_cache_memory_usage_gb 180.013
+sglang:num_retracted_requests_total 48.0
+sglang:num_retracted_input_tokens_total 38205.0
+sglang:num_retracted_reqs{pid="4741"} 1.0
+sglang:cached_tokens_total 4600439.0
+sglang:cache_hit_rate 0.0
+"""
+
+VLLM_METRICS = """\
+# TYPE vllm:num_preemptions_total counter
+vllm:num_preemptions_total{engine="0",model_name="qwen"} 458.0
+vllm:kv_cache_usage_perc 0.969
+vllm:prefix_cache_queries 1000.0
+vllm:prefix_cache_hits 529.0
+"""
+
+
+def test_parses_real_sglang_exposition():
+    fam = parse_prometheus_text(SGLANG_METRICS)
+    s = sample_from_families(fam)
+
+    assert s.engine == "sglang"
+    assert s.used_tokens == 27876.0
+    assert s.available_tokens == 2888.0
+    assert s.evictable_tokens == 2004.0
+    assert s.capacity_tokens == 32768.0
+    assert s.capacity_gb == 180.013
+    assert s.has_readings()
+
+
+def test_active_and_physical_usage_diverge():
+    """The whole reason occupancy is two fields and not one.
+
+    27876 held by running requests, 2004 more held by the prefix cache but
+    releasable. Reporting only the physical 0.91 would call this pool nearly
+    full when the pressure reading is 0.85.
+    """
+    s = sample_from_families(parse_prometheus_text(SGLANG_METRICS))
+
+    assert s.active_pool_usage == pytest.approx(0.8506)
+    assert s.physical_pool_usage == pytest.approx(29880 / 32768)
+    assert s.physical_pool_usage > s.active_pool_usage
+
+
+def test_reads_cumulative_retracts_not_the_instantaneous_gauge():
+    """``num_retracted_requests_total`` is 48; ``num_retracted_reqs`` is 1."""
+    s = sample_from_families(parse_prometheus_text(SGLANG_METRICS))
+
+    assert list(s.retract_total.values()) == [48.0]
+    assert 1.0 not in s.retract_total.values()
+
+
+def test_counters_are_kept_per_label_series():
+    """An engine restart resets one series; a flat total would hide that."""
+    fam = parse_prometheus_text(VLLM_METRICS)
+    s = sample_from_families(fam)
+
+    assert s.preempt_total == {'engine="0",model_name="qwen"': 458.0}
+
+
+def test_vllm_shape_and_legacy_usage_alias():
+    s = sample_from_families(parse_prometheus_text(VLLM_METRICS))
+    assert s.engine == "vllm"
+    assert s.active_pool_usage == pytest.approx(0.969)
+    assert s.prefix_cache_queries == 1000.0
+    assert s.prefix_cache_hits == 529.0
+
+    legacy = sample_from_families(parse_prometheus_text("vllm:gpu_cache_usage_perc 0.5\n"))
+    assert legacy.active_pool_usage == pytest.approx(0.5)
+
+
+def test_absent_metric_is_none_not_zero():
+    """vLLM cannot express physical occupancy; that must read as unknown."""
+    s = sample_from_families(parse_prometheus_text(VLLM_METRICS))
+
+    assert s.physical_pool_usage is None
+    assert s.evictable_tokens is None
+    assert s.capacity_tokens is None
+    assert s.capacity_gb is None
+
+
+def test_prefix_cache_off_omits_cached_tokens_entirely():
+    """The metric disappears rather than reading 0, so consumers must see None."""
+    without = SGLANG_METRICS.replace("sglang:cached_tokens_total 4600439.0\n", "")
+    s = sample_from_families(parse_prometheus_text(without))
+
+    assert s.cached_tokens_total is None
+
+
+def test_idle_zero_is_a_reading_not_an_absence():
+    """An engine nobody has queried reports a true 0.0 for minutes."""
+    s = sample_from_families(parse_prometheus_text("sglang:token_usage 0.0\nsglang:kv_used_tokens 0.0\n"))
+
+    assert s.active_pool_usage == 0.0
+    assert s.used_tokens == 0.0
+    assert s.has_readings()
+
+
+def test_hybrid_pool_takes_the_max_subpool_not_the_full_one():
+    """On a hybrid model the full-attention subpool understates real pressure."""
+    hybrid = "sglang:token_usage 0.10\nsglang:full_token_usage 0.10\nsglang:swa_token_usage 0.93\n"
+    s = sample_from_families(parse_prometheus_text(hybrid))
+
+    assert s.active_pool_usage == pytest.approx(0.93)
+
+
+def test_labels_comments_and_timestamps_are_handled():
+    text = '# HELP x help text\n# TYPE x gauge\n\nsglang:kv_used_tokens{tp_rank="0",note="a,b=c"} 12.0 1756880000123\n'
+    fam = parse_prometheus_text(text)
+
+    assert fam["sglang:kv_used_tokens"][0][0] == {"tp_rank": "0", "note": "a,b=c"}
+    assert fam["sglang:kv_used_tokens"][0][1] == 12.0
+
+
+def test_non_finite_values_are_dropped():
+    """NaN carries no occupancy meaning and would poison every max taken over it."""
+    fam = parse_prometheus_text("sglang:token_usage NaN\nsglang:kv_used_tokens +Inf\nsglang:kv_available_tokens 5.0\n")
+
+    assert "sglang:token_usage" not in fam
+    assert "sglang:kv_used_tokens" not in fam
+    assert fam["sglang:kv_available_tokens"][0][1] == 5.0
+
+
+def test_exposition_without_kv_metrics_has_no_readings():
+    """A reachable endpoint exposing only unrelated metrics is not a KV sample."""
+    s = sample_from_families(parse_prometheus_text("python_gc_objects_collected_total 12.0\n"))
+
+    assert s.engine == ""
+    assert not s.has_readings()
+
+
+def test_canonical_label_key_is_order_independent():
+    assert canonical_label_key({"b": "2", "a": "1"}) == canonical_label_key({"a": "1", "b": "2"})
+    assert canonical_label_key({}) == ""
+
+
+def test_port_resolution_prefers_config_over_env(monkeypatch):
+    monkeypatch.setenv("PORT", "9999")
+    assert resolve_metrics_port({"PORT": 31234}) == 31234
+    assert resolve_metrics_port({}) == 9999
+    monkeypatch.delenv("PORT", raising=False)
+    assert resolve_metrics_port({}) == DEFAULT_METRICS_PORT
+    assert resolve_metrics_port({"PORT": "not-a-port"}) == DEFAULT_METRICS_PORT
+
+
+def test_poller_availability_is_tristate_and_gives_up(monkeypatch):
+    """Unknown until proven; parked once an engine shows it has metrics off."""
+    poller = KvMetricsPoller(port=1)
+    assert poller.available is None
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.actions.executors._kv_metrics.urllib.request.urlopen",
+        _boom,
+    )
+    for _ in range(3):
+        assert poller.fetch() is None
+
+    assert poller.available is False
+
+    # Parked: no further requests are issued, so a later call cannot revive it.
+    def _explode(*_args, **_kwargs):
+        raise AssertionError("poller kept scraping after giving up")
+
+    monkeypatch.setattr(
+        "hyperloom.orchestrator.actions.executors._kv_metrics.urllib.request.urlopen",
+        _explode,
+    )
+    assert poller.fetch() is None
+
+
+def test_poller_sample_returns_none_when_endpoint_has_no_kv(monkeypatch):
+    poller = KvMetricsPoller(port=1)
+    monkeypatch.setattr(poller, "fetch", lambda: "python_gc_objects_collected_total 12.0\n")
+
+    assert poller.sample() is None
+
+
+def test_poller_sample_normalises_a_good_scrape(monkeypatch):
+    poller = KvMetricsPoller(port=1)
+    monkeypatch.setattr(poller, "fetch", lambda: SGLANG_METRICS)
+
+    sample = poller.sample()
+
+    assert sample is not None
+    assert sample.used_tokens == 27876.0
+    assert sample.mono > 0

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics.py
@@ -14,6 +14,7 @@ import pytest
 from hyperloom.orchestrator.actions.executors._kv_metrics import (
     DEFAULT_METRICS_PORT,
     KvMetricsPoller,
+    aggregate_series,
     canonical_label_key,
     parse_prometheus_text,
     resolve_metrics_port,
@@ -73,7 +74,7 @@ def test_active_and_physical_usage_diverge():
     """
     s = sample_from_families(parse_prometheus_text(SGLANG_METRICS))
 
-    assert s.active_pool_usage == pytest.approx(0.8506)
+    assert s.active_pool_usage == pytest.approx(0.85)
     assert s.physical_pool_usage == pytest.approx(29880 / 32768)
     assert s.physical_pool_usage > s.active_pool_usage
 
@@ -82,8 +83,7 @@ def test_reads_cumulative_retracts_not_the_instantaneous_gauge():
     """``num_retracted_requests_total`` is 48; ``num_retracted_reqs`` is 1."""
     s = sample_from_families(parse_prometheus_text(SGLANG_METRICS))
 
-    assert list(s.retract_total.values()) == [48.0]
-    assert 1.0 not in s.retract_total.values()
+    assert aggregate_series(s.retract_total) == 48.0
 
 
 def test_counters_are_kept_per_label_series():
@@ -91,7 +91,41 @@ def test_counters_are_kept_per_label_series():
     fam = parse_prometheus_text(VLLM_METRICS)
     s = sample_from_families(fam)
 
-    assert s.preempt_total == {'engine="0",model_name="qwen"': 458.0}
+    assert s.preempt_total == {'engine="0",model_name="qwen"': {'engine="0",model_name="qwen"': 458.0}}
+
+
+def test_shards_collapse_but_independent_engines_add_up():
+    """The two label kinds need opposite treatment; one rule is wrong either way."""
+    shards = "".join(f'sglang:num_retracted_requests_total{{tp_rank="{i}"}} 48.0\n' for i in range(8))
+    assert aggregate_series(sample_from_families(parse_prometheus_text(shards)).retract_total) == 48.0
+
+    engines = 'vllm:num_preemptions_total{engine="0"} 48.0\nvllm:num_preemptions_total{engine="1"} 48.0\n'
+    assert aggregate_series(sample_from_families(parse_prometheus_text(engines)).preempt_total) == 96.0
+
+
+def test_a_ranks_fields_are_never_welded_to_another_ranks():
+    """Per-field maxima across ranks combine numbers from different sides of the
+    engine. These two readings are individually valid and produced an occupancy
+    of 1.7 when mixed."""
+    text = (
+        'sglang:max_total_num_tokens{dp_rank="0"} 100.0\n'
+        'sglang:kv_used_tokens{dp_rank="0"} 10.0\n'
+        'sglang:kv_evictable_tokens{dp_rank="0"} 5.0\n'
+        'sglang:token_usage{dp_rank="0"} 0.10\n'
+        'sglang:max_total_num_tokens{dp_rank="1"} 80.0\n'
+        'sglang:kv_used_tokens{dp_rank="1"} 72.0\n'
+        'sglang:kv_evictable_tokens{dp_rank="1"} 4.0\n'
+        'sglang:token_usage{dp_rank="1"} 0.90\n'
+    )
+    s = sample_from_families(parse_prometheus_text(text))
+
+    assert s.physical_pool_usage is not None and s.physical_pool_usage <= 1.0
+    # The most pressured rank is reported whole: rank 1's capacity with rank 1's
+    # tokens, not rank 0's capacity with rank 1's tokens.
+    assert s.active_pool_usage == pytest.approx(0.90)
+    assert s.capacity_tokens == 80.0
+    assert s.used_tokens == 72.0
+    assert s.physical_pool_usage == pytest.approx(76 / 80)
 
 
 def test_vllm_shape_and_legacy_usage_alias():
@@ -132,12 +166,19 @@ def test_idle_zero_is_a_reading_not_an_absence():
     assert s.has_readings()
 
 
-def test_hybrid_pool_takes_the_max_subpool_not_the_full_one():
-    """On a hybrid model the full-attention subpool understates real pressure."""
-    hybrid = "sglang:token_usage 0.10\nsglang:full_token_usage 0.10\nsglang:swa_token_usage 0.93\n"
-    s = sample_from_families(parse_prometheus_text(hybrid))
+def test_token_usage_is_authoritative_when_present():
+    """Current SGLang already sets it to max(full, swa, mamba); recomputing that
+    here would duplicate upstream logic and drift from it."""
+    text = "sglang:token_usage 0.93\nsglang:full_token_usage 0.10\nsglang:swa_token_usage 0.93\n"
 
-    assert s.active_pool_usage == pytest.approx(0.93)
+    assert sample_from_families(parse_prometheus_text(text)).active_pool_usage == pytest.approx(0.93)
+
+
+def test_subpool_gauges_are_the_fallback_for_builds_without_token_usage():
+    """Reading only the full pool would understate a hybrid model's pressure."""
+    hybrid = "sglang:full_token_usage 0.10\nsglang:swa_token_usage 0.93\n"
+
+    assert sample_from_families(parse_prometheus_text(hybrid)).active_pool_usage == pytest.approx(0.93)
 
 
 def test_labels_comments_and_timestamps_are_handled():

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -125,6 +125,7 @@ def test_capacity_is_latched_from_the_first_reading_that_has_it():
     with the server gone must still carry it."""
     poller = _StubPoller([_sample(capacity_tokens=32768.0, capacity_gb=180.0), _sample()])
     rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
+    rec.note_phase("measured", 0.0)
     rec.tick(0.0)
     rec.tick(1.0)
 
@@ -152,6 +153,42 @@ def test_counter_delta_does_not_multiply_lockstep_ranks():
     last = {"": {f'tp_rank="{i}"': 48.0 for i in range(8)}}
 
     assert counter_delta(first, last) == 48.0
+
+
+def test_counter_deltas_are_attributed_to_the_phase_that_earned_them():
+    """An engine retracts through warmup and the accuracy eval too.
+
+    A round-wide difference folds both into the number that is supposed to
+    describe the measured window alone, and unlike the gauge rows -- which carry
+    their phase and can be re-sliced -- a counter difference cannot be taken
+    apart afterwards.
+    """
+    poller = _StubPoller([_sample(retract_total=_grouped(a=v)) for v in (0.0, 5.0, 5.0, 7.0, 7.0, 10.0)])
+    rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
+
+    rec.note_phase("warmup", 0.0)
+    rec.tick(0.0)
+    rec.tick(1.0)
+    rec.note_phase("measured", 2.0)
+    rec.tick(2.0)
+    rec.tick(3.0)
+    rec.note_phase("eval", 4.0)
+    rec.tick(4.0)
+    rec.tick(5.0)
+
+    summary = rec.summary()
+    assert summary["retract_delta"] == 2.0
+    assert summary["retract_delta_by_phase"] == {"warmup": 5.0, "measured": 2.0, "eval": 3.0}
+
+
+def test_measured_delta_is_none_when_no_sample_landed_there():
+    """Not an increment of zero: nothing was ever measured."""
+    poller = _StubPoller([_sample(retract_total=_grouped(a=5.0))])
+    rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
+    rec.note_phase("warmup", 0.0)
+    rec.tick(0.0)
+
+    assert rec.summary()["retract_delta"] is None
 
 
 def test_counter_delta_adds_independent_engines():
@@ -194,14 +231,14 @@ def test_prefix_cache_counters_are_bracketed_not_snapshotted():
         ]
     )
     rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
+    rec.note_phase("measured", 0.0)
     rec.tick(0.0)
     rec.tick(1.0)
 
     window = rec.summary()["prefix_cache"]
     assert window["prefix_cache_queries_delta"] == 400.0
     assert window["prefix_cache_hits_delta"] == 300.0
-    assert window["prefix_cache_queries_first"] == _grouped(a=1000.0)
-    assert window["prefix_cache_queries_last"] == _grouped(a=1400.0)
+    assert window["prefix_cache_queries_delta_by_phase"] == {"measured": 400.0}
 
 
 def test_prefix_cache_counters_add_across_independent_engines():
@@ -212,6 +249,7 @@ def test_prefix_cache_counters_add_across_independent_engines():
     last = {'engine="0"': {'engine="0"': 200.0}, 'engine="1"': {'engine="1"': 200.0}}
     poller = _StubPoller([_sample(prefix_cache_queries=first), _sample(prefix_cache_queries=last)])
     rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
+    rec.note_phase("measured", 0.0)
     rec.tick(0.0)
     rec.tick(1.0)
 
@@ -223,6 +261,7 @@ def test_prefix_cache_restart_credits_only_the_post_restart_count():
         [_sample(cached_tokens_total=_grouped(a=900.0)), _sample(cached_tokens_total=_grouped(a=12.0))]
     )
     rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
+    rec.note_phase("measured", 0.0)
     rec.tick(0.0)
     rec.tick(1.0)
 

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -44,7 +44,7 @@ def _sample(**kwargs) -> KvSample:
     return KvSample(**base)
 
 
-# ── scanner ────────────────────────────────────────────────────────────────
+# â”€â”€ scanner â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 def test_scan_survives_truncation_by_rescanning_from_the_top(tmp_path):
     """A rotated log is shorter than the consumed offset; markers in the new
     content must still be seen rather than skipped past."""
@@ -86,18 +86,46 @@ def test_resolve_scan_logs_includes_the_agentx_client_log(tmp_path):
     assert any(p.endswith("aiperf.log") for p in resolved)
 
 
-# ── recorder ───────────────────────────────────────────────────────────────
+# â”€â”€ recorder â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 def test_rows_are_tagged_with_the_phase_they_were_taken_in():
-    poller = _StubPoller([_sample(), _sample(), _sample()])
+    poller = _StubPoller([_sample() for _ in range(6)])
     rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
 
     rec.tick(0.0)
-    rec.note_phase("warmup", 1.0)
+    rec.note_phase("warmup", 1.0)  # boundary reading closes boot
     rec.tick(1.0)
-    rec.note_phase("measured", 2.0)
+    rec.note_phase("measured", 2.0)  # boundary reading closes warmup
     rec.tick(2.0)
 
-    assert [r["phase"] for r in rec.rows()] == ["boot", "warmup", "measured"]
+    assert [r["phase"] for r in rec.rows()] == ["boot", "boot", "warmup", "warmup", "measured"]
+
+
+def test_a_boundary_reading_closes_one_phase_and_opens_the_next():
+    """Deriving a phase total from its own first and last periodic samples
+    leaves up to a full interval at each end credited to neither phase."""
+    poller = _StubPoller([_sample(retract_total=_grouped(a=v)) for v in (7.0, 7.0, 9.0)])
+    rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
+    rec.tick(0.0)
+
+    rec.note_phase("measured", 1.0)
+    rec.tick(2.0)
+
+    # The single boundary read is both boot's endpoint and measured's baseline.
+    assert rec.summary()["retract_delta_by_phase"]["measured"] == 2.0
+
+
+def test_every_row_carries_gauges_and_raw_counters():
+    """Counters only at boundaries would blind the interior of a phase: one
+    burst and a steady trickle produce the same total, and a mid-phase engine
+    restart is invisible without the series."""
+    poller = _StubPoller([_sample(capacity_tokens=32768.0, retract_total=_grouped(a=48.0))])
+    rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
+    rec.tick(0.0)
+
+    row = rec.rows()[0]
+    assert row["capacity_tokens"] == 32768.0
+    assert row["counters_by_series"]["retract"] == _grouped(a=48.0)
+    assert "scrape_sec" in row and "mono" in row and "ts" in row
 
 
 def test_scrape_interval_is_enforced_on_the_monotonic_clock():
@@ -163,22 +191,27 @@ def test_counter_deltas_are_attributed_to_the_phase_that_earned_them():
     their phase and can be re-sliced -- a counter difference cannot be taken
     apart afterwards.
     """
-    poller = _StubPoller([_sample(retract_total=_grouped(a=v)) for v in (0.0, 5.0, 5.0, 7.0, 7.0, 10.0)])
+    # Reads in scrape order. The boundary scrapes are the 0, 5, 7 and the final
+    # 10; each closes one phase and opens the next, so the windows meet.
+    reads = (0.0, 2.0, 5.0, 5.0, 6.0, 7.0, 7.0, 9.0, 10.0, 10.0)
+    poller = _StubPoller([_sample(retract_total=_grouped(a=v)) for v in reads])
     rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
 
     rec.note_phase("warmup", 0.0)
-    rec.tick(0.0)
     rec.tick(1.0)
-    rec.note_phase("measured", 2.0)
     rec.tick(2.0)
-    rec.tick(3.0)
-    rec.note_phase("eval", 4.0)
+    rec.note_phase("measured", 3.0)
     rec.tick(4.0)
     rec.tick(5.0)
+    rec.note_phase("eval", 6.0)
+    rec.tick(7.0)
+    rec.tick(8.0)
+    rec.close()
 
     summary = rec.summary()
     assert summary["retract_delta"] == 2.0
-    assert summary["retract_delta_by_phase"] == {"warmup": 5.0, "measured": 2.0, "eval": 3.0}
+    by_phase = summary["retract_delta_by_phase"]
+    assert (by_phase["warmup"], by_phase["measured"], by_phase["eval"]) == (5.0, 2.0, 3.0)
 
 
 def test_measured_delta_is_none_when_no_sample_landed_there():
@@ -238,7 +271,7 @@ def test_prefix_cache_counters_are_bracketed_not_snapshotted():
     window = rec.summary()["prefix_cache"]
     assert window["prefix_cache_queries_delta"] == 400.0
     assert window["prefix_cache_hits_delta"] == 300.0
-    assert window["prefix_cache_queries_delta_by_phase"] == {"measured": 400.0}
+    assert window["prefix_cache_queries_delta_by_phase"]["measured"] == 400.0
 
 
 def test_prefix_cache_counters_add_across_independent_engines():
@@ -326,7 +359,7 @@ def test_sampling_failure_does_not_propagate():
     assert rec.rows() == []
 
 
-# ── loop integration ───────────────────────────────────────────────────────
+# â”€â”€ loop integration â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 class _Recorder:
     """Minimal stand-in matching the duck-typed contract the loop expects."""
 
@@ -534,7 +567,7 @@ def test_artifact_name_is_stable():
     assert Path(KV_ARTIFACT_NAME).suffix == ".json"
 
 
-# ── call-site wiring ───────────────────────────────────────────────────────
+# â”€â”€ call-site wiring â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 def test_no_recorder_without_a_server_log_path():
     """A helper subprocess has no engine to scrape and no round to scope to."""
     assert sk._build_kv_recorder(None, {}) is None

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -231,6 +231,36 @@ def test_recorder_is_closed_on_the_normal_return_path():
     )
 
     assert rec.closed_aborted is False
+
+
+def test_no_scraping_before_the_server_is_up():
+    """The scrape blocks, and before the engine binds its port every attempt is
+    a refused connection paid for inside the watchdog loop -- during boot, when
+    the ready marker and the death gate most need it responsive. Boot has no
+    traffic to measure anyway."""
+    rec = _Recorder()
+    sk._communicate_with_soft_deadline(
+        _DoneProc(),
+        hard_timeout=5,
+        soft_deadline_sec=5,
+        kv_recorder=rec,
+    )
+
+    assert rec.ticks == 0
+
+
+def test_warm_reuse_rounds_scrape_immediately():
+    """A round re-attaching to a live server writes no ready marker, so gating on
+    that marker alone would collect nothing for the entire round."""
+    rec = _Recorder()
+    sk._communicate_with_soft_deadline(
+        _DoneProc(),
+        hard_timeout=5,
+        soft_deadline_sec=5,
+        server_already_ready=True,
+        kv_recorder=rec,
+    )
+
     assert rec.ticks >= 1
 
 
@@ -300,3 +330,64 @@ def test_no_recorder_leaves_the_loop_unchanged():
 
 def test_artifact_name_is_stable():
     assert Path(KV_ARTIFACT_NAME).suffix == ".json"
+
+
+# ── call-site wiring ───────────────────────────────────────────────────────
+def test_no_recorder_without_a_server_log_path():
+    """A helper subprocess has no engine to scrape and no round to scope to."""
+    assert sk._build_kv_recorder(None, {}) is None
+    assert sk._build_kv_recorder("", {}) is None
+
+
+def test_kill_switch_disables_collection(tmp_path, monkeypatch):
+    """A loop this central needs a way out that does not require a redeploy."""
+    log_path = str(tmp_path / "server.log")
+    assert sk._build_kv_recorder(log_path, {}) is not None
+
+    monkeypatch.setenv(sk._KV_METRICS_ENV, "0")
+    assert sk._build_kv_recorder(log_path, {}) is None
+
+
+def test_recorder_targets_the_round_workspace_and_the_bound_port(tmp_path):
+    """The port is the per-session ephemeral one the config pinned, not 8888."""
+    rec = sk._build_kv_recorder(str(tmp_path / "server.log"), {"PORT": "31234"})
+
+    assert rec._output_path == str(tmp_path / KV_ARTIFACT_NAME)
+    assert ":31234/metrics" in rec._poller.url
+
+
+def test_run_with_session_kill_produces_the_artifact(tmp_path):
+    """End to end: the artifact has to exist on disk after a real round.
+
+    The wiring this covers was the gap between "the loop accepts a recorder" and
+    "a recorder is ever built" -- with it missing, every piece below had tests
+    that passed while nothing was ever collected.
+    """
+    import sys
+
+    log_path = tmp_path / "server.log"
+    log_path.write_text("Application startup complete\n", encoding="utf-8")
+
+    sk.run_with_session_kill(
+        [sys.executable, "-c", "import time; time.sleep(1.2)"],
+        timeout=30,
+        server_log_path=str(log_path),
+        server_dead_grace_sec=30.0,
+    )
+
+    artifact = tmp_path / KV_ARTIFACT_NAME
+    assert artifact.is_file()
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1
+    # No engine was listening, and that is recorded rather than reported as an
+    # idle pool: every metric stays absent instead of reading zero.
+    assert payload["available"] is not True
+    assert payload["capacity_tokens"] is None
+    assert payload["retract_delta"] is None
+
+
+def test_artifact_is_in_the_package_globs():
+    """It lives in the round workspace, which the bundle does not otherwise reach."""
+    from hyperloom.inference_optimizer.breakdown.session_package import PACKAGE_GLOBS
+
+    assert "runs/**/kv_metrics.json" in PACKAGE_GLOBS

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -189,8 +189,8 @@ def test_prefix_cache_counters_are_bracketed_not_snapshotted():
     """
     poller = _StubPoller(
         [
-            _sample(prefix_cache_queries=1000.0, prefix_cache_hits=800.0),
-            _sample(prefix_cache_queries=1400.0, prefix_cache_hits=1100.0),
+            _sample(prefix_cache_queries=_grouped(a=1000.0), prefix_cache_hits=_grouped(a=800.0)),
+            _sample(prefix_cache_queries=_grouped(a=1400.0), prefix_cache_hits=_grouped(a=1100.0)),
         ]
     )
     rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
@@ -200,12 +200,28 @@ def test_prefix_cache_counters_are_bracketed_not_snapshotted():
     window = rec.summary()["prefix_cache"]
     assert window["prefix_cache_queries_delta"] == 400.0
     assert window["prefix_cache_hits_delta"] == 300.0
-    assert window["first"]["prefix_cache_queries"] == 1000.0
-    assert window["last"]["prefix_cache_queries"] == 1400.0
+    assert window["prefix_cache_queries_first"] == _grouped(a=1000.0)
+    assert window["prefix_cache_queries_last"] == _grouped(a=1400.0)
+
+
+def test_prefix_cache_counters_add_across_independent_engines():
+    """Two vLLM engines serving 200 lookups each did 400, not 200. Taking the
+    max across series before diffing halved every cache figure on a DP
+    deployment."""
+    first = {'engine="0"': {'engine="0"': 0.0}, 'engine="1"': {'engine="1"': 0.0}}
+    last = {'engine="0"': {'engine="0"': 200.0}, 'engine="1"': {'engine="1"': 200.0}}
+    poller = _StubPoller([_sample(prefix_cache_queries=first), _sample(prefix_cache_queries=last)])
+    rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
+    rec.tick(0.0)
+    rec.tick(1.0)
+
+    assert rec.summary()["prefix_cache"]["prefix_cache_queries_delta"] == 400.0
 
 
 def test_prefix_cache_restart_credits_only_the_post_restart_count():
-    poller = _StubPoller([_sample(cached_tokens_total=900.0), _sample(cached_tokens_total=12.0)])
+    poller = _StubPoller(
+        [_sample(cached_tokens_total=_grouped(a=900.0)), _sample(cached_tokens_total=_grouped(a=12.0))]
+    )
     rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
     rec.tick(0.0)
     rec.tick(1.0)

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -634,3 +634,251 @@ def test_artifact_is_in_the_package_globs():
     from hyperloom.inference_optimizer.breakdown.session_package import PACKAGE_GLOBS
 
     assert "runs/**/kv_metrics.json" in PACKAGE_GLOBS
+
+
+# ---------------------------------------------------------------------------
+# authoritative phase boundaries
+# ---------------------------------------------------------------------------
+class _StubProgress:
+    """Serves canned ``/api/progress`` phase payloads."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    def poll(self):
+        self.calls += 1
+        return self._responses.pop(0) if self._responses else None
+
+
+def _ns(unix_seconds: float) -> int:
+    """Unix seconds as the nanosecond stamp aiperf reports."""
+    return int(unix_seconds * 1e9)
+
+
+def _now() -> float:
+    """A base near the real wall clock, which the epoch sanity check requires."""
+    import time
+
+    return time.time()
+
+
+def test_progress_address_is_read_from_the_round_directory(tmp_path):
+    """The client publishes it; the watchdog is a different process."""
+    from hyperloom.orchestrator.actions.executors._kv_metrics import AiperfProgressPoller
+
+    artifacts = tmp_path / "aiperf_artifacts"
+    artifacts.mkdir()
+    (artifacts / "progress_api.json").write_text(json.dumps({"url": "http://127.0.0.1:19090"}), encoding="utf-8")
+
+    assert AiperfProgressPoller(tmp_path)._resolve_url() == "http://127.0.0.1:19090"
+
+
+def test_progress_address_is_found_in_a_nested_benchmark_directory(tmp_path):
+    """An AgentX round nests its artifacts one level below the server log."""
+    from hyperloom.orchestrator.actions.executors._kv_metrics import AiperfProgressPoller
+
+    artifacts = tmp_path / "benchmark_agentx_1" / "aiperf_artifacts"
+    artifacts.mkdir(parents=True)
+    (artifacts / "progress_api.json").write_text(json.dumps({"url": "http://127.0.0.1:20001"}), encoding="utf-8")
+
+    assert AiperfProgressPoller(tmp_path)._resolve_url() == "http://127.0.0.1:20001"
+
+
+def test_missing_progress_address_is_not_an_error(tmp_path):
+    """Every non-AgentX round is this case."""
+    from hyperloom.orchestrator.actions.executors._kv_metrics import AiperfProgressPoller
+
+    poller = AiperfProgressPoller(tmp_path)
+    assert poller._resolve_url() is None
+    assert poller.poll() is None
+
+
+def test_authoritative_boundary_moves_rows_the_log_marker_mislabelled():
+    """The correction this exists for.
+
+    aiperf starts profiling at T, but writes the line the watchdog greps for
+    afterwards, and the watchdog reads it on its next pass. Samples taken in
+    that lag are stamped ``warmup`` while the measured phase is already running.
+    """
+    now = _now()
+    progress = _StubProgress(
+        [
+            {"warmup": {"start_ns": _ns(now), "requests_end_ns": None}},
+            {
+                "warmup": {"start_ns": _ns(now), "requests_end_ns": _ns(now + 10)},
+                "profiling": {"start_ns": _ns(now + 10), "requests_end_ns": None},
+            },
+            {"profiling": {"start_ns": _ns(now + 10), "requests_end_ns": None}},
+        ]
+    )
+    rec = KvMetricsRecorder(
+        poller=_StubPoller(
+            [
+                _sample(ts=now + 1),
+                _sample(ts=now + 12),  # after the real boundary, before the marker was read
+                _sample(ts=now + 20),
+            ]
+        ),
+        progress=progress,
+        min_interval_sec=0,
+    )
+    # No note_phase call: every row is stamped "boot", so the phases below come
+    # entirely from the authoritative timeline.
+    rec.tick(1.0)
+    rec.tick(2.0)
+    rec.tick(3.0)
+    payload = rec.summary()
+
+    assert payload["phase_source"] == "aiperf_progress_api"
+    phases = [row["phase"] for row in payload["samples"]]
+    assert phases[0] == "warmup"
+    # Both later samples belong to the measured window, whatever the watchdog believed.
+    assert phases[1] == "measured"
+    assert phases[2] == "measured"
+    assert payload["rows_reattributed"] == 3
+
+
+def test_counter_totals_follow_the_authoritative_boundary():
+    """Re-labelling the rows alone would leave the phase totals wrong.
+
+    The retract that happened after the real transition has to be booked to the
+    measured phase, not to the warmup window the watchdog had not yet closed.
+    """
+    now = _now()
+    progress = _StubProgress(
+        [
+            {"warmup": {"start_ns": _ns(now), "requests_end_ns": None}},
+            {
+                "warmup": {"start_ns": _ns(now), "requests_end_ns": _ns(now + 10)},
+                "profiling": {"start_ns": _ns(now + 10), "requests_end_ns": None},
+            },
+            {"profiling": {"start_ns": _ns(now + 10), "requests_end_ns": None}},
+        ]
+    )
+    rec = KvMetricsRecorder(
+        poller=_StubPoller(
+            [
+                _sample(ts=now + 1, retract_total=_grouped(a=1.0)),
+                _sample(ts=now + 12, retract_total=_grouped(a=5.0)),
+                _sample(ts=now + 20, retract_total=_grouped(a=9.0)),
+            ]
+        ),
+        progress=progress,
+        min_interval_sec=0,
+    )
+    rec.tick(1.0)
+    rec.tick(2.0)
+    rec.tick(3.0)
+    payload = rec.summary()
+
+    # Warmup opened at 1 and is closed by the first measured reading (5): 4.
+    assert payload["retract_delta_by_phase"]["warmup"] == 4.0
+    # Measured runs 5 -> 9, and shares the boundary reading rather than starting after it.
+    assert payload["retract_delta"] == 4.0
+
+
+def test_a_non_epoch_timestamp_is_rejected_rather_than_trusted():
+    """A monotonic ``start_ns`` would place every boundary in 1970 and sweep the
+    whole round into one phase. Fall back to the markers instead."""
+    rec = KvMetricsRecorder(
+        poller=_StubPoller([_sample(ts=_now()), _sample(ts=_now())]),
+        progress=_StubProgress(
+            [
+                {"profiling": {"start_ns": 12_345_678, "requests_end_ns": None}},
+                {"profiling": {"start_ns": 12_345_678, "requests_end_ns": None}},
+            ]
+        ),
+        min_interval_sec=0,
+    )
+    rec.note_phase("warmup", 1.0)  # consumes the boundary reading
+    rec.tick(2.0)
+    payload = rec.summary()
+
+    assert payload["phase_source"] == "log_markers"
+    assert payload["samples"][-1]["phase"] == "warmup"
+
+
+def test_eval_is_never_overwritten_by_the_workload_timeline():
+    """The accuracy run is not aiperf's traffic and it has no opinion about it."""
+    now = _now()
+    snapshot = {"profiling": {"start_ns": _ns(now), "requests_end_ns": None}}
+    rec = KvMetricsRecorder(
+        poller=_StubPoller([_sample(ts=now + 30), _sample(ts=now + 31)]),
+        progress=_StubProgress([snapshot, snapshot]),
+        min_interval_sec=0,
+    )
+    rec.note_phase("eval", 1.0)  # consumes the boundary reading
+    rec.tick(2.0)
+    payload = rec.summary()
+
+    assert payload["phase_source"] == "aiperf_progress_api"
+    assert payload["samples"][-1]["phase"] == "eval"
+
+
+def test_rows_carry_scrape_start_and_end_not_just_a_duration():
+    """A gauge read across a 300ms window describes some instant inside it, and
+    a single stamp would invite an alignment precision nobody measured."""
+    rec = KvMetricsRecorder(poller=_StubPoller([_sample()]), min_interval_sec=0)
+    rec.tick(1.0)
+    row = rec.summary()["samples"][0]
+
+    for key in ("scrape_start_unix", "scrape_end_unix", "scrape_start_mono", "scrape_end_mono", "scrape_sec"):
+        assert key in row, key
+    assert row["scrape_end_mono"] >= row["scrape_start_mono"]
+    assert row["scrape_end_unix"] >= row["scrape_start_unix"]
+
+
+def test_rows_carry_the_workload_in_flight_at_the_scrape():
+    """The correlation the timeline supports: engine-wide KV against the active
+    phase's own counters, at the granularity aiperf actually exposes."""
+    now = _now()
+    rec = KvMetricsRecorder(
+        poller=_StubPoller([_sample(ts=now + 1)]),
+        progress=_StubProgress(
+            [{"profiling": {"start_ns": _ns(now), "requests_end_ns": None, "sent": 12, "completed": 7}}]
+        ),
+        min_interval_sec=0,
+    )
+    rec.tick(1.0)
+    row = rec.summary()["samples"][0]
+
+    assert row["workload"]["aiperf_phase"] == "profiling"
+    assert row["workload"]["stats"] == {"sent": 12, "completed": 7}
+
+
+def test_timeline_survives_a_phase_aiperf_stops_reporting():
+    """aiperf drops a finished phase from its report; keeping only the latest
+    response would lose the warmup boundary the moment profiling starts."""
+    now = _now()
+    rec = KvMetricsRecorder(
+        poller=_StubPoller([_sample(ts=now + 1), _sample(ts=now + 12)]),
+        progress=_StubProgress(
+            [
+                {"warmup": {"start_ns": _ns(now), "requests_end_ns": None}},
+                {"profiling": {"start_ns": _ns(now + 10), "requests_end_ns": None}},
+            ]
+        ),
+        min_interval_sec=0,
+    )
+    rec.tick(1.0)
+    rec.tick(2.0)
+    payload = rec.summary()
+
+    assert set(payload["phase_timeline"]) == {"warmup", "profiling"}
+    assert payload["phase_bounds_unix"]["warmup"]["start"] == pytest.approx(now, abs=1e-3)
+
+
+def test_progress_failures_never_reach_the_round():
+    """Collection is observational; a broken endpoint costs nothing."""
+
+    class _Exploding:
+        def poll(self):
+            raise RuntimeError("progress API on fire")
+
+    rec = KvMetricsRecorder(poller=_StubPoller([_sample()]), progress=_Exploding(), min_interval_sec=0)
+    rec.tick(1.0)
+    payload = rec.summary()
+
+    assert payload["phase_source"] == "log_markers"
+    assert payload["sample_count"] == 1

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -133,20 +133,43 @@ def test_capacity_is_latched_from_the_first_reading_that_has_it():
     assert summary["capacity_gb"] == 180.0
 
 
+def _grouped(**shards) -> dict[str, dict[str, float]]:
+    """One independent unit carrying the given shard readings."""
+    return {"": dict(shards)}
+
+
 def test_counter_delta_credits_only_the_post_restart_count():
     """An engine restart zeroes its series; a flat subtraction would go negative."""
-    assert counter_delta({"a": 10.0}, {"a": 48.0}) == 38.0
-    assert counter_delta({"a": 100.0}, {"a": 3.0}) == 3.0
+    assert counter_delta(_grouped(a=10.0), _grouped(a=48.0)) == 38.0
+    assert counter_delta(_grouped(a=100.0), _grouped(a=3.0)) == 3.0
     assert counter_delta({}, {}) is None
-    assert counter_delta({}, {"a": 5.0}) == 5.0
+    assert counter_delta({}, _grouped(a=5.0)) == 5.0
 
 
 def test_counter_delta_does_not_multiply_lockstep_ranks():
     """Eight ranks reporting 48 describe 48 retracts, not 384."""
-    first = {f'tp_rank="{i}"': 0.0 for i in range(8)}
-    last = {f'tp_rank="{i}"': 48.0 for i in range(8)}
+    first = {"": {f'tp_rank="{i}"': 0.0 for i in range(8)}}
+    last = {"": {f'tp_rank="{i}"': 48.0 for i in range(8)}}
 
     assert counter_delta(first, last) == 48.0
+
+
+def test_counter_delta_adds_independent_engines():
+    first = {'engine="0"': {'engine="0"': 0.0}, 'engine="1"': {'engine="1"': 0.0}}
+    last = {'engine="0"': {'engine="0"': 48.0}, 'engine="1"': {'engine="1"': 48.0}}
+
+    assert counter_delta(first, last) == 96.0
+
+
+def test_rows_and_summary_use_the_same_counter_rule():
+    """Two rules inside one artifact is worse than either being wrong: nothing
+    on the page says which number was computed which way."""
+    shards = {"": {f'tp_rank="{i}"': 48.0 for i in range(8)}}
+    poller = _StubPoller([_sample(retract_total=shards)])
+    rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
+    rec.tick(0.0)
+
+    assert rec.rows()[0]["retract_total"] == 48.0
 
 
 def test_downsampling_respects_the_cap():
@@ -158,16 +181,36 @@ def test_downsampling_respects_the_cap():
     assert len(rec.rows()) <= 5000
 
 
-def test_prefix_cache_counters_reach_the_artifact():
-    """They were parsed and then dropped: read at cost, stored nowhere."""
-    poller = _StubPoller([_sample(prefix_cache_queries=1000.0, prefix_cache_hits=529.0)])
+def test_prefix_cache_counters_are_bracketed_not_snapshotted():
+    """Cumulative counters, and the engine outlives the round under warm reuse.
+
+    The latest absolute value therefore carries whatever the previous round
+    warmed the cache with, which is not attributable to this one.
+    """
+    poller = _StubPoller(
+        [
+            _sample(prefix_cache_queries=1000.0, prefix_cache_hits=800.0),
+            _sample(prefix_cache_queries=1400.0, prefix_cache_hits=1100.0),
+        ]
+    )
     rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
     rec.tick(0.0)
+    rec.tick(1.0)
 
-    assert rec.summary()["prefix_cache"] == {
-        "prefix_cache_queries": 1000.0,
-        "prefix_cache_hits": 529.0,
-    }
+    window = rec.summary()["prefix_cache"]
+    assert window["prefix_cache_queries_delta"] == 400.0
+    assert window["prefix_cache_hits_delta"] == 300.0
+    assert window["first"]["prefix_cache_queries"] == 1000.0
+    assert window["last"]["prefix_cache_queries"] == 1400.0
+
+
+def test_prefix_cache_restart_credits_only_the_post_restart_count():
+    poller = _StubPoller([_sample(cached_tokens_total=900.0), _sample(cached_tokens_total=12.0)])
+    rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
+    rec.tick(0.0)
+    rec.tick(1.0)
+
+    assert rec.summary()["prefix_cache"]["cached_tokens_total_delta"] == 12.0
 
 
 def test_capacity_provenance_and_series_count_reach_the_artifact():
@@ -191,7 +234,7 @@ def test_summary_availability_is_tristate():
 
 def test_close_writes_the_artifact_and_is_idempotent(tmp_path):
     out = tmp_path / KV_ARTIFACT_NAME
-    poller = _StubPoller([_sample(retract_total={"": 48.0})])
+    poller = _StubPoller([_sample(retract_total={"": {"": 48.0}})])
     rec = KvMetricsRecorder(poller=poller, output_path=str(out), min_interval_sec=0.0)
     rec.tick(0.0)
 

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -638,6 +638,147 @@ def test_artifact_is_in_the_package_globs():
 
 
 # ---------------------------------------------------------------------------
+# aiperf's own server-metrics export
+# ---------------------------------------------------------------------------
+def _slim_record(*, ts_ns: int, usage: float, retracts: float, phase: str = "profiling") -> dict:
+    """One line of aiperf's ``server_metrics_export.jsonl``, in its documented shape."""
+    return {
+        "endpoint_url": "http://localhost:34407/metrics",
+        "timestamp_ns": ts_ns,
+        "endpoint_latency_ns": 4_000_000,
+        "request_sent_ns": ts_ns - 4_000_000,
+        "benchmark_phase": phase,
+        "metrics": {
+            "sglang:token_usage": [{"labels": {"tp_rank": "0"}, "value": usage}],
+            "sglang:num_retracted_requests_total": [{"labels": {"tp_rank": "0"}, "value": retracts}],
+        },
+    }
+
+
+def _write_server_metrics(tmp_path, records) -> Path:
+    """Write the export where aiperf would put it."""
+    art = tmp_path / "aiperf_artifacts"
+    art.mkdir(exist_ok=True)
+    path = art / "server_metrics_export.jsonl"
+    path.write_text("".join(json.dumps(r) + "\n" for r in records), encoding="utf-8")
+    return path
+
+
+def test_aiperf_records_rebuild_the_same_normalised_sample(tmp_path):
+    """Labels survive aiperf's export, so one normalisation serves both sources.
+
+    ``SlimRecord.metrics`` is ``{name: [{labels, value}]}`` -- the same information
+    ``parse_prometheus_text`` produces -- so the per-rank assembly does not have to
+    be reimplemented for this path.
+    """
+    from hyperloom.orchestrator.actions.executors._kv_metrics import read_aiperf_server_metrics
+
+    path = _write_server_metrics(tmp_path, [_slim_record(ts_ns=1_789_000_000_000_000_000, usage=0.62, retracts=4)])
+    (sample, timing, phase) = read_aiperf_server_metrics(path)[0]
+
+    assert sample.engine == "sglang"
+    assert sample.active_pool_usage == 0.62
+    assert phase == "measured"  # aiperf's "profiling"
+    assert timing["scrape_sec"] == 0.004
+    assert timing["scrape_start_unix"] <= sample.ts <= timing["scrape_end_unix"]
+
+
+def test_aiperf_phase_stamp_is_used_verbatim(tmp_path):
+    """No re-attribution: aiperf stamps the phase at collection time, from the
+    process that owns the transition, so there is no boundary lag to correct."""
+    from hyperloom.orchestrator.actions.executors._kv_metrics import read_aiperf_server_metrics
+
+    base = 1_789_000_000_000_000_000
+    path = _write_server_metrics(
+        tmp_path,
+        [
+            _slim_record(ts_ns=base, usage=0.1, retracts=0, phase="warmup"),
+            _slim_record(ts_ns=base + 2_000_000_000, usage=0.5, retracts=3, phase="profiling"),
+        ],
+    )
+
+    assert [phase for _s, _t, phase in read_aiperf_server_metrics(path)] == ["warmup", "measured"]
+
+
+def test_recorder_prefers_aiperfs_scrapes_over_its_own(tmp_path):
+    """On an AgentX round aiperf is already scraping the same endpoint; its rows
+    win, and the live ones are discarded rather than interleaved."""
+    base = 1_789_000_000_000_000_000
+    _write_server_metrics(
+        tmp_path,
+        [
+            _slim_record(ts_ns=base, usage=0.10, retracts=1, phase="warmup"),
+            _slim_record(ts_ns=base + 2_000_000_000, usage=0.70, retracts=5, phase="profiling"),
+            _slim_record(ts_ns=base + 4_000_000_000, usage=0.80, retracts=9, phase="profiling"),
+        ],
+    )
+    rec = KvMetricsRecorder(
+        poller=_StubPoller([_sample(ts=_now(), active_pool_usage=0.99)]),
+        output_path=str(tmp_path / KV_ARTIFACT_NAME),
+        min_interval_sec=0,
+    )
+    rec.tick(1.0)
+    payload = rec.summary()
+
+    assert payload["sample_source"] == "aiperf_server_metrics"
+    assert payload["phase_source"] == "aiperf_server_metrics"
+    assert [r["phase"] for r in payload["samples"]] == ["warmup", "measured", "measured"]
+    # The live reading of 0.99 is gone: two collectors on one endpoint would bracket
+    # counters across interleaved readings of the same series.
+    assert [r["active_pool_usage"] for r in payload["samples"]] == [0.10, 0.70, 0.80]
+    # Warmup opened at 1 and is closed by the first measured reading; measured runs 5 -> 9.
+    assert payload["retract_delta_by_phase"]["warmup"] == 4.0
+    assert payload["retract_delta"] == 4.0
+
+
+def test_a_round_without_an_aiperf_export_keeps_the_watchdog_rows(tmp_path):
+    """Synthetic benchmarks, the accuracy eval and any round killed before aiperf
+    flushed have no export, and are still the majority of rounds."""
+    rec = KvMetricsRecorder(
+        poller=_StubPoller([_sample(active_pool_usage=0.42)]),
+        output_path=str(tmp_path / KV_ARTIFACT_NAME),
+        min_interval_sec=0,
+    )
+    rec.tick(1.0)
+    payload = rec.summary()
+
+    assert payload["sample_source"] == "watchdog_scrape"
+    assert payload["aiperf_server_metrics_path"] is None
+    assert [r["active_pool_usage"] for r in payload["samples"]] == [0.42]
+
+
+def test_an_unreadable_export_falls_back_rather_than_failing(tmp_path):
+    """A better source that cannot be read is not a reason to lose the round."""
+    art = tmp_path / "aiperf_artifacts"
+    art.mkdir()
+    (art / "server_metrics_export.jsonl").write_text("{not json\n", encoding="utf-8")
+    rec = KvMetricsRecorder(
+        poller=_StubPoller([_sample(active_pool_usage=0.42)]),
+        output_path=str(tmp_path / KV_ARTIFACT_NAME),
+        min_interval_sec=0,
+    )
+    rec.tick(1.0)
+    payload = rec.summary()
+
+    assert payload["sample_source"] == "watchdog_scrape"
+    assert payload["sample_count"] == 1
+
+
+def test_histogram_samples_are_skipped_not_mistaken_for_gauges(tmp_path):
+    """aiperf carries histograms as buckets with no ``value``."""
+    from hyperloom.orchestrator.actions.executors._kv_metrics import families_from_aiperf_record
+
+    families = families_from_aiperf_record(
+        {
+            "sglang:token_usage": [{"labels": {}, "value": 0.5}],
+            "sglang:e2e_latency_seconds": [{"labels": {}, "buckets": {"0.1": 3.0}, "sum": 1.0, "count": 3.0}],
+        }
+    )
+
+    assert families == {"sglang:token_usage": [({}, 0.5)]}
+
+
+# ---------------------------------------------------------------------------
 # port resolution
 # ---------------------------------------------------------------------------
 _ROUND_YAML = """\

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -531,7 +531,7 @@ def test_phase_transitions_reach_the_recorder(tmp_path, monkeypatch):
         ]
     )
     monkeypatch.setattr(sk, "_scan_logs_increment", lambda *_a, **_k: next(scans, sk._LogScan(*([False] * 7))))
-    monkeypatch.setattr(sk, "_stamp_server_ready", lambda *_a, **_k: None)
+    monkeypatch.setattr(sk, "stamp_server_ready", lambda *_a, **_k: None)
     monkeypatch.setattr(sk, "_server_log_shows_death", lambda *_a, **_k: None)
     log_path = tmp_path / "server.log"
     log_path.write_text("x\n", encoding="utf-8")

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -917,6 +917,63 @@ def test_an_unstamped_aiperf_record_is_boot_not_measured(tmp_path):
     assert [r["phase"] for r in payload["samples"]] == ["boot", "measured"]
 
 
+def test_a_profiling_stamp_that_precedes_warmup_is_not_measured(tmp_path):
+    """Ordered phases: profiling follows warmup, so one stamped before it is setup.
+
+    Verbatim shape from a live round -- two unstamped baselines, a ``profiling``
+    record 8ms after the second, then warmup two seconds later. Left in
+    ``measured`` it is the only phase allowed into a comparison, and the gap-free
+    bracketing runs that window into warmup's opening seconds.
+    """
+    from hyperloom.orchestrator.actions.executors._kv_metrics import read_aiperf_server_metrics
+
+    base = 1_789_094_031_527_000_000
+    path = _write_server_metrics(
+        tmp_path,
+        [
+            _slim_record(ts_ns=base, usage=0.0, retracts=0, phase=None),
+            _slim_record(ts_ns=base + 21_026_000_000, usage=0.0, retracts=0, phase=None),
+            _slim_record(ts_ns=base + 21_034_000_000, usage=0.0, retracts=0, phase="profiling"),
+            _slim_record(ts_ns=base + 23_041_000_000, usage=0.1, retracts=0, phase="warmup"),
+            _slim_record(ts_ns=base + 25_044_000_000, usage=0.2, retracts=0, phase="warmup"),
+        ],
+    )
+
+    assert [p for _s, _t, p in read_aiperf_server_metrics(path)] == ["boot", "boot", "boot", "warmup", "warmup"]
+
+
+def test_profiling_after_warmup_is_left_alone(tmp_path):
+    """The ordinary case, and the whole point of reading aiperf's stamp."""
+    from hyperloom.orchestrator.actions.executors._kv_metrics import read_aiperf_server_metrics
+
+    base = 1_789_094_031_527_000_000
+    path = _write_server_metrics(
+        tmp_path,
+        [
+            _slim_record(ts_ns=base, usage=0.1, retracts=0, phase="warmup"),
+            _slim_record(ts_ns=base + 60_000_000_000, usage=0.6, retracts=2, phase="profiling"),
+        ],
+    )
+
+    assert [p for _s, _t, p in read_aiperf_server_metrics(path)] == ["warmup", "measured"]
+
+
+def test_a_run_without_warmup_keeps_its_leading_profiling_records(tmp_path):
+    """Nothing to be premature relative to, so the stamp stands."""
+    from hyperloom.orchestrator.actions.executors._kv_metrics import read_aiperf_server_metrics
+
+    base = 1_789_094_031_527_000_000
+    path = _write_server_metrics(
+        tmp_path,
+        [
+            _slim_record(ts_ns=base, usage=0.5, retracts=0, phase="profiling"),
+            _slim_record(ts_ns=base + 2_000_000_000, usage=0.6, retracts=1, phase="profiling"),
+        ],
+    )
+
+    assert [p for _s, _t, p in read_aiperf_server_metrics(path)] == ["measured", "measured"]
+
+
 def test_the_port_is_read_from_the_server_the_config_did_not_pin(tmp_path):
     """On an AgentX round nothing pins ``PORT`` and vLLM binds its own 8000.
 

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -1620,8 +1620,9 @@ def test_recorder_writes_the_workload_timeline_beside_the_kv_artifact(tmp_path):
     ]
     assert {e["event"] for e in events} >= {"phase_start", "trajectory_start", "turn_start", "request_start"}
 
-    # The sample taken 5s in saw that trajectory running.
-    assert payload["samples"][0]["workload"]["in_flight"]["trajectory_ids"] == ["traj-1"]
+    # The sample taken 5s in saw that trajectory running; the timeline names it.
+    assert payload["samples"][0]["workload"]["in_flight"]["trajectories"] == 1
+    assert {e["trajectory_id"] for e in events if e["event"] == "trajectory_start"} == {"traj-1"}
 
 
 def test_a_round_without_an_aiperf_export_reports_no_timeline(tmp_path):

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -834,6 +834,85 @@ def test_eval_rows_survive_the_aiperf_adoption(tmp_path):
     assert payload["sample_source"] == "aiperf_server_metrics"
 
 
+def test_an_unstamped_aiperf_record_is_boot_not_measured(tmp_path):
+    """aiperf's baseline capture carries no phase, and it is not measured data.
+
+    Observed on a live AgentX round: two records stamped ``null`` sat before the
+    warmup `start_ns`, readings of an idle pool taken before any phase began.
+    Defaulting them to "measured" put them in the one phase allowed into a
+    comparison and produced a measured prefix-cache delta of 34,395 describing
+    nothing that happened.
+    """
+    base = 1_789_048_708_000_000_000
+    _write_server_metrics(
+        tmp_path,
+        [
+            {
+                "endpoint_url": "http://localhost:8000/metrics",
+                "timestamp_ns": base,
+                "endpoint_latency_ns": 19_658_211,
+                "request_sent_ns": base - 19_658_211,
+                "benchmark_phase": None,
+                "metrics": {"vllm:kv_cache_usage_perc": [{"labels": {"engine": "0"}, "value": 0.0}]},
+            },
+            _slim_record(ts_ns=base + 30_000_000_000, usage=0.5, retracts=0, phase="profiling"),
+        ],
+    )
+    rec = KvMetricsRecorder(
+        poller=_StubPoller([]),
+        output_path=str(tmp_path / KV_ARTIFACT_NAME),
+        min_interval_sec=0,
+    )
+    payload = rec.summary()
+
+    assert [r["phase"] for r in payload["samples"]] == ["boot", "measured"]
+
+
+def test_the_port_is_read_from_the_server_the_config_did_not_pin(tmp_path):
+    """On an AgentX round nothing pins ``PORT`` and vLLM binds its own 8000.
+
+    The synthetic path pins 8888, which is what the default matches, so a default
+    can only ever be right for one of the two. The server's own banner is right
+    for both.
+    """
+    from hyperloom.orchestrator.actions.executors._kv_metrics import port_from_server_log, resolve_metrics_port
+
+    nested = tmp_path / "benchmark_vllm_1"
+    nested.mkdir()
+    (nested / "server.log").write_text(
+        "INFO 09-10 13:57:01 [api_server.py:1] Starting vLLM API server\n"
+        "INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)\n"
+        "INFO:     Application startup complete.\n",
+        encoding="utf-8",
+    )
+
+    assert port_from_server_log(tmp_path) == 8000
+    assert resolve_metrics_port({}, tmp_path) == 8000
+
+
+def test_the_pinned_config_still_outranks_the_server_banner(tmp_path):
+    """Both exist on a synthetic round and the config is the earlier authority."""
+    from hyperloom.orchestrator.actions.executors._kv_metrics import resolve_metrics_port
+
+    (tmp_path / "baseline_lifecycle.yaml").write_text(_ROUND_YAML, encoding="utf-8")
+    (tmp_path / "server.log").write_text("INFO:     Uvicorn running on http://0.0.0.0:8000\n", encoding="utf-8")
+
+    assert resolve_metrics_port({}, tmp_path) == 34407
+
+
+def test_the_port_is_resolved_on_first_use_not_at_construction(tmp_path):
+    """The server writes its banner after the recorder is built, so resolving
+    eagerly would cache the default and scrape a port nothing is listening on."""
+    from hyperloom.orchestrator.actions.executors._kv_metrics import KvMetricsPoller
+
+    poller = KvMetricsPoller(workspace=tmp_path)
+    # The round has not booted yet; the log appears only now.
+    (tmp_path / "server.log").write_text("INFO:     Uvicorn running on http://0.0.0.0:8000\n", encoding="utf-8")
+
+    assert poller.port == 8000
+    assert poller.url == "http://127.0.0.1:8000/metrics"
+
+
 def test_a_round_without_an_aiperf_export_keeps_the_watchdog_rows(tmp_path):
     """Synthetic benchmarks, the accuracy eval and any round killed before aiperf
     flushed have no export, and are still the majority of rounds."""

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -638,6 +638,119 @@ def test_artifact_is_in_the_package_globs():
 
 
 # ---------------------------------------------------------------------------
+# port resolution
+# ---------------------------------------------------------------------------
+_ROUND_YAML = """\
+benchmark:
+  framework: vllm
+  model: /models/Qwen3-0.6B
+  envs:
+    TP: 1
+    CONC: 64
+    PORT: 34407
+"""
+
+
+def test_port_comes_from_the_round_config_not_the_default(tmp_path):
+    """The regression that cost a real session its measured round.
+
+    The port is pinned in the materialized ``benchmark.envs.PORT`` and never
+    exported into the subprocess environment, so resolving from the environment
+    alone lands on 8888 and scrapes a port nothing is listening on.
+    """
+    from hyperloom.orchestrator.actions.executors._kv_metrics import port_from_workspace, resolve_metrics_port
+
+    (tmp_path / "baseline_lifecycle.yaml").write_text(_ROUND_YAML, encoding="utf-8")
+
+    assert port_from_workspace(tmp_path) == 34407
+    assert resolve_metrics_port({}, tmp_path) == 34407
+
+
+def test_port_is_read_from_the_benchmark_config_too(tmp_path):
+    """A warm-reuse round carries it here rather than in a lifecycle YAML."""
+    from hyperloom.orchestrator.actions.executors._kv_metrics import port_from_workspace
+
+    nested = tmp_path / "benchmark_vllm_1"
+    nested.mkdir()
+    (nested / "config.yaml").write_text(_ROUND_YAML, encoding="utf-8")
+
+    assert port_from_workspace(tmp_path) == 34407
+
+
+def test_explicit_env_still_outranks_the_config(tmp_path):
+    """An operator pin has to win over a file we merely found."""
+    from hyperloom.orchestrator.actions.executors._kv_metrics import resolve_metrics_port
+
+    (tmp_path / "baseline_lifecycle.yaml").write_text(_ROUND_YAML, encoding="utf-8")
+
+    assert resolve_metrics_port({"PORT": "9001"}, tmp_path) == 9001
+
+
+def test_a_round_without_a_pinned_port_falls_back_to_the_default(tmp_path):
+    """Which is what the one round that worked was relying on."""
+    from hyperloom.orchestrator.actions.executors._kv_metrics import DEFAULT_METRICS_PORT, resolve_metrics_port
+
+    (tmp_path / "baseline_config.with_envs.yaml").write_text(
+        "benchmark:\n  framework: vllm\n  envs:\n    TP: 1\n", encoding="utf-8"
+    )
+
+    assert resolve_metrics_port({}, tmp_path) == DEFAULT_METRICS_PORT
+
+
+def test_unreadable_config_does_not_raise(tmp_path):
+    """Malformed YAML in a round directory is not a reason to fail a round."""
+    from hyperloom.orchestrator.actions.executors._kv_metrics import port_from_workspace
+
+    (tmp_path / "broken.yaml").write_text("benchmark: [unclosed\n", encoding="utf-8")
+
+    assert port_from_workspace(tmp_path) is None
+
+
+def _refuse(monkeypatch):
+    """Make every scrape fail the way a closed port does."""
+    from hyperloom.orchestrator.actions.executors import _kv_metrics as km
+
+    def _boom(*_a, **_k):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(km._OPENER, "open", _boom)
+
+
+def test_poller_does_not_give_up_on_a_slow_start(monkeypatch):
+    """Three misses inside six seconds is a slow engine, not an absent endpoint.
+
+    Giving up on the count alone parked collection for the rest of a round over a
+    server that was merely still binding.
+    """
+    from hyperloom.orchestrator.actions.executors._kv_metrics import KvMetricsPoller
+
+    _refuse(monkeypatch)
+    poller = KvMetricsPoller(port=1)
+    for _ in range(5):
+        poller.fetch()
+
+    assert poller.available is None  # still unknown, still trying
+
+
+def test_poller_gives_up_once_the_grace_has_also_passed(monkeypatch):
+    """An endpoint that answered nothing for a minute is not coming back."""
+    import time
+
+    from hyperloom.orchestrator.actions.executors._kv_metrics import _GIVE_UP_GRACE_SEC, KvMetricsPoller
+
+    _refuse(monkeypatch)
+    poller = KvMetricsPoller(port=1)
+    poller.fetch()
+    # Age the first attempt rather than the process clock: patching time.monotonic
+    # globally lets any other caller consume the fake readings.
+    poller._first_attempt_mono = time.monotonic() - (_GIVE_UP_GRACE_SEC + 1)
+    poller.fetch()
+    poller.fetch()
+
+    assert poller.available is False
+
+
+# ---------------------------------------------------------------------------
 # authoritative phase boundaries
 # ---------------------------------------------------------------------------
 class _StubProgress:

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -834,6 +834,55 @@ def test_eval_rows_survive_the_aiperf_adoption(tmp_path):
     assert payload["sample_source"] == "aiperf_server_metrics"
 
 
+def test_adopted_rows_make_the_round_available_whatever_the_poller_saw(tmp_path):
+    """``available`` answers "did this round get readings", not "did our poller".
+
+    On a containerised AgentX round the engine's port need not be reachable from
+    where the watchdog runs, and the poller backs off to a minute besides. A live
+    round produced `available: false` on an artifact carrying 1656 aiperf samples,
+    which the breakdown then folds into a session-level "no round ever reached the
+    endpoint".
+    """
+    base = 1_789_048_708_000_000_000
+    _write_server_metrics(tmp_path, [_slim_record(ts_ns=base, usage=0.5, retracts=0)])
+
+    class _NeverReached:
+        url = "http://127.0.0.1:8888/metrics"
+        available = False
+
+        def sample(self):
+            return None
+
+    rec = KvMetricsRecorder(
+        poller=_NeverReached(),
+        output_path=str(tmp_path / KV_ARTIFACT_NAME),
+        min_interval_sec=0,
+    )
+    payload = rec.summary()
+
+    assert payload["sample_source"] == "aiperf_server_metrics"
+    assert payload["available"] is True
+    assert payload["sample_count"] == 1
+
+
+def test_a_round_that_nobody_reached_is_still_unavailable(tmp_path):
+    """No export and a poller that gave up: the honest answer is still false."""
+
+    class _GaveUp:
+        url = "http://127.0.0.1:8888/metrics"
+        available = False
+
+        def sample(self):
+            return None
+
+    rec = KvMetricsRecorder(poller=_GaveUp(), output_path=str(tmp_path / KV_ARTIFACT_NAME), min_interval_sec=0)
+    rec.tick(1.0)
+    payload = rec.summary()
+
+    assert payload["available"] is False
+    assert payload["sample_count"] == 0
+
+
 def test_an_unstamped_aiperf_record_is_boot_not_measured(tmp_path):
     """aiperf's baseline capture carries no phase, and it is not measured data.
 

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -11,6 +11,7 @@ has been reachable and untested since it was written.
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 
 import pytest
@@ -829,6 +830,70 @@ def test_rows_carry_scrape_start_and_end_not_just_a_duration():
     assert row["scrape_end_unix"] >= row["scrape_start_unix"]
 
 
+def test_the_stored_scrape_window_contains_the_real_one():
+    """Widened to the enclosing millisecond, never rounded to the nearest.
+
+    These bounds are what workload records are joined against. Nearest-rounding
+    shrinks the window by up to half a millisecond at each end, so a request that
+    began inside a sub-millisecond scrape falls outside the window that observed
+    it -- silently, and only on a host whose clock is fine enough to notice.
+    """
+    import time
+
+    before = time.time()
+    rec = KvMetricsRecorder(poller=_StubPoller([_sample()]), min_interval_sec=0)
+    rec.tick(1.0)
+    after = time.time()
+    row = rec.summary()["samples"][0]
+
+    assert row["scrape_start_unix"] <= before
+    assert row["scrape_end_unix"] >= after
+    # Still milliseconds, not full float noise.
+    assert row["scrape_start_unix"] == round(row["scrape_start_unix"], 3)
+    assert row["scrape_end_unix"] == round(row["scrape_end_unix"], 3)
+
+
+def test_a_request_starting_at_the_scrape_instant_is_still_correlated(tmp_path):
+    """The regression: a sub-millisecond scrape must not lose the work it saw."""
+    from hyperloom.orchestrator.actions.executors._agentx_timeline import (
+        correlate_rows,
+        parse_profile_export,
+    )
+
+    art = tmp_path / "aiperf_artifacts"
+    art.mkdir()
+    # A request beginning a quarter of a millisecond after the window opens: inside
+    # it, but below the resolution the window is stored at.
+    start_ns = 1_789_000_000_144_255_000
+    (art / "profile_export.jsonl").write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "x_request_id": "req-1",
+                    "x_correlation_id": "traj-1",
+                    "turn_index": 0,
+                    "request_start_ns": start_ns,
+                    "request_end_ns": start_ns + 1_000_000_000,
+                },
+                "metrics": {},
+                "error": None,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    records = parse_profile_export(art / "profile_export.jsonl")
+    exact = start_ns / 1e9
+    rows = [
+        {
+            "scrape_start_unix": math.floor((exact - 0.00025) * 1000) / 1000,
+            "scrape_end_unix": math.ceil((exact - 0.00020) * 1000) / 1000,
+        }
+    ]
+
+    assert correlate_rows(rows, records) == 1
+
+
 def test_rows_carry_the_workload_in_flight_at_the_scrape():
     """The correlation the timeline supports: engine-wide KV against the active
     phase's own counters, at the granularity aiperf actually exposes."""
@@ -888,7 +953,10 @@ def test_recorder_writes_the_workload_timeline_beside_the_kv_artifact(tmp_path):
                     "conversation_id": "conv-1",
                     "turn_index": 0,
                     "request_start_ns": start_ns,
-                    "request_end_ns": start_ns + 10_000_000_000,
+                    # Generously long, so a loaded CI box cannot end the request
+                    # before the scrape below happens. What this test is about is
+                    # the wiring, not the width of the window.
+                    "request_end_ns": start_ns + 600_000_000_000,
                     "benchmark_phase": "profiling",
                 },
                 "metrics": {"time_to_first_token": {"value": 250.0, "unit": "ms"}},

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -928,15 +928,43 @@ def test_the_port_is_read_from_the_server_the_config_did_not_pin(tmp_path):
 
     nested = tmp_path / "benchmark_vllm_1"
     nested.mkdir()
+    # Verbatim from the round that exposed this: the build says "Starting vLLM
+    # server on", not the uvicorn banner an earlier pattern here assumed.
     (nested / "server.log").write_text(
-        "INFO 09-10 13:57:01 [api_server.py:1] Starting vLLM API server\n"
-        "INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)\n"
-        "INFO:     Application startup complete.\n",
+        "(APIServer pid=18877) INFO 09-10 15:50:09 [api_server.py:577] Supported tasks: ['generate']\n"
+        "(APIServer pid=18877) INFO 09-10 15:50:09 [api_server.py:581] Starting vLLM server on http://0.0.0.0:8000\n"
+        "(APIServer pid=18877) INFO:     Application startup complete.\n",
         encoding="utf-8",
     )
 
     assert port_from_server_log(tmp_path) == 8000
     assert resolve_metrics_port({}, tmp_path) == 8000
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        # The three phrasings seen across real runs on this cluster.
+        ("INFO 09-10 15:50:09 [api_server.py:581] Starting vLLM server on http://0.0.0.0:8000", 8000),
+        ("INFO 09-10 06:51:03 [api_server.py:581] Starting vLLM server on http://0.0.0.0:34407", 34407),
+        ("INFO:     Uvicorn running on http://0.0.0.0:30000 (Press CTRL+C to quit)", 30000),
+        # Not a bind announcement: a request log line carries an address but no scheme.
+        ('INFO:     127.0.0.1:38292 - "GET /health HTTP/1.1" 200 OK', None),
+        # Nor is an unrelated URL that happens to have a port.
+        ("INFO downloading from https://mirror.example.com:8443/models/x", None),
+    ],
+)
+def test_bind_line_recognition(tmp_path, line, expected):
+    """Recognised by what the line is about, not by its exact wording.
+
+    Enumerating phrasings is how this collector got its original bug, so the test
+    is the combination: a line announcing the server, carrying a URL with a port.
+    """
+    from hyperloom.orchestrator.actions.executors._kv_metrics import port_from_server_log
+
+    (tmp_path / "server.log").write_text(line + "\n", encoding="utf-8")
+
+    assert port_from_server_log(tmp_path) == expected
 
 
 def test_the_pinned_config_still_outranks_the_server_banner(tmp_path):

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -141,6 +141,45 @@ def test_counter_delta_credits_only_the_post_restart_count():
     assert counter_delta({}, {"a": 5.0}) == 5.0
 
 
+def test_counter_delta_does_not_multiply_lockstep_ranks():
+    """Eight ranks reporting 48 describe 48 retracts, not 384."""
+    first = {f'tp_rank="{i}"': 0.0 for i in range(8)}
+    last = {f'tp_rank="{i}"': 48.0 for i in range(8)}
+
+    assert counter_delta(first, last) == 48.0
+
+
+def test_downsampling_respects_the_cap():
+    """Integer division gave a stride of 1 for anything under twice the cap, so
+    5001 rows downsampled to 5001."""
+    rec = KvMetricsRecorder(poller=_StubPoller([]))
+    rec._rows = [{"i": i} for i in range(5001)]
+
+    assert len(rec.rows()) <= 5000
+
+
+def test_prefix_cache_counters_reach_the_artifact():
+    """They were parsed and then dropped: read at cost, stored nowhere."""
+    poller = _StubPoller([_sample(prefix_cache_queries=1000.0, prefix_cache_hits=529.0)])
+    rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
+    rec.tick(0.0)
+
+    assert rec.summary()["prefix_cache"] == {
+        "prefix_cache_queries": 1000.0,
+        "prefix_cache_hits": 529.0,
+    }
+
+
+def test_capacity_provenance_and_series_count_reach_the_artifact():
+    poller = _StubPoller([_sample(capacity_tokens=32768.0, capacity_derived=True, series_count=8)])
+    rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
+    rec.tick(0.0)
+
+    summary = rec.summary()
+    assert summary["capacity_derived"] is True
+    assert summary["series_count"] == 8
+
+
 def test_summary_availability_is_tristate():
     """Never reached is not the same as reached and found quiet."""
     unknown = KvMetricsRecorder(poller=_StubPoller([], available=None)).summary()
@@ -171,7 +210,8 @@ def test_close_never_raises_on_an_unwritable_path(tmp_path):
     # Parent dirs are created by the writer; make that impossible instead.
     (tmp_path / "nope").write_text("not a directory", encoding="utf-8")
 
-    assert rec.close()["schema_version"] == 1
+    payload = rec.close()
+    assert payload["schema_version"] == 1
 
 
 def test_sampling_failure_does_not_propagate():
@@ -249,9 +289,13 @@ def test_no_scraping_before_the_server_is_up():
     assert rec.ticks == 0
 
 
-def test_warm_reuse_rounds_scrape_immediately():
-    """A round re-attaching to a live server writes no ready marker, so gating on
-    that marker alone would collect nothing for the entire round."""
+def test_warm_reuse_rounds_scrape_immediately_and_are_tagged_measured():
+    """A round re-attaching to a live server writes no ready marker.
+
+    Gating on that marker alone collected nothing; gating only the *scrape* on
+    it was worse -- samples were taken but left in ``boot``, the one phase that
+    never enters a comparison, so the whole round aggregated to empty.
+    """
     rec = _Recorder()
     sk._communicate_with_soft_deadline(
         _DoneProc(),
@@ -262,6 +306,66 @@ def test_warm_reuse_rounds_scrape_immediately():
     )
 
     assert rec.ticks >= 1
+    assert rec.phases == ["measured"]
+
+
+def test_marker_split_across_a_read_boundary_is_still_seen(tmp_path):
+    """Half a marker is in neither chunk, so without a carried tail the phase
+    boundary is lost outright -- not seen late, never seen."""
+    log_path = tmp_path / "server.log"
+    log_path.write_text("Phase profiling (prof", encoding="utf-8")
+
+    residuals: dict[str, str] = {}
+    first = sk._scan_server_log_increment(str(log_path), 0, residuals.get("k", ""))
+    residuals["k"] = first.residual
+    assert first.saw_measured_begin is False
+
+    with log_path.open("a", encoding="utf-8") as f:
+        f.write("iling) started | phase_index=0\n")
+    second = sk._scan_server_log_increment(str(log_path), first.offset, residuals["k"])
+
+    assert second.saw_measured_begin is True
+
+
+def test_residual_is_held_per_path(tmp_path):
+    """The resolved logs have different writers; splicing one's tail into
+    another's next read would invent a line neither of them wrote."""
+    bench = tmp_path / "benchmark_sglang"
+    bench.mkdir()
+    (bench / "server.log").write_text("Phase profiling (prof", encoding="utf-8")
+    (bench / "benchmark_stderr.log").write_text("iling) started\n", encoding="utf-8")
+
+    offsets: dict[str, int] = {}
+    residuals: dict[str, str] = {}
+    scan = sk._scan_logs_increment(str(tmp_path / "server.log"), offsets, residuals)
+
+    assert scan.saw_measured_begin is False
+    assert len(residuals) >= 2
+
+
+def test_truncation_drops_the_carried_tail(tmp_path):
+    """The tail belonged to a file that no longer exists."""
+    log_path = tmp_path / "server.log"
+    log_path.write_text("Phase profiling (prof", encoding="utf-8")
+    first = sk._scan_server_log_increment(str(log_path), 0)
+    assert first.residual
+
+    log_path.write_text("iling) started\n", encoding="utf-8")
+    after = sk._scan_server_log_increment(str(log_path), 10_000, first.residual)
+
+    assert after.saw_measured_begin is False
+
+
+def test_scope_identifies_the_round_without_another_file(tmp_path):
+    """A consumer must not have to join against something else to know which
+    variant and action produced the artifact."""
+    workspace = tmp_path / "runs" / "explore" / "task-abc" / "variant_03_fp8" / "benchmark_sglang"
+    workspace.mkdir(parents=True)
+
+    rec = sk._build_kv_recorder(str(workspace / "server.log"), {})
+
+    assert rec._scope["workspace"] == "benchmark_sglang"
+    assert rec._scope["run_path"] == "explore/task-abc/variant_03_fp8/benchmark_sglang"
 
 
 def test_recorder_is_closed_as_aborted_when_a_gate_raises():

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -869,6 +869,74 @@ def test_timeline_survives_a_phase_aiperf_stops_reporting():
     assert payload["phase_bounds_unix"]["warmup"]["start"] == pytest.approx(now, abs=1e-3)
 
 
+def test_recorder_writes_the_workload_timeline_beside_the_kv_artifact(tmp_path):
+    """End to end: aiperf's export in, event stream plus correlated rows out.
+
+    The per-request export is written at aiperf's default export level, so this
+    needs nothing added to the invocation and nothing from upstream.
+    """
+    now = _now()
+    art = tmp_path / "aiperf_artifacts"
+    art.mkdir()
+    start_ns = int(now * 1e9)
+    (art / "profile_export.jsonl").write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "x_request_id": "req-1",
+                    "x_correlation_id": "traj-1",
+                    "conversation_id": "conv-1",
+                    "turn_index": 0,
+                    "request_start_ns": start_ns,
+                    "request_end_ns": start_ns + 10_000_000_000,
+                    "benchmark_phase": "profiling",
+                },
+                "metrics": {"time_to_first_token": {"value": 250.0, "unit": "ms"}},
+                "error": None,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rec = KvMetricsRecorder(
+        poller=_StubPoller([_sample(ts=now + 5)]),
+        progress=_StubProgress([{"profiling": {"start_ns": start_ns, "requests_end_ns": None}}]),
+        output_path=str(tmp_path / KV_ARTIFACT_NAME),
+        min_interval_sec=0,
+    )
+    rec.tick(1.0)
+    payload = rec.close()
+
+    timeline = payload["workload_timeline"]
+    assert timeline["requests"] == 1
+    assert timeline["trajectories"] == 1
+    assert timeline["path"] == "agentx_timeline.jsonl"
+    assert timeline["rows_correlated"] == 1
+
+    events = [
+        json.loads(line) for line in (tmp_path / "agentx_timeline.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert {e["event"] for e in events} >= {"phase_start", "trajectory_start", "turn_start", "request_start"}
+
+    # The sample taken 5s in saw that trajectory running.
+    assert payload["samples"][0]["workload"]["in_flight"]["trajectory_ids"] == ["traj-1"]
+
+
+def test_a_round_without_an_aiperf_export_reports_no_timeline(tmp_path):
+    """Every synthetic benchmark is this case, and it is not a failure."""
+    rec = KvMetricsRecorder(
+        poller=_StubPoller([_sample()]),
+        output_path=str(tmp_path / KV_ARTIFACT_NAME),
+        min_interval_sec=0,
+    )
+    rec.tick(1.0)
+    payload = rec.close()
+
+    assert payload["workload_timeline"] is None
+    assert not (tmp_path / "agentx_timeline.jsonl").exists()
+
+
 def test_progress_failures_never_reach_the_round():
     """Collection is observational; a broken endpoint costs nothing."""
 

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -867,6 +867,67 @@ def test_an_unreadable_export_falls_back_rather_than_failing(tmp_path):
     assert payload["sample_count"] == 1
 
 
+def test_counters_resolve_under_aiperfs_family_naming(tmp_path):
+    """aiperf names a counter by its Prometheus family, dropping the ``_total``.
+
+    Observed on a live AgentX round: of 47 families in one record, exactly one
+    ended in ``_total``, and vLLM's preemption counter -- written
+    ``vllm:num_preemptions_total`` in the exposition this module reads everywhere
+    else -- appears as ``vllm:num_preemptions``. Without the alias all three
+    cumulative counters come back empty on this path, and an empty counter looks
+    exactly like a round that never retracted.
+    """
+    from hyperloom.orchestrator.actions.executors._kv_metrics import families_from_aiperf_record
+
+    families = families_from_aiperf_record(
+        {
+            "vllm:num_preemptions": [{"labels": {"engine": "0"}, "value": 7.0}],
+            "sglang:num_retracted_requests": [{"labels": {"tp_rank": "0"}, "value": 48.0}],
+            "sglang:cached_tokens": [{"labels": {}, "value": 4600439.0}],
+        }
+    )
+
+    assert families["vllm:num_preemptions_total"] == [({"engine": "0"}, 7.0)]
+    assert families["sglang:num_retracted_requests_total"] == [({"tp_rank": "0"}, 48.0)]
+    assert families["sglang:cached_tokens_total"] == [({}, 4600439.0)]
+    # The name aiperf actually used still resolves too.
+    assert families["vllm:num_preemptions"] == [({"engine": "0"}, 7.0)]
+
+
+def test_a_real_aiperf_record_yields_the_preemption_counter(tmp_path):
+    """End to end through the reader, on the shape a live round produced."""
+    from hyperloom.orchestrator.actions.executors._kv_metrics import read_aiperf_server_metrics
+
+    model = "/shared_nfs/hyperloom/models/Llama-3.1-8B-Instruct"
+    path = _write_server_metrics(
+        tmp_path,
+        [
+            {
+                "endpoint_url": "http://localhost:8000/metrics",
+                "timestamp_ns": 1_789_048_708_183_834_288,
+                "endpoint_latency_ns": 19_658_211,
+                "request_sent_ns": 1_789_048_708_164_234_016,
+                "first_byte_ns": 1_789_048_708_183_834_288,
+                "benchmark_phase": "warmup",
+                "metrics": {
+                    "vllm:kv_cache_usage_perc": [{"labels": {"engine": "0", "model_name": model}, "value": 0.42}],
+                    "vllm:num_preemptions": [{"labels": {"engine": "0", "model_name": model}, "value": 3.0}],
+                },
+            }
+        ],
+    )
+    (sample, timing, phase) = read_aiperf_server_metrics(path)[0]
+
+    assert sample.engine == "vllm"
+    assert sample.active_pool_usage == 0.42
+    assert phase == "warmup"
+    # The counter the whole artifact exists to report.
+    from hyperloom.orchestrator.actions.executors._kv_metrics import aggregate_series
+
+    assert aggregate_series(sample.preempt_total) == 3.0
+    assert timing["scrape_sec"] == 0.0197
+
+
 def test_histogram_samples_are_skipped_not_mistaken_for_gauges(tmp_path):
     """aiperf carries histograms as buckets with no ``value``."""
     from hyperloom.orchestrator.actions.executors._kv_metrics import families_from_aiperf_record
@@ -878,7 +939,9 @@ def test_histogram_samples_are_skipped_not_mistaken_for_gauges(tmp_path):
         }
     )
 
-    assert families == {"sglang:token_usage": [({}, 0.5)]}
+    assert families["sglang:token_usage"] == [({}, 0.5)]
+    # Carried no scalar, so it is absent entirely rather than present and empty.
+    assert not any(name.startswith("sglang:e2e_latency_seconds") for name in families)
 
 
 # ---------------------------------------------------------------------------

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -1,0 +1,302 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for KV collection riding the watchdog loop.
+
+Covers the phase split, the recorder itself, and the ``finally`` that closes a
+window on every exit path. Also covers the scanner's truncation branch, which
+has been reachable and untested since it was written.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hyperloom.orchestrator.actions.executors import _subprocess_kill as sk
+from hyperloom.orchestrator.actions.executors._kv_metrics import (
+    KV_ARTIFACT_NAME,
+    KvMetricsRecorder,
+    KvSample,
+    counter_delta,
+)
+
+
+class _StubPoller:
+    """Hands out canned samples without touching the network."""
+
+    def __init__(self, samples, available=True):
+        self.url = "http://127.0.0.1:1/metrics"
+        self.available = available
+        self._samples = list(samples)
+        self.calls = 0
+
+    def sample(self):
+        self.calls += 1
+        return self._samples.pop(0) if self._samples else None
+
+
+def _sample(**kwargs) -> KvSample:
+    base = {"ts": 1.0, "mono": 1.0, "engine": "sglang", "active_pool_usage": 0.5}
+    base.update(kwargs)
+    return KvSample(**base)
+
+
+# ── scanner ────────────────────────────────────────────────────────────────
+def test_scan_survives_truncation_by_rescanning_from_the_top(tmp_path):
+    """A rotated log is shorter than the consumed offset; markers in the new
+    content must still be seen rather than skipped past."""
+    log_path = tmp_path / "server.log"
+    log_path.write_text("x" * 500 + "\n", encoding="utf-8")
+    first = sk._scan_server_log_increment(str(log_path), 0)
+    assert first.offset == log_path.stat().st_size
+
+    log_path.write_text("Application startup complete\n", encoding="utf-8")
+    after = sk._scan_server_log_increment(str(log_path), first.offset)
+
+    assert after.saw_ready is True
+    assert after.offset == log_path.stat().st_size
+
+
+def test_scan_reports_agentx_phase_boundaries(tmp_path):
+    """aiperf prints these itself; we add no marker of our own."""
+    log_path = tmp_path / "server.log"
+    log_path.write_text("Phase warmup (warmup) started | target: 44 requests\n", encoding="utf-8")
+    warm = sk._scan_server_log_increment(str(log_path), 0)
+    assert warm.saw_warmup_begin is True and warm.saw_measured_begin is False
+
+    with log_path.open("a", encoding="utf-8") as f:
+        f.write("Phase profiling (profiling) started | phase_index=0\n")
+    measured = sk._scan_server_log_increment(str(log_path), warm.offset)
+    assert measured.saw_measured_begin is True and measured.saw_warmup_begin is False
+
+
+def test_resolve_scan_logs_includes_the_agentx_client_log(tmp_path):
+    """An AgentX workspace has no benchmark_stderr.log, so without this the
+    phase lines are unreachable."""
+    bench = tmp_path / "benchmark_sglang_20260903"
+    (bench / "aiperf_artifacts" / "logs").mkdir(parents=True)
+    (bench / "server.log").write_text("up\n", encoding="utf-8")
+    (bench / "aiperf_artifacts" / "logs" / "aiperf.log").write_text("phases\n", encoding="utf-8")
+
+    resolved = sk._resolve_scan_logs(str(tmp_path / "server.log"))
+
+    assert any(p.endswith("aiperf.log") for p in resolved)
+
+
+# ── recorder ───────────────────────────────────────────────────────────────
+def test_rows_are_tagged_with_the_phase_they_were_taken_in():
+    poller = _StubPoller([_sample(), _sample(), _sample()])
+    rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
+
+    rec.tick(0.0)
+    rec.note_phase("warmup", 1.0)
+    rec.tick(1.0)
+    rec.note_phase("measured", 2.0)
+    rec.tick(2.0)
+
+    assert [r["phase"] for r in rec.rows()] == ["boot", "warmup", "measured"]
+
+
+def test_scrape_interval_is_enforced_on_the_monotonic_clock():
+    """The loop's slice shrinks below its nominal period near a deadline, so
+    counting passes would sample fastest exactly when the run is most loaded."""
+    poller = _StubPoller([_sample() for _ in range(5)])
+    rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.5)
+
+    rec.tick(0.0)
+    rec.tick(0.1)
+    rec.tick(0.2)
+    rec.tick(0.6)
+
+    assert poller.calls == 2
+
+
+def test_unknown_phase_is_ignored_rather_than_raising():
+    rec = KvMetricsRecorder(poller=_StubPoller([]), min_interval_sec=0.0)
+    rec.note_phase("nonsense", 1.0)
+    assert rec.phase == "boot"
+
+
+def test_capacity_is_latched_from_the_first_reading_that_has_it():
+    """Capacity is only observable while the engine is up; a round that ends
+    with the server gone must still carry it."""
+    poller = _StubPoller([_sample(capacity_tokens=32768.0, capacity_gb=180.0), _sample()])
+    rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
+    rec.tick(0.0)
+    rec.tick(1.0)
+
+    summary = rec.summary()
+    assert summary["capacity_tokens"] == 32768.0
+    assert summary["capacity_gb"] == 180.0
+
+
+def test_counter_delta_credits_only_the_post_restart_count():
+    """An engine restart zeroes its series; a flat subtraction would go negative."""
+    assert counter_delta({"a": 10.0}, {"a": 48.0}) == 38.0
+    assert counter_delta({"a": 100.0}, {"a": 3.0}) == 3.0
+    assert counter_delta({}, {}) is None
+    assert counter_delta({}, {"a": 5.0}) == 5.0
+
+
+def test_summary_availability_is_tristate():
+    """Never reached is not the same as reached and found quiet."""
+    unknown = KvMetricsRecorder(poller=_StubPoller([], available=None)).summary()
+    assert unknown["available"] is None
+
+    off = KvMetricsRecorder(poller=_StubPoller([], available=False)).summary()
+    assert off["available"] is False
+
+
+def test_close_writes_the_artifact_and_is_idempotent(tmp_path):
+    out = tmp_path / KV_ARTIFACT_NAME
+    poller = _StubPoller([_sample(retract_total={"": 48.0})])
+    rec = KvMetricsRecorder(poller=poller, output_path=str(out), min_interval_sec=0.0)
+    rec.tick(0.0)
+
+    rec.close()
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1
+    assert payload["sample_count"] == 1
+    assert payload["aborted"] is False
+
+    rec.close(aborted=True)  # the loop's finally may run after an explicit close
+    assert json.loads(out.read_text(encoding="utf-8"))["aborted"] is False
+
+
+def test_close_never_raises_on_an_unwritable_path(tmp_path):
+    rec = KvMetricsRecorder(poller=_StubPoller([]), output_path=str(tmp_path / "nope" / "x" / KV_ARTIFACT_NAME))
+    # Parent dirs are created by the writer; make that impossible instead.
+    (tmp_path / "nope").write_text("not a directory", encoding="utf-8")
+
+    assert rec.close()["schema_version"] == 1
+
+
+def test_sampling_failure_does_not_propagate():
+    class _Boom:
+        url = "http://x/metrics"
+        available = None
+
+        def sample(self):
+            raise RuntimeError("scrape exploded")
+
+    rec = KvMetricsRecorder(poller=_Boom(), min_interval_sec=0.0)
+    rec.tick(0.0)
+
+    assert rec.rows() == []
+
+
+# ── loop integration ───────────────────────────────────────────────────────
+class _Recorder:
+    """Minimal stand-in matching the duck-typed contract the loop expects."""
+
+    def __init__(self):
+        self.phases: list[str] = []
+        self.ticks = 0
+        self.closed_aborted: bool | None = None
+
+    def note_phase(self, phase, mono):
+        self.phases.append(phase)
+
+    def tick(self, mono):
+        self.ticks += 1
+
+    def close(self, *, aborted=False):
+        self.closed_aborted = aborted
+
+
+class _DoneProc:
+    args = ["x"]
+
+    def communicate(self, timeout=None):
+        return ("out", "err")
+
+
+class _HangingProc:
+    args = ["x"]
+
+    def communicate(self, timeout=None):
+        raise sk.subprocess.TimeoutExpired(self.args, timeout)
+
+
+def test_recorder_is_closed_on_the_normal_return_path():
+    rec = _Recorder()
+    sk._communicate_with_soft_deadline(
+        _DoneProc(),
+        hard_timeout=5,
+        soft_deadline_sec=5,
+        kv_recorder=rec,
+    )
+
+    assert rec.closed_aborted is False
+    assert rec.ticks >= 1
+
+
+def test_recorder_is_closed_as_aborted_when_a_gate_raises():
+    """The failure a consumer cannot recover from is a window that never closed."""
+    rec = _Recorder()
+    with pytest.raises(sk.subprocess.TimeoutExpired):
+        sk._communicate_with_soft_deadline(
+            _HangingProc(),
+            hard_timeout=0.01,
+            soft_deadline_sec=5,
+            kv_recorder=rec,
+        )
+
+    assert rec.closed_aborted is True
+
+
+def test_phase_transitions_reach_the_recorder(tmp_path, monkeypatch):
+    """Ready opens the measured window; AgentX's own lines refine it."""
+    rec = _Recorder()
+    scans = iter(
+        [
+            sk._LogScan(True, False, False, True, False, False, False),
+            sk._LogScan(False, False, False, True, False, True, False),
+            sk._LogScan(False, False, False, True, False, False, True),
+            sk._LogScan(False, False, True, True, False, False, False),
+        ]
+    )
+    monkeypatch.setattr(sk, "_scan_logs_increment", lambda *_a, **_k: next(scans, sk._LogScan(*([False] * 7))))
+    monkeypatch.setattr(sk, "_stamp_server_ready", lambda *_a, **_k: None)
+    monkeypatch.setattr(sk, "_server_log_shows_death", lambda *_a, **_k: None)
+    log_path = tmp_path / "server.log"
+    log_path.write_text("x\n", encoding="utf-8")
+
+    class _SlowProc:
+        args = ["x"]
+        calls = 0
+
+        def communicate(self, timeout=None):
+            _SlowProc.calls += 1
+            if _SlowProc.calls <= 4:
+                raise sk.subprocess.TimeoutExpired(self.args, timeout)
+            return ("out", "err")
+
+    sk._communicate_with_soft_deadline(
+        _SlowProc(),
+        hard_timeout=60,
+        soft_deadline_sec=60,
+        server_log_path=str(log_path),
+        server_dead_grace_sec=60,
+        kv_recorder=rec,
+    )
+
+    assert rec.phases == ["measured", "warmup", "measured", "eval"]
+    assert rec.closed_aborted is False
+
+
+def test_no_recorder_leaves_the_loop_unchanged():
+    """The default must be a strict no-op: this is a production watchdog."""
+    out = sk._communicate_with_soft_deadline(
+        _DoneProc(),
+        hard_timeout=5,
+        soft_deadline_sec=5,
+    )
+    assert out == ("out", "err")
+
+
+def test_artifact_name_is_stable():
+    assert Path(KV_ARTIFACT_NAME).suffix == ".json"

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -44,7 +44,9 @@ def _sample(**kwargs) -> KvSample:
     return KvSample(**base)
 
 
-# â”€â”€ scanner â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+# --------------------------------------------------------------------------
+# scanner
+# --------------------------------------------------------------------------
 def test_scan_survives_truncation_by_rescanning_from_the_top(tmp_path):
     """A rotated log is shorter than the consumed offset; markers in the new
     content must still be seen rather than skipped past."""
@@ -86,7 +88,9 @@ def test_resolve_scan_logs_includes_the_agentx_client_log(tmp_path):
     assert any(p.endswith("aiperf.log") for p in resolved)
 
 
-# â”€â”€ recorder â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+# --------------------------------------------------------------------------
+# recorder
+# --------------------------------------------------------------------------
 def test_rows_are_tagged_with_the_phase_they_were_taken_in():
     poller = _StubPoller([_sample() for _ in range(6)])
     rec = KvMetricsRecorder(poller=poller, min_interval_sec=0.0)
@@ -359,7 +363,9 @@ def test_sampling_failure_does_not_propagate():
     assert rec.rows() == []
 
 
-# â”€â”€ loop integration â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+# --------------------------------------------------------------------------
+# loop integration
+# --------------------------------------------------------------------------
 class _Recorder:
     """Minimal stand-in matching the duck-typed contract the loop expects."""
 
@@ -567,7 +573,9 @@ def test_artifact_name_is_stable():
     assert Path(KV_ARTIFACT_NAME).suffix == ".json"
 
 
-# â”€â”€ call-site wiring â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+# --------------------------------------------------------------------------
+# call-site wiring
+# --------------------------------------------------------------------------
 def test_no_recorder_without_a_server_log_path():
     """A helper subprocess has no engine to scrape and no round to scope to."""
     assert sk._build_kv_recorder(None, {}) is None

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -712,8 +712,9 @@ def test_recorder_prefers_aiperfs_scrapes_over_its_own(tmp_path):
             _slim_record(ts_ns=base + 4_000_000_000, usage=0.80, retracts=9, phase="profiling"),
         ],
     )
+    # A live reading taken inside aiperf's window, which is the redundant case.
     rec = KvMetricsRecorder(
-        poller=_StubPoller([_sample(ts=_now(), active_pool_usage=0.99)]),
+        poller=_StubPoller([_sample(ts=base / 1e9 + 1.0, active_pool_usage=0.99)]),
         output_path=str(tmp_path / KV_ARTIFACT_NAME),
         min_interval_sec=0,
     )
@@ -729,6 +730,108 @@ def test_recorder_prefers_aiperfs_scrapes_over_its_own(tmp_path):
     # Warmup opened at 1 and is closed by the first measured reading; measured runs 5 -> 9.
     assert payload["retract_delta_by_phase"]["warmup"] == 4.0
     assert payload["retract_delta"] == 4.0
+
+
+def test_live_scraping_backs_off_once_aiperf_is_collecting(tmp_path):
+    """The point of reading aiperf's export is to stop scraping the same endpoint twice.
+
+    Adopting its records while still polling at the full rate doubles the load on
+    the engine to produce rows that are then discarded -- worse on the very axis
+    the refactor set out to improve.
+    """
+    (tmp_path / "aiperf_artifacts").mkdir()
+    rec = KvMetricsRecorder(
+        poller=_StubPoller([_sample(), _sample(), _sample()]),
+        workspace=tmp_path,
+        min_interval_sec=2.0,
+    )
+    rec.tick(0.0)  # first tick always scrapes
+    rec.tick(10.0)  # ten seconds on: would scrape at the 2s rate, must not here
+    rec.tick(30.0)
+
+    assert rec._poller.calls == 1
+
+
+def test_backoff_still_leaves_a_coarse_trace(tmp_path):
+    """Backing off rather than stopping: if aiperf collected nothing after all, a
+    sparse series is a far better artifact than the empty one this shipped once."""
+    (tmp_path / "aiperf_artifacts").mkdir()
+    rec = KvMetricsRecorder(
+        poller=_StubPoller([_sample(), _sample()]),
+        workspace=tmp_path,
+        min_interval_sec=2.0,
+    )
+    rec.tick(0.0)
+    rec.tick(120.0)  # past the suspended interval
+
+    assert rec._poller.calls == 2
+
+
+def test_a_synthetic_round_is_unaffected_by_the_backoff(tmp_path):
+    """No aiperf directory, so nothing else is scraping and the full rate stands."""
+    rec = KvMetricsRecorder(
+        poller=_StubPoller([_sample(), _sample(), _sample()]),
+        workspace=tmp_path,
+        min_interval_sec=2.0,
+    )
+    rec.tick(0.0)
+    rec.tick(3.0)
+    rec.tick(6.0)
+
+    assert rec._poller.calls == 3
+
+
+def test_eval_resumes_the_full_rate(tmp_path):
+    """aiperf has exited by the accuracy eval, so that window is ours alone."""
+    (tmp_path / "aiperf_artifacts").mkdir()
+    rec = KvMetricsRecorder(
+        poller=_StubPoller([_sample() for _ in range(5)]),
+        workspace=tmp_path,
+        min_interval_sec=2.0,
+    )
+    rec.tick(0.0)
+    rec.note_phase("eval", 1.0)  # takes a boundary reading of its own
+    before = rec._poller.calls
+    rec.tick(10.0)
+    rec.tick(20.0)
+
+    assert rec._poller.calls == before + 2
+
+
+def test_eval_rows_survive_the_aiperf_adoption(tmp_path):
+    """aiperf covers warmup and profiling and nothing else, so discarding every
+    live row would throw away the only readings the eval phase will ever have."""
+    base = 1_789_000_000_000_000_000
+    _write_server_metrics(
+        tmp_path,
+        [
+            _slim_record(ts_ns=base, usage=0.10, retracts=1, phase="warmup"),
+            _slim_record(ts_ns=base + 2_000_000_000, usage=0.70, retracts=5, phase="profiling"),
+        ],
+    )
+    rec = KvMetricsRecorder(
+        poller=_StubPoller(
+            [
+                # The boundary reading note_phase takes, still inside aiperf's window.
+                _sample(ts=base / 1e9 + 1.0, active_pool_usage=0.99),
+                # The eval reading proper, after aiperf has exited.
+                _sample(ts=base / 1e9 + 60.0, active_pool_usage=0.33),
+            ]
+        ),
+        workspace=tmp_path,
+        output_path=str(tmp_path / KV_ARTIFACT_NAME),
+        min_interval_sec=0,
+    )
+    rec.note_phase("eval", 1.0)
+    rec.tick(2.0)
+    payload = rec.summary()
+
+    phases = [r["phase"] for r in payload["samples"]]
+    assert phases == ["warmup", "measured", "eval"]
+    # The eval reading is the live one, kept in time order after aiperf's window;
+    # the redundant one taken inside that window is gone.
+    assert payload["samples"][-1]["active_pool_usage"] == 0.33
+    assert payload["sample_source"] == "aiperf_server_metrics"
 
 
 def test_a_round_without_an_aiperf_export_keeps_the_watchdog_rows(tmp_path):

--- a/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
+++ b/src/hyperloom/inference_optimizer/tests/test_kv_metrics_wiring.py
@@ -1476,11 +1476,15 @@ def test_the_stored_scrape_window_contains_the_real_one():
     before = time.time()
     rec = KvMetricsRecorder(poller=_StubPoller([_sample()]), min_interval_sec=0)
     rec.tick(1.0)
-    after = time.time()
     row = rec.summary()["samples"][0]
 
-    assert row["scrape_start_unix"] <= before
-    assert row["scrape_end_unix"] >= after
+    # The scrape began after this test did, and the floor can only move that earlier.
+    assert row["scrape_start_unix"] <= time.time()
+    assert row["scrape_start_unix"] >= before - 0.001
+    # The stored window is never narrower than the round trip it brackets. Asserted
+    # against the measured duration rather than a clock read after ``tick`` returns:
+    # that read includes building the row, which the window is not claiming to cover.
+    assert row["scrape_end_unix"] - row["scrape_start_unix"] >= row["scrape_sec"]
     # Still milliseconds, not full float noise.
     assert row["scrape_start_unix"] == round(row["scrape_start_unix"], 3)
     assert row["scrape_end_unix"] == round(row["scrape_end_unix"], 3)

--- a/src/hyperloom/inference_optimizer/tests/test_scriptable_watchdog_gating.py
+++ b/src/hyperloom/inference_optimizer/tests/test_scriptable_watchdog_gating.py
@@ -36,7 +36,7 @@ def test_config_framework_reads_materialized_yaml(tmp_path):
 def _count_scans(monkeypatch) -> dict[str, int]:
     calls = {"scan": 0, "death": 0}
 
-    def _scan(server_log_path, offsets):
+    def _scan(server_log_path, offsets, residuals=None):
         calls["scan"] += 1
         return sk._LogScan(
             saw_ready=False,

--- a/src/hyperloom/orchestrator/actions/executors/_agentx_timeline.py
+++ b/src/hyperloom/orchestrator/actions/executors/_agentx_timeline.py
@@ -56,10 +56,6 @@ _EXPORT_RELPATHS = ("aiperf_artifacts/profile_export.jsonl", "*/aiperf_artifacts
 #: in-flight counts folded into the KV rows are computed from every record before any sampling.
 _MAX_REQUEST_EVENTS = 60000
 
-#: Cap on trajectory ids recorded against one KV row. Concurrency is tens, not thousands, so this only guards against a
-#: pathological run; the count beside it is never capped.
-_MAX_ROW_TRAJECTORIES = 32
-
 
 @dataclass(frozen=True)
 class RequestRecord:
@@ -321,15 +317,16 @@ def correlate_rows(rows: list[dict[str, Any]], records: list[RequestRecord]) -> 
         in_flight = [ordered[i] for _, i in active if ordered[i].overlaps(start, end)]
         if not in_flight:
             continue
-        trajectories = sorted({r.trajectory_id for r in in_flight if r.trajectory_id})
         workload = rows[index].setdefault("workload", {})
+        # Counts only. The identities live in the timeline, which carries each trajectory's full span and is written
+        # beside this artifact -- so "which trajectory was live when the pool spiked" is answered by intersecting the
+        # row's scrape window with those spans, exactly and without truncation. Repeating the ids here instead cost 1280
+        # bytes a row, measured: a trajectory lasts minutes while rows are seconds apart, so the same set was copied
+        # dozens of times over, and it made 65% of a 4.6 MB artifact that ships in the session bundle.
         workload["in_flight"] = {
             "requests": len(in_flight),
-            "trajectories": len(trajectories),
+            "trajectories": len({r.trajectory_id for r in in_flight if r.trajectory_id}),
             "turns": len({(r.trajectory_id, r.turn_index) for r in in_flight}),
-            # Ids, not just a count: "which trajectory was live when the pool spiked" is the question this exists for,
-            # and a count cannot answer it.
-            "trajectory_ids": trajectories[:_MAX_ROW_TRAJECTORIES],
         }
         annotated += 1
     return annotated

--- a/src/hyperloom/orchestrator/actions/executors/_agentx_timeline.py
+++ b/src/hyperloom/orchestrator/actions/executors/_agentx_timeline.py
@@ -1,0 +1,328 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""The AgentX workload timeline, read from aiperf's own per-request export.
+
+KV occupancy is engine-wide: it says the pool filled, never which work filled it. Answering "what was running when it
+filled" needs the workload's own timeline, and aiperf already writes one. ``profile_export.jsonl`` carries one record
+per request with epoch-nanosecond stamps and the identifiers that reconstruct the hierarchy above it -- session,
+conversation, turn index, request id -- at the default ``--export-level records``. Nothing has to be asked of aiperf
+and no flag has to be added; the file was simply never read.
+
+This module turns those records into two things:
+
+* an event stream (``phase`` / ``trajectory`` / ``turn`` / ``request`` start and end, plus ``first_token``), written
+  beside the KV artifact so a consumer can join the two on time;
+* an exact in-flight count per KV scrape window, folded into the KV rows themselves, so the common question -- which
+  trajectories were live when the pool spiked -- is answerable without the join.
+
+The same rule as everywhere else in this collection path: nothing here may raise, and nothing missing becomes zero. A
+round without the export is a round whose KV metrics are still worth having.
+"""
+
+from __future__ import annotations
+
+import heapq
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+log = logging.getLogger(__name__)
+
+
+__all__ = [
+    "TIMELINE_ARTIFACT_NAME",
+    "RequestRecord",
+    "build_events",
+    "correlate_rows",
+    "find_profile_export",
+    "parse_profile_export",
+    "write_timeline",
+]
+
+#: Artifact written beside ``kv_metrics.json``.
+TIMELINE_ARTIFACT_NAME = "agentx_timeline.jsonl"
+
+#: Where aiperf's per-request export lands, relative to the round's own directory. Mirrors how the progress-API address
+#: and the aiperf log are resolved, since an AgentX round may nest its benchmark one level down.
+_EXPORT_RELPATHS = ("aiperf_artifacts/profile_export.jsonl", "*/aiperf_artifacts/profile_export.jsonl")
+
+#: Cap on request-level events written out. A three-hour round at high concurrency produces well over a hundred
+#: thousand requests, and three events each would outweigh every other artifact in the session bundle combined. Over
+#: the cap the request layer is stride-sampled; the phase, trajectory and turn layers are always complete, and the
+#: in-flight counts folded into the KV rows are computed from every record before any sampling.
+_MAX_REQUEST_EVENTS = 60000
+
+#: Cap on trajectory ids recorded against one KV row. Concurrency is tens, not thousands, so this only guards against a
+#: pathological run; the count beside it is never capped.
+_MAX_ROW_TRAJECTORIES = 32
+
+
+@dataclass(frozen=True)
+class RequestRecord:
+    """One request from aiperf's export, reduced to what a timeline needs.
+
+    Times are epoch seconds. aiperf reports nanoseconds, which is the same clock the progress API stamps phases on, so
+    the two line up without conversion beyond scale.
+    """
+
+    request_id: str
+    trajectory_id: str
+    conversation_id: str
+    turn_index: int
+    start: float
+    end: float
+    first_token: float | None
+    phase: str
+    ok: bool
+
+    def overlaps(self, window_start: float, window_end: float) -> bool:
+        """Whether this request was in flight at any point in a window."""
+        return self.start <= window_end and self.end >= window_start
+
+
+def find_profile_export(workspace: Any) -> Path | None:
+    """Locate aiperf's per-request export under a round's directory."""
+    try:
+        root = Path(workspace)
+        for pattern in _EXPORT_RELPATHS:
+            for candidate in sorted(root.glob(pattern)):
+                if candidate.is_file():
+                    return candidate
+    except OSError:
+        return None
+    return None
+
+
+def _seconds(raw: Any) -> float | None:
+    """Epoch nanoseconds as epoch seconds, or ``None`` when unusable."""
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)) or raw <= 0:
+        return None
+    return float(raw) / 1e9
+
+
+def _metric(metrics: Any, name: str) -> float | None:
+    """One metric's value out of aiperf's ``{"value": x, "unit": u}`` wrapper."""
+    if not isinstance(metrics, dict):
+        return None
+    entry = metrics.get(name)
+    if isinstance(entry, dict):
+        entry = entry.get("value")
+    if isinstance(entry, bool) or not isinstance(entry, (int, float)):
+        return None
+    return float(entry)
+
+
+def _record_from(payload: dict[str, Any]) -> RequestRecord | None:
+    """Build one record, or ``None`` when the line cannot be used."""
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    start = _seconds(metadata.get("request_start_ns"))
+    end = _seconds(metadata.get("request_end_ns"))
+    if start is None or end is None or end < start:
+        return None
+    # The live session is the trajectory: it is what stays constant across the turns of one multi-turn conversation.
+    # ``conversation_id`` names the dataset entry being replayed, which can recur across trajectories, so it is carried
+    # alongside rather than used as the identity.
+    trajectory = metadata.get("x_correlation_id") or metadata.get("conversation_id") or ""
+    turn = metadata.get("turn_index")
+    ttft_ms = _metric(payload.get("metrics"), "time_to_first_token")
+    # Derived from TTFT rather than from ``request_ack_ns``: the ack is when the server accepted the request, which is
+    # not the same instant as the first token, and conflating them would misplace exactly the event a reader would use
+    # to line a decode-phase KV rise up against.
+    first_token = start + ttft_ms / 1000.0 if ttft_ms is not None else None
+    return RequestRecord(
+        request_id=str(metadata.get("x_request_id") or ""),
+        trajectory_id=str(trajectory),
+        conversation_id=str(metadata.get("conversation_id") or ""),
+        turn_index=int(turn) if isinstance(turn, int) and not isinstance(turn, bool) else 0,
+        start=start,
+        end=end,
+        first_token=first_token,
+        phase=str(metadata.get("benchmark_phase") or ""),
+        ok=payload.get("error") in (None, {}),
+    )
+
+
+def parse_profile_export(path: Path) -> list[RequestRecord]:
+    """Read every usable record from aiperf's JSONL export, sorted by start time.
+
+    Line-by-line and lenient: the export is written while the round is ending, and one truncated last line must not
+    cost the timeline everything before it.
+    """
+    records: list[RequestRecord] = []
+    try:
+        with path.open(encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except ValueError:
+                    continue
+                if isinstance(payload, dict):
+                    record = _record_from(payload)
+                    if record is not None:
+                        records.append(record)
+    except OSError as exc:
+        log.debug("agentx_timeline: could not read %s (%s)", path, exc)
+        return []
+    records.sort(key=lambda r: r.start)
+    return records
+
+
+def _span_events(
+    records: Iterable[RequestRecord],
+    kind: str,
+    key: Any,
+    fields: Any,
+) -> list[dict[str, Any]]:
+    """Start/end events for a grouping of requests, spanning first start to last end."""
+    spans: dict[Any, list[float]] = {}
+    identity: dict[Any, dict[str, Any]] = {}
+    for record in records:
+        group = key(record)
+        bounds = spans.get(group)
+        if bounds is None:
+            spans[group] = [record.start, record.end]
+            identity[group] = fields(record)
+        else:
+            bounds[0] = min(bounds[0], record.start)
+            bounds[1] = max(bounds[1], record.end)
+    events: list[dict[str, Any]] = []
+    for group, (start, end) in spans.items():
+        events.append({"event": f"{kind}_start", "ts": round(start, 6), **identity[group]})
+        events.append({"event": f"{kind}_end", "ts": round(end, 6), **identity[group]})
+    return events
+
+
+def build_events(
+    records: list[RequestRecord],
+    phase_bounds: dict[str, tuple[float, float | None]] | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Turn records into a time-ordered event stream, with a summary of what it covers.
+
+    Phase events come from the caller's authoritative bounds -- aiperf's progress API -- rather than from the records,
+    whose ``benchmark_phase`` currently reads ``profiling`` for everything it exports.
+    """
+    events: list[dict[str, Any]] = []
+    for phase, (start, end) in (phase_bounds or {}).items():
+        events.append({"event": "phase_start", "ts": round(start, 6), "phase": phase})
+        if end is not None:
+            events.append({"event": "phase_end", "ts": round(end, 6), "phase": phase})
+
+    events.extend(
+        _span_events(
+            records,
+            "trajectory",
+            lambda r: r.trajectory_id,
+            lambda r: {"trajectory_id": r.trajectory_id, "conversation_id": r.conversation_id},
+        )
+    )
+    events.extend(
+        _span_events(
+            records,
+            "turn",
+            lambda r: (r.trajectory_id, r.turn_index),
+            lambda r: {"trajectory_id": r.trajectory_id, "turn_index": r.turn_index},
+        )
+    )
+
+    kept = records
+    stride = 1
+    if len(records) > _MAX_REQUEST_EVENTS:
+        stride = -(-len(records) // _MAX_REQUEST_EVENTS)
+        kept = records[::stride]
+    for record in kept:
+        common = {
+            "request_id": record.request_id,
+            "trajectory_id": record.trajectory_id,
+            "turn_index": record.turn_index,
+        }
+        events.append({"event": "request_start", "ts": round(record.start, 6), **common})
+        if record.first_token is not None:
+            events.append({"event": "first_token", "ts": round(record.first_token, 6), **common})
+        events.append({"event": "request_end", "ts": round(record.end, 6), "ok": record.ok, **common})
+
+    events.sort(key=lambda e: e["ts"])
+    summary = {
+        "requests": len(records),
+        "trajectories": len({r.trajectory_id for r in records}),
+        "turns": len({(r.trajectory_id, r.turn_index) for r in records}),
+        "events": len(events),
+        # Stated rather than implied: a reader counting request_start events must be able to tell a sampled stream from
+        # a complete one, since the two support very different conclusions.
+        "request_events_complete": stride == 1,
+        "request_event_stride": stride,
+    }
+    return events, summary
+
+
+def write_timeline(path: Path, events: Iterable[dict[str, Any]]) -> bool:
+    """Write the event stream as JSONL. Returns whether it landed."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as handle:
+            for event in events:
+                handle.write(json.dumps(event, sort_keys=True) + "\n")
+    except (OSError, TypeError) as exc:
+        log.debug("agentx_timeline: could not write %s (%s)", path, exc)
+        return False
+    return True
+
+
+def _windows(rows: list[dict[str, Any]]) -> Iterator[tuple[int, float, float]]:
+    """Each row's scrape window as ``(index, start, end)``, skipping rows without one."""
+    for index, row in enumerate(rows):
+        start = row.get("scrape_start_unix")
+        end = row.get("scrape_end_unix", start)
+        if isinstance(start, (int, float)) and isinstance(end, (int, float)):
+            yield index, float(start), float(end)
+
+
+def correlate_rows(rows: list[dict[str, Any]], records: list[RequestRecord]) -> int:
+    """Fold the workload in flight during each scrape into that scrape's row.
+
+    A sweep rather than a scan per row: at a few thousand rows and a few hundred thousand records the naive form is
+    hundreds of millions of comparisons, inside the path that finishes a benchmark round.
+
+    Counts are exact -- computed from every record, before the event stream is ever sampled. Returns how many rows were
+    annotated.
+    """
+    if not rows or not records:
+        return 0
+    windows = sorted(_windows(rows), key=lambda w: w[1])
+    if not windows:
+        return 0
+    ordered = sorted(records, key=lambda r: r.start)
+
+    annotated = 0
+    cursor = 0
+    # Requests still open, keyed by end time so the earliest to finish leaves first.
+    active: list[tuple[float, int]] = []
+    for index, start, end in windows:
+        while cursor < len(ordered) and ordered[cursor].start <= end:
+            record = ordered[cursor]
+            heapq.heappush(active, (record.end, cursor))
+            cursor += 1
+        while active and active[0][0] < start:
+            heapq.heappop(active)
+        in_flight = [ordered[i] for _, i in active if ordered[i].overlaps(start, end)]
+        if not in_flight:
+            continue
+        trajectories = sorted({r.trajectory_id for r in in_flight if r.trajectory_id})
+        workload = rows[index].setdefault("workload", {})
+        workload["in_flight"] = {
+            "requests": len(in_flight),
+            "trajectories": len(trajectories),
+            "turns": len({(r.trajectory_id, r.turn_index) for r in in_flight}),
+            # Ids, not just a count: "which trajectory was live when the pool spiked" is the question this exists for,
+            # and a count cannot answer it.
+            "trajectory_ids": trajectories[:_MAX_ROW_TRAJECTORIES],
+        }
+        annotated += 1
+    return annotated

--- a/src/hyperloom/orchestrator/actions/executors/_agentx_timeline.py
+++ b/src/hyperloom/orchestrator/actions/executors/_agentx_timeline.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import heapq
 import json
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Iterator
@@ -263,12 +264,18 @@ def build_events(
 
 
 def write_timeline(path: Path, events: Iterable[dict[str, Any]]) -> bool:
-    """Write the event stream as JSONL. Returns whether it landed."""
+    """Write the event stream as JSONL. Returns whether it landed.
+
+    Owner-only, matching the KV artifact it sits beside: ``atomic_write_text`` masks every written payload to ``0o700``
+    on purpose, and a sibling artifact from the same collector should not be the one file in the directory that is
+    world-readable.
+    """
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("w", encoding="utf-8") as handle:
             for event in events:
                 handle.write(json.dumps(event, sort_keys=True) + "\n")
+        os.chmod(path, 0o600)
     except (OSError, TypeError) as exc:
         log.debug("agentx_timeline: could not write %s (%s)", path, exc)
         return False

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -62,8 +62,15 @@ DEFAULT_METRICS_PORT = 8888
 
 #: Scrape timeout. Deliberately well under the 0.5s poll interval of the loop
 #: this runs inside: a slow endpoint must not stretch the interval that the
-#: stall and soft-deadline gates are measured on.
-_SCRAPE_TIMEOUT_SEC = 1.5
+#: stall and soft-deadline gates are measured on. The engine is on loopback, so
+#: anything approaching this budget is already pathological.
+_SCRAPE_TIMEOUT_SEC = 0.4
+
+#: Opener that ignores the ambient proxy configuration. ``urlopen`` honours
+#: ``http_proxy`` by default, which on a corporate host routes a loopback scrape
+#: through an external proxy: wrong by construction, and slow enough that the
+#: blocking call visibly delays the watchdog loop it runs inside.
+_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 
 #: Consecutive failures after which the poller stops trying. A server that
 #: never exposes ``/metrics`` (SGLang without ``--enable-metrics``) would
@@ -522,7 +529,7 @@ class KvMetricsPoller:
         if self._gave_up:
             return None
         try:
-            with urllib.request.urlopen(self.url, timeout=self.timeout_sec) as response:  # noqa: S310
+            with _OPENER.open(self.url, timeout=self.timeout_sec) as response:
                 body = response.read().decode("utf-8", "ignore")
         except (urllib.error.URLError, OSError, ValueError) as exc:
             self._failures += 1

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -698,10 +698,35 @@ _COMPARABLE_PHASE = "measured"
 #: three-hour round at the scrape interval below lands well over this.
 _MAX_STORED_ROWS = 5000
 
-#: Floor between scrapes. The loop this runs in can iterate faster than its
-#: nominal 0.5s when a deadline bounds the slice, so the interval is enforced
-#: on the monotonic clock rather than by counting passes.
-_MIN_SCRAPE_INTERVAL_SEC = 0.5
+#: Floor between scrapes, enforced on the monotonic clock -- the loop this runs
+#: in iterates faster than its nominal period when a deadline bounds the slice,
+#: so counting passes would sample fastest exactly when the run is most loaded.
+#:
+#: Not the loop's 0.5s. A scrape is a synchronous HTTP round trip plus a parse
+#: of the engine's whole exposition, which is not free at that rate, and the
+#: engine's own gauges do not refresh anywhere near it -- most of those samples
+#: would be the same numbers read again. Two seconds keeps the trend visible at
+#: a fraction of the cost. Override with
+#: ``INFERENCE_OPTIMIZER_KV_SCRAPE_INTERVAL_SEC``.
+_SCRAPE_INTERVAL_ENV = "INFERENCE_OPTIMIZER_KV_SCRAPE_INTERVAL_SEC"
+_DEFAULT_SCRAPE_INTERVAL_SEC = 2.0
+
+
+def resolve_scrape_interval_sec() -> float:
+    """Seconds between scrapes, from the environment or the default.
+
+    Returns:
+        float: The interval. A non-numeric or negative setting falls back to
+        the default rather than disabling sampling by accident.
+    """
+    raw = os.environ.get(_SCRAPE_INTERVAL_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_SCRAPE_INTERVAL_SEC
+    try:
+        value = float(raw)
+    except ValueError:
+        return _DEFAULT_SCRAPE_INTERVAL_SEC
+    return value if value >= 0 else _DEFAULT_SCRAPE_INTERVAL_SEC
 
 
 def counter_delta(first: dict[str, dict[str, float]], last: dict[str, dict[str, float]]) -> float | None:
@@ -759,7 +784,7 @@ class KvMetricsRecorder:
         poller: KvMetricsPoller,
         output_path: str | None = None,
         scope: dict[str, Any] | None = None,
-        min_interval_sec: float = _MIN_SCRAPE_INTERVAL_SEC,
+        min_interval_sec: float | None = None,
     ) -> None:
         """Prepare a recorder without contacting anything.
 
@@ -776,7 +801,7 @@ class KvMetricsRecorder:
         self._poller = poller
         self._output_path = output_path
         self._scope = dict(scope or {})
-        self._min_interval = float(min_interval_sec)
+        self._min_interval = resolve_scrape_interval_sec() if min_interval_sec is None else float(min_interval_sec)
         self._phase = "boot"
         self._rows: list[dict[str, Any]] = []
         self._last_scrape_mono: float | None = None
@@ -806,8 +831,16 @@ class KvMetricsRecorder:
         """
         if phase not in PHASES or phase == self._phase:
             return
+        # One reading taken at the boundary closes the phase that is ending and
+        # opens the one beginning. Deriving a phase total from its own first and
+        # last periodic samples instead leaves a gap at each end -- up to a full
+        # interval of activity credited to neither phase -- and the gap lands
+        # exactly where a phase change makes the engine's behaviour change most.
+        boundary = None if self._closed else self._scrape(mono)
         self._phase = phase
         self._phase_marks.append({"phase": phase, "mono": round(float(mono), 3), "ts": time.time()})
+        if boundary is not None:
+            self._record_counters(boundary)
 
     def tick(self, mono: float) -> None:
         """Scrape if the interval has elapsed, tagging the sample with the phase.
@@ -819,21 +852,40 @@ class KvMetricsRecorder:
             return
         if self._last_scrape_mono is not None and (mono - self._last_scrape_mono) < self._min_interval:
             return
+        self._scrape(mono)
+
+    def _scrape(self, mono: float) -> KvSample | None:
+        """Take one reading unconditionally, timing the round trip.
+
+        The duration is recorded per sample because a scrape is a synchronous
+        HTTP call inside a watchdog loop: if it ever starts costing real time,
+        that has to be visible in the artifact rather than inferred from a
+        benchmark that mysteriously slowed down.
+
+        Args:
+            mono (float): The loop's current monotonic instant.
+
+        Returns:
+            KvSample | None: The reading, or ``None`` when nothing was read.
+        """
         self._last_scrape_mono = mono
+        started = time.monotonic()
         try:
             sample = self._poller.sample()
         except Exception:  # noqa: BLE001 - collection must never fail a round
             log.debug("kv_metrics: sample failed", exc_info=True)
-            return
+            return None
         if sample is None:
-            return
-        self._absorb(sample)
+            return None
+        self._absorb(sample, scrape_sec=time.monotonic() - started)
+        return sample
 
-    def _absorb(self, sample: KvSample) -> None:
+    def _absorb(self, sample: KvSample, *, scrape_sec: float = 0.0) -> None:
         """Fold one sample into the row buffer and the counter windows.
 
         Args:
             sample (KvSample): The reading to record.
+            scrape_sec (float): How long the round trip took.
         """
         # Pool capacity is only observable while the engine is up; latch the
         # first non-null reading so the artifact still carries it after a round
@@ -853,6 +905,47 @@ class KvMetricsRecorder:
         # folds both into the one number that is supposed to describe the
         # measured window alone. The gauge rows carry their phase and can be
         # re-sliced later; counters cannot, so the split has to happen here.
+        self._record_counters(sample)
+        # Every row carries the gauges *and* the cumulative counters, in raw
+        # per-series form. Recording counters only at phase boundaries would
+        # leave the interior of a phase blind: an engine that retracted in one
+        # burst and one that retracted steadily produce the same phase total,
+        # and an engine restart mid-phase is invisible without the series. With
+        # the raw maps present a consumer can difference any two adjacent rows
+        # and does not have to trust this module's aggregation to do it.
+        self._rows.append(
+            {
+                "phase": self._phase,
+                "ts": round(sample.ts, 3),
+                "mono": round(sample.mono, 3),
+                "scrape_sec": round(scrape_sec, 4),
+                "active_pool_usage": sample.active_pool_usage,
+                "physical_pool_usage": sample.physical_pool_usage,
+                "used_tokens": sample.used_tokens,
+                "evictable_tokens": sample.evictable_tokens,
+                "available_tokens": sample.available_tokens,
+                "capacity_tokens": sample.capacity_tokens,
+                # Same aggregation rule the summary uses. Rows and summary
+                # disagreeing inside one artifact is worse than either rule
+                # being wrong, because nothing on the page says which is which.
+                "retract_total": aggregate_series(sample.retract_total),
+                "preempt_total": aggregate_series(sample.preempt_total),
+                "counters_by_series": {
+                    "retract": sample.retract_total,
+                    "preempt": sample.preempt_total,
+                    "prefix_cache_queries": sample.prefix_cache_queries,
+                    "prefix_cache_hits": sample.prefix_cache_hits,
+                    "cached_tokens_total": sample.cached_tokens_total,
+                },
+            }
+        )
+
+    def _record_counters(self, sample: KvSample) -> None:
+        """Bracket every cumulative counter under the phase in force.
+
+        Args:
+            sample (KvSample): The reading whose counters to record.
+        """
         for name, series in (
             ("retract", sample.retract_total),
             ("preempt", sample.preempt_total),
@@ -865,22 +958,6 @@ class KvMetricsRecorder:
             snapshot = {g: dict(s) for g, s in series.items()}
             self._first_counters.setdefault(self._phase, {}).setdefault(name, snapshot)
             self._last_counters.setdefault(self._phase, {})[name] = snapshot
-        self._rows.append(
-            {
-                "phase": self._phase,
-                "ts": round(sample.ts, 3),
-                "mono": round(sample.mono, 3),
-                "active_pool_usage": sample.active_pool_usage,
-                "physical_pool_usage": sample.physical_pool_usage,
-                "used_tokens": sample.used_tokens,
-                "evictable_tokens": sample.evictable_tokens,
-                # Same aggregation rule the summary uses. Rows and summary
-                # disagreeing inside one artifact is worse than either rule
-                # being wrong, because nothing on the page says which is which.
-                "retract_total": aggregate_series(sample.retract_total),
-                "preempt_total": aggregate_series(sample.preempt_total),
-            }
-        )
 
     def _counter_deltas(self, name: str) -> tuple[float | None, dict[str, float | None]]:
         """Increment of one counter, attributed to the phase that earned it.
@@ -989,6 +1066,11 @@ class KvMetricsRecorder:
         Returns:
             dict[str, Any]: The artifact payload, written or not.
         """
+        # Final boundary reading, for the same reason the phase transitions take
+        # one: without it the last phase ends at whenever its last periodic
+        # sample happened to land, and everything after that is lost.
+        if not self._closed:
+            self._scrape(time.monotonic())
         payload = self.summary(aborted=aborted)
         if self._closed or not self._output_path:
             self._closed = True

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -41,9 +41,13 @@ log = logging.getLogger(__name__)
 
 __all__ = [
     "DEFAULT_METRICS_PORT",
+    "KV_ARTIFACT_NAME",
+    "PHASES",
     "KvMetricsPoller",
+    "KvMetricsRecorder",
     "KvSample",
     "canonical_label_key",
+    "counter_delta",
     "parse_prometheus_text",
     "resolve_metrics_port",
     "sample_from_families",
@@ -551,3 +555,241 @@ class KvMetricsPoller:
             return None
         sample = sample_from_families(parse_prometheus_text(body))
         return sample if sample.has_readings() else None
+
+
+#: Artifact the recorder writes, alongside the round's ``server.log``.
+KV_ARTIFACT_NAME = "kv_metrics.json"
+
+#: Collection phases. An engine process outlives the window that is actually
+#: being measured by a wide margin, and mixing them makes every statistic
+#: meaningless: ``boot`` has no traffic at all, ``warmup`` runs a deliberately
+#: cold cache, and ``eval`` drives accuracy traffic whose shape has nothing to
+#: do with the throughput benchmark. Only ``measured`` may enter a comparison.
+PHASES = ("boot", "warmup", "measured", "eval")
+
+#: Row cap before stride downsampling, mirroring ``_MN_GPU_SAMPLE_CAP``. A
+#: three-hour round at the scrape interval below lands well over this.
+_MAX_STORED_ROWS = 5000
+
+#: Floor between scrapes. The loop this runs in can iterate faster than its
+#: nominal 0.5s when a deadline bounds the slice, so the interval is enforced
+#: on the monotonic clock rather than by counting passes.
+_MIN_SCRAPE_INTERVAL_SEC = 0.5
+
+
+def counter_delta(first: dict[str, float], last: dict[str, float]) -> float | None:
+    """Increment of a labelled counter between two observations.
+
+    Diffed per label series rather than on a flat total, because an engine
+    restart zeroes its series: a flat subtraction would go negative, and
+    clamping that to zero would quietly discard the whole window. When a series
+    ends below where it started it is treated as having restarted, and only the
+    post-restart count is credited -- the increments before the restart are
+    genuinely unrecoverable, and inventing them would be worse than losing them.
+
+    Args:
+        first (dict[str, float]): Series readings at window open.
+        last (dict[str, float]): Series readings at window close.
+
+    Returns:
+        float | None: Total increment, or ``None`` when the counter was never
+        observed at all -- which is not the same as an increment of zero.
+    """
+    if not first and not last:
+        return None
+    total = 0.0
+    for key, end in last.items():
+        start = first.get(key)
+        total += end if start is None or end < start else end - start
+    return total
+
+
+class KvMetricsRecorder:
+    """Collects phase-tagged KV samples for one benchmark round.
+
+    Owns everything stateful about collection so the watchdog loop it hangs off
+    keeps a single call per pass and one ``finally``. Like the poller, nothing
+    here raises: a recorder that fails must cost the round nothing.
+
+    The phase machine is driven by markers the loop already detects, plus
+    aiperf's own phase lines under AgentX. It is never inferred from elapsed
+    time, because the boundaries move by tens of minutes between rounds -- an
+    AgentX warmup alone was measured at nearly 18 of them.
+    """
+
+    def __init__(
+        self,
+        *,
+        poller: KvMetricsPoller,
+        output_path: str | None = None,
+        scope: dict[str, Any] | None = None,
+        min_interval_sec: float = _MIN_SCRAPE_INTERVAL_SEC,
+    ) -> None:
+        """Prepare a recorder without contacting anything.
+
+        Args:
+            poller (KvMetricsPoller): The endpoint reader.
+            output_path (str | None): Where :meth:`close` writes its artifact.
+                ``None`` collects in memory only, which is what the tests and
+                any caller without a workspace want.
+            scope (dict[str, Any] | None): Identity carried into the artifact so
+                a consumer never has to join against another file to learn which
+                variant and round produced it.
+            min_interval_sec (float): Floor between scrapes.
+        """
+        self._poller = poller
+        self._output_path = output_path
+        self._scope = dict(scope or {})
+        self._min_interval = float(min_interval_sec)
+        self._phase = "boot"
+        self._rows: list[dict[str, Any]] = []
+        self._last_scrape_mono: float | None = None
+        self._phase_marks: list[dict[str, Any]] = []
+        self._first_counters: dict[str, dict[str, float]] = {}
+        self._last_counters: dict[str, dict[str, float]] = {}
+        self._capacity_tokens: float | None = None
+        self._capacity_gb: float | None = None
+        self._closed = False
+
+    @property
+    def phase(self) -> str:
+        """Current collection phase."""
+        return self._phase
+
+    def note_phase(self, phase: str, mono: float) -> None:
+        """Record a phase transition.
+
+        Args:
+            phase (str): One of :data:`PHASES`. Anything else is ignored rather
+                than raising -- an unrecognised marker must not end collection.
+            mono (float): Monotonic instant of the transition.
+        """
+        if phase not in PHASES or phase == self._phase:
+            return
+        self._phase = phase
+        self._phase_marks.append({"phase": phase, "mono": round(float(mono), 3), "ts": time.time()})
+
+    def tick(self, mono: float) -> None:
+        """Scrape if the interval has elapsed, tagging the sample with the phase.
+
+        Args:
+            mono (float): The loop's current monotonic instant.
+        """
+        if self._closed:
+            return
+        if self._last_scrape_mono is not None and (mono - self._last_scrape_mono) < self._min_interval:
+            return
+        self._last_scrape_mono = mono
+        try:
+            sample = self._poller.sample()
+        except Exception:  # noqa: BLE001 - collection must never fail a round
+            log.debug("kv_metrics: sample failed", exc_info=True)
+            return
+        if sample is None:
+            return
+        self._absorb(sample)
+
+    def _absorb(self, sample: KvSample) -> None:
+        """Fold one sample into the row buffer and the counter windows.
+
+        Args:
+            sample (KvSample): The reading to record.
+        """
+        # Pool capacity is only observable while the engine is up; latch the
+        # first non-null reading so the artifact still carries it after a round
+        # that ended with the server gone.
+        if self._capacity_tokens is None and sample.capacity_tokens is not None:
+            self._capacity_tokens = sample.capacity_tokens
+        if self._capacity_gb is None and sample.capacity_gb is not None:
+            self._capacity_gb = sample.capacity_gb
+        for name, series in (("retract", sample.retract_total), ("preempt", sample.preempt_total)):
+            if not series:
+                continue
+            self._first_counters.setdefault(name, dict(series))
+            self._last_counters[name] = dict(series)
+        self._rows.append(
+            {
+                "phase": self._phase,
+                "ts": round(sample.ts, 3),
+                "mono": round(sample.mono, 3),
+                "active_pool_usage": sample.active_pool_usage,
+                "physical_pool_usage": sample.physical_pool_usage,
+                "used_tokens": sample.used_tokens,
+                "evictable_tokens": sample.evictable_tokens,
+                "retract_total": sum(sample.retract_total.values()) if sample.retract_total else None,
+                "preempt_total": sum(sample.preempt_total.values()) if sample.preempt_total else None,
+            }
+        )
+
+    def rows(self) -> list[dict[str, Any]]:
+        """Collected rows, stride-downsampled to the row cap.
+
+        Returns:
+            list[dict[str, Any]]: Phase-tagged samples in collection order.
+        """
+        if len(self._rows) <= _MAX_STORED_ROWS:
+            return list(self._rows)
+        stride = max(1, len(self._rows) // _MAX_STORED_ROWS)
+        return self._rows[::stride]
+
+    def summary(self, *, aborted: bool = False) -> dict[str, Any]:
+        """Build the artifact payload.
+
+        Args:
+            aborted (bool): Whether the round left through an exception path.
+                Recorded rather than inferred so a consumer can tell a window
+                that closed from one that was cut short.
+
+        Returns:
+            dict[str, Any]: The artifact. ``available`` is tri-state: ``None``
+            means the endpoint was never reached one way or the other, which is
+            not the same as reaching it and finding no pressure.
+        """
+        return {
+            "schema_version": 1,
+            "source": "metrics",
+            "url": self._poller.url,
+            "available": self._poller.available,
+            "aborted": bool(aborted),
+            "scope": self._scope,
+            "capacity_tokens": self._capacity_tokens,
+            "capacity_gb": self._capacity_gb,
+            "phase_marks": self._phase_marks,
+            "retract_delta": counter_delta(
+                self._first_counters.get("retract", {}),
+                self._last_counters.get("retract", {}),
+            ),
+            "preempt_delta": counter_delta(
+                self._first_counters.get("preempt", {}),
+                self._last_counters.get("preempt", {}),
+            ),
+            "sample_count": len(self._rows),
+            "samples": self.rows(),
+        }
+
+    def close(self, *, aborted: bool = False) -> dict[str, Any]:
+        """Finish collection and write the artifact when a path was given.
+
+        Idempotent: the loop's ``finally`` may run after a caller has already
+        closed explicitly.
+
+        Args:
+            aborted (bool): Whether the round is unwinding through an exception.
+
+        Returns:
+            dict[str, Any]: The artifact payload, written or not.
+        """
+        payload = self.summary(aborted=aborted)
+        if self._closed or not self._output_path:
+            self._closed = True
+            return payload
+        self._closed = True
+        try:
+            from pathlib import Path
+
+            from hyperloom.common.io import atomic_write_json
+
+            atomic_write_json(Path(self._output_path), payload)
+        except Exception:  # noqa: BLE001 - an unwritten artifact must not fail a round
+            log.debug("kv_metrics: could not write %s", self._output_path, exc_info=True)
+        return payload

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -691,6 +691,9 @@ KV_ARTIFACT_NAME = "kv_metrics.json"
 #: do with the throughput benchmark. Only ``measured`` may enter a comparison.
 PHASES = ("boot", "warmup", "measured", "eval")
 
+#: The one phase whose numbers may be compared against another round's.
+_COMPARABLE_PHASE = "measured"
+
 #: Row cap before stride downsampling, mirroring ``_MN_GPU_SAMPLE_CAP``. A
 #: three-hour round at the scrape interval below lands well over this.
 _MAX_STORED_ROWS = 5000
@@ -778,8 +781,8 @@ class KvMetricsRecorder:
         self._rows: list[dict[str, Any]] = []
         self._last_scrape_mono: float | None = None
         self._phase_marks: list[dict[str, Any]] = []
-        self._first_counters: dict[str, dict[str, dict[str, float]]] = {}
-        self._last_counters: dict[str, dict[str, dict[str, float]]] = {}
+        self._first_counters: dict[str, dict[str, dict[str, dict[str, float]]]] = {}
+        self._last_counters: dict[str, dict[str, dict[str, dict[str, float]]]] = {}
         self._capacity_tokens: float | None = None
         self._capacity_derived = False
         self._capacity_gb: float | None = None
@@ -845,6 +848,11 @@ class KvMetricsRecorder:
         # and diff. The prefix-cache ones need it as much as the pressure ones,
         # because under warm reuse the engine outlives the round and its
         # absolute totals carry the previous round's cache warming.
+        # Bracketed per phase, not per round. An engine keeps retracting through
+        # warmup and the accuracy eval, and a round-wide difference silently
+        # folds both into the one number that is supposed to describe the
+        # measured window alone. The gauge rows carry their phase and can be
+        # re-sliced later; counters cannot, so the split has to happen here.
         for name, series in (
             ("retract", sample.retract_total),
             ("preempt", sample.preempt_total),
@@ -854,8 +862,9 @@ class KvMetricsRecorder:
         ):
             if not series:
                 continue
-            self._first_counters.setdefault(name, {g: dict(s) for g, s in series.items()})
-            self._last_counters[name] = {g: dict(s) for g, s in series.items()}
+            snapshot = {g: dict(s) for g, s in series.items()}
+            self._first_counters.setdefault(self._phase, {}).setdefault(name, snapshot)
+            self._last_counters.setdefault(self._phase, {})[name] = snapshot
         self._rows.append(
             {
                 "phase": self._phase,
@@ -873,6 +882,26 @@ class KvMetricsRecorder:
             }
         )
 
+    def _counter_deltas(self, name: str) -> tuple[float | None, dict[str, float | None]]:
+        """Increment of one counter, attributed to the phase that earned it.
+
+        Args:
+            name (str): Counter key used by :meth:`_absorb`.
+
+        Returns:
+            tuple[float | None, dict[str, float | None]]: The measured-phase
+            increment -- the only one that may enter a comparison -- and the
+            full per-phase breakdown. The measured figure is ``None`` when no
+            sample landed in that phase, which is not an increment of zero.
+        """
+        by_phase: dict[str, float | None] = {}
+        for phase in PHASES:
+            last = self._last_counters.get(phase, {}).get(name)
+            if not last:
+                continue
+            by_phase[phase] = counter_delta(self._first_counters.get(phase, {}).get(name, {}), last)
+        return by_phase.get(_COMPARABLE_PHASE), by_phase
+
     def _prefix_cache_window(self) -> dict[str, Any]:
         """Prefix-cache increments attributable to this round.
 
@@ -888,12 +917,11 @@ class KvMetricsRecorder:
         """
         window: dict[str, Any] = {}
         for name in ("prefix_cache_queries", "prefix_cache_hits", "cached_tokens_total"):
-            last = self._last_counters.get(name)
-            if not last:
+            measured, by_phase = self._counter_deltas(name)
+            if not by_phase:
                 continue
-            window[f"{name}_delta"] = counter_delta(self._first_counters.get(name, {}), last)
-            window[f"{name}_first"] = self._first_counters.get(name, {})
-            window[f"{name}_last"] = last
+            window[f"{name}_delta"] = measured
+            window[f"{name}_delta_by_phase"] = by_phase
         return window
 
     def rows(self) -> list[dict[str, Any]]:
@@ -922,6 +950,8 @@ class KvMetricsRecorder:
             means the endpoint was never reached one way or the other, which is
             not the same as reaching it and finding no pressure.
         """
+        retract_measured, retract_by_phase = self._counter_deltas("retract")
+        preempt_measured, preempt_by_phase = self._counter_deltas("preempt")
         return {
             "schema_version": 1,
             "source": "metrics",
@@ -935,14 +965,14 @@ class KvMetricsRecorder:
             "series_count": self._series_count,
             "prefix_cache": self._prefix_cache_window(),
             "phase_marks": self._phase_marks,
-            "retract_delta": counter_delta(
-                self._first_counters.get("retract", {}),
-                self._last_counters.get("retract", {}),
-            ),
-            "preempt_delta": counter_delta(
-                self._first_counters.get("preempt", {}),
-                self._last_counters.get("preempt", {}),
-            ),
+            # The headline figure is the measured phase alone, because that is
+            # the only phase the plan lets into a comparison. The breakdown is
+            # kept beside it so a round that retracted hard during warmup is
+            # still visible rather than rounded away.
+            "retract_delta": retract_measured,
+            "retract_delta_by_phase": retract_by_phase,
+            "preempt_delta": preempt_measured,
+            "preempt_delta_by_phase": preempt_by_phase,
             "sample_count": len(self._rows),
             "samples": self.rows(),
         }

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -226,6 +226,15 @@ def families_from_aiperf_record(metrics: Any) -> ParsedFamilies:
             families.setdefault(str(name), []).append(
                 ({str(k): str(v) for k, v in labels.items()} if isinstance(labels, dict) else {}, value)
             )
+    # aiperf names a counter by its Prometheus *family*, which drops the ``_total`` the exposition writes on the sample
+    # itself: the text carries ``vllm:num_preemptions_total`` and the export says ``vllm:num_preemptions``. Every
+    # cumulative counter this module reads is spelled the exposition way, so without the alias all three -- preemptions,
+    # SGLang retractions, cached tokens -- come back empty on this path, and an empty counter is indistinguishable from
+    # a round that never retracted. Aliasing here rather than widening every constant keeps one spelling in the lookups
+    # and confines the difference to the source that has it. The lists are shared, not copied.
+    for name, samples in list(families.items()):
+        if not name.endswith("_total"):
+            families.setdefault(f"{name}_total", samples)
     return families
 
 

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -1422,7 +1422,13 @@ class KvMetricsRecorder:
             "sample_source": "aiperf_server_metrics" if adopted else "watchdog_scrape",
             "aiperf_server_metrics_path": adopted,
             "url": self._poller.url,
-            "available": self._poller.available,
+            # Whether this round obtained readings at all, by whichever collector -- not whether the watchdog's own
+            # poller reached the endpoint. Once aiperf's records are adopted the poller may legitimately never succeed
+            # (it backs off to a minute, and on a containerised round the engine's port need not be reachable from
+            # where the watchdog runs) while aiperf, in there with it, collects the whole round. Reporting the poller's
+            # view alone put ``available: false`` on an artifact carrying 1656 samples, and the breakdown folds this
+            # field into a session-level "no round ever reached the endpoint".
+            "available": True if adopted else self._poller.available,
             "aborted": bool(aborted),
             "scope": self._scope,
             "capacity_tokens": self._capacity_tokens,

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -99,6 +99,11 @@ _OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 #: and a slow one.
 _SERVER_LOG_HEAD_BYTES = 262144
 
+#: A log line is a bind announcement when it is about the server coming up and carries a URL with a port. Split in two
+#: so neither half has to be exact: the hint tolerates a reworded banner, and the URL is what actually carries the port.
+_SERVER_BIND_HINT = re.compile(r"\b(?:server|uvicorn|listening|running)\b", re.IGNORECASE)
+_SERVER_BIND_URL = re.compile(r"https?://[^\s/:]+:(\d+)")
+
 #: Consecutive failures after which the poller stops trying. A server that never exposes ``/metrics`` (SGLang without
 #: ``--enable-metrics``) would otherwise pay a connection refusal every couple of seconds for the whole round.
 _MAX_CONSECUTIVE_FAILURES = 3
@@ -600,11 +605,18 @@ def port_from_server_log(workspace: Any) -> int | None:
                 # The banner is near the top; a served round's log grows to megabytes and is on shared storage.
                 with candidate.open(encoding="utf-8", errors="ignore") as handle:
                     head = handle.read(_SERVER_LOG_HEAD_BYTES)
-                match = re.search(r"(?:Uvicorn running on|running on)\s+https?://[^\s:]+:(\d+)", head)
-                if match:
-                    port = _port_value(match.group(1))
-                    if port is not None:
-                        return port
+                for line in head.splitlines():
+                    # Matched on what the line is about rather than on its exact wording. The observed builds say
+                    # "Starting vLLM server on http://0.0.0.0:8000"; older ones and SGLang say "Uvicorn running on".
+                    # Enumerating the phrasings is how this collector got its original bug, so the test is the
+                    # combination -- a line announcing the server, carrying a URL with a port.
+                    if not _SERVER_BIND_HINT.search(line):
+                        continue
+                    match = _SERVER_BIND_URL.search(line)
+                    if match:
+                        port = _port_value(match.group(1))
+                        if port is not None:
+                            return port
     except OSError:
         return None
     return None

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -306,14 +306,39 @@ def read_aiperf_server_metrics(path: Path) -> list[tuple[KvSample, dict[str, Any
                             "scrape_end_unix": math.ceil((start_unix + latency / 1e9) * 1000) / 1000,
                             "scrape_sec": round(latency / 1e9, 4),
                         },
-                        _CREDIT_PHASE_NAMES.get(str(record.get("benchmark_phase") or "").lower()),
+                        # Unstamped means aiperf took it before any phase began -- its baseline capture, of an idle
+                        # pool. That is boot, and naming it here keeps one value per meaning downstream.
+                        _CREDIT_PHASE_NAMES.get(str(record.get("benchmark_phase") or "").lower(), "boot"),
                     )
                 )
     except OSError as exc:
         log.debug("kv_metrics: could not read %s (%s)", path, exc)
         return []
     out.sort(key=lambda item: item[0].ts)
-    return out
+    return _demote_premature_measured(out)
+
+
+def _demote_premature_measured(
+    records: list[tuple[KvSample, dict[str, Any], str | None]],
+) -> list[tuple[KvSample, dict[str, Any], str | None]]:
+    """Re-file a measured-stamped record that arrives before warmup as boot.
+
+    The phases are ordered: profiling follows warmup. Observed on every AgentX round so far, aiperf stamps one record
+    ``profiling`` a couple of seconds *before* the first warmup record -- its phase context leaking during setup, not a
+    measurement of the profiling phase. Left alone it lands in ``measured``, which is the only phase allowed into a
+    comparison, and the gap-free bracketing then runs that window from the stray record to the first warmup reading and
+    credits warmup's opening seconds to it. On one round that was the whole of the measured prefix-cache delta.
+
+    Only demoted when warmup records exist and the stray precedes them; a run configured without a warmup has its
+    profiling records first legitimately, and those are left alone.
+    """
+    first_warmup = next((s.ts for s, _t, p in records if p == "warmup"), None)
+    if first_warmup is None:
+        return records
+    return [
+        (s, t, "boot" if p == "measured" and s.ts < first_warmup else p)  # type: ignore[misc]
+        for s, t, p in records
+    ]
 
 
 def parse_prometheus_text(text: str) -> ParsedFamilies:

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -776,14 +776,20 @@ class KvMetricsRecorder:
         end_mono = time.monotonic()
         if sample is None:
             return None
+        # Widened to the enclosing millisecond, not rounded to the nearest one. These two bound the interval that
+        # workload records are joined against, so the stored window has to contain the real one: nearest-rounding
+        # shrinks it by up to half a millisecond at each end, and a request that began inside a sub-millisecond scrape
+        # then falls outside the window that observed it. Measured at ~13% of scrapes on a host fast enough for the
+        # rounding to bite, and invisible on a coarse clock -- which is exactly how it reached CI unnoticed.
+        elapsed = end_mono - start_mono
         self._absorb(
             sample,
             timing={
-                "scrape_start_unix": round(start_unix, 3),
-                "scrape_end_unix": round(start_unix + (end_mono - start_mono), 3),
+                "scrape_start_unix": math.floor(start_unix * 1000) / 1000,
+                "scrape_end_unix": math.ceil((start_unix + elapsed) * 1000) / 1000,
                 "scrape_start_mono": round(start_mono, 3),
                 "scrape_end_mono": round(end_mono, 3),
-                "scrape_sec": round(end_mono - start_mono, 4),
+                "scrape_sec": round(elapsed, 4),
             },
             workload=workload,
         )

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -3,24 +3,20 @@
 
 """KV-cache observability sampled from the engine's ``/metrics`` endpoint.
 
-The engine is the only thing that knows how full its KV pool is, and until now
-nothing read it: a run could spend its whole budget retracting requests and the
-breakdown would show only "throughput low". This module is the reader.
+The engine is the only thing that knows how full its KV pool is, and until now nothing read it: a run could spend its
+whole budget retracting requests and the breakdown would show only "throughput low". This module is the reader.
 
-``/metrics`` is the primary source rather than ``server.log`` because it wins on
-every axis that matters here -- full float precision instead of the log's two
-decimals, stable metric names instead of names that branch on the model's pool
-type, explicit units, and ``kv_evictable_tokens``, which the log cannot express
-at all and which is the only way to separate the two occupancy readings this
-module reports (see :class:`KvSample`).
+``/metrics`` is the primary source rather than ``server.log`` because it wins on every axis that matters here -- full
+float precision instead of the log's two decimals, stable metric names instead of names that branch on the model's pool
+type, explicit units, and ``kv_evictable_tokens``, which the log cannot express at all and which is the only way to
+separate the two occupancy readings this module reports (see :class:`KvSample`).
 
 Two rules run through everything below:
 
-* **Never raise.** This samples a benchmark that is being measured; a scrape
-  failure must cost the run nothing. Every entry point returns a value.
-* **Never coerce a missing reading to zero.** A pool nobody sampled and a pool
-  that is genuinely empty are different findings, and collapsing them is how an
-  optimizer ends up steering on a number that was never measured. Absent means
+* **Never raise.** This samples a benchmark that is being measured; a scrape failure must cost the run nothing. Every
+  entry point returns a value.
+* **Never coerce a missing reading to zero.** A pool nobody sampled and a pool that is genuinely empty are different
+  findings, and collapsing them is how an optimizer ends up steering on a number that was never measured. Absent means
   ``None``, all the way out to the breakdown.
 """
 
@@ -54,27 +50,23 @@ __all__ = [
 ]
 
 
-#: Port the persistent server binds when ``benchmark.envs.PORT`` is unset.
-#: Mirrors ``_server_lifecycle.REUSE_PORT_DEFAULT``; duplicated rather than
-#: imported because that module imports ``_subprocess_kill``, which is where
-#: this one gets wired in.
+#: Port the persistent server binds when ``benchmark.envs.PORT`` is unset. Mirrors
+#: ``_server_lifecycle.REUSE_PORT_DEFAULT``; duplicated rather than imported because that module imports
+#: ``_subprocess_kill``, which is where this one gets wired in.
 DEFAULT_METRICS_PORT = 8888
 
-#: Scrape timeout. Deliberately well under the 0.5s poll interval of the loop
-#: this runs inside: a slow endpoint must not stretch the interval that the
-#: stall and soft-deadline gates are measured on. The engine is on loopback, so
-#: anything approaching this budget is already pathological.
+#: Scrape timeout. Deliberately well under the 0.5s poll interval of the loop this runs inside: a slow endpoint must not
+#: stretch the interval that the stall and soft-deadline gates are measured on. The engine is on loopback, so anything
+#: approaching this budget is already pathological.
 _SCRAPE_TIMEOUT_SEC = 0.4
 
-#: Opener that ignores the ambient proxy configuration. ``urlopen`` honours
-#: ``http_proxy`` by default, which on a corporate host routes a loopback scrape
-#: through an external proxy: wrong by construction, and slow enough that the
+#: Opener that ignores the ambient proxy configuration. ``urlopen`` honours ``http_proxy`` by default, which on a
+#: corporate host routes a loopback scrape through an external proxy: wrong by construction, and slow enough that the
 #: blocking call visibly delays the watchdog loop it runs inside.
 _OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 
-#: Consecutive failures after which the poller stops trying. A server that
-#: never exposes ``/metrics`` (SGLang without ``--enable-metrics``) would
-#: otherwise pay a connection refusal twice a second for the whole round.
+#: Consecutive failures after which the poller stops trying. A server that never exposes ``/metrics`` (SGLang without
+#: ``--enable-metrics``) would otherwise pay a connection refusal every couple of seconds for the whole round.
 _MAX_CONSECUTIVE_FAILURES = 3
 
 
@@ -82,51 +74,41 @@ _MAX_CONSECUTIVE_FAILURES = 3
 # Metric names
 # ---------------------------------------------------------------------------
 
-# Occupancy, SGLang. ``token_usage`` is the active reading -- its numerator
-# excludes blocks the prefix cache is holding but would hand back under
-# pressure. The per-subpool gauges are always exposed and read 0 on a model
-# that has no such subpool, so taking the max over all of them is both the
-# hybrid-correct answer (SGLang's own scheduler judges pressure that way) and a
-# no-op on an ordinary KV pool.
-# ``token_usage`` is already max(full, swa, mamba) on current SGLang, so it is
-# authoritative on its own. The per-subpool gauges are a fallback for a build
-# that predates it, where reading only the full pool would understate a hybrid
-# model's real pressure.
+# Occupancy, SGLang. ``token_usage`` is the active reading -- its numerator excludes blocks the prefix cache is holding
+# but would hand back under pressure. The per-subpool gauges are always exposed and read 0 on a model that has no such
+# subpool, so taking the max over all of them is both the hybrid-correct answer (SGLang's own scheduler judges pressure
+# that way) and a no-op on an ordinary KV pool. ``token_usage`` is already max(full, swa, mamba) on current SGLang, so
+# it is authoritative on its own. The per-subpool gauges are a fallback for a build that predates it, where reading only
+# the full pool would understate a hybrid model's real pressure.
 _SGL_USAGE_PRIMARY = "sglang:token_usage"
 _SGL_USAGE_FALLBACK = ("sglang:full_token_usage", "sglang:swa_token_usage", "sglang:mamba_usage")
 _SGL_USED = "sglang:kv_used_tokens"
 _SGL_AVAILABLE = "sglang:kv_available_tokens"
-# Only the main KV pool's evictable count. The SWA and Mamba pools have their
-# own capacities, and ``kv_used_tokens`` / ``kv_available_tokens`` describe the
-# main pool alone -- folding the other pools' evictable tokens into a ratio
-# built from main-pool numerators mixes two different denominators.
+# Only the main KV pool's evictable count. The SWA and Mamba pools have their own capacities, and ``kv_used_tokens`` /
+# ``kv_available_tokens`` describe the main pool alone -- folding the other pools' evictable tokens into a ratio built
+# from main-pool numerators mixes two different denominators.
 _SGL_EVICTABLE = "sglang:kv_evictable_tokens"
-# Pool capacity as the engine reports it. Preferred over deriving it, because
-# used + available + evictable can fall short of the true size: the gap is
-# tokens held in reserve (protected / session-held), and deriving would both
+# Pool capacity as the engine reports it. Preferred over deriving it, because used + available + evictable can fall
+# short of the true size: the gap is tokens held in reserve (protected / session-held), and deriving would both
 # understate capacity and overstate the physical occupancy computed from it.
 _SGL_CAPACITY_TOKENS = "sglang:max_total_num_tokens"
 _SGL_CAPACITY_GB = "sglang:kv_cache_memory_usage_gb"
-# Cumulative retract counter. NOT ``sglang:num_retracted_reqs``, which is the
-# most recent batch's instantaneous gauge and carries a ``pid`` label; the two
-# names differ by one word and reading the wrong one turns 48 retracts into 1.
+# Cumulative retract counter. NOT ``sglang:num_retracted_reqs``, which is the most recent batch's instantaneous gauge
+# and carries a ``pid`` label; the two names differ by one word and reading the wrong one turns 48 retracts into 1.
 _SGL_RETRACT_TOTAL = "sglang:num_retracted_requests_total"
 _SGL_CACHED_TOKENS = "sglang:cached_tokens_total"
 
-# Occupancy, vLLM. ``gpu_cache_usage_perc`` is the pre-rename spelling, kept so
-# an older image still reports.
+# Occupancy, vLLM. ``gpu_cache_usage_perc`` is the pre-rename spelling, kept so an older image still reports.
 _VLLM_USAGE = ("vllm:kv_cache_usage_perc", "vllm:gpu_cache_usage_perc")
-# The only workable preemption count: vLLM's log line for it is dead code
-# (``log()`` resets the counter before reading it), so this has no log fallback.
+# The only workable preemption count: vLLM's log line for it is dead code (``log()`` resets the counter before reading
+# it), so this has no log fallback.
 _VLLM_PREEMPT_TOTAL = "vllm:num_preemptions_total"
 _VLLM_PREFIX_QUERIES = "vllm:prefix_cache_queries"
 _VLLM_PREFIX_HITS = "vllm:prefix_cache_hits"
 
-# Deliberately not read: ``sglang:cache_hit_rate``. Observed reading 0.0 on a
-# server whose ``cached_tokens_total`` had already reached 4.6M, so it is not a
-# cumulative rate -- whether it is instantaneous or windowed is unresolved, and
-# a field nobody can interpret is worse than an absent one. The raw families
-# stay available to whoever settles it.
+# Deliberately not read: ``sglang:cache_hit_rate``. Observed reading 0.0 on a server whose ``cached_tokens_total`` had
+# already reached 4.6M, so it is not a cumulative rate -- whether it is instantaneous or windowed is unresolved, and a
+# field nobody can interpret is worse than an absent one. The raw families stay available to whoever settles it.
 
 
 ParsedFamilies = dict[str, list[tuple[dict[str, str], float]]]
@@ -135,16 +117,9 @@ ParsedFamilies = dict[str, list[tuple[dict[str, str], float]]]
 def canonical_label_key(labels: dict[str, str]) -> str:
     """Render a label set as a stable string usable as a dict key.
 
-    Counters are diffed per series, not in aggregate: an engine restart resets
-    a series to zero, and a naive total would read that as a negative delta or,
-    worse, silently absorb it. Sorting makes the key independent of the order
-    the exporter happened to emit.
-
-    Args:
-        labels (dict[str, str]): Label name to value.
-
-    Returns:
-        str: ``k="v",k2="v2"`` with names sorted; ``""`` for no labels.
+    Counters are diffed per series, not in aggregate: an engine restart resets a series to zero, and a naive total would
+    read that as a negative delta or, worse, silently absorb it. Sorting makes the key independent of the order the
+    exporter happened to emit.
     """
     return ",".join(f'{k}="{labels[k]}"' for k in sorted(labels))
 
@@ -152,16 +127,7 @@ def canonical_label_key(labels: dict[str, str]) -> str:
 def _split_labels(raw: str) -> dict[str, str]:
     """Parse the inside of a Prometheus label brace into a mapping.
 
-    Values may contain escaped quotes and commas, so the scan is character-wise
-    rather than a naive ``split(",")``.
-
-    Args:
-        raw (str): The text between ``{`` and ``}``, exclusive.
-
-    Returns:
-        dict[str, str]: Label name to unescaped value. Malformed fragments are
-        skipped rather than raising -- a label this module does not understand
-        must not cost it the sample's value.
+    Values may contain escaped quotes and commas, so the scan is character-wise rather than a naive ``split(",")``.
     """
     labels: dict[str, str] = {}
     index = 0
@@ -196,17 +162,9 @@ def _split_labels(raw: str) -> dict[str, str]:
 def parse_prometheus_text(text: str) -> ParsedFamilies:
     """Parse a Prometheus text exposition into metric families.
 
-    Handles the parts of the format an engine actually emits: comments, labels,
-    an optional trailing timestamp, and the ``NaN`` / ``+Inf`` / ``-Inf``
-    literals. Non-finite values are dropped -- they carry no occupancy meaning
-    and would poison any max or mean taken over them.
-
-    Args:
-        text (str): The response body of a ``/metrics`` GET.
-
-    Returns:
-        ParsedFamilies: Metric name to a list of ``(labels, value)``. A metric
-        that appears with several label sets keeps one entry per set.
+    Handles the parts of the format an engine actually emits: comments, labels, an optional trailing timestamp, and the
+    ``NaN`` / ``+Inf`` / ``-Inf`` literals. Non-finite values are dropped -- they carry no occupancy meaning and would
+    poison any max or mean taken over them.
     """
     families: ParsedFamilies = {}
     for line in text.splitlines():
@@ -240,27 +198,17 @@ def parse_prometheus_text(text: str) -> ParsedFamilies:
     return families
 
 
-#: Labels that identify a shard of one engine rather than an independent one.
-#: Shards schedule in lockstep, so each reports the same event; anything else
-#: (``dp_rank``, ``engine``, ``model_name``, ``pid``) marks a unit that
-#: retracts on its own account.
+#: Labels that identify a shard of one engine rather than an independent one. Shards schedule in lockstep, so each
+#: reports the same event; anything else (``dp_rank``, ``engine``, ``model_name``, ``pid``) marks a unit that retracts
+#: on its own account.
 _REPLICA_LABELS = frozenset({"tp_rank", "pp_rank"})
 
 
 def _series(families: ParsedFamilies, name: str) -> dict[str, dict[str, float]]:
     """Read a counter grouped by independent unit, then by shard.
 
-    Two levels because the two label kinds need opposite treatment and a flat
-    map cannot express that: shards of one engine duplicate each other's
-    counts, while separate engines contribute their own.
-
-    Args:
-        families (ParsedFamilies): Parsed exposition.
-        name (str): Metric name.
-
-    Returns:
-        dict[str, dict[str, float]]: Independent-unit key to shard key to
-        value; empty when the metric is absent.
+    Two levels because the two label kinds need opposite treatment and a flat map cannot express that: shards of one
+    engine duplicate each other's counts, while separate engines contribute their own.
     """
     out: dict[str, dict[str, float]] = {}
     for labels, value in families.get(name, []):
@@ -272,16 +220,9 @@ def _series(families: ParsedFamilies, name: str) -> dict[str, dict[str, float]]:
 def aggregate_series(grouped: dict[str, dict[str, float]]) -> float | None:
     """Collapse a grouped counter into one number.
 
-    Max within a group, sum across groups. Eight tensor-parallel ranks carrying
-    48 retracts describe 48 events, not 384; two data-parallel engines carrying
-    48 each describe 96. Applying one rule to both label kinds is wrong in one
+    Max within a group, sum across groups. Eight tensor-parallel ranks carrying 48 retracts describe 48 events, not 384;
+    two data-parallel engines carrying 48 each describe 96. Applying one rule to both label kinds is wrong in one
     direction or the other, which is why the grouping exists.
-
-    Args:
-        grouped (dict[str, dict[str, float]]): Output of :func:`_series`.
-
-    Returns:
-        float | None: The total, or ``None`` when the counter was never seen.
     """
     if not grouped:
         return None
@@ -289,15 +230,7 @@ def aggregate_series(grouped: dict[str, dict[str, float]]) -> float | None:
 
 
 def _rank_keys(families: ParsedFamilies, names: tuple[str, ...]) -> list[str]:
-    """Label keys the given gauges were reported under.
-
-    Args:
-        families (ParsedFamilies): Parsed exposition.
-        names (tuple[str, ...]): Metric names to inspect.
-
-    Returns:
-        list[str]: Canonical label keys, or ``[""]`` when nothing is labelled.
-    """
+    """Label keys the given gauges were reported under."""
     keys: list[str] = []
     for name in names:
         for labels, _ in families.get(name, []):
@@ -310,16 +243,7 @@ def _rank_keys(families: ParsedFamilies, names: tuple[str, ...]) -> list[str]:
 def _read(families: ParsedFamilies, name: str, key: str) -> float | None:
     """One gauge's value for one rank.
 
-    Falls back to an unlabelled series so a metric the engine reports once
-    globally still resolves for every rank.
-
-    Args:
-        families (ParsedFamilies): Parsed exposition.
-        name (str): Metric name.
-        key (str): Canonical label key of the rank being assembled.
-
-    Returns:
-        float | None: The value, or ``None`` when this rank has no reading.
+    Falls back to an unlabelled series so a metric the engine reports once globally still resolves for every rank.
     """
     series = families.get(name) or []
     for labels, value in series:
@@ -334,78 +258,46 @@ def _read(families: ParsedFamilies, name: str, key: str) -> float | None:
 class KvSample:
     """One ``/metrics`` scrape, normalised across engines.
 
-    Every metric is ``None`` when the engine did not expose it. Read them with
-    ``is None``, never with truthiness: an idle pool reports a true 0.0, and an
-    engine that has not been asked for a token yet reports 0.0 for minutes.
+    Every metric is ``None`` when the engine did not expose it. Read them with ``is None``, never with truthiness: an
+    idle pool reports a true 0.0, and an engine that has not been asked for a token yet reports 0.0 for minutes.
 
-    Attributes:
-        ts (float): Wall clock, for lining up with externally collected data.
-        mono (float): Monotonic clock, for intervals within the run.
-        engine (str): ``"sglang"``, ``"vllm"``, or ``""`` when unrecognised.
-        active_pool_usage (float | None): Fraction of the pool held by running
-            requests. This is the pressure reading.
-        physical_pool_usage (float | None): Fraction physically occupied,
-            including blocks the prefix cache holds but would release. A pool
-            at 100% physical can be under no pressure at all -- that is prefix
-            cache doing its job -- which is why this is reported separately and
-            never as "the" occupancy. SGLang only; vLLM cannot express it.
-        used_tokens (float | None): Tokens held by running requests.
-        evictable_tokens (float | None): Tokens the prefix cache holds and would
-            hand back under pressure.
-        available_tokens (float | None): Tokens free outright.
-        capacity_tokens (float | None): Pool size in tokens, read from the
-            engine when it reports one.
-        capacity_derived (bool): True when ``capacity_tokens`` had to be summed
-            from used + available + evictable because no capacity gauge was
-            exposed. That sum can fall short of the real pool -- tokens held in
-            reserve belong to none of the three -- so a derived capacity makes
-            ``physical_pool_usage`` an upper bound rather than a measurement.
-        series_count (int): Label series the occupancy gauge carried. Greater
-            than one means a sharded engine reported per-rank views that were
-            collapsed to their maximum; see :func:`_scalar`.
-        capacity_gb (float | None): Pool size in GiB as the engine reports it.
-            The engine's "GB" is 1024-based; do not rescale it.
-        retract_total (dict[str, dict[str, float]]): SGLang cumulative retracts,
-            grouped by independent unit then by shard. Kept per series so an
-            engine restart shows as a series resetting rather than as a total
-            going backwards, and so shards can be collapsed while separate
-            engines are added. Combine with :func:`aggregate_series`.
-        preempt_total (dict[str, dict[str, float]]): vLLM preemptions, likewise.
-        prefix_cache_queries (dict[str, dict[str, float]]): vLLM cumulative
-            prefix lookups, same grouping.
-        prefix_cache_hits (dict[str, dict[str, float]]): vLLM prefix hits.
-        cached_tokens_total (dict[str, dict[str, float]]): SGLang cumulative
-            prefix-cached tokens. Empty when prefix caching is off -- the metric
-            is not emitted at all, rather than emitted as zero.
+    The two occupancy readings are not interchangeable. ``active_pool_usage`` is the pressure reading; a pool at 100%
+    ``physical_pool_usage`` can be under no pressure at all, because the difference is prefix cache holding blocks it
+    would hand straight back. Reporting either one as "the" occupancy is how a healthy run gets read as a saturated one.
     """
 
-    ts: float
-    mono: float
-    engine: str = ""
+    ts: float  # wall clock, for lining up with externally collected data
+    mono: float  # monotonic clock, for intervals within the run
+    engine: str = ""  # "sglang", "vllm", or "" when unrecognised
     active_pool_usage: float | None = None
-    physical_pool_usage: float | None = None
+    physical_pool_usage: float | None = None  # SGLang only; vLLM cannot express it
     used_tokens: float | None = None
     evictable_tokens: float | None = None
     available_tokens: float | None = None
     capacity_tokens: float | None = None
+    # Set when no capacity gauge was exposed and capacity had to be summed from used + available + evictable. That sum
+    # can fall short of the real pool -- tokens held in reserve belong to none of the three -- which makes
+    # ``physical_pool_usage`` an upper bound rather than a measurement.
     capacity_derived: bool = False
+    # Label series the occupancy gauge carried. Above one means a sharded engine reported per-rank views that were
+    # collapsed to their maximum; see :func:`_scalar`.
     series_count: int = 0
-    capacity_gb: float | None = None
-    retract_total: dict[str, dict[str, float]] = field(default_factory=dict)
-    preempt_total: dict[str, dict[str, float]] = field(default_factory=dict)
-    prefix_cache_queries: dict[str, dict[str, float]] = field(default_factory=dict)
-    prefix_cache_hits: dict[str, dict[str, float]] = field(default_factory=dict)
+    capacity_gb: float | None = None  # the engine's "GB" is 1024-based; do not rescale
+    # Cumulative counters, grouped by independent unit then by shard. Kept per series so an engine restart shows as one
+    # series resetting rather than as a total going backwards, and so shards can be collapsed while separate engines are
+    # added. Combine with :func:`aggregate_series`.
+    retract_total: dict[str, dict[str, float]] = field(default_factory=dict)  # SGLang
+    preempt_total: dict[str, dict[str, float]] = field(default_factory=dict)  # vLLM
+    prefix_cache_queries: dict[str, dict[str, float]] = field(default_factory=dict)  # vLLM
+    prefix_cache_hits: dict[str, dict[str, float]] = field(default_factory=dict)  # vLLM
+    # SGLang. Empty when prefix caching is off -- the metric is not emitted at all, rather than emitted as zero.
     cached_tokens_total: dict[str, dict[str, float]] = field(default_factory=dict)
 
     def has_readings(self) -> bool:
         """Whether this scrape carried any KV signal at all.
 
-        A reachable endpoint that exposes no KV metric -- an engine started
-        without them, or one whose exposition this module does not recognise --
-        must not be recorded as a row of nothing.
-
-        Returns:
-            bool: True when at least one occupancy or pressure field is set.
+        A reachable endpoint that exposes no KV metric -- an engine started without them, or one whose exposition this
+        module does not recognise -- must not be recorded as a row of nothing.
         """
         return any(
             value is not None
@@ -419,14 +311,7 @@ class KvSample:
 
 
 def _detect_engine(families: ParsedFamilies) -> str:
-    """Identify the engine from its metric-name prefix.
-
-    Args:
-        families (ParsedFamilies): Parsed exposition.
-
-    Returns:
-        str: ``"sglang"``, ``"vllm"``, or ``""`` when neither prefix appears.
-    """
+    """Identify the engine from its metric-name prefix."""
     for name in families:
         if name.startswith("sglang:"):
             return "sglang"
@@ -441,34 +326,22 @@ def sample_from_families(
     ts: float | None = None,
     mono: float | None = None,
 ) -> KvSample:
-    """Build a normalised sample from a parsed exposition.
-
-    Args:
-        families (ParsedFamilies): Output of :func:`parse_prometheus_text`.
-        ts (float | None): Wall clock to stamp; defaults to now.
-        mono (float | None): Monotonic clock to stamp; defaults to now.
-
-    Returns:
-        KvSample: The normalised reading. Fields the engine did not expose stay
-        ``None``.
-    """
+    """Build a normalised sample from a parsed exposition."""
     engine = _detect_engine(families)
     occupancy_names = (_SGL_USAGE_PRIMARY,) + _SGL_USAGE_FALLBACK + _VLLM_USAGE + (_SGL_USED,)
     keys = _rank_keys(families, occupancy_names)
 
-    # Assemble each rank in full before choosing one. Taking a per-field max
-    # across ranks silently welds numbers from different sides of the engine
-    # together: rank A's capacity against rank B's used tokens produced a
-    # physical occupancy of 1.7 on two individually valid readings.
+    # Assemble each rank in full before choosing one. Taking a per-field max across ranks silently welds numbers from
+    # different sides of the engine together: rank A's capacity against rank B's used tokens produced a physical
+    # occupancy of 1.7 on two individually valid readings.
     best: dict[str, Any] | None = None
     for key in keys:
         used = _read(families, _SGL_USED, key)
         available = _read(families, _SGL_AVAILABLE, key)
         evictable = _read(families, _SGL_EVICTABLE, key)
 
-        # Engine-reported capacity wins; the sum is a fallback for builds that
-        # do not expose it, flagged so a consumer knows it may run short of the
-        # true pool size.
+        # Engine-reported capacity wins; the sum is a fallback for builds that do not expose it, flagged so a consumer
+        # knows it may run short of the true pool size.
         capacity = _read(families, _SGL_CAPACITY_TOKENS, key)
         capacity_derived = False
         if capacity is None and used is not None and available is not None:
@@ -479,10 +352,9 @@ def sample_from_families(
         if capacity and capacity > 0 and used is not None:
             physical = (used + (evictable or 0.0)) / capacity
 
-        # ``token_usage`` is already the maximum across the full, SWA and Mamba
-        # subpools on current SGLang, so it is read directly. The per-subpool
-        # gauges are only consulted when it is missing, which is what an older
-        # build looks like.
+        # ``token_usage`` is already the maximum across the full, SWA and Mamba subpools on current SGLang, so it is
+        # read directly. The per-subpool gauges are only consulted when it is missing, which is what an older build
+        # looks like.
         active = _read(families, _SGL_USAGE_PRIMARY, key)
         if active is None:
             active = max(
@@ -505,8 +377,8 @@ def sample_from_families(
             "capacity_derived": capacity_derived,
             "capacity_gb": _read(families, _SGL_CAPACITY_GB, key),
         }
-        # The most pressured rank is the one that will retract, so it is the one
-        # worth reporting. Fall back to physical, then to having read anything.
+        # The most pressured rank is the one that will retract, so it is the one worth reporting. Fall back to physical,
+        # then to having read anything.
         if best is None:
             best = candidate
             continue
@@ -539,8 +411,8 @@ def sample_from_families(
         capacity_tokens=capacity,
         capacity_derived=capacity_derived,
         series_count=len(keys) if keys != [""] else 0,
-        # From the rank that was assembled, not re-read: a fresh lookup would
-        # be free to land on a different rank than every field above it.
+        # From the rank that was assembled, not re-read: a fresh lookup would be free to land on a different rank than
+        # every field above it.
         capacity_gb=assembled.get("capacity_gb"),
         retract_total=_series(families, _SGL_RETRACT_TOTAL),
         preempt_total=_series(families, _VLLM_PREEMPT_TOTAL),
@@ -553,17 +425,9 @@ def sample_from_families(
 def resolve_metrics_port(config_envs: dict[str, Any] | None = None) -> int:
     """Resolve the port the engine serves ``/metrics`` on.
 
-    The server binds whatever ``benchmark.envs.PORT`` the materialized YAML
-    pins -- an ephemeral port assigned per session, not a constant -- so the
-    caller's config is the authoritative source and the ambient env is only a
-    fallback for paths that never materialize a YAML.
-
-    Args:
-        config_envs (dict[str, Any] | None): The materialized config's
-            ``benchmark.envs`` mapping, when the caller has it.
-
-    Returns:
-        int: The resolved port, falling back to :data:`DEFAULT_METRICS_PORT`.
+    The server binds whatever ``benchmark.envs.PORT`` the materialized YAML pins -- an ephemeral port assigned per
+    session, not a constant -- so the caller's config is the authoritative source and the ambient env is only a fallback
+    for paths that never materialize a YAML.
     """
     for source in (config_envs or {}, os.environ):
         raw = source.get("PORT")
@@ -581,15 +445,13 @@ def resolve_metrics_port(config_envs: dict[str, Any] | None = None) -> int:
 class KvMetricsPoller:
     """Scrapes one engine's ``/metrics``, degrading quietly when it cannot.
 
-    Built to sit inside the executors' existing 0.5s watchdog loop rather than
-    in a process of its own: a sampler racing the engine for CPU would show up
-    in the very latency numbers the round exists to measure.
+    Built to sit inside the executors' existing 0.5s watchdog loop rather than in a process of its own: a sampler racing
+    the engine for CPU would show up in the very latency numbers the round exists to measure.
 
-    Availability is tri-state and sticky. Until the first successful scrape the
-    poller is ``unknown``; a scrape that lands makes it available for good; a
-    run of consecutive failures parks it as unavailable and it stops issuing
-    requests, because the common cause is an engine started without
-    ``--enable-metrics``, and that will not fix itself mid-round.
+    Availability is tri-state and sticky. Until the first successful scrape the poller is ``unknown``; a scrape that
+    lands makes it available for good; a run of consecutive failures parks it as unavailable and it stops issuing
+    requests, because the common cause is an engine started without ``--enable-metrics``, and that will not fix itself
+    mid-round.
     """
 
     def __init__(
@@ -600,17 +462,7 @@ class KvMetricsPoller:
         config_envs: dict[str, Any] | None = None,
         timeout_sec: float = _SCRAPE_TIMEOUT_SEC,
     ) -> None:
-        """Bind the poller to an endpoint without contacting it.
-
-        Args:
-            port (int | None): Explicit port; resolved from config/env when
-                omitted.
-            host (str): Host to scrape. The engine is process-local on every
-                path that reaches here.
-            config_envs (dict[str, Any] | None): Materialized ``benchmark.envs``
-                used for port resolution.
-            timeout_sec (float): Per-scrape timeout.
-        """
+        """Bind the poller to an endpoint without contacting it."""
         self.port = int(port) if port else resolve_metrics_port(config_envs)
         self.url = f"http://{host}:{self.port}/metrics"
         self.timeout_sec = float(timeout_sec)
@@ -621,14 +473,7 @@ class KvMetricsPoller:
 
     @property
     def available(self) -> bool | None:
-        """Tri-state reachability of the endpoint.
-
-        Returns:
-            bool | None: ``True`` once a scrape has landed, ``False`` once the
-            poller has given up, ``None`` while still unknown. Callers must test
-            with ``is True`` / ``is False``; treating ``None`` as ``False`` would
-            record "no metrics" for a round that simply had not booted yet.
-        """
+        """Tri-state reachability of the endpoint."""
         if self._succeeded:
             return True
         if self._gave_up:
@@ -636,13 +481,7 @@ class KvMetricsPoller:
         return None
 
     def fetch(self) -> str | None:
-        """Scrape once.
-
-        Returns:
-            str | None: The response body, or ``None`` when the endpoint could
-            not be read (including when the poller has already given up). Never
-            raises: this runs alongside a measured benchmark.
-        """
+        """Scrape once."""
         if self._gave_up:
             return None
         try:
@@ -668,12 +507,7 @@ class KvMetricsPoller:
         return body
 
     def sample(self) -> KvSample | None:
-        """Scrape and normalise in one step.
-
-        Returns:
-            KvSample | None: The reading, or ``None`` when the endpoint was
-            unreadable or exposed no KV metric at all.
-        """
+        """Scrape and normalise in one step."""
         body = self.fetch()
         if body is None:
             return None
@@ -684,41 +518,32 @@ class KvMetricsPoller:
 #: Artifact the recorder writes, alongside the round's ``server.log``.
 KV_ARTIFACT_NAME = "kv_metrics.json"
 
-#: Collection phases. An engine process outlives the window that is actually
-#: being measured by a wide margin, and mixing them makes every statistic
-#: meaningless: ``boot`` has no traffic at all, ``warmup`` runs a deliberately
-#: cold cache, and ``eval`` drives accuracy traffic whose shape has nothing to
-#: do with the throughput benchmark. Only ``measured`` may enter a comparison.
+#: Collection phases. An engine process outlives the window that is actually being measured by a wide margin, and mixing
+#: them makes every statistic meaningless: ``boot`` has no traffic at all, ``warmup`` runs a deliberately cold cache,
+#: and ``eval`` drives accuracy traffic whose shape has nothing to do with the throughput benchmark. Only ``measured``
+#: may enter a comparison.
 PHASES = ("boot", "warmup", "measured", "eval")
 
 #: The one phase whose numbers may be compared against another round's.
 _COMPARABLE_PHASE = "measured"
 
-#: Row cap before stride downsampling, mirroring ``_MN_GPU_SAMPLE_CAP``. A
-#: three-hour round at the scrape interval below lands well over this.
+#: Row cap before stride downsampling, mirroring ``_MN_GPU_SAMPLE_CAP``. A three-hour round at the scrape interval below
+#: lands well over this.
 _MAX_STORED_ROWS = 5000
 
-#: Floor between scrapes, enforced on the monotonic clock -- the loop this runs
-#: in iterates faster than its nominal period when a deadline bounds the slice,
-#: so counting passes would sample fastest exactly when the run is most loaded.
+#: Floor between scrapes, enforced on the monotonic clock -- the loop this runs in iterates faster than its nominal
+#: period when a deadline bounds the slice, so counting passes would sample fastest exactly when the run is most loaded.
 #:
-#: Not the loop's 0.5s. A scrape is a synchronous HTTP round trip plus a parse
-#: of the engine's whole exposition, which is not free at that rate, and the
-#: engine's own gauges do not refresh anywhere near it -- most of those samples
-#: would be the same numbers read again. Two seconds keeps the trend visible at
-#: a fraction of the cost. Override with
+#: Not the loop's 0.5s. A scrape is a synchronous HTTP round trip plus a parse of the engine's whole exposition, which
+#: is not free at that rate, and the engine's own gauges do not refresh anywhere near it -- most of those samples would
+#: be the same numbers read again. Two seconds keeps the trend visible at a fraction of the cost. Override with
 #: ``INFERENCE_OPTIMIZER_KV_SCRAPE_INTERVAL_SEC``.
 _SCRAPE_INTERVAL_ENV = "INFERENCE_OPTIMIZER_KV_SCRAPE_INTERVAL_SEC"
 _DEFAULT_SCRAPE_INTERVAL_SEC = 2.0
 
 
 def resolve_scrape_interval_sec() -> float:
-    """Seconds between scrapes, from the environment or the default.
-
-    Returns:
-        float: The interval. A non-numeric or negative setting falls back to
-        the default rather than disabling sampling by accident.
-    """
+    """Seconds between scrapes, from the environment or the default."""
     raw = os.environ.get(_SCRAPE_INTERVAL_ENV, "").strip()
     if not raw:
         return _DEFAULT_SCRAPE_INTERVAL_SEC
@@ -732,27 +557,10 @@ def resolve_scrape_interval_sec() -> float:
 def counter_delta(first: dict[str, dict[str, float]], last: dict[str, dict[str, float]]) -> float | None:
     """Increment of a labelled counter between two observations.
 
-    Diffed per label series rather than on a flat total, because an engine
-    restart zeroes its series: a flat subtraction would go negative, and
-    clamping that to zero would quietly discard the whole window. When a series
-    ends below where it started it is treated as having restarted, and only the
-    post-restart count is credited -- the increments before the restart are
-    genuinely unrecoverable, and inventing them would be worse than losing them.
-
-    Args:
-        first (dict[str, float]): Series readings at window open.
-        last (dict[str, float]): Series readings at window close.
-
-    Per-shard deltas are then combined by :func:`aggregate_series`, so shards of
-    one engine collapse to one count while separate engines add up.
-
-    Args:
-        first (dict[str, dict[str, float]]): Grouped readings at window open.
-        last (dict[str, dict[str, float]]): Grouped readings at window close.
-
-    Returns:
-        float | None: The increment, or ``None`` when the counter was never
-        observed at all -- which is not the same as an increment of zero.
+    Diffed per label series rather than on a flat total, because an engine restart zeroes its series: a flat subtraction
+    would go negative, and clamping that to zero would quietly discard the whole window. When a series ends below where
+    it started it is treated as having restarted, and only the post-restart count is credited -- the increments before
+    the restart are genuinely unrecoverable, and inventing them would be worse than losing them.
     """
     if not first and not last:
         return None
@@ -768,14 +576,12 @@ def counter_delta(first: dict[str, dict[str, float]], last: dict[str, dict[str, 
 class KvMetricsRecorder:
     """Collects phase-tagged KV samples for one benchmark round.
 
-    Owns everything stateful about collection so the watchdog loop it hangs off
-    keeps a single call per pass and one ``finally``. Like the poller, nothing
-    here raises: a recorder that fails must cost the round nothing.
+    Owns everything stateful about collection so the watchdog loop it hangs off keeps a single call per pass and one
+    ``finally``. Like the poller, nothing here raises: a recorder that fails must cost the round nothing.
 
-    The phase machine is driven by markers the loop already detects, plus
-    aiperf's own phase lines under AgentX. It is never inferred from elapsed
-    time, because the boundaries move by tens of minutes between rounds -- an
-    AgentX warmup alone was measured at nearly 18 of them.
+    The phase machine is driven by markers the loop already detects, plus aiperf's own phase lines under AgentX. It is
+    never inferred from elapsed time, because the boundaries move by tens of minutes between rounds -- an AgentX warmup
+    alone was measured at nearly 18 of them.
     """
 
     def __init__(
@@ -786,18 +592,7 @@ class KvMetricsRecorder:
         scope: dict[str, Any] | None = None,
         min_interval_sec: float | None = None,
     ) -> None:
-        """Prepare a recorder without contacting anything.
-
-        Args:
-            poller (KvMetricsPoller): The endpoint reader.
-            output_path (str | None): Where :meth:`close` writes its artifact.
-                ``None`` collects in memory only, which is what the tests and
-                any caller without a workspace want.
-            scope (dict[str, Any] | None): Identity carried into the artifact so
-                a consumer never has to join against another file to learn which
-                variant and round produced it.
-            min_interval_sec (float): Floor between scrapes.
-        """
+        """Prepare a recorder without contacting anything."""
         self._poller = poller
         self._output_path = output_path
         self._scope = dict(scope or {})
@@ -822,20 +617,13 @@ class KvMetricsRecorder:
         return self._phase
 
     def note_phase(self, phase: str, mono: float) -> None:
-        """Record a phase transition.
-
-        Args:
-            phase (str): One of :data:`PHASES`. Anything else is ignored rather
-                than raising -- an unrecognised marker must not end collection.
-            mono (float): Monotonic instant of the transition.
-        """
+        """Record a phase transition."""
         if phase not in PHASES or phase == self._phase:
             return
-        # One reading taken at the boundary closes the phase that is ending and
-        # opens the one beginning. Deriving a phase total from its own first and
-        # last periodic samples instead leaves a gap at each end -- up to a full
-        # interval of activity credited to neither phase -- and the gap lands
-        # exactly where a phase change makes the engine's behaviour change most.
+        # One reading taken at the boundary closes the phase that is ending and opens the one beginning. Deriving a
+        # phase total from its own first and last periodic samples instead leaves a gap at each end -- up to a full
+        # interval of activity credited to neither phase -- and the gap lands exactly where a phase change makes the
+        # engine's behaviour change most.
         boundary = None if self._closed else self._scrape(mono)
         self._phase = phase
         self._phase_marks.append({"phase": phase, "mono": round(float(mono), 3), "ts": time.time()})
@@ -843,11 +631,7 @@ class KvMetricsRecorder:
             self._record_counters(boundary)
 
     def tick(self, mono: float) -> None:
-        """Scrape if the interval has elapsed, tagging the sample with the phase.
-
-        Args:
-            mono (float): The loop's current monotonic instant.
-        """
+        """Scrape if the interval has elapsed, tagging the sample with the phase."""
         if self._closed:
             return
         if self._last_scrape_mono is not None and (mono - self._last_scrape_mono) < self._min_interval:
@@ -857,16 +641,9 @@ class KvMetricsRecorder:
     def _scrape(self, mono: float) -> KvSample | None:
         """Take one reading unconditionally, timing the round trip.
 
-        The duration is recorded per sample because a scrape is a synchronous
-        HTTP call inside a watchdog loop: if it ever starts costing real time,
-        that has to be visible in the artifact rather than inferred from a
-        benchmark that mysteriously slowed down.
-
-        Args:
-            mono (float): The loop's current monotonic instant.
-
-        Returns:
-            KvSample | None: The reading, or ``None`` when nothing was read.
+        The duration is recorded per sample because a scrape is a synchronous HTTP call inside a watchdog loop: if it
+        ever starts costing real time, that has to be visible in the artifact rather than inferred from a benchmark that
+        mysteriously slowed down.
         """
         self._last_scrape_mono = mono
         started = time.monotonic()
@@ -881,38 +658,27 @@ class KvMetricsRecorder:
         return sample
 
     def _absorb(self, sample: KvSample, *, scrape_sec: float = 0.0) -> None:
-        """Fold one sample into the row buffer and the counter windows.
-
-        Args:
-            sample (KvSample): The reading to record.
-            scrape_sec (float): How long the round trip took.
-        """
-        # Pool capacity is only observable while the engine is up; latch the
-        # first non-null reading so the artifact still carries it after a round
-        # that ended with the server gone.
+        """Fold one sample into the row buffer and the counter windows."""
+        # Pool capacity is only observable while the engine is up; latch the first non-null reading so the artifact
+        # still carries it after a round that ended with the server gone.
         if self._capacity_tokens is None and sample.capacity_tokens is not None:
             self._capacity_tokens = sample.capacity_tokens
             self._capacity_derived = sample.capacity_derived
         if self._capacity_gb is None and sample.capacity_gb is not None:
             self._capacity_gb = sample.capacity_gb
         self._series_count = max(self._series_count, sample.series_count)
-        # Every cumulative counter gets the same treatment: bracket the round
-        # and diff. The prefix-cache ones need it as much as the pressure ones,
-        # because under warm reuse the engine outlives the round and its
-        # absolute totals carry the previous round's cache warming.
-        # Bracketed per phase, not per round. An engine keeps retracting through
-        # warmup and the accuracy eval, and a round-wide difference silently
-        # folds both into the one number that is supposed to describe the
-        # measured window alone. The gauge rows carry their phase and can be
-        # re-sliced later; counters cannot, so the split has to happen here.
+        # Every cumulative counter gets the same treatment: bracket the round and diff. The prefix-cache ones need it as
+        # much as the pressure ones, because under warm reuse the engine outlives the round and its absolute totals
+        # carry the previous round's cache warming. Bracketed per phase, not per round. An engine keeps retracting
+        # through warmup and the accuracy eval, and a round-wide difference silently folds both into the one number that
+        # is supposed to describe the measured window alone. The gauge rows carry their phase and can be re-sliced
+        # later; counters cannot, so the split has to happen here.
         self._record_counters(sample)
-        # Every row carries the gauges *and* the cumulative counters, in raw
-        # per-series form. Recording counters only at phase boundaries would
-        # leave the interior of a phase blind: an engine that retracted in one
-        # burst and one that retracted steadily produce the same phase total,
-        # and an engine restart mid-phase is invisible without the series. With
-        # the raw maps present a consumer can difference any two adjacent rows
-        # and does not have to trust this module's aggregation to do it.
+        # Every row carries the gauges *and* the cumulative counters, in raw per-series form. Recording counters only at
+        # phase boundaries would leave the interior of a phase blind: an engine that retracted in one burst and one that
+        # retracted steadily produce the same phase total, and an engine restart mid-phase is invisible without the
+        # series. With the raw maps present a consumer can difference any two adjacent rows and does not have to trust
+        # this module's aggregation to do it.
         self._rows.append(
             {
                 "phase": self._phase,
@@ -925,9 +691,8 @@ class KvMetricsRecorder:
                 "evictable_tokens": sample.evictable_tokens,
                 "available_tokens": sample.available_tokens,
                 "capacity_tokens": sample.capacity_tokens,
-                # Same aggregation rule the summary uses. Rows and summary
-                # disagreeing inside one artifact is worse than either rule
-                # being wrong, because nothing on the page says which is which.
+                # Same aggregation rule the summary uses. Rows and summary disagreeing inside one artifact is worse than
+                # either rule being wrong, because nothing on the page says which is which.
                 "retract_total": aggregate_series(sample.retract_total),
                 "preempt_total": aggregate_series(sample.preempt_total),
                 "counters_by_series": {
@@ -941,11 +706,7 @@ class KvMetricsRecorder:
         )
 
     def _record_counters(self, sample: KvSample) -> None:
-        """Bracket every cumulative counter under the phase in force.
-
-        Args:
-            sample (KvSample): The reading whose counters to record.
-        """
+        """Bracket every cumulative counter under the phase in force."""
         for name, series in (
             ("retract", sample.retract_total),
             ("preempt", sample.preempt_total),
@@ -960,17 +721,7 @@ class KvMetricsRecorder:
             self._last_counters.setdefault(self._phase, {})[name] = snapshot
 
     def _counter_deltas(self, name: str) -> tuple[float | None, dict[str, float | None]]:
-        """Increment of one counter, attributed to the phase that earned it.
-
-        Args:
-            name (str): Counter key used by :meth:`_absorb`.
-
-        Returns:
-            tuple[float | None, dict[str, float | None]]: The measured-phase
-            increment -- the only one that may enter a comparison -- and the
-            full per-phase breakdown. The measured figure is ``None`` when no
-            sample landed in that phase, which is not an increment of zero.
-        """
+        """Increment of one counter, attributed to the phase that earned it."""
         by_phase: dict[str, float | None] = {}
         for phase in PHASES:
             last = self._last_counters.get(phase, {}).get(name)
@@ -982,15 +733,9 @@ class KvMetricsRecorder:
     def _prefix_cache_window(self) -> dict[str, Any]:
         """Prefix-cache increments attributable to this round.
 
-        Each counter is diffed per label series and combined by the shared
-        grouping rule, so two data-parallel engines that served 200 lookups
-        each report 400 rather than 200. Reporting the round's delta rather
-        than the running total is what makes a hit rate belong to the round
-        that earned it.
-
-        Returns:
-            dict[str, Any]: ``<name>_delta`` per counter, plus its per-series
-            endpoints for audit. Empty when no counter was ever read.
+        Each counter is diffed per label series and combined by the shared grouping rule, so two data-parallel engines
+        that served 200 lookups each report 400 rather than 200. Reporting the round's delta rather than the running
+        total is what makes a hit rate belong to the round that earned it.
         """
         window: dict[str, Any] = {}
         for name in ("prefix_cache_queries", "prefix_cache_hits", "cached_tokens_total"):
@@ -1002,31 +747,16 @@ class KvMetricsRecorder:
         return window
 
     def rows(self) -> list[dict[str, Any]]:
-        """Collected rows, stride-downsampled to the row cap.
-
-        Returns:
-            list[dict[str, Any]]: Phase-tagged samples in collection order.
-        """
+        """Collected rows, stride-downsampled to the row cap."""
         if len(self._rows) <= _MAX_STORED_ROWS:
             return list(self._rows)
-        # Round the stride up. Integer division gives 1 for anything under
-        # twice the cap, so 5001 rows would have downsampled to 5001.
+        # Round the stride up. Integer division gives 1 for anything under twice the cap, so 5001 rows would have
+        # downsampled to 5001.
         stride = -(-len(self._rows) // _MAX_STORED_ROWS)
         return self._rows[::stride]
 
     def summary(self, *, aborted: bool = False) -> dict[str, Any]:
-        """Build the artifact payload.
-
-        Args:
-            aborted (bool): Whether the round left through an exception path.
-                Recorded rather than inferred so a consumer can tell a window
-                that closed from one that was cut short.
-
-        Returns:
-            dict[str, Any]: The artifact. ``available`` is tri-state: ``None``
-            means the endpoint was never reached one way or the other, which is
-            not the same as reaching it and finding no pressure.
-        """
+        """Build the artifact payload."""
         retract_measured, retract_by_phase = self._counter_deltas("retract")
         preempt_measured, preempt_by_phase = self._counter_deltas("preempt")
         return {
@@ -1042,10 +772,9 @@ class KvMetricsRecorder:
             "series_count": self._series_count,
             "prefix_cache": self._prefix_cache_window(),
             "phase_marks": self._phase_marks,
-            # The headline figure is the measured phase alone, because that is
-            # the only phase the plan lets into a comparison. The breakdown is
-            # kept beside it so a round that retracted hard during warmup is
-            # still visible rather than rounded away.
+            # The headline figure is the measured phase alone, because that is the only phase the plan lets into a
+            # comparison. The breakdown is kept beside it so a round that retracted hard during warmup is still visible
+            # rather than rounded away.
             "retract_delta": retract_measured,
             "retract_delta_by_phase": retract_by_phase,
             "preempt_delta": preempt_measured,
@@ -1057,18 +786,10 @@ class KvMetricsRecorder:
     def close(self, *, aborted: bool = False) -> dict[str, Any]:
         """Finish collection and write the artifact when a path was given.
 
-        Idempotent: the loop's ``finally`` may run after a caller has already
-        closed explicitly.
-
-        Args:
-            aborted (bool): Whether the round is unwinding through an exception.
-
-        Returns:
-            dict[str, Any]: The artifact payload, written or not.
+        Idempotent: the loop's ``finally`` may run after a caller has already closed explicitly.
         """
-        # Final boundary reading, for the same reason the phase transitions take
-        # one: without it the last phase ends at whenever its last periodic
-        # sample happened to land, and everything after that is lost.
+        # Final boundary reading, for the same reason the phase transitions take one: without it the last phase ends at
+        # whenever its last periodic sample happened to land, and everything after that is lost.
         if not self._closed:
             self._scrape(time.monotonic())
         payload = self.summary(aborted=aborted)
@@ -1083,11 +804,9 @@ class KvMetricsRecorder:
 
             atomic_write_json(Path(self._output_path), payload)
         except Exception:  # noqa: BLE001 - an unwritten artifact must not fail a round
-            # Warning, not debug. Not failing the round is the requirement; being
-            # quiet about it is not. A round that collected samples and then
-            # dropped them on the floor looks identical afterwards to one that
-            # never collected any, and nobody goes looking for a file they were
-            # never told was missing.
+            # Warning, not debug. Not failing the round is the requirement; being quiet about it is not. A round that
+            # collected samples and then dropped them on the floor looks identical afterwards to one that never
+            # collected any, and nobody goes looking for a file they were never told was missing.
             log.warning(
                 "kv_metrics: could not write %s (%d samples collected this round are lost)",
                 self._output_path,

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -11,6 +11,18 @@ float precision instead of the log's two decimals, stable metric names instead o
 type, explicit units, and ``kv_evictable_tokens``, which the log cannot express at all and which is the only way to
 separate the two occupancy readings this module reports (see :class:`KvSample`).
 
+Phase attribution has two sources, and the artifact always says which one it used. Preferred is aiperf's progress API,
+whose ``phases.<name>.start_ns`` is stamped when the phase actually begins; the fallback is the ``aiperf.log`` line the
+watchdog greps for, which is written after the transition and read on the next poll. Both lags land on the boundary, so
+under the fallback the samples either side of it are systematically credited to the phase that just ended. When the
+authoritative stamps are available the rows are re-labelled and the counter windows re-bracketed from them at close --
+which is why every row carries its raw per-series counters, and not just a phase-level first/last pair.
+
+What this does not do is stop the workload at a boundary. An exact counter total needs the client to quiesce, take one
+snapshot, and resume, and aiperf exposes no such control: the boundary here is exact to aiperf's own stamp, and the
+counter attribution to the scrape interval either side of it. Per-trajectory, per-turn and per-request timelines are
+likewise not available -- the progress API reports per phase, so that is the granularity a row records.
+
 Two rules run through everything below:
 
 * **Never raise.** This samples a benchmark that is being measured; a scrape failure must cost the run nothing. Every
@@ -22,6 +34,7 @@ Two rules run through everything below:
 
 from __future__ import annotations
 
+import json
 import logging
 import math
 import os
@@ -29,6 +42,7 @@ import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 
@@ -39,6 +53,7 @@ __all__ = [
     "DEFAULT_METRICS_PORT",
     "KV_ARTIFACT_NAME",
     "PHASES",
+    "AiperfProgressPoller",
     "KvMetricsPoller",
     "KvMetricsRecorder",
     "KvSample",
@@ -515,6 +530,97 @@ class KvMetricsPoller:
         return sample if sample.has_readings() else None
 
 
+#: Address file ``aiperf_client.sh`` publishes so this process can find the progress API. Searched under the round's own
+#: directory first, then one level down, matching how the watchdog resolves a nested benchmark's logs.
+_PROGRESS_ADDRESS_RELPATHS = ("aiperf_artifacts/progress_api.json", "*/aiperf_artifacts/progress_api.json")
+
+#: aiperf's phase names, mapped onto ours. It has no notion of the accuracy eval, which is why ``eval`` is not here and
+#: stays owned by the log markers.
+_AIPERF_PHASE_NAMES = {"warmup": "warmup", "profiling": "measured"}
+
+#: How far an authoritative timestamp may sit from this process's clock before it is rejected. Wide, because it is only
+#: meant to catch a clock domain that is not the Unix epoch at all -- a monotonic ``start_ns`` is off by decades, not by
+#: hours -- rather than to police skew.
+_PROGRESS_CLOCK_SANITY_SEC = 86400.0
+
+
+def _number(raw: Any) -> float | None:
+    """Coerce a JSON value to a float, or ``None`` when it is not one.
+
+    ``bool`` is excluded on purpose: it is a subclass of ``int``, and a ``True`` where a timestamp belongs would
+    otherwise become 1.0 -- a Unix time in 1970 that the sanity check would then reject for the wrong reason.
+    """
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        return None
+    return float(raw) if math.isfinite(raw) else None
+
+
+class AiperfProgressPoller:
+    """Reads AIPerf's phase timeline from its local progress API.
+
+    This is the authority on when a phase actually began. The alternative -- and what the recorder falls back to -- is
+    grepping ``aiperf.log`` for a human-readable line, which aiperf writes after the transition and the watchdog then
+    reads on its next pass. Those two lags land squarely on the boundary, so warmup traffic gets counted as measured.
+
+    Everything here degrades to ``None``: the endpoint only exists when the round is an AgentX one whose client managed
+    to publish an address, and a round that cannot reach it must still produce KV metrics.
+    """
+
+    def __init__(self, workspace: Any, *, timeout_sec: float = _SCRAPE_TIMEOUT_SEC) -> None:
+        """Bind to a round's directory without reading anything from it."""
+        self._workspace = workspace
+        self.timeout_sec = float(timeout_sec)
+        self.url: str | None = None
+        self._resolved = False
+        self._failures = 0
+        self._succeeded = False
+        self._gave_up = False
+
+    def _resolve_url(self) -> str | None:
+        """Find the published address, once the client has written it.
+
+        Resolution is retried until it succeeds because the address file appears when the benchmark client starts, which
+        is after the server is up and therefore after the first scrapes have already happened.
+        """
+        if self.url is not None:
+            return self.url
+        try:
+            root = Path(self._workspace)
+            for pattern in _PROGRESS_ADDRESS_RELPATHS:
+                for candidate in sorted(root.glob(pattern)):
+                    payload = json.loads(candidate.read_text(encoding="utf-8"))
+                    url = payload.get("url") if isinstance(payload, dict) else None
+                    if isinstance(url, str) and url.startswith("http"):
+                        self.url = url
+                        return url
+        except (OSError, ValueError, TypeError):
+            return None
+        return None
+
+    def poll(self) -> dict[str, Any] | None:
+        """Return the raw ``phases`` mapping, or ``None`` when it cannot be read."""
+        if self._gave_up:
+            return None
+        url = self._resolve_url()
+        if url is None:
+            return None
+        try:
+            with _OPENER.open(f"{url.rstrip('/')}/api/progress", timeout=self.timeout_sec) as response:
+                payload = json.loads(response.read().decode("utf-8", "ignore"))
+        except (urllib.error.URLError, OSError, ValueError) as exc:
+            self._failures += 1
+            # Only give up on an endpoint that never worked. One that answered before and is failing now is an aiperf
+            # that has exited, and the timeline already collected is still the authority for this round.
+            if self._failures >= _MAX_CONSECUTIVE_FAILURES and not self._succeeded:
+                self._gave_up = True
+                log.debug("kv_metrics: aiperf progress API unreachable at %s (%s)", url, exc)
+            return None
+        self._failures = 0
+        self._succeeded = True
+        phases = payload.get("phases") if isinstance(payload, dict) else None
+        return phases if isinstance(phases, dict) else None
+
+
 #: Artifact the recorder writes, alongside the round's ``server.log``.
 KV_ARTIFACT_NAME = "kv_metrics.json"
 
@@ -591,12 +697,15 @@ class KvMetricsRecorder:
         output_path: str | None = None,
         scope: dict[str, Any] | None = None,
         min_interval_sec: float | None = None,
+        progress: AiperfProgressPoller | None = None,
     ) -> None:
         """Prepare a recorder without contacting anything."""
         self._poller = poller
         self._output_path = output_path
         self._scope = dict(scope or {})
         self._min_interval = resolve_scrape_interval_sec() if min_interval_sec is None else float(min_interval_sec)
+        self._progress = progress
+        self._phase_timeline: dict[str, dict[str, Any]] = {}
         self._phase = "boot"
         self._rows: list[dict[str, Any]] = []
         self._last_scrape_mono: float | None = None
@@ -641,23 +750,76 @@ class KvMetricsRecorder:
     def _scrape(self, mono: float) -> KvSample | None:
         """Take one reading unconditionally, timing the round trip.
 
-        The duration is recorded per sample because a scrape is a synchronous HTTP call inside a watchdog loop: if it
-        ever starts costing real time, that has to be visible in the artifact rather than inferred from a benchmark that
-        mysteriously slowed down.
+        Both ends of the round trip are recorded, not just the duration. A gauge read over a 300 ms scrape describes
+        some instant inside that window and the consumer cannot say which, so a bracket is the honest representation;
+        a single stamp would invite lining KV samples up against a workload timeline to a precision that was never
+        measured.
         """
         self._last_scrape_mono = mono
-        started = time.monotonic()
+        # Polled first, and regardless of whether the engine answers: the phase timeline is what makes any of the rows
+        # comparable, and an engine that is briefly unreachable must not cost us the boundary.
+        workload = self._poll_progress()
+        start_mono = time.monotonic()
+        start_unix = time.time()
         try:
             sample = self._poller.sample()
         except Exception:  # noqa: BLE001 - collection must never fail a round
             log.debug("kv_metrics: sample failed", exc_info=True)
             return None
+        end_mono = time.monotonic()
         if sample is None:
             return None
-        self._absorb(sample, scrape_sec=time.monotonic() - started)
+        self._absorb(
+            sample,
+            timing={
+                "scrape_start_unix": round(start_unix, 3),
+                "scrape_end_unix": round(start_unix + (end_mono - start_mono), 3),
+                "scrape_start_mono": round(start_mono, 3),
+                "scrape_end_mono": round(end_mono, 3),
+                "scrape_sec": round(end_mono - start_mono, 4),
+            },
+            workload=workload,
+        )
         return sample
 
-    def _absorb(self, sample: KvSample, *, scrape_sec: float = 0.0) -> None:
+    def _poll_progress(self) -> dict[str, Any] | None:
+        """Fold one progress reading into the timeline and return the phase in flight.
+
+        The timeline accumulates rather than replaces: aiperf drops a phase from its report once the next one begins, so
+        keeping only the latest response would lose the warmup boundary the moment profiling starts.
+        """
+        if self._progress is None:
+            return None
+        try:
+            phases = self._progress.poll()
+        except Exception:  # noqa: BLE001 - collection must never fail a round
+            log.debug("kv_metrics: progress poll failed", exc_info=True)
+            return None
+        if not phases:
+            return None
+        active: dict[str, Any] | None = None
+        active_start = -1.0
+        for name, stats in phases.items():
+            if not isinstance(stats, dict):
+                continue
+            self._phase_timeline.setdefault(name, {}).update(stats)
+            start_ns = _number(stats.get("start_ns"))
+            if start_ns is None or stats.get("requests_end_ns") is not None:
+                continue
+            if start_ns > active_start:
+                active_start = start_ns
+                # Timestamps live in the timeline; a row only needs to say which phase it fell in and how much work was
+                # in flight, which is the granularity aiperf actually exposes.
+                active = {"aiperf_phase": name, "stats": {k: v for k, v in stats.items() if not k.endswith("_ns")}}
+        return active
+
+    def _absorb(
+        self,
+        sample: KvSample,
+        *,
+        timing: dict[str, float] | None = None,
+        workload: dict[str, Any] | None = None,
+    ) -> None:
         """Fold one sample into the row buffer and the counter windows."""
         # Pool capacity is only observable while the engine is up; latch the first non-null reading so the artifact
         # still carries it after a round that ended with the server gone.
@@ -679,12 +841,17 @@ class KvMetricsRecorder:
         # retracted steadily produce the same phase total, and an engine restart mid-phase is invisible without the
         # series. With the raw maps present a consumer can difference any two adjacent rows and does not have to trust
         # this module's aggregation to do it.
+        row = {
+            "phase": self._phase,
+            "ts": round(sample.ts, 3),
+            "mono": round(sample.mono, 3),
+            **(timing or {"scrape_sec": 0.0}),
+        }
+        if workload is not None:
+            row["workload"] = workload
         self._rows.append(
             {
-                "phase": self._phase,
-                "ts": round(sample.ts, 3),
-                "mono": round(sample.mono, 3),
-                "scrape_sec": round(scrape_sec, 4),
+                **row,
                 "active_pool_usage": sample.active_pool_usage,
                 "physical_pool_usage": sample.physical_pool_usage,
                 "used_tokens": sample.used_tokens,
@@ -746,6 +913,106 @@ class KvMetricsRecorder:
             window[f"{name}_delta_by_phase"] = by_phase
         return window
 
+    def _authoritative_bounds(self) -> dict[str, tuple[float, float | None]] | None:
+        """Phase windows in Unix seconds, from aiperf's own stamps, or ``None`` when unusable.
+
+        ``start_ns`` is rejected rather than trusted blindly when it does not land near this process's wall clock. The
+        API reports nanoseconds but does not say from which epoch, and a monotonic reading would silently place every
+        boundary in 1970 and re-attribute the whole round to one phase.
+        """
+        if not self._phase_timeline:
+            return None
+        now = time.time()
+        bounds: dict[str, tuple[float, float | None]] = {}
+        for name, stats in self._phase_timeline.items():
+            phase = _AIPERF_PHASE_NAMES.get(name)
+            start_ns = _number(stats.get("start_ns"))
+            if phase is None or start_ns is None or start_ns <= 0:
+                continue
+            start = start_ns / 1e9
+            if abs(start - now) > _PROGRESS_CLOCK_SANITY_SEC:
+                return None
+            end_ns = _number(stats.get("requests_end_ns"))
+            end = end_ns / 1e9 if end_ns and end_ns > 0 else None
+            if end is not None and end < start:
+                return None
+            bounds[phase] = (start, end)
+        return bounds or None
+
+    def _reattribute_phases(self) -> dict[str, Any]:
+        """Re-label rows from the authoritative timeline, reporting what was used.
+
+        Re-labelling after the fact is what makes the boundary exact. A row is stamped with whatever phase the watchdog
+        believed at the time, and the watchdog only learns of a transition once aiperf has written a log line and the
+        next poll has read it -- so the rows straddling a boundary are systematically attributed to the phase that just
+        ended. The stamps say when the phase actually began, so the correction is applied to the stored rows.
+
+        ``eval`` is never overwritten. It is the accuracy run, which aiperf has no part in and no opinion about.
+        """
+        bounds = self._authoritative_bounds()
+        if bounds is None:
+            return {"phase_source": "log_markers", "phase_timeline": self._phase_timeline or None}
+        # Latest-starting window wins, so a row inside profiling is not also claimed by warmup, whose end the API leaves
+        # null until its requests drain.
+        ordered = sorted(bounds.items(), key=lambda item: item[1][0], reverse=True)
+        moved = 0
+        for row in self._rows:
+            if row.get("phase") == "eval":
+                continue
+            ts = _number(row.get("ts"))
+            if ts is None:
+                continue
+            for phase, (start, end) in ordered:
+                if ts >= start and (end is None or ts <= end):
+                    if row["phase"] != phase:
+                        row["phase"] = phase
+                        moved += 1
+                    break
+        self._rebuild_counter_windows()
+        return {
+            "phase_source": "aiperf_progress_api",
+            "phase_timeline": self._phase_timeline,
+            "phase_bounds_unix": {p: {"start": s, "requests_end": e} for p, (s, e) in bounds.items()},
+            "rows_reattributed": moved,
+        }
+
+    def _rebuild_counter_windows(self) -> None:
+        """Re-bracket every counter from the re-attributed rows.
+
+        Re-labelling the rows alone would leave the phase totals wrong, which is the whole point of the exercise: the
+        windows were closed when the watchdog *noticed* a transition, so the increments earned in the lag were already
+        booked to the phase that had ended. Every row carries its raw per-series counters precisely so the windows can
+        be rebuilt from them once the true boundary is known.
+
+        Adjacent phases share the snapshot at their boundary -- the reading that closes one opens the next -- so this
+        keeps the gap-free property the boundary scrapes give, rather than trading it for accuracy.
+        """
+        ordered = [r for r in self._rows if isinstance(r.get("counters_by_series"), dict)]
+        if not ordered:
+            return
+        first: dict[str, dict[str, dict[str, dict[str, float]]]] = {}
+        last: dict[str, dict[str, dict[str, dict[str, float]]]] = {}
+
+        def _apply(phase: str, row: dict[str, Any], *, opening: bool) -> None:
+            """Record one row's counters as a window edge for ``phase``."""
+            for name, series in (row.get("counters_by_series") or {}).items():
+                if not series:
+                    continue
+                snapshot = {g: dict(s) for g, s in series.items()}
+                if opening:
+                    first.setdefault(phase, {}).setdefault(name, snapshot)
+                else:
+                    last.setdefault(phase, {})[name] = snapshot
+
+        _apply(ordered[0]["phase"], ordered[0], opening=True)
+        for previous, row in zip(ordered, ordered[1:]):
+            if row["phase"] != previous["phase"]:
+                _apply(previous["phase"], row, opening=False)
+                _apply(row["phase"], row, opening=True)
+            _apply(row["phase"], row, opening=False)
+        self._first_counters = first
+        self._last_counters = last
+
     def rows(self) -> list[dict[str, Any]]:
         """Collected rows, stride-downsampled to the row cap."""
         if len(self._rows) <= _MAX_STORED_ROWS:
@@ -757,9 +1024,13 @@ class KvMetricsRecorder:
 
     def summary(self, *, aborted: bool = False) -> dict[str, Any]:
         """Build the artifact payload."""
+        # First: it re-labels rows and re-brackets the counter windows the deltas below are read from, so the rows, the
+        # phase totals and the timeline in one artifact cannot disagree with each other.
+        attribution = self._reattribute_phases()
         retract_measured, retract_by_phase = self._counter_deltas("retract")
         preempt_measured, preempt_by_phase = self._counter_deltas("preempt")
         return {
+            **attribution,
             "schema_version": 1,
             "source": "metrics",
             "url": self._poller.url,

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -18,10 +18,13 @@ under the fallback the samples either side of it are systematically credited to 
 authoritative stamps are available the rows are re-labelled and the counter windows re-bracketed from them at close --
 which is why every row carries its raw per-series counters, and not just a phase-level first/last pair.
 
+Below the phase, the workload timeline comes from aiperf's per-request export; see :mod:`._agentx_timeline`. That gives
+each row the trajectories, turns and requests in flight during its scrape window, and writes the event stream beside
+this artifact.
+
 What this does not do is stop the workload at a boundary. An exact counter total needs the client to quiesce, take one
 snapshot, and resume, and aiperf exposes no such control: the boundary here is exact to aiperf's own stamp, and the
-counter attribution to the scrape interval either side of it. Per-trajectory, per-turn and per-request timelines are
-likewise not available -- the progress API reports per phase, so that is the granularity a row records.
+counter attribution to the scrape interval either side of it.
 
 Two rules run through everything below:
 
@@ -698,10 +701,14 @@ class KvMetricsRecorder:
         scope: dict[str, Any] | None = None,
         min_interval_sec: float | None = None,
         progress: AiperfProgressPoller | None = None,
+        workspace: Any = None,
     ) -> None:
         """Prepare a recorder without contacting anything."""
         self._poller = poller
         self._output_path = output_path
+        # The round's own directory, which is where both aiperf's export and our artifacts live. Derived from the
+        # output path when not given, so the two can never point at different rounds.
+        self._workspace = workspace if workspace is not None else (Path(output_path).parent if output_path else None)
         self._scope = dict(scope or {})
         self._min_interval = resolve_scrape_interval_sec() if min_interval_sec is None else float(min_interval_sec)
         self._progress = progress
@@ -1013,6 +1020,43 @@ class KvMetricsRecorder:
         self._first_counters = first
         self._last_counters = last
 
+    def _build_workload_timeline(self) -> dict[str, Any] | None:
+        """Emit the AgentX event stream and fold the in-flight work into the rows.
+
+        Read from aiperf's own per-request export rather than asked of it: ``profile_export.jsonl`` is written at the
+        default export level, so every AgentX round already has one. A round that has none -- any synthetic benchmark,
+        or an AgentX round killed before aiperf flushed -- simply reports ``None``.
+        """
+        if self._workspace is None:
+            return None
+        try:
+            from ._agentx_timeline import (
+                TIMELINE_ARTIFACT_NAME,
+                build_events,
+                correlate_rows,
+                find_profile_export,
+                parse_profile_export,
+                write_timeline,
+            )
+
+            export = find_profile_export(self._workspace)
+            if export is None:
+                return None
+            records = parse_profile_export(export)
+            if not records:
+                return None
+            events, summary = build_events(records, self._authoritative_bounds())
+            # Correlation runs over every record, so the counts on a row stay exact even when the event stream above
+            # had to be sampled.
+            summary["rows_correlated"] = correlate_rows(self._rows, records)
+            path = Path(self._workspace) / TIMELINE_ARTIFACT_NAME
+            summary["path"] = path.name if write_timeline(path, events) else None
+            summary["source"] = str(export)
+            return summary
+        except Exception:  # noqa: BLE001 - a timeline must never fail a round
+            log.debug("kv_metrics: workload timeline unavailable", exc_info=True)
+            return None
+
     def rows(self) -> list[dict[str, Any]]:
         """Collected rows, stride-downsampled to the row cap."""
         if len(self._rows) <= _MAX_STORED_ROWS:
@@ -1027,10 +1071,13 @@ class KvMetricsRecorder:
         # First: it re-labels rows and re-brackets the counter windows the deltas below are read from, so the rows, the
         # phase totals and the timeline in one artifact cannot disagree with each other.
         attribution = self._reattribute_phases()
+        # After attribution, so the phase events in the timeline are the same boundaries the rows were labelled by.
+        workload = self._build_workload_timeline()
         retract_measured, retract_by_phase = self._counter_deltas("retract")
         preempt_measured, preempt_by_phase = self._counter_deltas("preempt")
         return {
             **attribution,
+            "workload_timeline": workload,
             "schema_version": 1,
             "source": "metrics",
             "url": self._poller.url,

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -91,11 +91,16 @@ _MAX_CONSECUTIVE_FAILURES = 3
 _SGL_USAGE = ("sglang:token_usage", "sglang:full_token_usage", "sglang:swa_token_usage")
 _SGL_USED = "sglang:kv_used_tokens"
 _SGL_AVAILABLE = "sglang:kv_available_tokens"
-_SGL_EVICTABLE = (
-    "sglang:kv_evictable_tokens",
-    "sglang:swa_evictable_tokens",
-    "sglang:mamba_evictable_tokens",
-)
+# Only the main KV pool's evictable count. The SWA and Mamba pools have their
+# own capacities, and ``kv_used_tokens`` / ``kv_available_tokens`` describe the
+# main pool alone -- folding the other pools' evictable tokens into a ratio
+# built from main-pool numerators mixes two different denominators.
+_SGL_EVICTABLE = "sglang:kv_evictable_tokens"
+# Pool capacity as the engine reports it. Preferred over deriving it, because
+# used + available + evictable can fall short of the true size: the gap is
+# tokens held in reserve (protected / session-held), and deriving would both
+# understate capacity and overstate the physical occupancy computed from it.
+_SGL_CAPACITY_TOKENS = "sglang:max_total_num_tokens"
 _SGL_CAPACITY_GB = "sglang:kv_cache_memory_usage_gb"
 # Cumulative retract counter. NOT ``sglang:num_retracted_reqs``, which is the
 # most recent batch's instantaneous gauge and carries a ``pid`` label; the two
@@ -231,7 +236,18 @@ def parse_prometheus_text(text: str) -> ParsedFamilies:
 
 
 def _scalar(families: ParsedFamilies, name: str) -> float | None:
-    """Read a single-series gauge, summing across label sets when several exist.
+    """Read a gauge, taking the largest reading when several series exist.
+
+    **Never sums.** A sharded engine exposes one series per rank
+    (``tp_rank`` / ``pp_rank`` / ``dp_rank``), and every one of them describes
+    the same pool from its own side: the ranks hold different head slices of
+    the same tokens, so their capacities and occupancies are views, not parts.
+    Adding them turns an 85%-full pool on TP=8 into an occupancy of 6.8 and
+    multiplies capacity eightfold -- the same mistake the log path guards
+    against by de-duplicating capacity lines per rank.
+
+    Max rather than first-rank so an imbalanced deployment reports its most
+    pressured rank, which is the one that will retract.
 
     Args:
         families (ParsedFamilies): Parsed exposition.
@@ -244,7 +260,7 @@ def _scalar(families: ParsedFamilies, name: str) -> float | None:
     series = families.get(name)
     if not series:
         return None
-    return sum(value for _, value in series)
+    return max(value for _, value in series)
 
 
 def _max_scalar(families: ParsedFamilies, names: tuple[str, ...]) -> float | None:
@@ -261,18 +277,21 @@ def _max_scalar(families: ParsedFamilies, names: tuple[str, ...]) -> float | Non
     return max(values) if values else None
 
 
-def _sum_scalar(families: ParsedFamilies, names: tuple[str, ...]) -> float | None:
-    """Sum of several gauges, ignoring the ones not present.
+def _series_count(families: ParsedFamilies, names: tuple[str, ...]) -> int:
+    """How many label series the largest of these metrics carried.
+
+    Surfaced in the artifact so a consumer can tell a single-rank reading from
+    a collapsed multi-rank one, and judge for itself whether the aggregation
+    rule above was the right one for its deployment.
 
     Args:
         families (ParsedFamilies): Parsed exposition.
-        names (tuple[str, ...]): Metric names to add.
+        names (tuple[str, ...]): Metric names to inspect.
 
     Returns:
-        float | None: The sum, or ``None`` when none of the names appeared.
+        int: The largest series count among the named metrics; 0 when absent.
     """
-    values = [v for name in names if (v := _scalar(families, name)) is not None]
-    return sum(values) if values else None
+    return max((len(families.get(name) or ()) for name in names), default=0)
 
 
 def _series(families: ParsedFamilies, name: str) -> dict[str, float]:
@@ -311,8 +330,16 @@ class KvSample:
         evictable_tokens (float | None): Tokens the prefix cache holds and would
             hand back under pressure.
         available_tokens (float | None): Tokens free outright.
-        capacity_tokens (float | None): Pool size, derived as used + available +
-            evictable. Not read from a gauge because none reports it directly.
+        capacity_tokens (float | None): Pool size in tokens, read from the
+            engine when it reports one.
+        capacity_derived (bool): True when ``capacity_tokens`` had to be summed
+            from used + available + evictable because no capacity gauge was
+            exposed. That sum can fall short of the real pool -- tokens held in
+            reserve belong to none of the three -- so a derived capacity makes
+            ``physical_pool_usage`` an upper bound rather than a measurement.
+        series_count (int): Label series the occupancy gauge carried. Greater
+            than one means a sharded engine reported per-rank views that were
+            collapsed to their maximum; see :func:`_scalar`.
         capacity_gb (float | None): Pool size in GiB as the engine reports it.
             The engine's "GB" is 1024-based; do not rescale it.
         retract_total (dict[str, float]): SGLang cumulative retracts, per label
@@ -335,6 +362,8 @@ class KvSample:
     evictable_tokens: float | None = None
     available_tokens: float | None = None
     capacity_tokens: float | None = None
+    capacity_derived: bool = False
+    series_count: int = 0
     capacity_gb: float | None = None
     retract_total: dict[str, float] = field(default_factory=dict)
     preempt_total: dict[str, float] = field(default_factory=dict)
@@ -400,11 +429,16 @@ def sample_from_families(
     engine = _detect_engine(families)
     used = _scalar(families, _SGL_USED)
     available = _scalar(families, _SGL_AVAILABLE)
-    evictable = _sum_scalar(families, _SGL_EVICTABLE)
+    evictable = _scalar(families, _SGL_EVICTABLE)
 
-    capacity: float | None = None
-    if used is not None and available is not None:
+    # Engine-reported capacity wins; the sum is a fallback for builds that do
+    # not expose it, and is marked as derived so a consumer knows it may run
+    # short of the true pool size.
+    capacity = _scalar(families, _SGL_CAPACITY_TOKENS)
+    capacity_derived = False
+    if capacity is None and used is not None and available is not None:
         capacity = used + available + (evictable or 0.0)
+        capacity_derived = True
 
     physical: float | None = None
     if capacity and capacity > 0 and used is not None:
@@ -424,6 +458,8 @@ def sample_from_families(
         evictable_tokens=evictable,
         available_tokens=available,
         capacity_tokens=capacity,
+        capacity_derived=capacity_derived,
+        series_count=_series_count(families, _SGL_USAGE + _VLLM_USAGE),
         capacity_gb=_scalar(families, _SGL_CAPACITY_GB),
         retract_total=_series(families, _SGL_RETRACT_TOTAL),
         preempt_total=_series(families, _VLLM_PREEMPT_TOTAL),
@@ -598,17 +634,30 @@ def counter_delta(first: dict[str, float], last: dict[str, float]) -> float | No
         first (dict[str, float]): Series readings at window open.
         last (dict[str, float]): Series readings at window close.
 
+    Series are combined by **max, not sum**, for the same reason gauges are: a
+    sharded engine reports one series per rank and the ranks retract in
+    lockstep, so eight series carrying 48 describe 48 events, not 384. This
+    under-counts a deployment whose series really are independent engines;
+    that trade is deliberate, because an inflated pressure count would send the
+    optimizer chasing a bottleneck that is not there, while an under-count only
+    understates one that is. ``series_count`` on the sample says which case a
+    reading came from.
+
+    Args:
+        first (dict[str, float]): Series readings at window open.
+        last (dict[str, float]): Series readings at window close.
+
     Returns:
-        float | None: Total increment, or ``None`` when the counter was never
+        float | None: The increment, or ``None`` when the counter was never
         observed at all -- which is not the same as an increment of zero.
     """
     if not first and not last:
         return None
-    total = 0.0
+    deltas: list[float] = []
     for key, end in last.items():
         start = first.get(key)
-        total += end if start is None or end < start else end - start
-    return total
+        deltas.append(end if start is None or end < start else end - start)
+    return max(deltas) if deltas else 0.0
 
 
 class KvMetricsRecorder:
@@ -655,7 +704,10 @@ class KvMetricsRecorder:
         self._first_counters: dict[str, dict[str, float]] = {}
         self._last_counters: dict[str, dict[str, float]] = {}
         self._capacity_tokens: float | None = None
+        self._capacity_derived = False
         self._capacity_gb: float | None = None
+        self._series_count = 0
+        self._prefix_cache: dict[str, float] = {}
         self._closed = False
 
     @property
@@ -707,8 +759,17 @@ class KvMetricsRecorder:
         # that ended with the server gone.
         if self._capacity_tokens is None and sample.capacity_tokens is not None:
             self._capacity_tokens = sample.capacity_tokens
+            self._capacity_derived = sample.capacity_derived
         if self._capacity_gb is None and sample.capacity_gb is not None:
             self._capacity_gb = sample.capacity_gb
+        self._series_count = max(self._series_count, sample.series_count)
+        # Prefix-cache counters are cumulative, so the newest reading is the
+        # whole story; keeping the latest non-null avoids a column of repeats
+        # in every row.
+        for attr in ("prefix_cache_queries", "prefix_cache_hits", "cached_tokens_total"):
+            value = getattr(sample, attr)
+            if value is not None:
+                self._prefix_cache[attr] = value
         for name, series in (("retract", sample.retract_total), ("preempt", sample.preempt_total)):
             if not series:
                 continue
@@ -736,7 +797,9 @@ class KvMetricsRecorder:
         """
         if len(self._rows) <= _MAX_STORED_ROWS:
             return list(self._rows)
-        stride = max(1, len(self._rows) // _MAX_STORED_ROWS)
+        # Round the stride up. Integer division gives 1 for anything under
+        # twice the cap, so 5001 rows would have downsampled to 5001.
+        stride = -(-len(self._rows) // _MAX_STORED_ROWS)
         return self._rows[::stride]
 
     def summary(self, *, aborted: bool = False) -> dict[str, Any]:
@@ -760,7 +823,10 @@ class KvMetricsRecorder:
             "aborted": bool(aborted),
             "scope": self._scope,
             "capacity_tokens": self._capacity_tokens,
+            "capacity_derived": self._capacity_derived,
             "capacity_gb": self._capacity_gb,
+            "series_count": self._series_count,
+            "prefix_cache": dict(self._prefix_cache),
             "phase_marks": self._phase_marks,
             "retract_delta": counter_delta(
                 self._first_counters.get("retract", {}),
@@ -798,5 +864,15 @@ class KvMetricsRecorder:
 
             atomic_write_json(Path(self._output_path), payload)
         except Exception:  # noqa: BLE001 - an unwritten artifact must not fail a round
-            log.debug("kv_metrics: could not write %s", self._output_path, exc_info=True)
+            # Warning, not debug. Not failing the round is the requirement; being
+            # quiet about it is not. A round that collected samples and then
+            # dropped them on the floor looks identical afterwards to one that
+            # never collected any, and nobody goes looking for a file they were
+            # never told was missing.
+            log.warning(
+                "kv_metrics: could not write %s (%d samples collected this round are lost)",
+                self._output_path,
+                len(self._rows),
+                exc_info=True,
+            )
         return payload

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -11,6 +11,13 @@ float precision instead of the log's two decimals, stable metric names instead o
 type, explicit units, and ``kv_evictable_tokens``, which the log cannot express at all and which is the only way to
 separate the two occupancy readings this module reports (see :class:`KvSample`).
 
+There are two collectors, and the artifact says which one produced its rows in ``sample_source``. On an AgentX round
+aiperf is already scraping the same endpoint for its own purposes, so its export is adopted wholesale: it samples on a
+tighter cadence, takes a reading at each phase boundary of its own accord, and stamps every record with the phase from
+the process that owns the transition -- which removes the boundary lag rather than correcting for it. Everything else
+-- synthetic benchmarks, the accuracy eval, boot, and any round killed before aiperf flushed -- has no such export, and
+is covered by scraping from the watchdog loop below.
+
 Phase attribution has two sources, and the artifact always says which one it used. Preferred is aiperf's progress API,
 whose ``phases.<name>.start_ns`` is stamped when the phase actually begins; the fallback is the ``aiperf.log`` line the
 watchdog greps for, which is written after the transition and read on the next poll. Both lags land on the boundary, so
@@ -62,7 +69,10 @@ __all__ = [
     "KvSample",
     "canonical_label_key",
     "counter_delta",
+    "families_from_aiperf_record",
+    "find_server_metrics_export",
     "parse_prometheus_text",
+    "read_aiperf_server_metrics",
     "resolve_metrics_port",
     "sample_from_families",
 ]
@@ -179,6 +189,111 @@ def _split_labels(raw: str) -> dict[str, str]:
             labels[name] = "".join(chars)
         index = cursor + 1
     return labels
+
+
+#: aiperf's own export of the engine's ``/metrics``, written into the round's artifact dir.
+_SERVER_METRICS_RELPATHS = (
+    "aiperf_artifacts/server_metrics_export.jsonl",
+    "*/aiperf_artifacts/server_metrics_export.jsonl",
+)
+
+#: aiperf's ``CreditPhase`` values, mapped onto ours. It has no notion of the accuracy eval or of boot, which is why the
+#: live path still covers those.
+_CREDIT_PHASE_NAMES = {"warmup": "warmup", "profiling": "measured"}
+
+
+def families_from_aiperf_record(metrics: Any) -> ParsedFamilies:
+    """Rebuild the parser's internal shape from one aiperf scrape record.
+
+    aiperf stores ``{name: [{"labels": {...}, "value": x}]}``, which is the same information
+    :func:`parse_prometheus_text` produces from the raw exposition -- crucially including the labels, without which the
+    per-rank assembly below could not be done at all. Rebuilding rather than re-deriving means both sources go through
+    one normalisation, so an aiperf-fed round and a live-scraped one cannot disagree about what a number means.
+    """
+    families: ParsedFamilies = {}
+    if not isinstance(metrics, dict):
+        return families
+    for name, samples in metrics.items():
+        if not isinstance(samples, list):
+            continue
+        for sample in samples:
+            if not isinstance(sample, dict):
+                continue
+            value = _number(sample.get("value"))
+            if value is None:  # histograms carry buckets instead, and are not read here
+                continue
+            labels = sample.get("labels")
+            families.setdefault(str(name), []).append(
+                ({str(k): str(v) for k, v in labels.items()} if isinstance(labels, dict) else {}, value)
+            )
+    return families
+
+
+def find_server_metrics_export(workspace: Any) -> Path | None:
+    """Locate aiperf's server-metrics export under a round's directory."""
+    try:
+        root = Path(workspace)
+        for pattern in _SERVER_METRICS_RELPATHS:
+            for candidate in sorted(root.glob(pattern)):
+                if candidate.is_file():
+                    return candidate
+    except OSError:
+        return None
+    return None
+
+
+def read_aiperf_server_metrics(path: Path) -> list[tuple[KvSample, dict[str, Any], str | None]]:
+    """Read aiperf's scrape records as ``(sample, timing, phase)``, oldest first.
+
+    Every field the live path measures for itself is already on the record: ``timestamp_ns`` for the reading,
+    ``request_sent_ns`` and ``endpoint_latency_ns`` for the round trip, and ``benchmark_phase`` for the phase. That last
+    one is why this source is preferred where it exists -- aiperf stamps the phase at collection time, from the process
+    that owns the transition, so there is no lag between the boundary and the label and nothing to re-attribute.
+    """
+    out: list[tuple[KvSample, dict[str, Any], str | None]] = []
+    try:
+        with path.open(encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                stamp = _number(record.get("timestamp_ns"))
+                if stamp is None or stamp <= 0:
+                    continue
+                families = families_from_aiperf_record(record.get("metrics"))
+                if not families:
+                    continue
+                ts = stamp / 1e9
+                sample = sample_from_families(families, ts=ts, mono=ts)
+                if not sample.has_readings():
+                    continue
+                started = _number(record.get("request_sent_ns"))
+                latency = _number(record.get("endpoint_latency_ns")) or 0.0
+                start_unix = started / 1e9 if started and started > 0 else ts
+                out.append(
+                    (
+                        sample,
+                        {
+                            # Widened to the enclosing millisecond for the same reason the live path does it: these
+                            # bound the interval workload records are joined against.
+                            "scrape_start_unix": math.floor(start_unix * 1000) / 1000,
+                            "scrape_end_unix": math.ceil((start_unix + latency / 1e9) * 1000) / 1000,
+                            "scrape_sec": round(latency / 1e9, 4),
+                        },
+                        _CREDIT_PHASE_NAMES.get(str(record.get("benchmark_phase") or "").lower()),
+                    )
+                )
+    except OSError as exc:
+        log.debug("kv_metrics: could not read %s (%s)", path, exc)
+        return []
+    out.sort(key=lambda item: item[0].ts)
+    return out
 
 
 def parse_prometheus_text(text: str) -> ParsedFamilies:
@@ -983,6 +1098,45 @@ class KvMetricsRecorder:
             window[f"{name}_delta_by_phase"] = by_phase
         return window
 
+    def _adopt_aiperf_samples(self) -> str | None:
+        """Replace the live rows with aiperf's own scrapes when it collected any.
+
+        aiperf drives the AgentX workload, so on those rounds it is the better source in every way that matters: it
+        scrapes the same endpoint on a tighter cadence, takes its own reading at each phase boundary, and stamps each
+        record with the phase from the process that owns the transition -- so there is no boundary lag to correct and
+        nothing to re-attribute afterwards.
+
+        The live rows are discarded rather than merged. Two collectors on one endpoint produce interleaved readings of
+        the same counters at slightly different instants, and a window bracketed across both would attribute an
+        increment to whichever happened to be sampled either side of it.
+        """
+        if self._workspace is None:
+            return None
+        try:
+            export = find_server_metrics_export(self._workspace)
+            if export is None:
+                return None
+            records = read_aiperf_server_metrics(export)
+            if not records:
+                return None
+            # Rebuilt from scratch so no live reading survives into the counter windows below.
+            self._rows = []
+            self._first_counters = {}
+            self._last_counters = {}
+            previous_phase = self._phase
+            for sample, timing, phase in records:
+                self._phase = phase or "measured"
+                self._absorb(sample, timing=timing)
+            self._phase = previous_phase
+            # Adjacent phases share the reading at their boundary here too. aiperf takes its own scrape at each
+            # transition, but tags it with the phase that is ending, so without this the next phase's window would open
+            # at its first periodic sample and the increment in between would be credited to neither.
+            self._rebuild_counter_windows()
+            return str(export)
+        except Exception:  # noqa: BLE001 - a better source that cannot be read is not a reason to fail a round
+            log.debug("kv_metrics: aiperf server metrics unavailable", exc_info=True)
+            return None
+
     def _authoritative_bounds(self) -> dict[str, tuple[float, float | None]] | None:
         """Phase windows in Unix seconds, from aiperf's own stamps, or ``None`` when unusable.
 
@@ -1131,9 +1285,14 @@ class KvMetricsRecorder:
 
     def summary(self, *, aborted: bool = False) -> dict[str, Any]:
         """Build the artifact payload."""
-        # First: it re-labels rows and re-brackets the counter windows the deltas below are read from, so the rows, the
-        # phase totals and the timeline in one artifact cannot disagree with each other.
-        attribution = self._reattribute_phases()
+        # Before attribution, because adopting aiperf's rows replaces the very rows attribution would re-label -- and
+        # makes re-labelling unnecessary, since those rows already carry the phase aiperf stamped at collection time.
+        adopted = self._adopt_aiperf_samples()
+        attribution = (
+            {"phase_source": "aiperf_server_metrics", "phase_timeline": self._phase_timeline or None}
+            if adopted
+            else self._reattribute_phases()
+        )
         # After attribution, so the phase events in the timeline are the same boundaries the rows were labelled by.
         workload = self._build_workload_timeline()
         retract_measured, retract_by_phase = self._counter_deltas("retract")
@@ -1143,6 +1302,10 @@ class KvMetricsRecorder:
             "workload_timeline": workload,
             "schema_version": 1,
             "source": "metrics",
+            # Which collector produced the rows. The two differ in cadence and in how the phase was decided, so a
+            # consumer comparing rounds has to be able to tell them apart.
+            "sample_source": "aiperf_server_metrics" if adopted else "watchdog_scrape",
+            "aiperf_server_metrics_path": adopted,
             "url": self._poller.url,
             "available": self._poller.available,
             "aborted": bool(aborted),

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -240,65 +240,6 @@ def parse_prometheus_text(text: str) -> ParsedFamilies:
     return families
 
 
-def _scalar(families: ParsedFamilies, name: str) -> float | None:
-    """Read a gauge, taking the largest reading when several series exist.
-
-    **Never sums.** A sharded engine exposes one series per rank
-    (``tp_rank`` / ``pp_rank`` / ``dp_rank``), and every one of them describes
-    the same pool from its own side: the ranks hold different head slices of
-    the same tokens, so their capacities and occupancies are views, not parts.
-    Adding them turns an 85%-full pool on TP=8 into an occupancy of 6.8 and
-    multiplies capacity eightfold -- the same mistake the log path guards
-    against by de-duplicating capacity lines per rank.
-
-    Max rather than first-rank so an imbalanced deployment reports its most
-    pressured rank, which is the one that will retract.
-
-    Args:
-        families (ParsedFamilies): Parsed exposition.
-        name (str): Metric name.
-
-    Returns:
-        float | None: The value, or ``None`` when the metric is absent. Absent
-        is never 0.0: several of these gauges legitimately read zero.
-    """
-    series = families.get(name)
-    if not series:
-        return None
-    return max(value for _, value in series)
-
-
-def _max_scalar(families: ParsedFamilies, names: tuple[str, ...]) -> float | None:
-    """Largest reading across several gauges, ignoring the ones not present.
-
-    Args:
-        families (ParsedFamilies): Parsed exposition.
-        names (tuple[str, ...]): Metric names to consider.
-
-    Returns:
-        float | None: The max, or ``None`` when none of the names appeared.
-    """
-    values = [v for name in names if (v := _scalar(families, name)) is not None]
-    return max(values) if values else None
-
-
-def _series_count(families: ParsedFamilies, names: tuple[str, ...]) -> int:
-    """How many label series the largest of these metrics carried.
-
-    Surfaced in the artifact so a consumer can tell a single-rank reading from
-    a collapsed multi-rank one, and judge for itself whether the aggregation
-    rule above was the right one for its deployment.
-
-    Args:
-        families (ParsedFamilies): Parsed exposition.
-        names (tuple[str, ...]): Metric names to inspect.
-
-    Returns:
-        int: The largest series count among the named metrics; 0 when absent.
-    """
-    return max((len(families.get(name) or ()) for name in names), default=0)
-
-
 #: Labels that identify a shard of one engine rather than an independent one.
 #: Shards schedule in lockstep, so each reports the same event; anything else
 #: (``dp_rank``, ``engine``, ``model_name``, ``pid``) marks a unit that
@@ -424,15 +365,18 @@ class KvSample:
             collapsed to their maximum; see :func:`_scalar`.
         capacity_gb (float | None): Pool size in GiB as the engine reports it.
             The engine's "GB" is 1024-based; do not rescale it.
-        retract_total (dict[str, float]): SGLang cumulative retracts, per label
-            series. Kept per series so an engine restart shows up as a series
-            resetting rather than as a total going backwards.
-        preempt_total (dict[str, float]): vLLM cumulative preemptions, likewise.
-        prefix_cache_queries (float | None): vLLM cumulative prefix lookups.
-        prefix_cache_hits (float | None): vLLM cumulative prefix hits.
-        cached_tokens_total (float | None): SGLang cumulative prefix-cached
-            tokens. Absent entirely when prefix caching is off -- the metric is
-            not emitted at all, rather than emitted as zero.
+        retract_total (dict[str, dict[str, float]]): SGLang cumulative retracts,
+            grouped by independent unit then by shard. Kept per series so an
+            engine restart shows as a series resetting rather than as a total
+            going backwards, and so shards can be collapsed while separate
+            engines are added. Combine with :func:`aggregate_series`.
+        preempt_total (dict[str, dict[str, float]]): vLLM preemptions, likewise.
+        prefix_cache_queries (dict[str, dict[str, float]]): vLLM cumulative
+            prefix lookups, same grouping.
+        prefix_cache_hits (dict[str, dict[str, float]]): vLLM prefix hits.
+        cached_tokens_total (dict[str, dict[str, float]]): SGLang cumulative
+            prefix-cached tokens. Empty when prefix caching is off -- the metric
+            is not emitted at all, rather than emitted as zero.
     """
 
     ts: float
@@ -447,11 +391,11 @@ class KvSample:
     capacity_derived: bool = False
     series_count: int = 0
     capacity_gb: float | None = None
-    retract_total: dict[str, float] = field(default_factory=dict)
-    preempt_total: dict[str, float] = field(default_factory=dict)
-    prefix_cache_queries: float | None = None
-    prefix_cache_hits: float | None = None
-    cached_tokens_total: float | None = None
+    retract_total: dict[str, dict[str, float]] = field(default_factory=dict)
+    preempt_total: dict[str, dict[str, float]] = field(default_factory=dict)
+    prefix_cache_queries: dict[str, dict[str, float]] = field(default_factory=dict)
+    prefix_cache_hits: dict[str, dict[str, float]] = field(default_factory=dict)
+    cached_tokens_total: dict[str, dict[str, float]] = field(default_factory=dict)
 
     def has_readings(self) -> bool:
         """Whether this scrape carried any KV signal at all.
@@ -595,12 +539,14 @@ def sample_from_families(
         capacity_tokens=capacity,
         capacity_derived=capacity_derived,
         series_count=len(keys) if keys != [""] else 0,
-        capacity_gb=_scalar(families, _SGL_CAPACITY_GB),
+        # From the rank that was assembled, not re-read: a fresh lookup would
+        # be free to land on a different rank than every field above it.
+        capacity_gb=assembled.get("capacity_gb"),
         retract_total=_series(families, _SGL_RETRACT_TOTAL),
         preempt_total=_series(families, _VLLM_PREEMPT_TOTAL),
-        prefix_cache_queries=_scalar(families, _VLLM_PREFIX_QUERIES),
-        prefix_cache_hits=_scalar(families, _VLLM_PREFIX_HITS),
-        cached_tokens_total=_scalar(families, _SGL_CACHED_TOKENS),
+        prefix_cache_queries=_series(families, _VLLM_PREFIX_QUERIES),
+        prefix_cache_hits=_series(families, _VLLM_PREFIX_HITS),
+        cached_tokens_total=_series(families, _SGL_CACHED_TOKENS),
     )
 
 
@@ -755,7 +701,7 @@ _MAX_STORED_ROWS = 5000
 _MIN_SCRAPE_INTERVAL_SEC = 0.5
 
 
-def counter_delta(first: dict[str, float], last: dict[str, float]) -> float | None:
+def counter_delta(first: dict[str, dict[str, float]], last: dict[str, dict[str, float]]) -> float | None:
     """Increment of a labelled counter between two observations.
 
     Diffed per label series rather than on a flat total, because an engine
@@ -832,8 +778,8 @@ class KvMetricsRecorder:
         self._rows: list[dict[str, Any]] = []
         self._last_scrape_mono: float | None = None
         self._phase_marks: list[dict[str, Any]] = []
-        self._first_counters: dict[str, dict[str, float]] = {}
-        self._last_counters: dict[str, dict[str, float]] = {}
+        self._first_counters: dict[str, dict[str, dict[str, float]]] = {}
+        self._last_counters: dict[str, dict[str, dict[str, float]]] = {}
         self._capacity_tokens: float | None = None
         self._capacity_derived = False
         self._capacity_gb: float | None = None
@@ -895,21 +841,21 @@ class KvMetricsRecorder:
         if self._capacity_gb is None and sample.capacity_gb is not None:
             self._capacity_gb = sample.capacity_gb
         self._series_count = max(self._series_count, sample.series_count)
-        # Prefix-cache counters are cumulative and the engine outlives the
-        # round under warm reuse, so the latest absolute value carries the
-        # previous round's hits too. Bracket the window instead: first reading
-        # in, last reading out, difference attributable to this round.
-        for attr in ("prefix_cache_queries", "prefix_cache_hits", "cached_tokens_total"):
-            value = getattr(sample, attr)
-            if value is None:
-                continue
-            self._prefix_first.setdefault(attr, value)
-            self._prefix_last[attr] = value
-        for name, series in (("retract", sample.retract_total), ("preempt", sample.preempt_total)):
+        # Every cumulative counter gets the same treatment: bracket the round
+        # and diff. The prefix-cache ones need it as much as the pressure ones,
+        # because under warm reuse the engine outlives the round and its
+        # absolute totals carry the previous round's cache warming.
+        for name, series in (
+            ("retract", sample.retract_total),
+            ("preempt", sample.preempt_total),
+            ("prefix_cache_queries", sample.prefix_cache_queries),
+            ("prefix_cache_hits", sample.prefix_cache_hits),
+            ("cached_tokens_total", sample.cached_tokens_total),
+        ):
             if not series:
                 continue
-            self._first_counters.setdefault(name, dict(series))
-            self._last_counters[name] = dict(series)
+            self._first_counters.setdefault(name, {g: dict(s) for g, s in series.items()})
+            self._last_counters[name] = {g: dict(s) for g, s in series.items()}
         self._rows.append(
             {
                 "phase": self._phase,
@@ -928,25 +874,26 @@ class KvMetricsRecorder:
         )
 
     def _prefix_cache_window(self) -> dict[str, Any]:
-        """Prefix-cache counters attributable to this round.
+        """Prefix-cache increments attributable to this round.
 
-        Reports the increment across the round, plus the raw endpoints so a
-        consumer can audit it. Absolute values alone are unusable under warm
-        reuse: the engine survives the round boundary, so they carry whatever
-        the previous round warmed the cache with.
+        Each counter is diffed per label series and combined by the shared
+        grouping rule, so two data-parallel engines that served 200 lookups
+        each report 400 rather than 200. Reporting the round's delta rather
+        than the running total is what makes a hit rate belong to the round
+        that earned it.
 
         Returns:
-            dict[str, Any]: ``<name>_delta`` per counter plus ``first`` /
-            ``last`` maps. Empty when no counter was ever read.
+            dict[str, Any]: ``<name>_delta`` per counter, plus its per-series
+            endpoints for audit. Empty when no counter was ever read.
         """
-        if not self._prefix_last:
-            return {}
-        window: dict[str, Any] = {"first": dict(self._prefix_first), "last": dict(self._prefix_last)}
-        for name, end in self._prefix_last.items():
-            start = self._prefix_first.get(name)
-            # A counter that went backwards means the engine restarted; credit
-            # only what has accumulated since, as the retract counters do.
-            window[f"{name}_delta"] = end if start is None or end < start else end - start
+        window: dict[str, Any] = {}
+        for name in ("prefix_cache_queries", "prefix_cache_hits", "cached_tokens_total"):
+            last = self._last_counters.get(name)
+            if not last:
+                continue
+            window[f"{name}_delta"] = counter_delta(self._first_counters.get(name, {}), last)
+            window[f"{name}_first"] = self._first_counters.get(name, {})
+            window[f"{name}_last"] = last
         return window
 
     def rows(self) -> list[dict[str, Any]]:

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -88,7 +88,12 @@ _MAX_CONSECUTIVE_FAILURES = 3
 # that has no such subpool, so taking the max over all of them is both the
 # hybrid-correct answer (SGLang's own scheduler judges pressure that way) and a
 # no-op on an ordinary KV pool.
-_SGL_USAGE = ("sglang:token_usage", "sglang:full_token_usage", "sglang:swa_token_usage")
+# ``token_usage`` is already max(full, swa, mamba) on current SGLang, so it is
+# authoritative on its own. The per-subpool gauges are a fallback for a build
+# that predates it, where reading only the full pool would understate a hybrid
+# model's real pressure.
+_SGL_USAGE_PRIMARY = "sglang:token_usage"
+_SGL_USAGE_FALLBACK = ("sglang:full_token_usage", "sglang:swa_token_usage", "sglang:mamba_usage")
 _SGL_USED = "sglang:kv_used_tokens"
 _SGL_AVAILABLE = "sglang:kv_available_tokens"
 # Only the main KV pool's evictable count. The SWA and Mamba pools have their
@@ -294,17 +299,94 @@ def _series_count(families: ParsedFamilies, names: tuple[str, ...]) -> int:
     return max((len(families.get(name) or ()) for name in names), default=0)
 
 
-def _series(families: ParsedFamilies, name: str) -> dict[str, float]:
-    """Read a counter as a per-label-set mapping.
+#: Labels that identify a shard of one engine rather than an independent one.
+#: Shards schedule in lockstep, so each reports the same event; anything else
+#: (``dp_rank``, ``engine``, ``model_name``, ``pid``) marks a unit that
+#: retracts on its own account.
+_REPLICA_LABELS = frozenset({"tp_rank", "pp_rank"})
+
+
+def _series(families: ParsedFamilies, name: str) -> dict[str, dict[str, float]]:
+    """Read a counter grouped by independent unit, then by shard.
+
+    Two levels because the two label kinds need opposite treatment and a flat
+    map cannot express that: shards of one engine duplicate each other's
+    counts, while separate engines contribute their own.
 
     Args:
         families (ParsedFamilies): Parsed exposition.
         name (str): Metric name.
 
     Returns:
-        dict[str, float]: Canonical label key to value; empty when absent.
+        dict[str, dict[str, float]]: Independent-unit key to shard key to
+        value; empty when the metric is absent.
     """
-    return {canonical_label_key(labels): value for labels, value in families.get(name, [])}
+    out: dict[str, dict[str, float]] = {}
+    for labels, value in families.get(name, []):
+        group = canonical_label_key({k: v for k, v in labels.items() if k not in _REPLICA_LABELS})
+        out.setdefault(group, {})[canonical_label_key(labels)] = value
+    return out
+
+
+def aggregate_series(grouped: dict[str, dict[str, float]]) -> float | None:
+    """Collapse a grouped counter into one number.
+
+    Max within a group, sum across groups. Eight tensor-parallel ranks carrying
+    48 retracts describe 48 events, not 384; two data-parallel engines carrying
+    48 each describe 96. Applying one rule to both label kinds is wrong in one
+    direction or the other, which is why the grouping exists.
+
+    Args:
+        grouped (dict[str, dict[str, float]]): Output of :func:`_series`.
+
+    Returns:
+        float | None: The total, or ``None`` when the counter was never seen.
+    """
+    if not grouped:
+        return None
+    return sum(max(shards.values()) for shards in grouped.values() if shards)
+
+
+def _rank_keys(families: ParsedFamilies, names: tuple[str, ...]) -> list[str]:
+    """Label keys the given gauges were reported under.
+
+    Args:
+        families (ParsedFamilies): Parsed exposition.
+        names (tuple[str, ...]): Metric names to inspect.
+
+    Returns:
+        list[str]: Canonical label keys, or ``[""]`` when nothing is labelled.
+    """
+    keys: list[str] = []
+    for name in names:
+        for labels, _ in families.get(name, []):
+            key = canonical_label_key(labels)
+            if key not in keys:
+                keys.append(key)
+    return keys or [""]
+
+
+def _read(families: ParsedFamilies, name: str, key: str) -> float | None:
+    """One gauge's value for one rank.
+
+    Falls back to an unlabelled series so a metric the engine reports once
+    globally still resolves for every rank.
+
+    Args:
+        families (ParsedFamilies): Parsed exposition.
+        name (str): Metric name.
+        key (str): Canonical label key of the rank being assembled.
+
+    Returns:
+        float | None: The value, or ``None`` when this rank has no reading.
+    """
+    series = families.get(name) or []
+    for labels, value in series:
+        if canonical_label_key(labels) == key:
+            return value
+    if len(series) == 1 and not series[0][0]:
+        return series[0][1]
+    return None
 
 
 @dataclass(frozen=True)
@@ -427,26 +509,79 @@ def sample_from_families(
         ``None``.
     """
     engine = _detect_engine(families)
-    used = _scalar(families, _SGL_USED)
-    available = _scalar(families, _SGL_AVAILABLE)
-    evictable = _scalar(families, _SGL_EVICTABLE)
+    occupancy_names = (_SGL_USAGE_PRIMARY,) + _SGL_USAGE_FALLBACK + _VLLM_USAGE + (_SGL_USED,)
+    keys = _rank_keys(families, occupancy_names)
 
-    # Engine-reported capacity wins; the sum is a fallback for builds that do
-    # not expose it, and is marked as derived so a consumer knows it may run
-    # short of the true pool size.
-    capacity = _scalar(families, _SGL_CAPACITY_TOKENS)
-    capacity_derived = False
-    if capacity is None and used is not None and available is not None:
-        capacity = used + available + (evictable or 0.0)
-        capacity_derived = True
+    # Assemble each rank in full before choosing one. Taking a per-field max
+    # across ranks silently welds numbers from different sides of the engine
+    # together: rank A's capacity against rank B's used tokens produced a
+    # physical occupancy of 1.7 on two individually valid readings.
+    best: dict[str, Any] | None = None
+    for key in keys:
+        used = _read(families, _SGL_USED, key)
+        available = _read(families, _SGL_AVAILABLE, key)
+        evictable = _read(families, _SGL_EVICTABLE, key)
 
-    physical: float | None = None
-    if capacity and capacity > 0 and used is not None:
-        physical = (used + (evictable or 0.0)) / capacity
+        # Engine-reported capacity wins; the sum is a fallback for builds that
+        # do not expose it, flagged so a consumer knows it may run short of the
+        # true pool size.
+        capacity = _read(families, _SGL_CAPACITY_TOKENS, key)
+        capacity_derived = False
+        if capacity is None and used is not None and available is not None:
+            capacity = used + available + (evictable or 0.0)
+            capacity_derived = True
 
-    active = _max_scalar(families, _SGL_USAGE)
-    if active is None:
-        active = _max_scalar(families, _VLLM_USAGE)
+        physical: float | None = None
+        if capacity and capacity > 0 and used is not None:
+            physical = (used + (evictable or 0.0)) / capacity
+
+        # ``token_usage`` is already the maximum across the full, SWA and Mamba
+        # subpools on current SGLang, so it is read directly. The per-subpool
+        # gauges are only consulted when it is missing, which is what an older
+        # build looks like.
+        active = _read(families, _SGL_USAGE_PRIMARY, key)
+        if active is None:
+            active = max(
+                (v for n in _SGL_USAGE_FALLBACK if (v := _read(families, n, key)) is not None),
+                default=None,
+            )
+        if active is None:
+            active = max(
+                (v for n in _VLLM_USAGE if (v := _read(families, n, key)) is not None),
+                default=None,
+            )
+
+        candidate = {
+            "active": active,
+            "physical": physical,
+            "used": used,
+            "available": available,
+            "evictable": evictable,
+            "capacity": capacity,
+            "capacity_derived": capacity_derived,
+            "capacity_gb": _read(families, _SGL_CAPACITY_GB, key),
+        }
+        # The most pressured rank is the one that will retract, so it is the one
+        # worth reporting. Fall back to physical, then to having read anything.
+        if best is None:
+            best = candidate
+            continue
+        for metric in ("active", "physical", "used"):
+            mine, theirs = candidate.get(metric), best.get(metric)
+            if mine is None and theirs is None:
+                continue
+            if theirs is None or (mine is not None and mine > theirs):
+                best = candidate
+            break
+
+    assembled = best or {}
+    used = assembled.get("used")
+    available = assembled.get("available")
+    evictable = assembled.get("evictable")
+    capacity = assembled.get("capacity")
+    capacity_derived = bool(assembled.get("capacity_derived"))
+    physical = assembled.get("physical")
+    active = assembled.get("active")
 
     return KvSample(
         ts=time.time() if ts is None else ts,
@@ -459,7 +594,7 @@ def sample_from_families(
         available_tokens=available,
         capacity_tokens=capacity,
         capacity_derived=capacity_derived,
-        series_count=_series_count(families, _SGL_USAGE + _VLLM_USAGE),
+        series_count=len(keys) if keys != [""] else 0,
         capacity_gb=_scalar(families, _SGL_CAPACITY_GB),
         retract_total=_series(families, _SGL_RETRACT_TOTAL),
         preempt_total=_series(families, _VLLM_PREEMPT_TOTAL),
@@ -634,18 +769,12 @@ def counter_delta(first: dict[str, float], last: dict[str, float]) -> float | No
         first (dict[str, float]): Series readings at window open.
         last (dict[str, float]): Series readings at window close.
 
-    Series are combined by **max, not sum**, for the same reason gauges are: a
-    sharded engine reports one series per rank and the ranks retract in
-    lockstep, so eight series carrying 48 describe 48 events, not 384. This
-    under-counts a deployment whose series really are independent engines;
-    that trade is deliberate, because an inflated pressure count would send the
-    optimizer chasing a bottleneck that is not there, while an under-count only
-    understates one that is. ``series_count`` on the sample says which case a
-    reading came from.
+    Per-shard deltas are then combined by :func:`aggregate_series`, so shards of
+    one engine collapse to one count while separate engines add up.
 
     Args:
-        first (dict[str, float]): Series readings at window open.
-        last (dict[str, float]): Series readings at window close.
+        first (dict[str, dict[str, float]]): Grouped readings at window open.
+        last (dict[str, dict[str, float]]): Grouped readings at window close.
 
     Returns:
         float | None: The increment, or ``None`` when the counter was never
@@ -653,11 +782,13 @@ def counter_delta(first: dict[str, float], last: dict[str, float]) -> float | No
     """
     if not first and not last:
         return None
-    deltas: list[float] = []
-    for key, end in last.items():
-        start = first.get(key)
-        deltas.append(end if start is None or end < start else end - start)
-    return max(deltas) if deltas else 0.0
+    deltas: dict[str, dict[str, float]] = {}
+    for group, shards in last.items():
+        opened = first.get(group) or {}
+        for key, end in shards.items():
+            start = opened.get(key)
+            deltas.setdefault(group, {})[key] = end if start is None or end < start else end - start
+    return aggregate_series(deltas) or 0.0
 
 
 class KvMetricsRecorder:
@@ -707,7 +838,8 @@ class KvMetricsRecorder:
         self._capacity_derived = False
         self._capacity_gb: float | None = None
         self._series_count = 0
-        self._prefix_cache: dict[str, float] = {}
+        self._prefix_first: dict[str, float] = {}
+        self._prefix_last: dict[str, float] = {}
         self._closed = False
 
     @property
@@ -763,13 +895,16 @@ class KvMetricsRecorder:
         if self._capacity_gb is None and sample.capacity_gb is not None:
             self._capacity_gb = sample.capacity_gb
         self._series_count = max(self._series_count, sample.series_count)
-        # Prefix-cache counters are cumulative, so the newest reading is the
-        # whole story; keeping the latest non-null avoids a column of repeats
-        # in every row.
+        # Prefix-cache counters are cumulative and the engine outlives the
+        # round under warm reuse, so the latest absolute value carries the
+        # previous round's hits too. Bracket the window instead: first reading
+        # in, last reading out, difference attributable to this round.
         for attr in ("prefix_cache_queries", "prefix_cache_hits", "cached_tokens_total"):
             value = getattr(sample, attr)
-            if value is not None:
-                self._prefix_cache[attr] = value
+            if value is None:
+                continue
+            self._prefix_first.setdefault(attr, value)
+            self._prefix_last[attr] = value
         for name, series in (("retract", sample.retract_total), ("preempt", sample.preempt_total)):
             if not series:
                 continue
@@ -784,10 +919,35 @@ class KvMetricsRecorder:
                 "physical_pool_usage": sample.physical_pool_usage,
                 "used_tokens": sample.used_tokens,
                 "evictable_tokens": sample.evictable_tokens,
-                "retract_total": sum(sample.retract_total.values()) if sample.retract_total else None,
-                "preempt_total": sum(sample.preempt_total.values()) if sample.preempt_total else None,
+                # Same aggregation rule the summary uses. Rows and summary
+                # disagreeing inside one artifact is worse than either rule
+                # being wrong, because nothing on the page says which is which.
+                "retract_total": aggregate_series(sample.retract_total),
+                "preempt_total": aggregate_series(sample.preempt_total),
             }
         )
+
+    def _prefix_cache_window(self) -> dict[str, Any]:
+        """Prefix-cache counters attributable to this round.
+
+        Reports the increment across the round, plus the raw endpoints so a
+        consumer can audit it. Absolute values alone are unusable under warm
+        reuse: the engine survives the round boundary, so they carry whatever
+        the previous round warmed the cache with.
+
+        Returns:
+            dict[str, Any]: ``<name>_delta`` per counter plus ``first`` /
+            ``last`` maps. Empty when no counter was ever read.
+        """
+        if not self._prefix_last:
+            return {}
+        window: dict[str, Any] = {"first": dict(self._prefix_first), "last": dict(self._prefix_last)}
+        for name, end in self._prefix_last.items():
+            start = self._prefix_first.get(name)
+            # A counter that went backwards means the engine restarted; credit
+            # only what has accumulated since, as the retract counters do.
+            window[f"{name}_delta"] = end if start is None or end < start else end - start
+        return window
 
     def rows(self) -> list[dict[str, Any]]:
         """Collected rows, stride-downsampled to the row cap.
@@ -826,7 +986,7 @@ class KvMetricsRecorder:
             "capacity_derived": self._capacity_derived,
             "capacity_gb": self._capacity_gb,
             "series_count": self._series_count,
-            "prefix_cache": dict(self._prefix_cache),
+            "prefix_cache": self._prefix_cache_window(),
             "phase_marks": self._phase_marks,
             "retract_delta": counter_delta(
                 self._first_counters.get("retract", {}),

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -48,6 +48,7 @@ import json
 import logging
 import math
 import os
+import re
 import time
 import urllib.error
 import urllib.request
@@ -92,6 +93,11 @@ _SCRAPE_TIMEOUT_SEC = 0.4
 #: corporate host routes a loopback scrape through an external proxy: wrong by construction, and slow enough that the
 #: blocking call visibly delays the watchdog loop it runs inside.
 _OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+#: How much of a server log to read when hunting for the bound-port banner. It is logged during startup and these logs
+#: grow to megabytes on shared storage, so reading the head is both sufficient and the difference between a cheap check
+#: and a slow one.
+_SERVER_LOG_HEAD_BYTES = 262144
 
 #: Consecutive failures after which the poller stops trying. A server that never exposes ``/metrics`` (SGLang without
 #: ``--enable-metrics``) would otherwise pay a connection refusal every couple of seconds for the whole round.
@@ -579,6 +585,31 @@ def _port_value(raw: Any) -> int | None:
     return port if port > 0 else None
 
 
+def port_from_server_log(workspace: Any) -> int | None:
+    """Read the port the server actually bound out of its own log.
+
+    The last resort before the default, and the only source that is right by construction: it is what the server said
+    it was listening on. Needed because the port is not always pinned anywhere else -- on an AgentX round the config
+    carries no ``PORT`` at all and vLLM falls back to its own 8000, while the synthetic path pins 8888. A default can
+    only ever match one of those.
+    """
+    try:
+        root = Path(workspace)
+        for pattern in ("server.log", "*/server.log"):
+            for candidate in sorted(root.glob(pattern)):
+                # The banner is near the top; a served round's log grows to megabytes and is on shared storage.
+                with candidate.open(encoding="utf-8", errors="ignore") as handle:
+                    head = handle.read(_SERVER_LOG_HEAD_BYTES)
+                match = re.search(r"(?:Uvicorn running on|running on)\s+https?://[^\s:]+:(\d+)", head)
+                if match:
+                    port = _port_value(match.group(1))
+                    if port is not None:
+                        return port
+    except OSError:
+        return None
+    return None
+
+
 def port_from_workspace(workspace: Any) -> int | None:
     """Read ``benchmark.envs.PORT`` out of the round's materialized config.
 
@@ -624,9 +655,10 @@ def resolve_metrics_port(config_envs: dict[str, Any] | None = None, workspace: A
         if port is not None:
             return port
     if workspace is not None:
-        port = port_from_workspace(workspace)
-        if port is not None:
-            return port
+        for probe in (port_from_workspace, port_from_server_log):
+            port = probe(workspace)
+            if port is not None:
+                return port
     return DEFAULT_METRICS_PORT
 
 
@@ -651,15 +683,35 @@ class KvMetricsPoller:
         timeout_sec: float = _SCRAPE_TIMEOUT_SEC,
         workspace: Any = None,
     ) -> None:
-        """Bind the poller to an endpoint without contacting it."""
-        self.port = int(port) if port else resolve_metrics_port(config_envs, workspace)
-        self.url = f"http://{host}:{self.port}/metrics"
+        """Bind the poller to an endpoint without contacting it, or yet resolving it.
+
+        The port is resolved on first use rather than here, because the most reliable source for it -- the line the
+        server logs when it binds -- does not exist when the recorder is built. By the first scrape it does: ticking is
+        gated on the ready marker, which the server writes after that line.
+        """
+        self._explicit_port = int(port) if port else None
+        self._config_envs = dict(config_envs or {})
+        self._host = host
+        self._port_workspace = workspace
+        self._port: int | None = None
         self.timeout_sec = float(timeout_sec)
         self._failures = 0
         self._succeeded = False
         self._gave_up = False
         self._warned = False
         self._first_attempt_mono: float | None = None
+
+    @property
+    def port(self) -> int:
+        """Port the engine serves ``/metrics`` on, resolved once on first use."""
+        if self._port is None:
+            self._port = self._explicit_port or resolve_metrics_port(self._config_envs, self._port_workspace)
+        return self._port
+
+    @property
+    def url(self) -> str:
+        """Endpoint this poller scrapes."""
+        return f"http://{self._host}:{self.port}/metrics"
 
     @property
     def available(self) -> bool | None:
@@ -1181,7 +1233,11 @@ class KvMetricsRecorder:
             self._last_counters = {}
             previous_phase = self._phase
             for sample, timing, phase in records:
-                self._phase = phase or "measured"
+                # An unstamped record is one aiperf took before any phase began -- its baseline capture, of an idle
+                # pool. That is boot. Defaulting it to "measured" put readings of a pool under no load into the one
+                # phase allowed into a comparison: observed on a live round, where three such rows produced a measured
+                # prefix-cache delta of 34,395 describing nothing that happened.
+                self._phase = phase or "boot"
                 self._absorb(sample, timing=timing)
             self._phase = previous_phase
             if kept:

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -822,6 +822,14 @@ _MAX_STORED_ROWS = 5000
 _SCRAPE_INTERVAL_ENV = "INFERENCE_OPTIMIZER_KV_SCRAPE_INTERVAL_SEC"
 _DEFAULT_SCRAPE_INTERVAL_SEC = 2.0
 
+#: Interval used while aiperf is scraping the same endpoint. Not zero: a sparse series is what remains if aiperf turns
+#: out to have collected nothing, and an artifact with a coarse trace beats one with no rows at all.
+_SUSPENDED_SCRAPE_INTERVAL_SEC = 60.0
+
+#: Where the AgentX client puts its artifacts. The directory is created before the server boots, so its presence is the
+#: earliest signal that aiperf owns the scraping for this round.
+_AIPERF_ARTIFACT_DIRS = ("aiperf_artifacts", "*/aiperf_artifacts")
+
 
 def resolve_scrape_interval_sec() -> float:
     """Seconds between scrapes, from the environment or the default."""
@@ -885,6 +893,8 @@ class KvMetricsRecorder:
         self._min_interval = resolve_scrape_interval_sec() if min_interval_sec is None else float(min_interval_sec)
         self._progress = progress
         self._phase_timeline: dict[str, dict[str, Any]] = {}
+        # Tri-state: unknown until the round directory is first looked at.
+        self._aiperf_present: bool | None = None
         self._phase = "boot"
         self._rows: list[dict[str, Any]] = []
         self._last_scrape_mono: float | None = None
@@ -922,9 +932,33 @@ class KvMetricsRecorder:
         """Scrape if the interval has elapsed, tagging the sample with the phase."""
         if self._closed:
             return
-        if self._last_scrape_mono is not None and (mono - self._last_scrape_mono) < self._min_interval:
+        interval = _SUSPENDED_SCRAPE_INTERVAL_SEC if self._aiperf_owns_scraping() else self._min_interval
+        if self._last_scrape_mono is not None and (mono - self._last_scrape_mono) < interval:
             return
         self._scrape(mono)
+
+    def _aiperf_owns_scraping(self) -> bool:
+        """Whether aiperf is scraping this engine, making our own polling redundant.
+
+        On an AgentX round aiperf scrapes the same endpoint on its own schedule and its records replace ours at close,
+        so polling at the full rate only doubles the load on the engine to produce rows that get discarded. Backing off
+        rather than stopping outright keeps a coarse trace: if aiperf turns out to have collected nothing -- disabled,
+        crashed, killed before it flushed -- a sparse series is a far better artifact than an empty one, which is
+        exactly the failure this collector already shipped once.
+
+        The eval phase is excluded because aiperf has exited by then, so that window is ours alone.
+        """
+        if self._phase == "eval":
+            return False
+        if self._aiperf_present is None and self._workspace is not None:
+            try:
+                root = Path(self._workspace)
+                self._aiperf_present = any(
+                    candidate.is_dir() for pattern in _AIPERF_ARTIFACT_DIRS for candidate in root.glob(pattern)
+                )
+            except OSError:
+                self._aiperf_present = False
+        return bool(self._aiperf_present)
 
     def _scrape(self, mono: float) -> KvSample | None:
         """Take one reading unconditionally, timing the round trip.
@@ -1106,9 +1140,11 @@ class KvMetricsRecorder:
         record with the phase from the process that owns the transition -- so there is no boundary lag to correct and
         nothing to re-attribute afterwards.
 
-        The live rows are discarded rather than merged. Two collectors on one endpoint produce interleaved readings of
-        the same counters at slightly different instants, and a window bracketed across both would attribute an
-        increment to whichever happened to be sampled either side of it.
+        Only the window aiperf covers is replaced. It starts after the server is up and exits before the accuracy eval,
+        so readings outside that span -- boot, and the whole eval phase -- are ours and are kept. Inside it, its
+        records replace ours outright rather than merging: two collectors reading the same counters at slightly
+        different instants would let a window bracket across both and credit an increment to whichever was sampled
+        either side of it. Across the boundary there is no such risk, because the two sets are disjoint in time.
         """
         if self._workspace is None:
             return None
@@ -1119,7 +1155,18 @@ class KvMetricsRecorder:
             records = read_aiperf_server_metrics(export)
             if not records:
                 return None
-            # Rebuilt from scratch so no live reading survives into the counter windows below.
+            # Kept by time, not by phase label. aiperf covers one contiguous window -- it starts after the server is up
+            # and exits before the accuracy eval -- so a live row outside that span is a reading nothing else took,
+            # while one inside it is redundant by definition. Judging on the label instead would keep a row whose
+            # timestamp lands mid-window and let it close a counter window it has no business closing.
+            covered_from = records[0][0].ts
+            covered_to = records[-1][0].ts
+            kept = [
+                r
+                for r in self._rows
+                if isinstance(r.get("ts"), (int, float)) and not (covered_from <= r["ts"] <= covered_to)
+            ]
+            # Rebuilt from scratch so no superseded live reading survives into the counter windows below.
             self._rows = []
             self._first_counters = {}
             self._last_counters = {}
@@ -1128,6 +1175,9 @@ class KvMetricsRecorder:
                 self._phase = phase or "measured"
                 self._absorb(sample, timing=timing)
             self._phase = previous_phase
+            if kept:
+                # Time order, because the counter windows below are bracketed by walking the rows in sequence.
+                self._rows = sorted([*self._rows, *kept], key=lambda r: r.get("ts") or 0.0)
             # Adjacent phases share the reading at their boundary here too. aiperf takes its own scrape at each
             # transition, but tags it with the phase that is ending, so without this the next phase's window would open
             # at its first periodic sample and the increment in between would be credited to neither.

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -1,0 +1,553 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""KV-cache observability sampled from the engine's ``/metrics`` endpoint.
+
+The engine is the only thing that knows how full its KV pool is, and until now
+nothing read it: a run could spend its whole budget retracting requests and the
+breakdown would show only "throughput low". This module is the reader.
+
+``/metrics`` is the primary source rather than ``server.log`` because it wins on
+every axis that matters here -- full float precision instead of the log's two
+decimals, stable metric names instead of names that branch on the model's pool
+type, explicit units, and ``kv_evictable_tokens``, which the log cannot express
+at all and which is the only way to separate the two occupancy readings this
+module reports (see :class:`KvSample`).
+
+Two rules run through everything below:
+
+* **Never raise.** This samples a benchmark that is being measured; a scrape
+  failure must cost the run nothing. Every entry point returns a value.
+* **Never coerce a missing reading to zero.** A pool nobody sampled and a pool
+  that is genuinely empty are different findings, and collapsing them is how an
+  optimizer ends up steering on a number that was never measured. Absent means
+  ``None``, all the way out to the breakdown.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any
+
+
+log = logging.getLogger(__name__)
+
+
+__all__ = [
+    "DEFAULT_METRICS_PORT",
+    "KvMetricsPoller",
+    "KvSample",
+    "canonical_label_key",
+    "parse_prometheus_text",
+    "resolve_metrics_port",
+    "sample_from_families",
+]
+
+
+#: Port the persistent server binds when ``benchmark.envs.PORT`` is unset.
+#: Mirrors ``_server_lifecycle.REUSE_PORT_DEFAULT``; duplicated rather than
+#: imported because that module imports ``_subprocess_kill``, which is where
+#: this one gets wired in.
+DEFAULT_METRICS_PORT = 8888
+
+#: Scrape timeout. Deliberately well under the 0.5s poll interval of the loop
+#: this runs inside: a slow endpoint must not stretch the interval that the
+#: stall and soft-deadline gates are measured on.
+_SCRAPE_TIMEOUT_SEC = 1.5
+
+#: Consecutive failures after which the poller stops trying. A server that
+#: never exposes ``/metrics`` (SGLang without ``--enable-metrics``) would
+#: otherwise pay a connection refusal twice a second for the whole round.
+_MAX_CONSECUTIVE_FAILURES = 3
+
+
+# ---------------------------------------------------------------------------
+# Metric names
+# ---------------------------------------------------------------------------
+
+# Occupancy, SGLang. ``token_usage`` is the active reading -- its numerator
+# excludes blocks the prefix cache is holding but would hand back under
+# pressure. The per-subpool gauges are always exposed and read 0 on a model
+# that has no such subpool, so taking the max over all of them is both the
+# hybrid-correct answer (SGLang's own scheduler judges pressure that way) and a
+# no-op on an ordinary KV pool.
+_SGL_USAGE = ("sglang:token_usage", "sglang:full_token_usage", "sglang:swa_token_usage")
+_SGL_USED = "sglang:kv_used_tokens"
+_SGL_AVAILABLE = "sglang:kv_available_tokens"
+_SGL_EVICTABLE = (
+    "sglang:kv_evictable_tokens",
+    "sglang:swa_evictable_tokens",
+    "sglang:mamba_evictable_tokens",
+)
+_SGL_CAPACITY_GB = "sglang:kv_cache_memory_usage_gb"
+# Cumulative retract counter. NOT ``sglang:num_retracted_reqs``, which is the
+# most recent batch's instantaneous gauge and carries a ``pid`` label; the two
+# names differ by one word and reading the wrong one turns 48 retracts into 1.
+_SGL_RETRACT_TOTAL = "sglang:num_retracted_requests_total"
+_SGL_CACHED_TOKENS = "sglang:cached_tokens_total"
+
+# Occupancy, vLLM. ``gpu_cache_usage_perc`` is the pre-rename spelling, kept so
+# an older image still reports.
+_VLLM_USAGE = ("vllm:kv_cache_usage_perc", "vllm:gpu_cache_usage_perc")
+# The only workable preemption count: vLLM's log line for it is dead code
+# (``log()`` resets the counter before reading it), so this has no log fallback.
+_VLLM_PREEMPT_TOTAL = "vllm:num_preemptions_total"
+_VLLM_PREFIX_QUERIES = "vllm:prefix_cache_queries"
+_VLLM_PREFIX_HITS = "vllm:prefix_cache_hits"
+
+# Deliberately not read: ``sglang:cache_hit_rate``. Observed reading 0.0 on a
+# server whose ``cached_tokens_total`` had already reached 4.6M, so it is not a
+# cumulative rate -- whether it is instantaneous or windowed is unresolved, and
+# a field nobody can interpret is worse than an absent one. The raw families
+# stay available to whoever settles it.
+
+
+ParsedFamilies = dict[str, list[tuple[dict[str, str], float]]]
+
+
+def canonical_label_key(labels: dict[str, str]) -> str:
+    """Render a label set as a stable string usable as a dict key.
+
+    Counters are diffed per series, not in aggregate: an engine restart resets
+    a series to zero, and a naive total would read that as a negative delta or,
+    worse, silently absorb it. Sorting makes the key independent of the order
+    the exporter happened to emit.
+
+    Args:
+        labels (dict[str, str]): Label name to value.
+
+    Returns:
+        str: ``k="v",k2="v2"`` with names sorted; ``""`` for no labels.
+    """
+    return ",".join(f'{k}="{labels[k]}"' for k in sorted(labels))
+
+
+def _split_labels(raw: str) -> dict[str, str]:
+    """Parse the inside of a Prometheus label brace into a mapping.
+
+    Values may contain escaped quotes and commas, so the scan is character-wise
+    rather than a naive ``split(",")``.
+
+    Args:
+        raw (str): The text between ``{`` and ``}``, exclusive.
+
+    Returns:
+        dict[str, str]: Label name to unescaped value. Malformed fragments are
+        skipped rather than raising -- a label this module does not understand
+        must not cost it the sample's value.
+    """
+    labels: dict[str, str] = {}
+    index = 0
+    length = len(raw)
+    while index < length:
+        eq = raw.find("=", index)
+        if eq < 0:
+            break
+        name = raw[index:eq].strip().strip(",").strip()
+        quote = raw.find('"', eq)
+        if quote < 0:
+            break
+        cursor = quote + 1
+        chars: list[str] = []
+        while cursor < length:
+            char = raw[cursor]
+            if char == "\\" and cursor + 1 < length:
+                nxt = raw[cursor + 1]
+                chars.append({"n": "\n", "t": "\t"}.get(nxt, nxt))
+                cursor += 2
+                continue
+            if char == '"':
+                break
+            chars.append(char)
+            cursor += 1
+        if name:
+            labels[name] = "".join(chars)
+        index = cursor + 1
+    return labels
+
+
+def parse_prometheus_text(text: str) -> ParsedFamilies:
+    """Parse a Prometheus text exposition into metric families.
+
+    Handles the parts of the format an engine actually emits: comments, labels,
+    an optional trailing timestamp, and the ``NaN`` / ``+Inf`` / ``-Inf``
+    literals. Non-finite values are dropped -- they carry no occupancy meaning
+    and would poison any max or mean taken over them.
+
+    Args:
+        text (str): The response body of a ``/metrics`` GET.
+
+    Returns:
+        ParsedFamilies: Metric name to a list of ``(labels, value)``. A metric
+        that appears with several label sets keeps one entry per set.
+    """
+    families: ParsedFamilies = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "{" in stripped:
+            brace = stripped.index("{")
+            close = stripped.rfind("}")
+            if close < brace:
+                continue
+            name = stripped[:brace].strip()
+            labels = _split_labels(stripped[brace + 1 : close])
+            rest = stripped[close + 1 :].strip()
+        else:
+            parts = stripped.split(None, 1)
+            if len(parts) < 2:
+                continue
+            name = parts[0]
+            labels = {}
+            rest = parts[1].strip()
+        if not name or not rest:
+            continue
+        try:
+            value = float(rest.split()[0])
+        except (ValueError, IndexError):
+            continue
+        if not math.isfinite(value):
+            continue
+        families.setdefault(name, []).append((labels, value))
+    return families
+
+
+def _scalar(families: ParsedFamilies, name: str) -> float | None:
+    """Read a single-series gauge, summing across label sets when several exist.
+
+    Args:
+        families (ParsedFamilies): Parsed exposition.
+        name (str): Metric name.
+
+    Returns:
+        float | None: The value, or ``None`` when the metric is absent. Absent
+        is never 0.0: several of these gauges legitimately read zero.
+    """
+    series = families.get(name)
+    if not series:
+        return None
+    return sum(value for _, value in series)
+
+
+def _max_scalar(families: ParsedFamilies, names: tuple[str, ...]) -> float | None:
+    """Largest reading across several gauges, ignoring the ones not present.
+
+    Args:
+        families (ParsedFamilies): Parsed exposition.
+        names (tuple[str, ...]): Metric names to consider.
+
+    Returns:
+        float | None: The max, or ``None`` when none of the names appeared.
+    """
+    values = [v for name in names if (v := _scalar(families, name)) is not None]
+    return max(values) if values else None
+
+
+def _sum_scalar(families: ParsedFamilies, names: tuple[str, ...]) -> float | None:
+    """Sum of several gauges, ignoring the ones not present.
+
+    Args:
+        families (ParsedFamilies): Parsed exposition.
+        names (tuple[str, ...]): Metric names to add.
+
+    Returns:
+        float | None: The sum, or ``None`` when none of the names appeared.
+    """
+    values = [v for name in names if (v := _scalar(families, name)) is not None]
+    return sum(values) if values else None
+
+
+def _series(families: ParsedFamilies, name: str) -> dict[str, float]:
+    """Read a counter as a per-label-set mapping.
+
+    Args:
+        families (ParsedFamilies): Parsed exposition.
+        name (str): Metric name.
+
+    Returns:
+        dict[str, float]: Canonical label key to value; empty when absent.
+    """
+    return {canonical_label_key(labels): value for labels, value in families.get(name, [])}
+
+
+@dataclass(frozen=True)
+class KvSample:
+    """One ``/metrics`` scrape, normalised across engines.
+
+    Every metric is ``None`` when the engine did not expose it. Read them with
+    ``is None``, never with truthiness: an idle pool reports a true 0.0, and an
+    engine that has not been asked for a token yet reports 0.0 for minutes.
+
+    Attributes:
+        ts (float): Wall clock, for lining up with externally collected data.
+        mono (float): Monotonic clock, for intervals within the run.
+        engine (str): ``"sglang"``, ``"vllm"``, or ``""`` when unrecognised.
+        active_pool_usage (float | None): Fraction of the pool held by running
+            requests. This is the pressure reading.
+        physical_pool_usage (float | None): Fraction physically occupied,
+            including blocks the prefix cache holds but would release. A pool
+            at 100% physical can be under no pressure at all -- that is prefix
+            cache doing its job -- which is why this is reported separately and
+            never as "the" occupancy. SGLang only; vLLM cannot express it.
+        used_tokens (float | None): Tokens held by running requests.
+        evictable_tokens (float | None): Tokens the prefix cache holds and would
+            hand back under pressure.
+        available_tokens (float | None): Tokens free outright.
+        capacity_tokens (float | None): Pool size, derived as used + available +
+            evictable. Not read from a gauge because none reports it directly.
+        capacity_gb (float | None): Pool size in GiB as the engine reports it.
+            The engine's "GB" is 1024-based; do not rescale it.
+        retract_total (dict[str, float]): SGLang cumulative retracts, per label
+            series. Kept per series so an engine restart shows up as a series
+            resetting rather than as a total going backwards.
+        preempt_total (dict[str, float]): vLLM cumulative preemptions, likewise.
+        prefix_cache_queries (float | None): vLLM cumulative prefix lookups.
+        prefix_cache_hits (float | None): vLLM cumulative prefix hits.
+        cached_tokens_total (float | None): SGLang cumulative prefix-cached
+            tokens. Absent entirely when prefix caching is off -- the metric is
+            not emitted at all, rather than emitted as zero.
+    """
+
+    ts: float
+    mono: float
+    engine: str = ""
+    active_pool_usage: float | None = None
+    physical_pool_usage: float | None = None
+    used_tokens: float | None = None
+    evictable_tokens: float | None = None
+    available_tokens: float | None = None
+    capacity_tokens: float | None = None
+    capacity_gb: float | None = None
+    retract_total: dict[str, float] = field(default_factory=dict)
+    preempt_total: dict[str, float] = field(default_factory=dict)
+    prefix_cache_queries: float | None = None
+    prefix_cache_hits: float | None = None
+    cached_tokens_total: float | None = None
+
+    def has_readings(self) -> bool:
+        """Whether this scrape carried any KV signal at all.
+
+        A reachable endpoint that exposes no KV metric -- an engine started
+        without them, or one whose exposition this module does not recognise --
+        must not be recorded as a row of nothing.
+
+        Returns:
+            bool: True when at least one occupancy or pressure field is set.
+        """
+        return any(
+            value is not None
+            for value in (
+                self.active_pool_usage,
+                self.physical_pool_usage,
+                self.used_tokens,
+                self.capacity_gb,
+            )
+        ) or bool(self.retract_total or self.preempt_total)
+
+
+def _detect_engine(families: ParsedFamilies) -> str:
+    """Identify the engine from its metric-name prefix.
+
+    Args:
+        families (ParsedFamilies): Parsed exposition.
+
+    Returns:
+        str: ``"sglang"``, ``"vllm"``, or ``""`` when neither prefix appears.
+    """
+    for name in families:
+        if name.startswith("sglang:"):
+            return "sglang"
+        if name.startswith("vllm:"):
+            return "vllm"
+    return ""
+
+
+def sample_from_families(
+    families: ParsedFamilies,
+    *,
+    ts: float | None = None,
+    mono: float | None = None,
+) -> KvSample:
+    """Build a normalised sample from a parsed exposition.
+
+    Args:
+        families (ParsedFamilies): Output of :func:`parse_prometheus_text`.
+        ts (float | None): Wall clock to stamp; defaults to now.
+        mono (float | None): Monotonic clock to stamp; defaults to now.
+
+    Returns:
+        KvSample: The normalised reading. Fields the engine did not expose stay
+        ``None``.
+    """
+    engine = _detect_engine(families)
+    used = _scalar(families, _SGL_USED)
+    available = _scalar(families, _SGL_AVAILABLE)
+    evictable = _sum_scalar(families, _SGL_EVICTABLE)
+
+    capacity: float | None = None
+    if used is not None and available is not None:
+        capacity = used + available + (evictable or 0.0)
+
+    physical: float | None = None
+    if capacity and capacity > 0 and used is not None:
+        physical = (used + (evictable or 0.0)) / capacity
+
+    active = _max_scalar(families, _SGL_USAGE)
+    if active is None:
+        active = _max_scalar(families, _VLLM_USAGE)
+
+    return KvSample(
+        ts=time.time() if ts is None else ts,
+        mono=time.monotonic() if mono is None else mono,
+        engine=engine,
+        active_pool_usage=active,
+        physical_pool_usage=physical,
+        used_tokens=used,
+        evictable_tokens=evictable,
+        available_tokens=available,
+        capacity_tokens=capacity,
+        capacity_gb=_scalar(families, _SGL_CAPACITY_GB),
+        retract_total=_series(families, _SGL_RETRACT_TOTAL),
+        preempt_total=_series(families, _VLLM_PREEMPT_TOTAL),
+        prefix_cache_queries=_scalar(families, _VLLM_PREFIX_QUERIES),
+        prefix_cache_hits=_scalar(families, _VLLM_PREFIX_HITS),
+        cached_tokens_total=_scalar(families, _SGL_CACHED_TOKENS),
+    )
+
+
+def resolve_metrics_port(config_envs: dict[str, Any] | None = None) -> int:
+    """Resolve the port the engine serves ``/metrics`` on.
+
+    The server binds whatever ``benchmark.envs.PORT`` the materialized YAML
+    pins -- an ephemeral port assigned per session, not a constant -- so the
+    caller's config is the authoritative source and the ambient env is only a
+    fallback for paths that never materialize a YAML.
+
+    Args:
+        config_envs (dict[str, Any] | None): The materialized config's
+            ``benchmark.envs`` mapping, when the caller has it.
+
+    Returns:
+        int: The resolved port, falling back to :data:`DEFAULT_METRICS_PORT`.
+    """
+    for source in (config_envs or {}, os.environ):
+        raw = source.get("PORT")
+        if raw in (None, ""):
+            continue
+        try:
+            port = int(str(raw).strip())
+        except (TypeError, ValueError):
+            continue
+        if port > 0:
+            return port
+    return DEFAULT_METRICS_PORT
+
+
+class KvMetricsPoller:
+    """Scrapes one engine's ``/metrics``, degrading quietly when it cannot.
+
+    Built to sit inside the executors' existing 0.5s watchdog loop rather than
+    in a process of its own: a sampler racing the engine for CPU would show up
+    in the very latency numbers the round exists to measure.
+
+    Availability is tri-state and sticky. Until the first successful scrape the
+    poller is ``unknown``; a scrape that lands makes it available for good; a
+    run of consecutive failures parks it as unavailable and it stops issuing
+    requests, because the common cause is an engine started without
+    ``--enable-metrics``, and that will not fix itself mid-round.
+    """
+
+    def __init__(
+        self,
+        *,
+        port: int | None = None,
+        host: str = "127.0.0.1",
+        config_envs: dict[str, Any] | None = None,
+        timeout_sec: float = _SCRAPE_TIMEOUT_SEC,
+    ) -> None:
+        """Bind the poller to an endpoint without contacting it.
+
+        Args:
+            port (int | None): Explicit port; resolved from config/env when
+                omitted.
+            host (str): Host to scrape. The engine is process-local on every
+                path that reaches here.
+            config_envs (dict[str, Any] | None): Materialized ``benchmark.envs``
+                used for port resolution.
+            timeout_sec (float): Per-scrape timeout.
+        """
+        self.port = int(port) if port else resolve_metrics_port(config_envs)
+        self.url = f"http://{host}:{self.port}/metrics"
+        self.timeout_sec = float(timeout_sec)
+        self._failures = 0
+        self._succeeded = False
+        self._gave_up = False
+        self._warned = False
+
+    @property
+    def available(self) -> bool | None:
+        """Tri-state reachability of the endpoint.
+
+        Returns:
+            bool | None: ``True`` once a scrape has landed, ``False`` once the
+            poller has given up, ``None`` while still unknown. Callers must test
+            with ``is True`` / ``is False``; treating ``None`` as ``False`` would
+            record "no metrics" for a round that simply had not booted yet.
+        """
+        if self._succeeded:
+            return True
+        if self._gave_up:
+            return False
+        return None
+
+    def fetch(self) -> str | None:
+        """Scrape once.
+
+        Returns:
+            str | None: The response body, or ``None`` when the endpoint could
+            not be read (including when the poller has already given up). Never
+            raises: this runs alongside a measured benchmark.
+        """
+        if self._gave_up:
+            return None
+        try:
+            with urllib.request.urlopen(self.url, timeout=self.timeout_sec) as response:  # noqa: S310
+                body = response.read().decode("utf-8", "ignore")
+        except (urllib.error.URLError, OSError, ValueError) as exc:
+            self._failures += 1
+            if self._failures >= _MAX_CONSECUTIVE_FAILURES and not self._succeeded:
+                self._gave_up = True
+                if not self._warned:
+                    self._warned = True
+                    log.info(
+                        "kv_metrics: %s unreachable after %d attempts (%s); KV metrics "
+                        "recorded as unavailable for this round. SGLang needs "
+                        "--enable-metrics; vLLM exposes it by default.",
+                        self.url,
+                        self._failures,
+                        exc,
+                    )
+            return None
+        self._failures = 0
+        self._succeeded = True
+        return body
+
+    def sample(self) -> KvSample | None:
+        """Scrape and normalise in one step.
+
+        Returns:
+            KvSample | None: The reading, or ``None`` when the endpoint was
+            unreadable or exposed no KV metric at all.
+        """
+        body = self.fetch()
+        if body is None:
+            return None
+        sample = sample_from_families(parse_prometheus_text(body))
+        return sample if sample.has_readings() else None

--- a/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
+++ b/src/hyperloom/orchestrator/actions/executors/_kv_metrics.py
@@ -87,6 +87,10 @@ _OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 #: ``--enable-metrics``) would otherwise pay a connection refusal every couple of seconds for the whole round.
 _MAX_CONSECUTIVE_FAILURES = 3
 
+#: ...but not before this much time has passed since the first attempt. The count alone gives up after roughly six
+#: seconds, which an engine can easily still be inside after logging that it is ready.
+_GIVE_UP_GRACE_SEC = 60.0
+
 
 # ---------------------------------------------------------------------------
 # Metric names
@@ -440,22 +444,64 @@ def sample_from_families(
     )
 
 
-def resolve_metrics_port(config_envs: dict[str, Any] | None = None) -> int:
+def _port_value(raw: Any) -> int | None:
+    """One PORT reading as a usable port number, or ``None``."""
+    if raw in (None, ""):
+        return None
+    try:
+        port = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    return port if port > 0 else None
+
+
+def port_from_workspace(workspace: Any) -> int | None:
+    """Read ``benchmark.envs.PORT`` out of the round's materialized config.
+
+    This is the only place the port is reliably written. The subprocess environment does not carry it -- the port is
+    pinned in the YAML that Magpie reads, not exported to the parent -- so resolving from the environment alone lands
+    on the default and scrapes a port nothing is listening on. Observed on a real session: two of three rounds bound an
+    ephemeral 34407 while collection sat on 8888 and recorded the engine as unavailable, and the one round that worked
+    did so only because it happened to bind the default.
+    """
+    try:
+        root = Path(workspace)
+        # The round's own config first, then the benchmark's copy, which only exists once the client has started.
+        for pattern in ("*.yaml", "*/config.yaml"):
+            for candidate in sorted(root.glob(pattern)):
+                try:
+                    import yaml
+
+                    payload = yaml.safe_load(candidate.read_text(encoding="utf-8"))
+                except Exception:  # noqa: BLE001 - a config we cannot read is not a reason to fail a round
+                    continue
+                if not isinstance(payload, dict):
+                    continue
+                envs = (
+                    (payload.get("benchmark") or {}).get("envs") if isinstance(payload.get("benchmark"), dict) else None
+                )
+                port = _port_value(envs.get("PORT")) if isinstance(envs, dict) else None
+                if port is not None:
+                    return port
+    except OSError:
+        return None
+    return None
+
+
+def resolve_metrics_port(config_envs: dict[str, Any] | None = None, workspace: Any = None) -> int:
     """Resolve the port the engine serves ``/metrics`` on.
 
     The server binds whatever ``benchmark.envs.PORT`` the materialized YAML pins -- an ephemeral port assigned per
-    session, not a constant -- so the caller's config is the authoritative source and the ambient env is only a fallback
-    for paths that never materialize a YAML.
+    session, not a constant. The YAML is therefore the authority; the caller's env and the ambient env are fallbacks for
+    paths that never materialize one, and the default is a last resort that is only ever right by coincidence.
     """
     for source in (config_envs or {}, os.environ):
-        raw = source.get("PORT")
-        if raw in (None, ""):
-            continue
-        try:
-            port = int(str(raw).strip())
-        except (TypeError, ValueError):
-            continue
-        if port > 0:
+        port = _port_value(source.get("PORT"))
+        if port is not None:
+            return port
+    if workspace is not None:
+        port = port_from_workspace(workspace)
+        if port is not None:
             return port
     return DEFAULT_METRICS_PORT
 
@@ -479,15 +525,17 @@ class KvMetricsPoller:
         host: str = "127.0.0.1",
         config_envs: dict[str, Any] | None = None,
         timeout_sec: float = _SCRAPE_TIMEOUT_SEC,
+        workspace: Any = None,
     ) -> None:
         """Bind the poller to an endpoint without contacting it."""
-        self.port = int(port) if port else resolve_metrics_port(config_envs)
+        self.port = int(port) if port else resolve_metrics_port(config_envs, workspace)
         self.url = f"http://{host}:{self.port}/metrics"
         self.timeout_sec = float(timeout_sec)
         self._failures = 0
         self._succeeded = False
         self._gave_up = False
         self._warned = False
+        self._first_attempt_mono: float | None = None
 
     @property
     def available(self) -> bool | None:
@@ -502,21 +550,30 @@ class KvMetricsPoller:
         """Scrape once."""
         if self._gave_up:
             return None
+        now = time.monotonic()
+        if self._first_attempt_mono is None:
+            self._first_attempt_mono = now
         try:
             with _OPENER.open(self.url, timeout=self.timeout_sec) as response:
                 body = response.read().decode("utf-8", "ignore")
         except (urllib.error.URLError, OSError, ValueError) as exc:
             self._failures += 1
-            if self._failures >= _MAX_CONSECUTIVE_FAILURES and not self._succeeded:
+            # Both a count and a clock. On the count alone, three misses inside six seconds park the poller for the rest
+            # of the round -- and an engine that has logged "ready" can still be a few seconds from accepting a request,
+            # so a round would go dark for the whole of it over a start that was merely slow. The grace makes giving up
+            # mean "nothing answered here for a minute", which is the case the sticky give-up was written for.
+            waited = now - (self._first_attempt_mono or now)
+            if self._failures >= _MAX_CONSECUTIVE_FAILURES and waited >= _GIVE_UP_GRACE_SEC and not self._succeeded:
                 self._gave_up = True
                 if not self._warned:
                     self._warned = True
                     log.info(
-                        "kv_metrics: %s unreachable after %d attempts (%s); KV metrics "
-                        "recorded as unavailable for this round. SGLang needs "
-                        "--enable-metrics; vLLM exposes it by default.",
+                        "kv_metrics: %s unreachable after %d attempts over %.0fs (%s); KV metrics "
+                        "recorded as unavailable for this round. Check the port against the round's "
+                        "benchmark.envs.PORT; SGLang also needs --enable-metrics (vLLM exposes it by default).",
                         self.url,
                         self._failures,
+                        waited,
                         exc,
                     )
             return None

--- a/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
+++ b/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
@@ -1,25 +1,30 @@
 # SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Reliable subprocess-tree teardown for Magpie-launched servers."""
+"""Reliable subprocess-tree teardown for Magpie-launched servers.
+
+Magpie's shell wrappers ``trap``/``setsid``/``nohup`` the vLLM/SGLang server,
+so on a Hyperloom-side timeout or error the server child can survive, holding
+GPU memory and keeping a ``bash`` alive that may later re-source a script
+mid-copy. To prevent that, Magpie is launched in its own POSIX session
+(``start_new_session=True``) so ``os.killpg`` reaps the whole tree, and
+:func:`kill_my_spawned_server` is called from every exit path (idempotent,
+never raises). Scoped strictly to the tree we created, so it's safe on every
+benchmark call.
+"""
 
 from __future__ import annotations
 
 import glob
 import logging
 import os
+import signal
 import subprocess
 import sys
 import threading
 import time
 from pathlib import Path
-from typing import Callable, NamedTuple
-
-# ``TERM_GRACE_SECONDS`` is this module's name for the shared SIGTERM-to-SIGKILL
-# grace: a driver-side teardown of a server a round left behind waits for the
-# same thing on the same signal, so it waits exactly as long.
-from hyperloom.common.proctree import TERM_GRACE_SEC as TERM_GRACE_SECONDS
-from hyperloom.common.proctree import collect_tree, group_alive, kill_tree, signal_group
+from typing import Any, Callable, NamedTuple
 
 from .bypass_analysis import parse_server_log_throughput
 
@@ -28,25 +33,45 @@ from ..cancel_channel import CancelScope, cancel_scope_listener
 log = logging.getLogger(__name__)
 
 
+# Grace window between SIGTERM and SIGKILL, here and for a driver-side teardown
+# of a server a round left behind: the same signal, the same thing being waited
+# for.
+TERM_GRACE_SECONDS: float = 5.0
+
 # How long the reaper waits to collect the SIGKILL'd child before giving up on it.
 _REAP_COLLECT_SECONDS: float = 1.0
 
 # How long draining a reaped child's capture threads is given.
 _CAPTURE_DRAIN_SECONDS: float = 2.0
 
-# How often the blocking side looks up from the child to check its stop gates -- the session deadline and the cancel
-# scope among them.
+# How often the blocking side looks up from the child to check its stop gates --
+# the session deadline and the cancel scope among them. Short enough that the
+# check costs a stop almost nothing on top of the reap, long enough not to spin.
 STOP_GATE_POLL_SECONDS: float = 0.5
 
-# What stopping a running round costs, end to end, from the moment something asks it to: noticing at the poll,
-# SIGTERM'ing the tree, waiting out the grace before SIGKILL, collecting the child, and draining its pipes.
+# What stopping a running round costs, end to end, from the moment something asks
+# it to: noticing at the poll, SIGTERM'ing the tree, waiting out the grace before
+# SIGKILL, collecting the child, and draining its pipes.
+#
+# Every window that waits for a round to stop itself is derived from this rather
+# than picked next to it -- the Ray submitter's grace and the dispatcher's
+# cooperative window both are. A window shorter than what stopping costs looks
+# generous in isolation and still expires every time, and what it discards is the
+# honest sentinel the round was about to return, replacing it with a hard kill
+# and an unattributed failure.
 COOPERATIVE_REAP_BUDGET_SEC: float = (
     STOP_GATE_POLL_SECONDS + TERM_GRACE_SECONDS + _REAP_COLLECT_SECONDS + _CAPTURE_DRAIN_SECONDS
 )
 
 
 def new_session_kwargs() -> dict:
-    """``Popen`` kwargs so the child gets its own POSIX session (killable via ``os.killpg``)."""
+    """``Popen`` kwargs so the child gets its own POSIX session (killable via
+    ``os.killpg``). Returns ``{}`` on non-POSIX.
+
+    Returns:
+        A kwargs dict to splat into ``Popen``; ``{"start_new_session": True}``
+        on POSIX, otherwise an empty dict.
+    """
     if os.name == "posix":
         return {"start_new_session": True}
     return {}
@@ -55,6 +80,9 @@ def new_session_kwargs() -> dict:
 def _process_group_alive(pgid: int) -> bool:
     """Return True iff at least one process is still in ``pgid``.
 
+    ``killpg(pgid, 0)`` raises ``ProcessLookupError`` once the group is empty;
+    any other ``OSError`` (e.g. sandbox ``EPERM``) is treated as "still alive".
+
     Args:
         pgid: The POSIX process-group id to probe.
 
@@ -62,7 +90,15 @@ def _process_group_alive(pgid: int) -> bool:
         True if the group still has at least one member (or liveness is
         indeterminate), False once the group is empty or on non-POSIX.
     """
-    return group_alive(pgid)
+    if os.name != "posix":
+        return False
+    try:
+        os.killpg(pgid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except OSError:
+        return True
 
 
 def _signal_group(pgid: int, sig: int) -> None:
@@ -72,7 +108,19 @@ def _signal_group(pgid: int, sig: int) -> None:
         pgid (int): The POSIX process-group id to signal.
         sig (int): The signal number to send.
     """
-    signal_group(pgid, sig, what="_subprocess_kill")
+    if os.name != "posix":
+        return
+    try:
+        os.killpg(pgid, sig)
+    except ProcessLookupError:
+        pass
+    except OSError as exc:
+        log.warning(
+            "_subprocess_kill: killpg(%d, %d) failed: %s",
+            pgid,
+            sig,
+            exc,
+        )
 
 
 def kill_my_spawned_server(
@@ -80,7 +128,20 @@ def kill_my_spawned_server(
     *,
     grace_seconds: float = TERM_GRACE_SECONDS,
 ) -> None:
-    """Tear down the entire process tree rooted at ``proc``."""
+    """Tear down the entire process tree rooted at ``proc``.
+
+    No-op when ``proc`` is ``None`` or already exited. SIGTERM the group, wait
+    up to ``grace_seconds``, then SIGKILL survivors. Never raises (logs a
+    warning on unexpected signalling failure). Requires the child to have been
+    launched with :func:`new_session_kwargs` so its pgid is distinct from
+    Hyperloom's own; asserted defensively below.
+
+    Args:
+        proc: The spawned process whose tree should be reaped; ``None`` is a
+            no-op.
+        grace_seconds: Seconds to wait after SIGTERM before SIGKILLing
+            survivors.
+    """
     if proc is None:
         return
     if proc.poll() is not None:
@@ -125,14 +186,16 @@ def kill_my_spawned_server(
         )
         return
 
-    try:
-        tree = collect_tree([proc.pid])
-    except OSError as exc:
-        # Every caller reaps from a ``finally:``, so an unreadable procfs has to
-        # be reported rather than raised on top of whatever sent us here.
-        log.error("_subprocess_kill: cannot enumerate the tree under pid=%d: %s", proc.pid, exc)
-        return
-    kill_tree(tree, grace_sec=grace_seconds, confirm_sec=grace_seconds)
+    _signal_group(pgid, signal.SIGTERM)
+
+    deadline = time.monotonic() + grace_seconds
+    while time.monotonic() < deadline:
+        if not _process_group_alive(pgid):
+            break
+        time.sleep(0.05)
+
+    if _process_group_alive(pgid):
+        _signal_group(pgid, signal.SIGKILL)
 
     try:
         proc.wait(timeout=_REAP_COLLECT_SECONDS)
@@ -149,18 +212,39 @@ def kill_my_spawned_server(
         pass
 
 
-# Sentinel ``returncode`` allocation.
+# Sentinel ``returncode`` allocation. This module is not the only owner of the
+# space -- ``_ray_serving`` hands out Ray-actor codes from it too, and both
+# arrive at their consumer as a bare ``returncode`` carrying no other tag. A
+# number claimed by a second cause therefore makes attribution a coin flip, so
+# allocate an unused one; ``test_every_sentinel_returncode_names_exactly_one_cause``
+# enumerates both modules and fails on reuse.
 
-# Sentinel ``returncode`` when ``run_with_session_kill`` reaps a child for an elapsed ``soft_deadline_sec`` (vs the
-# ``timeout=`` hard cap, which raises ``TimeoutExpired``).
+# Sentinel ``returncode`` when ``run_with_session_kill`` reaps a child for an
+# elapsed ``soft_deadline_sec`` (vs the ``timeout=`` hard cap, which raises
+# ``TimeoutExpired``). Chosen not to collide with a real signal-based returncode.
 OVERTIME_KILL_RETURNCODE: int = -909
 
-# Sentinel ``returncode`` when the server-liveness watchdog reaps a child whose engine/worker bootstrap died but whose
-# parent ``vllm serve`` / ``sglang.launch_server`` process hung instead of exiting.
+# Sentinel ``returncode`` when the server-liveness watchdog reaps a child whose
+# engine/worker bootstrap died but whose parent ``vllm serve`` /
+# ``sglang.launch_server`` process hung instead of exiting.
 SERVER_DEAD_RETURNCODE: int = -910
 
-# Fatal server-init markers: once any appears in ``server.log`` the engine is unrecoverable within the same Magpie
-# subprocess.
+# Fatal server-init markers: once any appears in ``server.log`` the engine is
+# unrecoverable within the same Magpie subprocess. Kept specific (terminal
+# bootstrap failures, never transient per-shape warnings) so the watchdog cannot
+# false-positive on a server that is merely slow to load.
+#
+# Two families:
+#  1. Runtime engine/worker bootstrap crashes (engine core / worker proc).
+#  2. Config-validation-stage failures that die BEFORE the engine starts — most
+#     importantly a brand-new checkpoint ``model_type`` that the installed
+#     transformers / vLLM does not recognise (``pydantic`` ``ModelConfig``
+#     ``ValidationError``). These are just as terminal, and surfacing their
+#     excerpt is what lets the enablement failure classifier see
+#     ``missing_model_arch`` (and seed the ``pip install -U transformers/vllm``
+#     bridge) instead of the Magpie wrapper's uninformative ``subprocess_nonzero``
+#     stdout tail, which classifies as ``unknown`` and starves every enablement
+#     round of the real root cause.
 _SERVER_DEAD_MARKERS: tuple[str, ...] = (
     # (1) runtime engine/worker bootstrap crashes
     "WorkerProc initialization failed",
@@ -170,23 +254,31 @@ _SERVER_DEAD_MARKERS: tuple[str, ...] = (
     "AsyncEngineDeadError",
     "raise EngineDeadError",
     "Failed core proc(s)",
-    # (2) config-validation-stage terminal failures (pre-engine).
+    # (2) config-validation-stage terminal failures (pre-engine). Kept to
+    #     specific failure phrases (never a bare "Model architectures" INFO
+    #     banner) so the liveness watchdog cannot false-positive on a healthy
+    #     slow-loading server.
     "does not recognize this architecture",
     "Transformers does not recognize",
     "ValidationError for ModelConfig",
     "are not supported for now",
 )
 
-# Default grace after the first fatal marker before forcing a reap.
+# Default grace after the first fatal marker before forcing a reap. Overridable
+# via ``INFERENCE_OPTIMIZER_SERVER_DEAD_GRACE_SEC``.
 _SERVER_DEAD_GRACE_SEC_DEFAULT: float = 120.0
 
 
-# Sentinel ``returncode`` when the detokenizer-stall watchdog reaps a child that came up healthy but then produced no
-# generation progress (hung engine / detokenizer wedge).
+# Sentinel ``returncode`` when the detokenizer-stall watchdog reaps a child that
+# came up healthy but then produced no generation progress (hung engine /
+# detokenizer wedge). Distinct so callers can label it
+# ``error_class="detokenizer_stall"``.
 DETOKENIZER_STALL_RETURNCODE: int = -911
 
-# Sentinel ``returncode`` returned by the _run_magpie AgentX hook when the execution-boundary preflight fails (aiperf
-# missing or not weka-trace capable) before any benchmark launches.
+# Sentinel ``returncode`` returned by the _run_magpie AgentX hook when the
+# execution-boundary preflight fails (aiperf missing or not weka-trace capable)
+# before any benchmark launches. Distinct so callers label it
+# ``error_class="agentx_preflight"`` and surface the guidance instead of crashing.
 AGENTX_PREFLIGHT_RETURNCODE: int = -912
 
 #: The ``error_class`` that sentinel must carry, wherever it is classified. Named
@@ -203,17 +295,30 @@ AGENTX_PREFLIGHT_ERROR_CLASS: str = "agentx_preflight"
 
 # -913 is ``_ray_serving._RAY_ACTOR_DIED_RC``.
 
-# Sentinel ``returncode`` returned by the _run_magpie eval hook when the generation bounds / pathology probe cannot be
-# installed even though the target file is present and this variant runs eval.
+# Sentinel ``returncode`` returned by the _run_magpie eval hook when the
+# generation bounds / pathology probe cannot be installed even though the target
+# file is present and this variant runs eval. Distinct so callers label it
+# ``error_class="eval_probe_unpatchable"`` -- the same class the baseline arm
+# already fails with, so a bounds gap reads identically on both arms.
 EVAL_PROBE_UNPATCHABLE_RETURNCODE: int = -914
 
-# Sentinel ``returncode`` when the session wall-clock budget ran out mid-round and the tree was reaped.
+# Sentinel ``returncode`` when the session wall-clock budget ran out mid-round and
+# the tree was reaped. Deliberately distinct from ``OVERTIME_KILL_RETURNCODE``:
+# that one says "this variant ran far longer than the baseline", which is a
+# judgement about the variant, while this one says "the run was out of time",
+# which says nothing about the variant at all. Sharing a code would teach the KB
+# that a variant is slow whenever a session happened to end during it.
 SESSION_TIME_EXHAUSTED_RETURNCODE: int = -915
 
 # -916 is ``_ray_serving._ACTOR_TIMEOUT_RC``.
 
-# Sentinel ``returncode`` when the orchestrator cancelled the action this child was launched for -- a shutdown, or a
-# budget that is spent.
+# Sentinel ``returncode`` when the orchestrator cancelled the action this child
+# was launched for -- a shutdown, or a budget that is spent. Distinct from
+# ``SESSION_TIME_EXHAUSTED_RETURNCODE`` because the two causes are told apart at
+# the source: that one is the round's own deadline elapsing where it runs, this
+# one is a decision taken outside it, and only one of them is still true when the
+# same session resumes. Distinct from ``OVERTIME_KILL_RETURNCODE`` for the reason
+# that one already carries: neither says anything about the variant.
 ORCHESTRATOR_CANCELLED_RETURNCODE: int = -917
 
 # Server-ready markers: their appearance in ``server.log`` means the server has
@@ -226,20 +331,41 @@ _SERVER_READY_MARKERS: tuple[str, ...] = (
     "The server is fired up and ready to roll",
 )
 
-# Accuracy-eval start markers: their appearance means the benchmark phase of the run is over and the accuracy eval has
-# begun.
+# Accuracy-eval start markers: their appearance means the benchmark phase of the
+# run is over and the accuracy eval has begun. The soft deadline measures
+# throughput only, so it stops being enforced from this point on — eval duration
+# is not a throughput signal and the anchor it is compared against excludes it.
+# The hard timeout and the dead/stall watchdogs stay armed.
 _EVAL_START_MARKERS: tuple[str, ...] = (
     "HYPERLOOM_EVAL_START",
     "[magpie_bench_remote_compat] lm_eval cmd:",
 )
 
-# The benchmark body's own stderr: Magpie redirects it here rather than into ``server.log`` or the parent's pipe, so
-# it is both where the eval-start marker lands and the one resolved log whose growth is output of the very child this
+# The benchmark body's own stderr: Magpie redirects it here rather than into
+# ``server.log`` or the parent's pipe, so it is both where the eval-start marker
+# lands and the one resolved log whose growth is output of the very child this
 # module is waiting on.
 _EVAL_LOG_NAME: str = "benchmark_stderr.log"
 
-# Default grace: how long after the server reports ready it may emit no log output before the watchdog declares a hang
-# / detokenizer stall.
+# AgentX phase boundaries. The agentic client runs a long cold-cache warmup --
+# measured at nearly 18 minutes -- before the window that is actually being
+# measured opens, and mixing the two makes every KV statistic meaningless. The
+# boundary needs no marker of ours: aiperf already prints structured phase
+# transitions at NOTICE with millisecond stamps, so these match its own text.
+# Anchored on the parenthesised phase id rather than the whole line so a change
+# to the human-readable half does not silently stop the split.
+_AGENTX_WARMUP_BEGIN_MARKERS: tuple[str, ...] = ("(warmup) started",)
+_AGENTX_MEASURED_BEGIN_MARKERS: tuple[str, ...] = ("(profiling) started",)
+
+# aiperf writes only this file: an AgentX benchmark directory has no
+# ``benchmark_stdout.log`` / ``benchmark_stderr.log`` the way a synthetic one
+# does, so the phase lines are unreachable unless it is scanned explicitly.
+_AGENTX_LOG_RELPATH: str = "aiperf_artifacts/logs/aiperf.log"
+
+# Default grace: how long after the server reports ready it may emit no log
+# output before the watchdog declares a hang / detokenizer stall. Measured from
+# the ready marker so the cold start is never counted. ``<= 0`` disables the
+# gate. Overridable via ``INFERENCE_OPTIMIZER_DETOK_STALL_GRACE_SEC``.
 _DETOK_STALL_GRACE_SEC_DEFAULT: float = 1800.0
 
 
@@ -253,7 +379,15 @@ class _StreamCapture:
         text: bool,
         on_output: Callable[[], None] | None = None,
     ) -> None:
-        """Set up capture/mirror threads for a child's stdout and stderr."""
+        """Set up capture/mirror threads for a child's stdout and stderr.
+
+        Args:
+            proc: The child process whose pipes should be captured.
+            text: Whether the pipes are in text (``str``) or bytes mode.
+            on_output: Called once per observed unit of child output, from the
+                pump thread. Used as liveness evidence by callers that report
+                progress for a long step.
+        """
         self._text = text
         self._on_output = on_output
         self._stdout_chunks: list[str | bytes] = []
@@ -282,7 +416,15 @@ class _StreamCapture:
             thread.start()
 
     def finish(self, timeout: float = 2.0) -> tuple[str | bytes, str | bytes]:
-        """Join the capture threads and return the captured output."""
+        """Join the capture threads and return the captured output.
+
+        Args:
+            timeout: Per-thread join timeout in seconds.
+
+        Returns:
+            A ``(stdout, stderr)`` tuple of the captured streams (``str`` or
+            ``bytes`` depending on the capture mode).
+        """
         for thread in self._threads:
             thread.join(timeout=timeout)
         empty: str | bytes = "" if self._text else b""
@@ -301,11 +443,24 @@ class _StreamCapture:
             pass
 
     def _join(self, chunks: list[str | bytes]) -> str | bytes:
-        """Concatenate captured chunks using the appropriate empty separator."""
+        """Concatenate captured chunks using the appropriate empty separator.
+
+        Args:
+            chunks: Captured stdout or stderr chunks.
+
+        Returns:
+            The joined ``str`` or ``bytes`` output.
+        """
         return "".join(chunks) if self._text else b"".join(chunks)  # type: ignore[arg-type,return-value]
 
     def _pump(self, pipe, chunks: list[str | bytes], mirror) -> None:
-        """Read a pipe line-by-line, capturing and mirroring each line."""
+        """Read a pipe line-by-line, capturing and mirroring each line.
+
+        Args:
+            pipe: The child pipe to read from.
+            chunks: List that read chunks are appended to.
+            mirror: Parent stream the chunks are echoed to.
+        """
         try:
             while True:
                 chunk = pipe.readline()
@@ -321,7 +476,12 @@ class _StreamCapture:
                 pass
 
     def _mirror(self, chunk: str | bytes, mirror) -> None:
-        """Echo a captured chunk to the parent stream, ignoring errors."""
+        """Echo a captured chunk to the parent stream, ignoring errors.
+
+        Args:
+            chunk: The captured ``str``/``bytes`` chunk.
+            mirror: Parent stream to write to.
+        """
         try:
             if isinstance(chunk, bytes):
                 stream = getattr(mirror, "buffer", mirror)
@@ -336,13 +496,28 @@ class _StreamCapture:
 # Bytes read from the tail of ``server.log`` per scan.
 _SERVER_LOG_TAIL_BYTES: int = 65536
 
-# Glob (relative to the watched path's directory) for nested per-run server logs Magpie writes when its wrapper
-# ignores ``$SERVER_LOG`` and emits to a ``benchmark_<framework>_<timestamp>/server.log`` subdir instead.
+# Glob (relative to the watched path's directory) for nested per-run server logs
+# Magpie writes when its wrapper ignores ``$SERVER_LOG`` and emits to a
+# ``benchmark_<framework>_<timestamp>/server.log`` subdir instead.
 _NESTED_SERVER_LOG_GLOB: str = "benchmark_*/server.log"
 
 
 def _server_log_tail_has_marker(path: str) -> str | None:
-    """Return the death marker present in the tail of the single file ``path``, else None."""
+    """Return the death marker present in the tail of the single file ``path``,
+    else None.
+
+    Best-effort and never raises: a missing / unreadable log reads as "not
+    dead" (returns None).
+
+    Args:
+        path: Filesystem path to the server's ``server.log``.
+
+    Returns:
+        The first matched terminal engine/worker-init marker string if the log
+        tail contains one, otherwise None (including when the log is missing or
+        unreadable). Returning the marker (rather than a bare bool) lets the
+        watchdog report which fatal line tripped it instead of a placeholder.
+    """
     try:
         with open(path, "rb") as fh:
             try:
@@ -359,7 +534,27 @@ def _server_log_tail_has_marker(path: str) -> str | None:
 
 
 def _server_log_shows_death(path: str) -> str | None:
-    """Return the terminal engine/worker-init marker present in a server log, else None."""
+    """Return the terminal engine/worker-init marker present in a server log,
+    else None.
+
+    Scans the watched ``path`` AND any nested ``benchmark_*/server.log`` files in
+    the same directory. The nested fallback covers Magpie wrappers that ignore
+    ``$SERVER_LOG`` and write the real server log to a per-run subdir, which
+    otherwise leaves the watchdog reading an empty/absent file forever.
+
+    Best-effort and never raises: a missing / unreadable log (server hasn't
+    written yet) reads as "not dead" so a slow cold start is never misjudged.
+    Returning the marker (rather than a bare bool) lets the watchdog report
+    which fatal line tripped it instead of a placeholder.
+
+    Args:
+        path: Filesystem path to the server's ``server.log``.
+
+    Returns:
+        The first matched terminal engine/worker-init marker string from any
+        candidate log tail, or None when none is present (including when no log
+        is present or readable).
+    """
     marker = _server_log_tail_has_marker(path)
     if marker is not None:
         return marker
@@ -376,7 +571,24 @@ def _server_log_shows_death(path: str) -> str | None:
 
 
 def server_log_death_excerpt(path: str, *, max_chars: int = 1200) -> str | None:
-    """Return a short ``server.log`` excerpt around the first terminal engine/worker-init marker, or ``None`` when no fatal marker is present."""
+    """Return a short ``server.log`` excerpt around the first terminal
+    engine/worker-init marker, or ``None`` when no fatal marker is present.
+
+    Baseline / profile / explore failure classification calls this to surface
+    the real server-side root cause — e.g. vLLM's ``RuntimeError: Engine core
+    initialization failed`` — instead of the Magpie wrapper's generic
+    stdout/stderr tail. The excerpt keeps a couple of lines of context around
+    the marker. Best-effort: a missing / unreadable log returns ``None``.
+
+    Args:
+        path: Filesystem path to the server's ``server.log``.
+        max_chars: Maximum length of the returned excerpt; the tail is kept
+            when the excerpt is longer.
+
+    Returns:
+        A short multi-line excerpt around the first terminal init marker, or
+        ``None`` when no fatal marker is present.
+    """
     candidates = [path]
     try:
         base_dir = os.path.dirname(path) or "."
@@ -404,7 +616,8 @@ def server_log_death_excerpt(path: str, *, max_chars: int = 1200) -> str | None:
     return None
 
 
-# Name of the stamp written beside the caller's ``server.log`` the moment the server first reports ready.
+# Name of the stamp written beside the caller's ``server.log`` the moment the
+# server first reports ready.
 _READY_STAMP_NAME = "server_ready_at"
 
 
@@ -413,7 +626,7 @@ def _ready_stamp_path(server_log_path: str) -> Path:
     return Path(server_log_path).parent / _READY_STAMP_NAME
 
 
-def stamp_server_ready(server_log_path: str, boot_sec: float) -> None:
+def _stamp_server_ready(server_log_path: str, boot_sec: float) -> None:
     """Record, beside ``server_log_path``, that the server just reported ready.
 
     Two numbers, because they answer two questions and one clock cannot answer
@@ -457,7 +670,11 @@ def stamp_server_ready(server_log_path: str, boot_sec: float) -> None:
 
 
 def clear_server_ready_stamp(server_log_path: str) -> None:
-    """Drop any ready stamp an earlier round left in this output directory."""
+    """Drop any ready stamp an earlier round left in this output directory.
+
+    Args:
+        server_log_path: The ``<output_dir>/server.log`` path from the caller.
+    """
     try:
         _ready_stamp_path(server_log_path).unlink(missing_ok=True)
     except OSError as exc:
@@ -465,7 +682,20 @@ def clear_server_ready_stamp(server_log_path: str) -> None:
 
 
 def _read_ready_stamp(server_log_path: str) -> tuple[float, float] | None:
-    """Return a round's ``(ready_unix, boot_sec)``, or ``None`` when unrecorded."""
+    """Return a round's ``(ready_unix, boot_sec)``, or ``None`` when unrecorded.
+
+    Both fields are required. A stamp missing its boot is reported as no stamp at
+    all rather than as a boot of zero: zero is a legitimate boot, so it cannot
+    also stand for "not recorded", and reading it that way would hand the whole
+    round to the benchmark -- the figure every later variant is then admitted on.
+
+    Args:
+        server_log_path: The ``<output_dir>/server.log`` path from the caller.
+
+    Returns:
+        tuple[float, float] | None: The wall-clock instant the stamp was written
+        and the boot it measured, or ``None`` when no readable stamp exists.
+    """
     try:
         fields = _ready_stamp_path(server_log_path).read_text(encoding="utf-8").split()
         ready_unix = float(fields[0])
@@ -476,7 +706,15 @@ def _read_ready_stamp(server_log_path: str) -> tuple[float, float] | None:
 
 
 def server_ready_unix(server_log_path: str) -> float | None:
-    """Return when the server reported ready, or ``None`` when nothing recorded it."""
+    """Return when the server reported ready, or ``None`` when nothing recorded it.
+
+    Args:
+        server_log_path: The ``<output_dir>/server.log`` path from the caller.
+
+    Returns:
+        float | None: The wall-clock instant, or ``None`` when no stamp exists or
+        it is unreadable.
+    """
     stamp = _read_ready_stamp(server_log_path)
     return None if stamp is None else stamp[0]
 
@@ -487,7 +725,29 @@ def post_ready_runtime_sec(
     started_unix: float,
     runtime_sec: float,
 ) -> float | None:
-    """Return how long a round ran *after* its server was ready."""
+    """Return how long a round ran *after* its server was ready.
+
+    This is the part of a round's wall-clock that is the benchmark itself, with
+    boot, weight load, compile and graph capture excluded. It is what makes two
+    rounds comparable when one paid for a cold start and the other re-attached to
+    a server already up.
+
+    The round's wall-clock less the boot the stamp measured. The boot is a
+    duration taken on one clock, so this holds however far apart the writer and
+    the reader are; ``started_unix`` is only compared against the stamp's own
+    instant, to tell this round's stamp from one an earlier round left behind.
+
+    Args:
+        server_log_path: The ``<output_dir>/server.log`` path from the caller.
+        started_unix: When the round was spawned.
+        runtime_sec: The round's full wall-clock.
+
+    Returns:
+        float | None: Seconds after ready, bounded by the round's own runtime, or
+        ``None`` when the round never reported ready or the only stamp present
+        predates it (an earlier round's, left behind by a failed clear -- reading
+        it would report a cold round as though it had never booted).
+    """
     stamp = _read_ready_stamp(server_log_path)
     if stamp is None or stamp[0] < started_unix:
         return None
@@ -495,7 +755,21 @@ def post_ready_runtime_sec(
 
 
 def _resolve_scan_logs(server_log_path: str) -> list[str]:
-    """Return the log files to scan for markers, newest-nesting first."""
+    """Return the log files to scan for markers, newest-nesting first.
+
+    The caller passes ``<output_dir>/server.log``, but the Magpie benchmark
+    scripts write their logs into a ``benchmark_<fw>_<ts>/`` subdir of
+    ``$RESULT_DIR``, so that exact path usually does not exist. Resolve the
+    nested location and pair each ``server.log`` with the sibling
+    ``benchmark_stderr.log`` that carries the eval-start marker (the patcher
+    echoes it to stderr, which never reaches ``server.log``).
+
+    Args:
+        server_log_path: The ``<output_dir>/server.log`` path from the caller.
+
+    Returns:
+        Existing log paths to scan; empty when none are present yet.
+    """
     primary = Path(server_log_path)
     out: list[str] = []
     candidates = [primary]
@@ -504,7 +778,9 @@ def _resolve_scan_logs(server_log_path: str) -> list[str]:
     except OSError:
         pass
     for log in candidates:
-        for name in (log, log.with_name(_EVAL_LOG_NAME)):
+        # The AgentX client's own log sits under the benchmark workspace and is
+        # the only place its phase transitions appear.
+        for name in (log, log.with_name(_EVAL_LOG_NAME), log.parent / _AGENTX_LOG_RELPATH):
             text = str(name)
             if text not in out and name.exists():
                 out.append(text)
@@ -512,17 +788,74 @@ def _resolve_scan_logs(server_log_path: str) -> list[str]:
 
 
 class _LogScan(NamedTuple):
-    """What one pass over the resolved logs found in the bytes appended since the last."""
+    """What one pass over the resolved logs found in the bytes appended since the last.
+
+    Attributes:
+        saw_ready: A server-ready marker appeared.
+        saw_progress: A periodic decode-throughput line reported a non-zero
+            rate, so tokens were being produced during the interval whoever
+            logged them.
+        saw_eval_start: The accuracy eval announced itself.
+        grew: Some resolved log got longer, from any writer at all.
+        child_spoke: The benchmark body's own redirected stderr got longer,
+            which is output of the child being waited on that never reaches its
+            pipe.
+    """
 
     saw_ready: bool
     saw_progress: bool
     saw_eval_start: bool
     grew: bool
     child_spoke: bool
+    saw_warmup_begin: bool = False
+    saw_measured_begin: bool = False
+
+
+class _IncrementScan(NamedTuple):
+    """What one file's newly appended bytes carried.
+
+    A named shape rather than a bare tuple because the marker set grows: the
+    phase boundaries were added here after the fact, and a caller unpacking by
+    position would have had to change with them.
+
+    Attributes:
+        offset: Byte offset now consumed, to seed the next scan.
+        saw_ready: A server-ready marker appeared.
+        saw_progress: A decode-throughput line reported a non-zero rate.
+        saw_eval_start: The accuracy eval announced itself.
+        saw_warmup_begin: AgentX entered its cold-cache warmup.
+        saw_measured_begin: AgentX opened the measured window.
+    """
+
+    offset: int
+    saw_ready: bool
+    saw_progress: bool
+    saw_eval_start: bool
+    saw_warmup_begin: bool = False
+    saw_measured_begin: bool = False
 
 
 def _stale_scan_log_sizes(server_log_path: str) -> dict[str, int]:
-    """Current byte length of each nested log that already exists at spawn."""
+    """Current byte length of each nested log that already exists at spawn.
+
+    Seeded as starting offsets so such a log contributes only what it grows by,
+    never what a previous attempt left in it.
+
+    Only the nested ``benchmark_*/`` workspaces, not the path the caller named.
+    That one the caller owns: it clears it when it means this round to start
+    clean, and a caller that means to attach to a server already up says so with
+    ``server_already_ready``. The nested ones are found by globbing a directory
+    the caller reuses, so nothing in them was asserted by anyone -- and a stale
+    ready line there would otherwise latch on the first poll and report a boot
+    that took minutes as one that took none.
+
+    Args:
+        server_log_path: The ``<output_dir>/server.log`` path from the caller.
+
+    Returns:
+        dict[str, int]: Per-path byte lengths; a path whose size cannot be read
+        is left out, so it is scanned from the start as an absent one would be.
+    """
     owned_dir = Path(server_log_path).parent
     sizes: dict[str, int] = {}
     for path in _resolve_scan_logs(server_log_path):
@@ -537,56 +870,143 @@ def _stale_scan_log_sizes(server_log_path: str) -> dict[str, int]:
 
 
 def _scan_logs_increment(server_log_path: str, offsets: dict[str, int]) -> _LogScan:
-    """Scan every resolved log for markers, advancing ``offsets`` in place."""
+    """Scan every resolved log for markers, advancing ``offsets`` in place.
+
+    Args:
+        server_log_path: The ``<output_dir>/server.log`` path from the caller.
+        offsets: Per-path byte offsets already consumed; mutated in place.
+
+    Returns:
+        _LogScan: The markers seen in the newly appended bytes, plus who — if
+        anyone — did the appending.
+    """
     saw_ready = saw_progress = saw_eval_start = grew = child_spoke = False
+    saw_warmup_begin = saw_measured_begin = False
     for path in _resolve_scan_logs(server_log_path):
         prev = offsets.get(path, 0)
-        new_offset, ready, progress, eval_start = _scan_server_log_increment(path, prev)
-        offsets[path] = new_offset
-        saw_ready = saw_ready or ready
-        saw_progress = saw_progress or progress
-        saw_eval_start = saw_eval_start or eval_start
-        if new_offset > prev:
+        scan = _scan_server_log_increment(path, prev)
+        offsets[path] = scan.offset
+        saw_ready = saw_ready or scan.saw_ready
+        saw_progress = saw_progress or scan.saw_progress
+        saw_eval_start = saw_eval_start or scan.saw_eval_start
+        saw_warmup_begin = saw_warmup_begin or scan.saw_warmup_begin
+        saw_measured_begin = saw_measured_begin or scan.saw_measured_begin
+        if scan.offset > prev:
             grew = True
             child_spoke = child_spoke or Path(path).name == _EVAL_LOG_NAME
-    return _LogScan(saw_ready, saw_progress, saw_eval_start, grew, child_spoke)
+    return _LogScan(
+        saw_ready,
+        saw_progress,
+        saw_eval_start,
+        grew,
+        child_spoke,
+        saw_warmup_begin,
+        saw_measured_begin,
+    )
 
 
-def _scan_server_log_increment(path: str, from_offset: int) -> tuple[int, bool, bool, bool]:
-    """Incrementally scan the bytes appended to ``server.log`` since ``from_offset`` for ready / generation-progress / eval-start markers."""
+def _scan_server_log_increment(path: str, from_offset: int) -> _IncrementScan:
+    """Incrementally scan the bytes appended to ``server.log`` since
+    ``from_offset`` for ready / generation-progress / eval-start markers.
+
+    Reading only the NEW tail (not the whole file) keeps the per-poll cost flat
+    and — crucially — makes "progress" mean *fresh* progress: a throughput line
+    written ten minutes ago that still sits in the file is read exactly once,
+    so a wedged server that stops appending lines correctly reads as "no new
+    progress" on subsequent polls. Handles truncation/rotation (size shrank
+    below the offset) by rescanning from the start. Best-effort: a missing /
+    unreadable log reads as "no new markers" and leaves the offset unchanged so
+    a slow cold start is never misjudged.
+
+    Args:
+        path: Filesystem path to the server's ``server.log``.
+        from_offset: Byte offset already consumed by a prior scan.
+
+    Returns:
+        _IncrementScan: The advanced offset plus which markers the newly read
+        bytes carried.
+    """
     try:
         size = os.path.getsize(path)
     except OSError:
-        return from_offset, False, False, False
+        return _IncrementScan(from_offset, False, False, False)
     start = from_offset
     if size < start:  # truncated / rotated — rescan from the top.
         start = 0
     if size <= start:  # nothing new appended
-        return start, False, False, False
+        return _IncrementScan(start, False, False, False)
     try:
         with open(path, "rb") as fh:
             fh.seek(start)
             chunk = fh.read().decode("utf-8", "ignore")
     except (OSError, ValueError):
-        return from_offset, False, False, False
+        return _IncrementScan(from_offset, False, False, False)
     saw_ready = any(marker in chunk for marker in _SERVER_READY_MARKERS)
-    # Progress is the rate on the periodic decode-throughput line, not the line's presence: some vLLM builds log ``Avg
-    # generation throughput: 0.0 tokens/s`` on an idle engine, and an engine goes idle precisely when the client
-    # driving it wedges, so the marker alone lets the server vouch for the client that stopped asking it for tokens.
+    # Progress is the rate on the periodic decode-throughput line, not the
+    # line's presence: some vLLM builds log ``Avg generation throughput: 0.0
+    # tokens/s`` on an idle engine, and an engine goes idle precisely when the
+    # client driving it wedges, so the marker alone lets the server vouch for
+    # the client that stopped asking it for tokens. Reusing the post-mortem
+    # estimator's parse keeps the frameworks the two recognise from drifting
+    # apart. A line whose rate it cannot read counts as no progress: this
+    # evidence only ever suppresses a stall accusation, and one suppressed by
+    # mistake is invisible, where a missing one is visible and answerable from
+    # the child's own redirected stderr. The stall gate is deliberately broader
+    # and keys on raw log activity (any new bytes); see
+    # :func:`_communicate_with_soft_deadline`.
     saw_progress = bool(parse_server_log_throughput(chunk))
     saw_eval_start = any(marker in chunk for marker in _EVAL_START_MARKERS)
-    return size, saw_ready, saw_progress, saw_eval_start
+    # Phase boundaries are matched the same way the markers above are, and share
+    # their one weakness: a marker split across two reads is missed. That is
+    # tolerable for a transition -- the phase simply starts at the next scrape,
+    # half a second late in a window measured in minutes -- but it is not
+    # tolerable for per-line extraction, which is why the log-parsing fallback
+    # needs a residual buffer this scan deliberately does not have.
+    saw_warmup_begin = any(marker in chunk for marker in _AGENTX_WARMUP_BEGIN_MARKERS)
+    saw_measured_begin = any(marker in chunk for marker in _AGENTX_MEASURED_BEGIN_MARKERS)
+    return _IncrementScan(size, saw_ready, saw_progress, saw_eval_start, saw_warmup_begin, saw_measured_begin)
 
 
 def session_deadline_to_remaining_sec(session_deadline_sec: float | None) -> float | None:
-    """Convert an in-process session deadline into seconds still left on it."""
+    """Convert an in-process session deadline into seconds still left on it.
+
+    The pair of this and :func:`session_remaining_to_deadline_sec` is how a
+    session deadline crosses a process boundary. ``time.monotonic()`` has an
+    unspecified, per-process origin, so the absolute instant means nothing to a
+    reader in another process; a duration means the same thing everywhere.
+
+    Args:
+        session_deadline_sec: Absolute ``time.monotonic()`` instant at which the
+            session budget expires, or ``None`` when the budget is unbounded.
+
+    Returns:
+        Seconds left on the budget, or ``None`` when unbounded. Non-positive
+        when the deadline has already passed, which the receiving side is meant
+        to act on immediately rather than treat as "no budget given".
+    """
     if session_deadline_sec is None:
         return None
     return float(session_deadline_sec) - time.monotonic()
 
 
 def session_remaining_to_deadline_sec(session_remaining_sec: float | None) -> float | None:
-    """Re-anchor a remaining session budget onto this process's monotonic clock."""
+    """Re-anchor a remaining session budget onto this process's monotonic clock.
+
+    The inverse of :func:`session_deadline_to_remaining_sec`. Whatever the trip
+    itself cost is forgiven: no clock is shared across the boundary to measure it
+    with, so the receiver starts a fresh window of the full duration. The
+    receiver can therefore run marginally past the sender's deadline, which is
+    the safe direction -- the alternative is guessing at the transit and charging
+    a round for time it never had.
+
+    Args:
+        session_remaining_sec: Seconds left on the session budget as measured by
+            the sender, or ``None`` when the budget is unbounded.
+
+    Returns:
+        An absolute ``time.monotonic()`` deadline usable in this process, or
+        ``None`` when unbounded.
+    """
     if session_remaining_sec is None:
         return None
     return time.monotonic() + float(session_remaining_sec)
@@ -607,7 +1027,31 @@ def run_with_session_kill(
     on_output: Callable[[], None] | None = None,
     session_deadline_sec: float | None = None,
 ) -> subprocess.CompletedProcess:
-    """Run a subprocess in its own session and reap descendants on every exit path."""
+    """Run a subprocess in its own session and reap descendants on every exit path.
+
+    ``session_deadline_sec`` is an absolute ``time.monotonic()`` instant, unlike
+    ``soft_deadline_sec`` which is a relative duration. It is the session's own
+    wall-clock budget and is enforced in every phase, including the accuracy
+    eval -- the phase that retires ``soft_deadline_sec``. That distinction is the
+    reason it is a separate channel rather than a reuse of the soft deadline: the
+    eval-start boundary is meaningful for "is this variant abnormally slow" and
+    meaningless for "is the run out of time".
+
+    The cancel scope published by the dispatcher (:mod:`..cancel_channel`) is
+    watched for as long as the child lives, so an orchestrator that cancels the
+    action reaches the tree rather than just the coroutine awaiting this call.
+    Every cause that reaps the tree is reported as its own sentinel
+    ``returncode``, which is all a caller of a subprocess gets to tell them apart
+    by.
+
+    Args:
+        on_output: Called from a reader thread each time the child produces
+            output, so a caller can report a long step alive on the child's own
+            activity rather than on a timer.
+        session_deadline_sec: Absolute ``time.monotonic()`` instant at which the
+            session budget expires. Reaps the tree and returns
+            ``SESSION_TIME_EXHAUSTED_RETURNCODE``.
+    """
     if server_dead_grace_sec is None:
         try:
             server_dead_grace_sec = float(
@@ -630,7 +1074,6 @@ def run_with_session_kill(
             detok_stall_grace_sec = _DETOK_STALL_GRACE_SEC_DEFAULT
     proc: subprocess.Popen | None = None
     capture: _StreamCapture | None = None
-    empty: str | bytes = "" if text else b""
     try:
         with cancel_scope_listener() as cancel_scope:
             proc = subprocess.Popen(  # noqa: S603 — cmd is caller's responsibility
@@ -677,6 +1120,7 @@ def run_with_session_kill(
                     stdout=stdout,
                     stderr=stderr,
                 )
+            empty: str | bytes = "" if text else b""
             return subprocess.CompletedProcess(
                 args=cmd,
                 returncode=proc.returncode,
@@ -688,7 +1132,17 @@ def run_with_session_kill(
 
 
 def _finish_capture(capture: _StreamCapture | None, *, text: bool) -> tuple[str | bytes, str | bytes]:
-    """Drain the capture threads of a reaped child, never returning ``None``."""
+    """Drain the capture threads of a reaped child, never returning ``None``.
+
+    Args:
+        capture: The stream capture to finish, or ``None`` when the child's
+            output was not captured.
+        text: Whether the streams are ``str`` (``True``) or ``bytes``, which
+            decides what an absent stream reads as.
+
+    Returns:
+        tuple[str | bytes, str | bytes]: The captured ``(stdout, stderr)``.
+    """
     empty: str | bytes = "" if text else b""
     if capture is None:
         return empty, empty
@@ -700,7 +1154,14 @@ def _finish_capture(capture: _StreamCapture | None, *, text: bool) -> tuple[str 
 
 
 class _ReapedByWatchdog(Exception):
-    """Internal base for a cause that reaps the tree and names itself."""
+    """Internal base for a cause that reaps the tree and names itself.
+
+    None of these bubble past :func:`run_with_session_kill`: each is converted
+    to a ``CompletedProcess`` carrying the subclass's own ``returncode``, since
+    a returncode is the only thing that survives the trip back to a caller of a
+    subprocess. Subclasses build their own message and declare how much the
+    event is worth logging.
+    """
 
     returncode: int = -1
     log_level: int = logging.WARNING
@@ -712,7 +1173,12 @@ class _SessionDeadlineExceeded(_ReapedByWatchdog):
     returncode = SESSION_TIME_EXHAUSTED_RETURNCODE
 
     def __init__(self, *, overrun_sec: float, elapsed_sec: float) -> None:
-        """Record how far past the session deadline the round got."""
+        """Record how far past the session deadline the round got.
+
+        Args:
+            overrun_sec (float): Seconds past the session deadline at trip time.
+            elapsed_sec (float): Wall-clock elapsed for this round at trip time.
+        """
         super().__init__(
             f"the session wall-clock budget was exhausted {overrun_sec:.1f}s ago (round elapsed={elapsed_sec:.1f}s)"
         )
@@ -721,12 +1187,22 @@ class _SessionDeadlineExceeded(_ReapedByWatchdog):
 
 
 class _OrchestratorCancelled(_ReapedByWatchdog):
-    """Internal sentinel: the orchestrator cancelled the action this child serves."""
+    """Internal sentinel: the orchestrator cancelled the action this child serves.
+
+    The cause is a decision taken outside the round -- a shutdown, or a budget
+    the dispatcher found spent -- which is why it carries the caller's reason
+    rather than a measurement of its own.
+    """
 
     returncode = ORCHESTRATOR_CANCELLED_RETURNCODE
 
     def __init__(self, *, reason: str, elapsed_sec: float) -> None:
-        """Record who asked for the stop and how far the round had got."""
+        """Record who asked for the stop and how far the round had got.
+
+        Args:
+            reason (str): Short cause from the canceller, e.g. ``shutdown_requested``.
+            elapsed_sec (float): Wall-clock elapsed for this round at trip time.
+        """
         super().__init__(
             f"the orchestrator cancelled this action ({reason or 'no reason given'}; round elapsed={elapsed_sec:.1f}s)"
         )
@@ -741,14 +1217,21 @@ class _SoftDeadlineExceeded(_ReapedByWatchdog):
     log_level = logging.INFO
 
     def __init__(self, *, deadline_sec: float, elapsed_sec: float) -> None:
-        """Record the deadline and actual elapsed time on the sentinel."""
+        """Record the deadline and actual elapsed time on the sentinel.
+
+        Args:
+            deadline_sec (float): The soft deadline that was exceeded.
+            elapsed_sec (float): The actual wall-clock elapsed at trip time.
+        """
         super().__init__(f"soft_deadline_sec={deadline_sec:.1f}s elapsed (actual={elapsed_sec:.1f}s)")
         self.deadline_sec = float(deadline_sec)
         self.elapsed_sec = float(elapsed_sec)
 
 
 class _ServerDeadDetected(_ReapedByWatchdog):
-    """Internal sentinel: the server-liveness watchdog saw a terminal engine / worker init marker that persisted past the grace window."""
+    """Internal sentinel: the server-liveness watchdog saw a terminal engine /
+    worker init marker that persisted past the grace window.
+    """
 
     returncode = SERVER_DEAD_RETURNCODE
 
@@ -759,7 +1242,13 @@ class _ServerDeadDetected(_ReapedByWatchdog):
         grace_sec: float,
         elapsed_sec: float,
     ) -> None:
-        """Build the error message describing the hung-after-death condition."""
+        """Build the error message describing the hung-after-death condition.
+
+        Args:
+            marker: Log marker that indicated the server init died.
+            grace_sec: Grace period the parent was allowed after the marker.
+            elapsed_sec: Actual wall-clock elapsed at trip time.
+        """
         super().__init__(
             f"server init died (marker={marker!r}) and the parent hung past "
             f"grace {grace_sec:.1f}s (elapsed={elapsed_sec:.1f}s)"
@@ -770,7 +1259,9 @@ class _ServerDeadDetected(_ReapedByWatchdog):
 
 
 class _ServerStalledDetected(_ReapedByWatchdog):
-    """Internal sentinel: the detokenizer-stall watchdog saw the server report ready and then produce no generation progress for the grace window."""
+    """Internal sentinel: the detokenizer-stall watchdog saw the server report
+    ready and then produce no generation progress for the grace window.
+    """
 
     returncode = DETOKENIZER_STALL_RETURNCODE
 
@@ -780,7 +1271,13 @@ class _ServerStalledDetected(_ReapedByWatchdog):
         grace_sec: float,
         elapsed_sec: float,
     ) -> None:
-        """Build the error message describing the ready-but-no-progress stall."""
+        """Build the error message describing the ready-but-no-progress stall.
+
+        Args:
+            grace_sec: How long the ready server was allowed to produce no
+                generation progress before the watchdog tripped.
+            elapsed_sec: Actual wall-clock elapsed at trip time.
+        """
         super().__init__(
             f"server reported ready but emitted no log output for "
             f"{grace_sec:.1f}s (hung engine / detokenizer stall; "
@@ -802,16 +1299,30 @@ def _communicate_with_soft_deadline(
     server_already_ready: bool = False,
     session_deadline_sec: float | None = None,
     cancel_scope: CancelScope | None = None,
+    kv_recorder: Any = None,
 ) -> tuple[str | bytes, str | bytes]:
-    """Communicate with a child while enforcing soft and server-log watchdogs."""
+    """Communicate with a child while enforcing soft and server-log watchdogs.
+
+    ``kv_recorder`` is an optional KV-metrics collector
+    (:class:`._kv_metrics.KvMetricsRecorder`). It is duck-typed rather than
+    imported so this watchdog keeps no dependency on the collector: the
+    contract is ``note_phase(phase, mono)``, ``tick(mono)`` and
+    ``close(aborted=...)``, and ``None`` disables collection entirely. It rides
+    this loop because this is the only place that sees both the server-ready
+    marker and the eval-start marker, so it is the only place that can tell the
+    measured window from the boot and eval traffic around it -- and because a
+    sampler in a process of its own would contend for CPU with the very
+    benchmark being measured.
+    """
     watchdog_active = bool(server_log_path) and (
         server_dead_grace_sec is not None and float(server_dead_grace_sec) > 0.0
     )
     stall_active = bool(server_log_path) and (detok_stall_grace_sec is not None and float(detok_stall_grace_sec) > 0.0)
     soft_active = soft_deadline_sec is not None and float(soft_deadline_sec) > 0.0
     session_active = session_deadline_sec is not None
-    # A cancel scope is polled like any other gate, so its presence rules out the single-wait fast paths below: a call
-    # that blocks until the child exits cannot notice a cancel that arrives while it is blocked.
+    # A cancel scope is polled like any other gate, so its presence rules out the
+    # single-wait fast paths below: a call that blocks until the child exits
+    # cannot notice a cancel that arrives while it is blocked.
     gated = soft_active or watchdog_active or stall_active or session_active or cancel_scope is not None
     if capture is None and not gated:
         return proc.communicate(timeout=hard_timeout)
@@ -822,8 +1333,13 @@ def _communicate_with_soft_deadline(
     deadline_sec = float(soft_deadline_sec) if soft_active else None
     grace_sec = float(server_dead_grace_sec) if watchdog_active else None
     stall_grace_sec = float(detok_stall_grace_sec) if stall_active else None
-    # When a ``server.log`` is available the soft deadline measures only the post-ready phase (clock starts at the
-    # server-ready marker, excluding boot / weight load / first-request JIT).
+    # When a ``server.log`` is available the soft deadline measures only the
+    # post-ready phase (clock starts at the server-ready marker, excluding boot /
+    # weight load / first-request JIT). Without a ``server.log`` it falls back to
+    # the from-spawn clock. Opt out with
+    # ``INFERENCE_OPTIMIZER_SOFT_DEADLINE_FROM_READY=0``.
+    # ``server_already_ready`` (warm reuse round) forces the from-spawn path
+    # since no ready marker is written, so the from-ready clock would never arm.
     soft_from_ready = (
         soft_active
         and bool(server_log_path)
@@ -831,128 +1347,195 @@ def _communicate_with_soft_deadline(
         and os.environ.get("INFERENCE_OPTIMIZER_SOFT_DEADLINE_FROM_READY", "1").strip().lower()
         not in {"0", "false", "no", "off"}
     )
-    # The log increment scan feeds the stall watchdog, the from-ready soft-deadline anchor, the eval-start boundary
-    # and the ready timestamp the caller prices later work off; run it once per slice whenever a log is present.
+    # The log increment scan feeds the stall watchdog, the from-ready
+    # soft-deadline anchor, the eval-start boundary and the ready timestamp the
+    # caller prices later work off; run it once per slice whenever a log is
+    # present. Not narrowed to the watchdogs that consume it: tying it to
+    # ``stall_active`` let an unrelated knob
+    # (``INFERENCE_OPTIMIZER_DETOK_STALL_GRACE_SEC=0``) silently withdraw the
+    # boot/benchmark split for a whole session. It costs nothing where it did not
+    # already run, since without a gate this call never enters the loop at all.
     scan_active = bool(server_log_path) and gated
     poll_interval = STOP_GATE_POLL_SECONDS
     start = time.monotonic()
     dead_marker_since: float | None = None
-    # Detokenizer-stall watchdog state: per-log byte offsets consumed so far, whether a ready marker has been seen,
-    # and the last time a log showed any new output (seeded to the ready time).
+    # Detokenizer-stall watchdog state: per-log byte offsets consumed so far,
+    # whether a ready marker has been seen, and the last time a log showed any
+    # new output (seeded to the ready time). The gate only arms once
+    # ``server_ready_since`` is set.
     scan_offsets: dict[str, int] = {}
     if scan_active:
-        # A reused output_dir can still hold a prior attempt's nested workspace, whose markers are not this round's.
+        # A reused output_dir can still hold a prior attempt's nested workspace,
+        # whose markers are not this round's. The workspace this round creates
+        # does not exist yet, so it is discovered later at offset zero, which is
+        # correct: all of its bytes are this round's.
         scan_offsets.update(_stale_scan_log_sizes(server_log_path))  # type: ignore[arg-type]
     server_ready_since: float | None = None
     last_activity_at: float | None = None
-    # Latched once the accuracy eval starts: the soft deadline bounds the throughput phase only, so it is retired for
-    # the rest of the process.
+    # Latched once the accuracy eval starts: the soft deadline bounds the
+    # throughput phase only, so it is retired for the rest of the process.
     soft_deadline_suspended = False
-    while True:
-        now = time.monotonic()
-        elapsed = now - start
-        # Session budget.
-        if session_active and session_deadline_sec is not None and now >= session_deadline_sec:
-            raise _SessionDeadlineExceeded(
-                overrun_sec=now - float(session_deadline_sec),
-                elapsed_sec=elapsed,
-            )
-        # Orchestrator cancellation.
-        if cancel_scope is not None and cancel_scope.cancelled:
-            raise _OrchestratorCancelled(
-                reason=cancel_scope.reason,
-                elapsed_sec=elapsed,
-            )
-        # Advance the log scan, latching the server-ready, last-activity and eval-start signals.
-        if scan_active:
-            scan = _scan_logs_increment(
-                server_log_path,  # type: ignore[arg-type]
-                scan_offsets,
-            )
-            if scan.saw_ready and server_ready_since is None:
-                server_ready_since = now
-                last_activity_at = now  # start the silence clock at ready
-                # Recorded for the caller, which prices later work off the
-                # post-ready segment rather than the whole round: a pass that
-                # re-attaches to this server pays none of the boot. Taken as
-                # ``now - start`` so the boot is measured end to end on this
-                # process's own clock, whatever host the caller reads it on.
-                stamp_server_ready(server_log_path, now - start)  # type: ignore[arg-type]
-            if scan.saw_eval_start and not soft_deadline_suspended:
-                soft_deadline_suspended = True
-                log.info(
-                    "_subprocess_kill: accuracy eval started; soft_deadline_sec=%.1fs no longer enforced "
-                    "(it bounds the throughput phase only)",
-                    float(deadline_sec or 0.0),
-                )
-            # Any new bytes count as liveness; only total silence trips the stall gate.
-            if scan.grew:
-                last_activity_at = now
-            # The liveness callback makes a narrower claim than the stall gate — that this child is working, not that
-            # something on the box is — so it takes narrower evidence: tokens flowing, or the child's own redirected
-            # stderr growing.
-            if capture is not None and (scan.saw_progress or scan.child_spoke):
-                capture.note_output()
-        # Soft deadline.
-        if soft_active and deadline_sec is not None and not soft_deadline_suspended:
-            if soft_from_ready:
-                if server_ready_since is not None:
-                    soft_elapsed = now - server_ready_since
-                    if deadline_sec - soft_elapsed <= 0.0:
-                        raise _SoftDeadlineExceeded(
-                            deadline_sec=deadline_sec,
-                            elapsed_sec=soft_elapsed,
-                        )
-            elif deadline_sec - elapsed <= 0.0:
-                raise _SoftDeadlineExceeded(
-                    deadline_sec=deadline_sec,
+    # Distinguishes a child that finished from a gate that raised. The recorder
+    # is closed in the ``finally`` below so every exit path is covered: the five
+    # gate exceptions, the hard timeout, and the normal return. An unclosed
+    # window is the one failure a consumer cannot recover from -- it has no way
+    # to tell a round still running from one that died mid-window.
+    completed = False
+    try:
+        while True:
+            now = time.monotonic()
+            elapsed = now - start
+            # Session budget. Checked before every other gate and never suspended:
+            # unlike the soft deadline it makes no claim about the variant, so the
+            # eval-start boundary that retires the soft deadline does not apply. An
+            # accuracy eval that starts one minute before the run is out of time still
+            # has to stop.
+            if session_active and session_deadline_sec is not None and now >= session_deadline_sec:
+                raise _SessionDeadlineExceeded(
+                    overrun_sec=now - float(session_deadline_sec),
                     elapsed_sec=elapsed,
                 )
-        if watchdog_active and grace_sec is not None:
-            death_marker = _server_log_shows_death(server_log_path)  # type: ignore[arg-type]
-            if death_marker is not None:
-                if dead_marker_since is None:
-                    dead_marker_since = now
-                elif now - dead_marker_since >= grace_sec:
-                    raise _ServerDeadDetected(
-                        marker=death_marker,
-                        grace_sec=grace_sec,
+            # Orchestrator cancellation. Checked after the session deadline so a
+            # round that was already out of time keeps that reason: the budget is a
+            # fact about the run, while the cancel is only the dispatcher acting on
+            # it, and the more specific of the two is the one worth recording.
+            if cancel_scope is not None and cancel_scope.cancelled:
+                raise _OrchestratorCancelled(
+                    reason=cancel_scope.reason,
+                    elapsed_sec=elapsed,
+                )
+            # Advance the log scan, latching the server-ready, last-activity
+            # and eval-start signals.
+            if scan_active:
+                scan = _scan_logs_increment(
+                    server_log_path,  # type: ignore[arg-type]
+                    scan_offsets,
+                )
+                if scan.saw_ready and server_ready_since is None:
+                    server_ready_since = now
+                    last_activity_at = now  # start the silence clock at ready
+                    # Recorded for the caller, which prices later work off the
+                    # post-ready segment rather than the whole round: a pass that
+                    # re-attaches to this server pays none of the boot. Taken as
+                    # ``now - start`` so the boot is measured end to end on this
+                    # process's own clock, whatever host the caller reads it on.
+                    _stamp_server_ready(server_log_path, now - start)  # type: ignore[arg-type]
+                    # Ready opens the measured window for a synthetic round,
+                    # which has no warmup marker of its own. AgentX corrects
+                    # this a moment later: aiperf announces its cold-cache
+                    # warmup right after the server comes up, so the handful of
+                    # samples in between carry the wrong label and no more.
+                    if kv_recorder is not None:
+                        kv_recorder.note_phase("measured", now)
+                if kv_recorder is not None:
+                    if scan.saw_warmup_begin:
+                        kv_recorder.note_phase("warmup", now)
+                    if scan.saw_measured_begin:
+                        kv_recorder.note_phase("measured", now)
+                    if scan.saw_eval_start:
+                        # Eval traffic is not the throughput benchmark: its
+                        # request shape is different and it would drag both
+                        # occupancy and hit rate toward numbers no comparison
+                        # should see.
+                        kv_recorder.note_phase("eval", now)
+                if scan.saw_eval_start and not soft_deadline_suspended:
+                    soft_deadline_suspended = True
+                    log.info(
+                        "_subprocess_kill: accuracy eval started; soft_deadline_sec=%.1fs no longer enforced "
+                        "(it bounds the throughput phase only)",
+                        float(deadline_sec or 0.0),
+                    )
+                # Any new bytes count as liveness; only total silence trips the
+                # stall gate.
+                if scan.grew:
+                    last_activity_at = now
+                # The liveness callback makes a narrower claim than the stall gate —
+                # that this child is working, not that something on the box is — so
+                # it takes narrower evidence: tokens flowing, or the child's own
+                # redirected stderr growing. A ``server.log`` that grew is neither.
+                # The server keeps logging while its benchmark client is wedged, and
+                # both vLLM and sglang write an access line per request, including
+                # the health probe the robustness agent issues on its own tick —
+                # which would let the monitor manufacture the evidence that
+                # suppresses its own stall accusation.
+                if capture is not None and (scan.saw_progress or scan.child_spoke):
+                    capture.note_output()
+            # KV sampling. Outside the ``scan_active`` guard because it reads the
+            # engine's HTTP endpoint, not the logs, and rate-limits itself on the
+            # monotonic clock: this loop's slice shrinks below its nominal 0.5s
+            # whenever a deadline bounds it, so counting passes would sample
+            # faster exactly when the run is closest to its limits.
+            if kv_recorder is not None:
+                kv_recorder.tick(now)
+            # Soft deadline. With ``soft_from_ready`` the overtime clock is measured
+            # from the server-ready marker and stays dormant until ready; otherwise
+            # it is the from-spawn elapsed.
+            if soft_active and deadline_sec is not None and not soft_deadline_suspended:
+                if soft_from_ready:
+                    if server_ready_since is not None:
+                        soft_elapsed = now - server_ready_since
+                        if deadline_sec - soft_elapsed <= 0.0:
+                            raise _SoftDeadlineExceeded(
+                                deadline_sec=deadline_sec,
+                                elapsed_sec=soft_elapsed,
+                            )
+                elif deadline_sec - elapsed <= 0.0:
+                    raise _SoftDeadlineExceeded(
+                        deadline_sec=deadline_sec,
                         elapsed_sec=elapsed,
                     )
-            else:
-                dead_marker_since = None
-        # Detokenizer-stall watchdog — armed only once the server is ready.
-        if stall_active and stall_grace_sec is not None:
-            if server_ready_since is not None and last_activity_at is not None:
-                if now - last_activity_at >= stall_grace_sec:
-                    raise _ServerStalledDetected(
-                        grace_sec=stall_grace_sec,
-                        elapsed_sec=elapsed,
-                    )
-        # Slice bounded by every active remaining window so the right gate fires first; the child can still finish
-        # inside any slice.
-        slice_sec = poll_interval
-        if session_active and session_deadline_sec is not None:
-            slice_sec = min(slice_sec, float(session_deadline_sec) - now)
-        if soft_active and deadline_sec is not None and not soft_deadline_suspended:
-            if soft_from_ready:
-                if server_ready_since is not None:
-                    slice_sec = min(slice_sec, deadline_sec - (now - server_ready_since))
-            else:
-                slice_sec = min(slice_sec, deadline_sec - elapsed)
-        if hard_timeout is not None:
-            hard_remaining = float(hard_timeout) - elapsed
-            if hard_remaining <= 0.0:
-                raise subprocess.TimeoutExpired(proc.args, hard_timeout)
-            slice_sec = min(slice_sec, hard_remaining)
-        slice_sec = max(slice_sec, 0.0)
-        try:
-            if capture is None:
-                return proc.communicate(timeout=slice_sec)
-            proc.wait(timeout=slice_sec)
-            return capture.finish()
-        except subprocess.TimeoutExpired:
-            continue
+            if watchdog_active and grace_sec is not None:
+                death_marker = _server_log_shows_death(server_log_path)  # type: ignore[arg-type]
+                if death_marker is not None:
+                    if dead_marker_since is None:
+                        dead_marker_since = now
+                    elif now - dead_marker_since >= grace_sec:
+                        raise _ServerDeadDetected(
+                            marker=death_marker,
+                            grace_sec=grace_sec,
+                            elapsed_sec=elapsed,
+                        )
+                else:
+                    dead_marker_since = None
+            # Detokenizer-stall watchdog — armed only once the server is ready.
+            if stall_active and stall_grace_sec is not None:
+                if server_ready_since is not None and last_activity_at is not None:
+                    if now - last_activity_at >= stall_grace_sec:
+                        raise _ServerStalledDetected(
+                            grace_sec=stall_grace_sec,
+                            elapsed_sec=elapsed,
+                        )
+            # Slice bounded by every active remaining window so the right gate
+            # fires first; the child can still finish inside any slice.
+            slice_sec = poll_interval
+            if session_active and session_deadline_sec is not None:
+                slice_sec = min(slice_sec, float(session_deadline_sec) - now)
+            if soft_active and deadline_sec is not None and not soft_deadline_suspended:
+                if soft_from_ready:
+                    if server_ready_since is not None:
+                        slice_sec = min(slice_sec, deadline_sec - (now - server_ready_since))
+                else:
+                    slice_sec = min(slice_sec, deadline_sec - elapsed)
+            if hard_timeout is not None:
+                hard_remaining = float(hard_timeout) - elapsed
+                if hard_remaining <= 0.0:
+                    raise subprocess.TimeoutExpired(proc.args, hard_timeout)
+                slice_sec = min(slice_sec, hard_remaining)
+            slice_sec = max(slice_sec, 0.0)
+            try:
+                if capture is None:
+                    result = proc.communicate(timeout=slice_sec)
+                    completed = True
+                    return result
+                proc.wait(timeout=slice_sec)
+                captured = capture.finish()
+                completed = True
+                return captured
+            except subprocess.TimeoutExpired:
+                continue
+    finally:
+        if kv_recorder is not None:
+            kv_recorder.close(aborted=not completed)
 
 
 __all__ = [
@@ -976,5 +1559,4 @@ __all__ = [
     "server_ready_unix",
     "session_deadline_to_remaining_sec",
     "session_remaining_to_deadline_sec",
-    "stamp_server_ready",
 ]

--- a/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
+++ b/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
@@ -833,6 +833,13 @@ class _IncrementScan(NamedTuple):
     saw_eval_start: bool
     saw_warmup_begin: bool = False
     saw_measured_begin: bool = False
+    residual: str = ""
+
+
+#: Cap on the carried-over tail. A writer that never emits a newline would
+#: otherwise grow this without bound; a marker longer than this is not one we
+#: match on.
+_RESIDUAL_MAX_CHARS = 8192
 
 
 def _stale_scan_log_sizes(server_log_path: str) -> dict[str, int]:
@@ -869,12 +876,21 @@ def _stale_scan_log_sizes(server_log_path: str) -> dict[str, int]:
     return sizes
 
 
-def _scan_logs_increment(server_log_path: str, offsets: dict[str, int]) -> _LogScan:
+def _scan_logs_increment(
+    server_log_path: str,
+    offsets: dict[str, int],
+    residuals: dict[str, str] | None = None,
+) -> _LogScan:
     """Scan every resolved log for markers, advancing ``offsets`` in place.
 
     Args:
         server_log_path: The ``<output_dir>/server.log`` path from the caller.
         offsets: Per-path byte offsets already consumed; mutated in place.
+        residuals: Per-path unterminated tails carried from the previous scan;
+            mutated in place. Held per path rather than as one shared tail
+            because the resolved logs are written by different processes and
+            interleaving one's tail into another's next read would invent lines
+            neither of them wrote.
 
     Returns:
         _LogScan: The markers seen in the newly appended bytes, plus who — if
@@ -884,8 +900,10 @@ def _scan_logs_increment(server_log_path: str, offsets: dict[str, int]) -> _LogS
     saw_warmup_begin = saw_measured_begin = False
     for path in _resolve_scan_logs(server_log_path):
         prev = offsets.get(path, 0)
-        scan = _scan_server_log_increment(path, prev)
+        scan = _scan_server_log_increment(path, prev, "" if residuals is None else residuals.get(path, ""))
         offsets[path] = scan.offset
+        if residuals is not None:
+            residuals[path] = scan.residual
         saw_ready = saw_ready or scan.saw_ready
         saw_progress = saw_progress or scan.saw_progress
         saw_eval_start = saw_eval_start or scan.saw_eval_start
@@ -905,7 +923,7 @@ def _scan_logs_increment(server_log_path: str, offsets: dict[str, int]) -> _LogS
     )
 
 
-def _scan_server_log_increment(path: str, from_offset: int) -> _IncrementScan:
+def _scan_server_log_increment(path: str, from_offset: int, residual: str = "") -> _IncrementScan:
     """Incrementally scan the bytes appended to ``server.log`` since
     ``from_offset`` for ready / generation-progress / eval-start markers.
 
@@ -929,18 +947,30 @@ def _scan_server_log_increment(path: str, from_offset: int) -> _IncrementScan:
     try:
         size = os.path.getsize(path)
     except OSError:
-        return _IncrementScan(from_offset, False, False, False)
+        return _IncrementScan(from_offset, False, False, False, residual=residual)
     start = from_offset
+    carried = residual
     if size < start:  # truncated / rotated — rescan from the top.
         start = 0
+        carried = ""  # the tail belonged to a file that no longer exists
     if size <= start:  # nothing new appended
-        return _IncrementScan(start, False, False, False)
+        return _IncrementScan(start, False, False, False, residual=carried)
     try:
         with open(path, "rb") as fh:
             fh.seek(start)
             chunk = fh.read().decode("utf-8", "ignore")
     except (OSError, ValueError):
-        return _IncrementScan(from_offset, False, False, False)
+        return _IncrementScan(from_offset, False, False, False, residual=carried)
+    # Splice the previous read's unterminated tail back on before matching. A
+    # marker straddling a read boundary appears in neither half, so without this
+    # it is not merely seen late -- it is never seen at all, and the phase it
+    # announced is silently attributed to the wrong window for the whole round.
+    chunk = carried + chunk
+    tail_at = chunk.rfind("\n")
+    next_residual = "" if tail_at < 0 else chunk[tail_at + 1 :]
+    if tail_at < 0:
+        next_residual = chunk
+    next_residual = next_residual[-_RESIDUAL_MAX_CHARS:]
     saw_ready = any(marker in chunk for marker in _SERVER_READY_MARKERS)
     # Progress is the rate on the periodic decode-throughput line, not the
     # line's presence: some vLLM builds log ``Avg generation throughput: 0.0
@@ -956,15 +986,17 @@ def _scan_server_log_increment(path: str, from_offset: int) -> _IncrementScan:
     # :func:`_communicate_with_soft_deadline`.
     saw_progress = bool(parse_server_log_throughput(chunk))
     saw_eval_start = any(marker in chunk for marker in _EVAL_START_MARKERS)
-    # Phase boundaries are matched the same way the markers above are, and share
-    # their one weakness: a marker split across two reads is missed. That is
-    # tolerable for a transition -- the phase simply starts at the next scrape,
-    # half a second late in a window measured in minutes -- but it is not
-    # tolerable for per-line extraction, which is why the log-parsing fallback
-    # needs a residual buffer this scan deliberately does not have.
     saw_warmup_begin = any(marker in chunk for marker in _AGENTX_WARMUP_BEGIN_MARKERS)
     saw_measured_begin = any(marker in chunk for marker in _AGENTX_MEASURED_BEGIN_MARKERS)
-    return _IncrementScan(size, saw_ready, saw_progress, saw_eval_start, saw_warmup_begin, saw_measured_begin)
+    return _IncrementScan(
+        size,
+        saw_ready,
+        saw_progress,
+        saw_eval_start,
+        saw_warmup_begin,
+        saw_measured_begin,
+        residual=next_residual,
+    )
 
 
 def session_deadline_to_remaining_sec(session_deadline_sec: float | None) -> float | None:
@@ -1046,14 +1078,43 @@ def _build_kv_recorder(server_log_path: str | None, env: dict[str, str] | None) 
     try:
         from ._kv_metrics import KV_ARTIFACT_NAME, KvMetricsPoller, KvMetricsRecorder
 
+        workspace = Path(server_log_path).parent
         return KvMetricsRecorder(
             poller=KvMetricsPoller(config_envs=dict(env or {})),
-            output_path=str(Path(server_log_path).parent / KV_ARTIFACT_NAME),
-            scope={"server_log_path": str(server_log_path)},
+            output_path=str(workspace / KV_ARTIFACT_NAME),
+            # Self-sufficient on purpose: a consumer must be able to say which
+            # round produced this without joining against another file. The
+            # workspace directory name carries the variant, and the path under
+            # ``runs/`` carries the action and task that spawned it.
+            scope={
+                "server_log_path": str(server_log_path),
+                "workspace": workspace.name,
+                "run_path": _run_relative_path(workspace),
+                "session_id": os.environ.get("INFERENCE_OPTIMIZER_SESSION_ID", ""),
+            },
         )
     except Exception:  # noqa: BLE001 - collection is never worth a failed round
-        log.debug("kv_metrics: recorder unavailable", exc_info=True)
+        # Warning, not debug: this is the difference between "no KV data because
+        # the engine had none" and "no KV data because nothing ever asked", and
+        # the artifact's absence cannot tell them apart.
+        log.warning("kv_metrics: recorder could not be built; this round collects nothing", exc_info=True)
         return None
+
+
+def _run_relative_path(workspace: Path) -> str:
+    """Path of a round workspace relative to the session's ``runs/`` root.
+
+    Args:
+        workspace (Path): The round's output directory.
+
+    Returns:
+        str: e.g. ``explore/<task>/<variant>/<benchmark>``, or the bare
+        directory name when no ``runs`` component is present.
+    """
+    parts = workspace.parts
+    if "runs" in parts:
+        return "/".join(parts[parts.index("runs") + 1 :])
+    return workspace.name
 
 
 def run_with_session_kill(
@@ -1415,6 +1476,16 @@ def _communicate_with_soft_deadline(
         # does not exist yet, so it is discovered later at offset zero, which is
         # correct: all of its bytes are this round's.
         scan_offsets.update(_stale_scan_log_sizes(server_log_path))  # type: ignore[arg-type]
+    # Unterminated tails carried between scans, per path. Without them a marker
+    # landing across a read boundary is in neither half and is lost outright.
+    scan_residuals: dict[str, str] = {}
+    # A warm-reuse round re-attaches to a server that is already up, so no ready
+    # marker is ever written and the phase would otherwise sit at ``boot`` for
+    # the whole round -- putting every measured sample in the one bucket that
+    # never enters a comparison. The caller telling us the server is ready is
+    # the same statement the marker would have made.
+    if kv_recorder is not None and server_already_ready:
+        kv_recorder.note_phase("measured", start)
     server_ready_since: float | None = None
     last_activity_at: float | None = None
     # Latched once the accuracy eval starts: the soft deadline bounds the
@@ -1455,6 +1526,7 @@ def _communicate_with_soft_deadline(
                 scan = _scan_logs_increment(
                     server_log_path,  # type: ignore[arg-type]
                     scan_offsets,
+                    scan_residuals,
                 )
                 if scan.saw_ready and server_ready_since is None:
                     server_ready_since = now

--- a/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
+++ b/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
@@ -249,6 +249,11 @@ _AGENTX_MEASURED_BEGIN_MARKERS: tuple[str, ...] = ("(profiling) started",)
 # the way a synthetic one does, so the phase lines are unreachable unless it is scanned explicitly.
 _AGENTX_LOG_RELPATH: str = "aiperf_artifacts/logs/aiperf.log"
 
+# How long a round may go without any resolvable server log before it is treated as re-attached to a server an earlier
+# round booted. Such a round owns no log and no ready marker will ever appear in its scan set, so KV collection has to
+# start on some other signal or it never starts at all.
+_WARM_REUSE_PROBE_AFTER_SEC: float = 30.0
+
 # Default grace: how long after the server reports ready it may emit no log output before the watchdog declares a hang
 # / detokenizer stall.
 _DETOK_STALL_GRACE_SEC_DEFAULT: float = 1800.0
@@ -668,7 +673,9 @@ def _build_kv_recorder(server_log_path: str | None, env: dict[str, str] | None) 
 
         workspace = Path(server_log_path).parent
         return KvMetricsRecorder(
-            poller=KvMetricsPoller(config_envs=dict(env or {})),
+            # The workspace is where the port actually lives: it is pinned in the round's materialized
+            # ``benchmark.envs.PORT``, which is never exported into the subprocess environment.
+            poller=KvMetricsPoller(config_envs=dict(env or {}), workspace=workspace),
             # Authoritative phase boundaries when this round is an AgentX one; a no-op otherwise, since no other client
             # publishes a progress address and the poller then never resolves a URL.
             progress=AiperfProgressPoller(workspace),
@@ -1026,9 +1033,14 @@ def _communicate_with_soft_deadline(
                 # stderr growing.
                 if capture is not None and (scan.saw_progress or scan.child_spoke):
                     capture.note_output()
-            # Held until the engine is actually up: scraping during boot only collects connection refusals, and on a
-            # warm-reuse round there is no boot to wait through.
-            if kv_recorder is not None and (server_ready_since is not None or server_already_ready):
+            # Held until the engine is up, because scraping during boot only collects connection refusals. The third
+            # arm is the warm-reuse round: it re-attaches to a server an earlier round booted, so it owns no log and no
+            # ready marker will ever land in its scan set. Waiting for one there means never collecting at all -- which
+            # is what a real session did, on the measured round, the only phase allowed into a comparison.
+            # The elapsed guard keeps a normal round from scraping through its own boot: a round that owns a server
+            # writes its log within seconds, so still having none this late means nobody is going to write one.
+            warm_reuse_round = scan_active and not scan_offsets and elapsed >= _WARM_REUSE_PROBE_AFTER_SEC
+            if kv_recorder is not None and (server_ready_since is not None or server_already_ready or warm_reuse_round):
                 kv_recorder.tick(now)
             # Soft deadline.
             if soft_active and deadline_sec is not None and not soft_deadline_suspended:

--- a/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
+++ b/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
@@ -1090,7 +1090,12 @@ def _build_kv_recorder(server_log_path: str | None, env: dict[str, str] | None) 
                 "server_log_path": str(server_log_path),
                 "workspace": workspace.name,
                 "run_path": _run_relative_path(workspace),
-                "session_id": os.environ.get("INFERENCE_OPTIMIZER_SESSION_ID", ""),
+                # From the session directory, which the CLI does export. There
+                # is no INFERENCE_OPTIMIZER_SESSION_ID: nothing in the tree sets
+                # one, so reading it produced a field that was always empty.
+                "session": os.path.basename(
+                    os.environ.get("INFERENCE_OPTIMIZER_CURRENT_SESSION_DIR", "").rstrip("/\\")
+                ),
             },
         )
     except Exception:  # noqa: BLE001 - collection is never worth a failed round

--- a/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
+++ b/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
@@ -1012,6 +1012,50 @@ def session_remaining_to_deadline_sec(session_remaining_sec: float | None) -> fl
     return time.monotonic() + float(session_remaining_sec)
 
 
+#: Kill switch for KV sampling. Collection is best-effort and cannot fail a
+#: round by construction, but a loop this central needs a way out of the path
+#: that does not require a redeploy. Set to ``0`` to disable.
+_KV_METRICS_ENV = "INFERENCE_OPTIMIZER_KV_METRICS"
+
+
+def _build_kv_recorder(server_log_path: str | None, env: dict[str, str] | None) -> Any:
+    """Create the KV sampler for one round, or ``None`` when it does not apply.
+
+    Gated on ``server_log_path`` because that is what marks a call as a served
+    benchmark rather than an arbitrary subprocess: a scriptable workload or a
+    helper command has no engine to scrape and no round-scoped place to put an
+    artifact.
+
+    Args:
+        server_log_path (str | None): The round's ``<output_dir>/server.log``.
+            Its parent is the round workspace and receives the artifact.
+        env (dict[str, str] | None): The child's environment. This is the
+            materialized config's ``benchmark.envs``, so it carries the
+            per-session ephemeral ``PORT`` the server actually bound -- the
+            default 8888 is only correct when nothing pinned one.
+
+    Returns:
+        Any: A recorder, or ``None`` when collection is off, inapplicable, or
+        could not be constructed. Never raises: a sampler that cannot be built
+        must not stop the benchmark it was going to watch.
+    """
+    if not server_log_path:
+        return None
+    if os.environ.get(_KV_METRICS_ENV, "1").strip().lower() in {"0", "false", "no", "off"}:
+        return None
+    try:
+        from ._kv_metrics import KV_ARTIFACT_NAME, KvMetricsPoller, KvMetricsRecorder
+
+        return KvMetricsRecorder(
+            poller=KvMetricsPoller(config_envs=dict(env or {})),
+            output_path=str(Path(server_log_path).parent / KV_ARTIFACT_NAME),
+            scope={"server_log_path": str(server_log_path)},
+        )
+    except Exception:  # noqa: BLE001 - collection is never worth a failed round
+        log.debug("kv_metrics: recorder unavailable", exc_info=True)
+        return None
+
+
 def run_with_session_kill(
     cmd: list[str],
     *,
@@ -1099,6 +1143,7 @@ def run_with_session_kill(
                     server_already_ready=server_already_ready,
                     session_deadline_sec=session_deadline_sec,
                     cancel_scope=cancel_scope,
+                    kv_recorder=_build_kv_recorder(server_log_path, env),
                 )
             except subprocess.TimeoutExpired:
                 kill_my_spawned_server(proc)
@@ -1465,7 +1510,14 @@ def _communicate_with_soft_deadline(
             # monotonic clock: this loop's slice shrinks below its nominal 0.5s
             # whenever a deadline bounds it, so counting passes would sample
             # faster exactly when the run is closest to its limits.
-            if kv_recorder is not None:
+            #
+            # Held off until the server is up. The scrape is a blocking call, and
+            # before the engine binds its port every attempt is a refused
+            # connection paid for inside the loop -- during boot, which is
+            # precisely when the ready marker and the death watchdog need this
+            # loop to be responsive. Boot carries no traffic to measure anyway,
+            # and pool capacity is readable the moment the server answers.
+            if kv_recorder is not None and (server_ready_since is not None or server_already_ready):
                 kv_recorder.tick(now)
             # Soft deadline. With ``soft_from_ready`` the overtime clock is measured
             # from the server-ready marker and stays dormant until ready; otherwise

--- a/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
+++ b/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
@@ -664,11 +664,14 @@ def _build_kv_recorder(server_log_path: str | None, env: dict[str, str] | None) 
     if os.environ.get(_KV_METRICS_ENV, "1").strip().lower() in {"0", "false", "no", "off"}:
         return None
     try:
-        from ._kv_metrics import KV_ARTIFACT_NAME, KvMetricsPoller, KvMetricsRecorder
+        from ._kv_metrics import KV_ARTIFACT_NAME, AiperfProgressPoller, KvMetricsPoller, KvMetricsRecorder
 
         workspace = Path(server_log_path).parent
         return KvMetricsRecorder(
             poller=KvMetricsPoller(config_envs=dict(env or {})),
+            # Authoritative phase boundaries when this round is an AgentX one; a no-op otherwise, since no other client
+            # publishes a progress address and the poller then never resolves a URL.
+            progress=AiperfProgressPoller(workspace),
             output_path=str(workspace / KV_ARTIFACT_NAME),
             scope={
                 "server_log_path": str(server_log_path),

--- a/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
+++ b/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
@@ -648,7 +648,9 @@ def _build_kv_recorder(server_log_path: str | None, env: dict[str, str] | None) 
                 "server_log_path": str(server_log_path),
                 "workspace": workspace.name,
                 "run_path": _run_relative_path(workspace),
-                "session": os.path.basename(os.environ.get("INFERENCE_OPTIMIZER_CURRENT_SESSION_DIR", "").rstrip("/\\")),
+                "session": os.path.basename(
+                    os.environ.get("INFERENCE_OPTIMIZER_CURRENT_SESSION_DIR", "").rstrip("/\\")
+                ),
             },
         )
     except Exception:

--- a/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
+++ b/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import glob
 import logging
 import os
-import signal
 import subprocess
 import sys
 import threading
@@ -16,16 +15,18 @@ import time
 from pathlib import Path
 from typing import Any, Callable, NamedTuple
 
+# ``TERM_GRACE_SECONDS`` is this module's name for the shared SIGTERM-to-SIGKILL
+# grace: a driver-side teardown of a server a round left behind waits for the
+# same thing on the same signal, so it waits exactly as long.
+from hyperloom.common.proctree import TERM_GRACE_SEC as TERM_GRACE_SECONDS
+from hyperloom.common.proctree import collect_tree, group_alive, kill_tree, signal_group
+
 from .bypass_analysis import parse_server_log_throughput
 
 from ..cancel_channel import CancelScope, cancel_scope_listener
 
 log = logging.getLogger(__name__)
 
-
-# Grace window between SIGTERM and SIGKILL, here and for a driver-side teardown of a server a round left behind: the
-# same signal, the same thing being waited for.
-TERM_GRACE_SECONDS: float = 5.0
 
 # How long the reaper waits to collect the SIGKILL'd child before giving up on it.
 _REAP_COLLECT_SECONDS: float = 1.0
@@ -52,33 +53,26 @@ def new_session_kwargs() -> dict:
 
 
 def _process_group_alive(pgid: int) -> bool:
-    """Return True iff at least one process is still in ``pgid``."""
-    if os.name != "posix":
-        return False
-    try:
-        os.killpg(pgid, 0)
-        return True
-    except ProcessLookupError:
-        return False
-    except OSError:
-        return True
+    """Return True iff at least one process is still in ``pgid``.
+
+    Args:
+        pgid: The POSIX process-group id to probe.
+
+    Returns:
+        True if the group still has at least one member (or liveness is
+        indeterminate), False once the group is empty or on non-POSIX.
+    """
+    return group_alive(pgid)
 
 
 def _signal_group(pgid: int, sig: int) -> None:
-    """Send ``sig`` to every member of ``pgid``; swallow ``ESRCH``."""
-    if os.name != "posix":
-        return
-    try:
-        os.killpg(pgid, sig)
-    except ProcessLookupError:
-        pass
-    except OSError as exc:
-        log.warning(
-            "_subprocess_kill: killpg(%d, %d) failed: %s",
-            pgid,
-            sig,
-            exc,
-        )
+    """Send ``sig`` to every member of ``pgid``; swallow ``ESRCH``.
+
+    Args:
+        pgid (int): The POSIX process-group id to signal.
+        sig (int): The signal number to send.
+    """
+    signal_group(pgid, sig, what="_subprocess_kill")
 
 
 def kill_my_spawned_server(
@@ -131,16 +125,14 @@ def kill_my_spawned_server(
         )
         return
 
-    _signal_group(pgid, signal.SIGTERM)
-
-    deadline = time.monotonic() + grace_seconds
-    while time.monotonic() < deadline:
-        if not _process_group_alive(pgid):
-            break
-        time.sleep(0.05)
-
-    if _process_group_alive(pgid):
-        _signal_group(pgid, signal.SIGKILL)
+    try:
+        tree = collect_tree([proc.pid])
+    except OSError as exc:
+        # Every caller reaps from a ``finally:``, so an unreadable procfs has to
+        # be reported rather than raised on top of whatever sent us here.
+        log.error("_subprocess_kill: cannot enumerate the tree under pid=%d: %s", proc.pid, exc)
+        return
+    kill_tree(tree, grace_sec=grace_seconds, confirm_sec=grace_seconds)
 
     try:
         proc.wait(timeout=_REAP_COLLECT_SECONDS)
@@ -224,8 +216,10 @@ SESSION_TIME_EXHAUSTED_RETURNCODE: int = -915
 # budget that is spent.
 ORCHESTRATOR_CANCELLED_RETURNCODE: int = -917
 
-# Server-ready markers: their appearance in ``server.log`` means the server has finished startup and is accepting
-# traffic.
+# Server-ready markers: their appearance in ``server.log`` means the server has
+# finished startup and is accepting traffic. Only after one is observed does the
+# detokenizer-stall clock start. Covers the uvicorn frontend (vLLM + sglang) and
+# sglang's own ready banner.
 _SERVER_READY_MARKERS: tuple[str, ...] = (
     "Application startup complete",
     "Uvicorn running on",
@@ -430,8 +424,40 @@ def _ready_stamp_path(server_log_path: str) -> Path:
     return Path(server_log_path).parent / _READY_STAMP_NAME
 
 
-def _stamp_server_ready(server_log_path: str, boot_sec: float) -> None:
-    """Record, beside ``server_log_path``, that the server just reported ready."""
+def stamp_server_ready(server_log_path: str, boot_sec: float) -> None:
+    """Record, beside ``server_log_path``, that the server just reported ready.
+
+    Two numbers, because they answer two questions and one clock cannot answer
+    both. ``boot_sec`` is how long the round took to come up, measured from spawn
+    to this moment on one ``time.monotonic()`` reading in the process that
+    spawned the child. The wall-clock instant beside it only ever says *which
+    round* the stamp belongs to.
+
+    Keeping the boot a duration is what makes it safe to read across a process
+    boundary. On the Ray path the round runs inside an actor, possibly on another
+    host; subtracting the actor's wall-clock from the driver's would charge the
+    boot for whatever the two clocks disagree by, and a positive disagreement
+    inflates the boot and makes the budget gates refuse rounds that fit. A
+    duration crosses the boundary meaning the same thing on both sides -- the
+    same reason ``session_remaining_sec`` is passed to the actor as a duration
+    rather than as a deadline.
+
+    A file is used because it crosses that boundary without widening the round's
+    return value, and the round's output directory is already how post-mortem
+    evidence gets back (the caller reads the same directory's ``server.log`` to
+    classify server deaths).
+
+    Best effort: a round whose stamp cannot be written loses a measurement, which
+    callers already have to handle, and must not lose the round.
+
+    Args:
+        server_log_path: The ``<output_dir>/server.log`` path from the caller.
+        boot_sec: Seconds from spawn to this moment, on the spawning process's
+            monotonic clock. Required rather than defaulted: a caller that
+            omitted it would write a well-formed stamp claiming the round booted
+            instantly, which reads as a whole round of benchmark and is the one
+            wrong answer the two-field format exists to make impossible.
+    """
     try:
         _ready_stamp_path(server_log_path).write_text(
             f"{time.time():.3f} {max(0.0, float(boot_sec)):.3f}\n",
@@ -704,6 +730,7 @@ def run_with_session_kill(
             detok_stall_grace_sec = _DETOK_STALL_GRACE_SEC_DEFAULT
     proc: subprocess.Popen | None = None
     capture: _StreamCapture | None = None
+    empty: str | bytes = "" if text else b""
     try:
         with cancel_scope_listener() as cancel_scope:
             proc = subprocess.Popen(  # noqa: S603 — cmd is caller's responsibility
@@ -751,7 +778,6 @@ def run_with_session_kill(
                     stdout=stdout,
                     stderr=stderr,
                 )
-            empty: str | bytes = "" if text else b""
             return subprocess.CompletedProcess(
                 args=cmd,
                 returncode=proc.returncode,
@@ -962,9 +988,12 @@ def _communicate_with_soft_deadline(
                 if scan.saw_ready and server_ready_since is None:
                     server_ready_since = now
                     last_activity_at = now  # start the silence clock at ready
-                    # Recorded for the caller, which prices later work off the post-ready segment rather than the whole
-                    # round: a pass that re-attaches to this server pays none of the boot.
-                    _stamp_server_ready(server_log_path, now - start)  # type: ignore[arg-type]
+                    # Recorded for the caller, which prices later work off the
+                    # post-ready segment rather than the whole round: a pass that
+                    # re-attaches to this server pays none of the boot. Taken as
+                    # ``now - start`` so the boot is measured end to end on this
+                    # process's own clock, whatever host the caller reads it on.
+                    stamp_server_ready(server_log_path, now - start)  # type: ignore[arg-type]
                     # Ready opens the measured window for a synthetic round, which has no warmup marker of its own.
                     # AgentX corrects this a moment later, when aiperf announces its cold-cache warmup, so only the
                     # handful of samples in between carry the wrong label.
@@ -1088,4 +1117,5 @@ __all__ = [
     "server_ready_unix",
     "session_deadline_to_remaining_sec",
     "session_remaining_to_deadline_sec",
+    "stamp_server_ready",
 ]

--- a/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
+++ b/src/hyperloom/orchestrator/actions/executors/_subprocess_kill.py
@@ -1,17 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Reliable subprocess-tree teardown for Magpie-launched servers.
-
-Magpie's shell wrappers ``trap``/``setsid``/``nohup`` the vLLM/SGLang server,
-so on a Hyperloom-side timeout or error the server child can survive, holding
-GPU memory and keeping a ``bash`` alive that may later re-source a script
-mid-copy. To prevent that, Magpie is launched in its own POSIX session
-(``start_new_session=True``) so ``os.killpg`` reaps the whole tree, and
-:func:`kill_my_spawned_server` is called from every exit path (idempotent,
-never raises). Scoped strictly to the tree we created, so it's safe on every
-benchmark call.
-"""
+"""Reliable subprocess-tree teardown for Magpie-launched servers."""
 
 from __future__ import annotations
 
@@ -33,9 +23,8 @@ from ..cancel_channel import CancelScope, cancel_scope_listener
 log = logging.getLogger(__name__)
 
 
-# Grace window between SIGTERM and SIGKILL, here and for a driver-side teardown
-# of a server a round left behind: the same signal, the same thing being waited
-# for.
+# Grace window between SIGTERM and SIGKILL, here and for a driver-side teardown of a server a round left behind: the
+# same signal, the same thing being waited for.
 TERM_GRACE_SECONDS: float = 5.0
 
 # How long the reaper waits to collect the SIGKILL'd child before giving up on it.
@@ -44,52 +33,26 @@ _REAP_COLLECT_SECONDS: float = 1.0
 # How long draining a reaped child's capture threads is given.
 _CAPTURE_DRAIN_SECONDS: float = 2.0
 
-# How often the blocking side looks up from the child to check its stop gates --
-# the session deadline and the cancel scope among them. Short enough that the
-# check costs a stop almost nothing on top of the reap, long enough not to spin.
+# How often the blocking side looks up from the child to check its stop gates -- the session deadline and the cancel
+# scope among them.
 STOP_GATE_POLL_SECONDS: float = 0.5
 
-# What stopping a running round costs, end to end, from the moment something asks
-# it to: noticing at the poll, SIGTERM'ing the tree, waiting out the grace before
-# SIGKILL, collecting the child, and draining its pipes.
-#
-# Every window that waits for a round to stop itself is derived from this rather
-# than picked next to it -- the Ray submitter's grace and the dispatcher's
-# cooperative window both are. A window shorter than what stopping costs looks
-# generous in isolation and still expires every time, and what it discards is the
-# honest sentinel the round was about to return, replacing it with a hard kill
-# and an unattributed failure.
+# What stopping a running round costs, end to end, from the moment something asks it to: noticing at the poll,
+# SIGTERM'ing the tree, waiting out the grace before SIGKILL, collecting the child, and draining its pipes.
 COOPERATIVE_REAP_BUDGET_SEC: float = (
     STOP_GATE_POLL_SECONDS + TERM_GRACE_SECONDS + _REAP_COLLECT_SECONDS + _CAPTURE_DRAIN_SECONDS
 )
 
 
 def new_session_kwargs() -> dict:
-    """``Popen`` kwargs so the child gets its own POSIX session (killable via
-    ``os.killpg``). Returns ``{}`` on non-POSIX.
-
-    Returns:
-        A kwargs dict to splat into ``Popen``; ``{"start_new_session": True}``
-        on POSIX, otherwise an empty dict.
-    """
+    """``Popen`` kwargs so the child gets its own POSIX session (killable via ``os.killpg``)."""
     if os.name == "posix":
         return {"start_new_session": True}
     return {}
 
 
 def _process_group_alive(pgid: int) -> bool:
-    """Return True iff at least one process is still in ``pgid``.
-
-    ``killpg(pgid, 0)`` raises ``ProcessLookupError`` once the group is empty;
-    any other ``OSError`` (e.g. sandbox ``EPERM``) is treated as "still alive".
-
-    Args:
-        pgid: The POSIX process-group id to probe.
-
-    Returns:
-        True if the group still has at least one member (or liveness is
-        indeterminate), False once the group is empty or on non-POSIX.
-    """
+    """Return True iff at least one process is still in ``pgid``."""
     if os.name != "posix":
         return False
     try:
@@ -102,12 +65,7 @@ def _process_group_alive(pgid: int) -> bool:
 
 
 def _signal_group(pgid: int, sig: int) -> None:
-    """Send ``sig`` to every member of ``pgid``; swallow ``ESRCH``.
-
-    Args:
-        pgid (int): The POSIX process-group id to signal.
-        sig (int): The signal number to send.
-    """
+    """Send ``sig`` to every member of ``pgid``; swallow ``ESRCH``."""
     if os.name != "posix":
         return
     try:
@@ -128,20 +86,7 @@ def kill_my_spawned_server(
     *,
     grace_seconds: float = TERM_GRACE_SECONDS,
 ) -> None:
-    """Tear down the entire process tree rooted at ``proc``.
-
-    No-op when ``proc`` is ``None`` or already exited. SIGTERM the group, wait
-    up to ``grace_seconds``, then SIGKILL survivors. Never raises (logs a
-    warning on unexpected signalling failure). Requires the child to have been
-    launched with :func:`new_session_kwargs` so its pgid is distinct from
-    Hyperloom's own; asserted defensively below.
-
-    Args:
-        proc: The spawned process whose tree should be reaped; ``None`` is a
-            no-op.
-        grace_seconds: Seconds to wait after SIGTERM before SIGKILLing
-            survivors.
-    """
+    """Tear down the entire process tree rooted at ``proc``."""
     if proc is None:
         return
     if proc.poll() is not None:
@@ -212,39 +157,18 @@ def kill_my_spawned_server(
         pass
 
 
-# Sentinel ``returncode`` allocation. This module is not the only owner of the
-# space -- ``_ray_serving`` hands out Ray-actor codes from it too, and both
-# arrive at their consumer as a bare ``returncode`` carrying no other tag. A
-# number claimed by a second cause therefore makes attribution a coin flip, so
-# allocate an unused one; ``test_every_sentinel_returncode_names_exactly_one_cause``
-# enumerates both modules and fails on reuse.
+# Sentinel ``returncode`` allocation.
 
-# Sentinel ``returncode`` when ``run_with_session_kill`` reaps a child for an
-# elapsed ``soft_deadline_sec`` (vs the ``timeout=`` hard cap, which raises
-# ``TimeoutExpired``). Chosen not to collide with a real signal-based returncode.
+# Sentinel ``returncode`` when ``run_with_session_kill`` reaps a child for an elapsed ``soft_deadline_sec`` (vs the
+# ``timeout=`` hard cap, which raises ``TimeoutExpired``).
 OVERTIME_KILL_RETURNCODE: int = -909
 
-# Sentinel ``returncode`` when the server-liveness watchdog reaps a child whose
-# engine/worker bootstrap died but whose parent ``vllm serve`` /
-# ``sglang.launch_server`` process hung instead of exiting.
+# Sentinel ``returncode`` when the server-liveness watchdog reaps a child whose engine/worker bootstrap died but whose
+# parent ``vllm serve`` / ``sglang.launch_server`` process hung instead of exiting.
 SERVER_DEAD_RETURNCODE: int = -910
 
-# Fatal server-init markers: once any appears in ``server.log`` the engine is
-# unrecoverable within the same Magpie subprocess. Kept specific (terminal
-# bootstrap failures, never transient per-shape warnings) so the watchdog cannot
-# false-positive on a server that is merely slow to load.
-#
-# Two families:
-#  1. Runtime engine/worker bootstrap crashes (engine core / worker proc).
-#  2. Config-validation-stage failures that die BEFORE the engine starts — most
-#     importantly a brand-new checkpoint ``model_type`` that the installed
-#     transformers / vLLM does not recognise (``pydantic`` ``ModelConfig``
-#     ``ValidationError``). These are just as terminal, and surfacing their
-#     excerpt is what lets the enablement failure classifier see
-#     ``missing_model_arch`` (and seed the ``pip install -U transformers/vllm``
-#     bridge) instead of the Magpie wrapper's uninformative ``subprocess_nonzero``
-#     stdout tail, which classifies as ``unknown`` and starves every enablement
-#     round of the real root cause.
+# Fatal server-init markers: once any appears in ``server.log`` the engine is unrecoverable within the same Magpie
+# subprocess.
 _SERVER_DEAD_MARKERS: tuple[str, ...] = (
     # (1) runtime engine/worker bootstrap crashes
     "WorkerProc initialization failed",
@@ -254,31 +178,23 @@ _SERVER_DEAD_MARKERS: tuple[str, ...] = (
     "AsyncEngineDeadError",
     "raise EngineDeadError",
     "Failed core proc(s)",
-    # (2) config-validation-stage terminal failures (pre-engine). Kept to
-    #     specific failure phrases (never a bare "Model architectures" INFO
-    #     banner) so the liveness watchdog cannot false-positive on a healthy
-    #     slow-loading server.
+    # (2) config-validation-stage terminal failures (pre-engine).
     "does not recognize this architecture",
     "Transformers does not recognize",
     "ValidationError for ModelConfig",
     "are not supported for now",
 )
 
-# Default grace after the first fatal marker before forcing a reap. Overridable
-# via ``INFERENCE_OPTIMIZER_SERVER_DEAD_GRACE_SEC``.
+# Default grace after the first fatal marker before forcing a reap.
 _SERVER_DEAD_GRACE_SEC_DEFAULT: float = 120.0
 
 
-# Sentinel ``returncode`` when the detokenizer-stall watchdog reaps a child that
-# came up healthy but then produced no generation progress (hung engine /
-# detokenizer wedge). Distinct so callers can label it
-# ``error_class="detokenizer_stall"``.
+# Sentinel ``returncode`` when the detokenizer-stall watchdog reaps a child that came up healthy but then produced no
+# generation progress (hung engine / detokenizer wedge).
 DETOKENIZER_STALL_RETURNCODE: int = -911
 
-# Sentinel ``returncode`` returned by the _run_magpie AgentX hook when the
-# execution-boundary preflight fails (aiperf missing or not weka-trace capable)
-# before any benchmark launches. Distinct so callers label it
-# ``error_class="agentx_preflight"`` and surface the guidance instead of crashing.
+# Sentinel ``returncode`` returned by the _run_magpie AgentX hook when the execution-boundary preflight fails (aiperf
+# missing or not weka-trace capable) before any benchmark launches.
 AGENTX_PREFLIGHT_RETURNCODE: int = -912
 
 #: The ``error_class`` that sentinel must carry, wherever it is classified. Named
@@ -295,77 +211,52 @@ AGENTX_PREFLIGHT_ERROR_CLASS: str = "agentx_preflight"
 
 # -913 is ``_ray_serving._RAY_ACTOR_DIED_RC``.
 
-# Sentinel ``returncode`` returned by the _run_magpie eval hook when the
-# generation bounds / pathology probe cannot be installed even though the target
-# file is present and this variant runs eval. Distinct so callers label it
-# ``error_class="eval_probe_unpatchable"`` -- the same class the baseline arm
-# already fails with, so a bounds gap reads identically on both arms.
+# Sentinel ``returncode`` returned by the _run_magpie eval hook when the generation bounds / pathology probe cannot be
+# installed even though the target file is present and this variant runs eval.
 EVAL_PROBE_UNPATCHABLE_RETURNCODE: int = -914
 
-# Sentinel ``returncode`` when the session wall-clock budget ran out mid-round and
-# the tree was reaped. Deliberately distinct from ``OVERTIME_KILL_RETURNCODE``:
-# that one says "this variant ran far longer than the baseline", which is a
-# judgement about the variant, while this one says "the run was out of time",
-# which says nothing about the variant at all. Sharing a code would teach the KB
-# that a variant is slow whenever a session happened to end during it.
+# Sentinel ``returncode`` when the session wall-clock budget ran out mid-round and the tree was reaped.
 SESSION_TIME_EXHAUSTED_RETURNCODE: int = -915
 
 # -916 is ``_ray_serving._ACTOR_TIMEOUT_RC``.
 
-# Sentinel ``returncode`` when the orchestrator cancelled the action this child
-# was launched for -- a shutdown, or a budget that is spent. Distinct from
-# ``SESSION_TIME_EXHAUSTED_RETURNCODE`` because the two causes are told apart at
-# the source: that one is the round's own deadline elapsing where it runs, this
-# one is a decision taken outside it, and only one of them is still true when the
-# same session resumes. Distinct from ``OVERTIME_KILL_RETURNCODE`` for the reason
-# that one already carries: neither says anything about the variant.
+# Sentinel ``returncode`` when the orchestrator cancelled the action this child was launched for -- a shutdown, or a
+# budget that is spent.
 ORCHESTRATOR_CANCELLED_RETURNCODE: int = -917
 
-# Server-ready markers: their appearance in ``server.log`` means the server has
-# finished startup and is accepting traffic. Only after one is observed does the
-# detokenizer-stall clock start. Covers the uvicorn frontend (vLLM + sglang) and
-# sglang's own ready banner.
+# Server-ready markers: their appearance in ``server.log`` means the server has finished startup and is accepting
+# traffic.
 _SERVER_READY_MARKERS: tuple[str, ...] = (
     "Application startup complete",
     "Uvicorn running on",
     "The server is fired up and ready to roll",
 )
 
-# Accuracy-eval start markers: their appearance means the benchmark phase of the
-# run is over and the accuracy eval has begun. The soft deadline measures
-# throughput only, so it stops being enforced from this point on — eval duration
-# is not a throughput signal and the anchor it is compared against excludes it.
-# The hard timeout and the dead/stall watchdogs stay armed.
+# Accuracy-eval start markers: their appearance means the benchmark phase of the run is over and the accuracy eval has
+# begun.
 _EVAL_START_MARKERS: tuple[str, ...] = (
     "HYPERLOOM_EVAL_START",
     "[magpie_bench_remote_compat] lm_eval cmd:",
 )
 
-# The benchmark body's own stderr: Magpie redirects it here rather than into
-# ``server.log`` or the parent's pipe, so it is both where the eval-start marker
-# lands and the one resolved log whose growth is output of the very child this
+# The benchmark body's own stderr: Magpie redirects it here rather than into ``server.log`` or the parent's pipe, so
+# it is both where the eval-start marker lands and the one resolved log whose growth is output of the very child this
 # module is waiting on.
 _EVAL_LOG_NAME: str = "benchmark_stderr.log"
 
-# AgentX phase boundaries. The agentic client runs a long cold-cache warmup --
-# measured at nearly 18 minutes -- before the window that is actually being
-# measured opens, and mixing the two makes every KV statistic meaningless. The
-# boundary needs no marker of ours: aiperf already prints structured phase
-# transitions at NOTICE with millisecond stamps, so these match its own text.
-# Anchored on the parenthesised phase id rather than the whole line so a change
-# to the human-readable half does not silently stop the split.
+# AgentX phase boundaries. The agentic client runs a long cold-cache warmup -- close to 18 minutes on the runs measured
+# so far -- before the window under measurement opens, and mixing the two makes every KV statistic meaningless. aiperf
+# already announces its phase transitions, so these match its own text; anchored on the parenthesised phase id rather
+# than the whole line so a reword of the human-readable half does not silently stop the split.
 _AGENTX_WARMUP_BEGIN_MARKERS: tuple[str, ...] = ("(warmup) started",)
 _AGENTX_MEASURED_BEGIN_MARKERS: tuple[str, ...] = ("(profiling) started",)
 
-# aiperf writes only this file: an AgentX benchmark directory has no
-# ``benchmark_stdout.log`` / ``benchmark_stderr.log`` the way a synthetic one
-# does, so the phase lines are unreachable unless it is scanned explicitly.
+# aiperf writes only this file: an AgentX benchmark directory has no ``benchmark_stdout.log`` / ``benchmark_stderr.log``
+# the way a synthetic one does, so the phase lines are unreachable unless it is scanned explicitly.
 _AGENTX_LOG_RELPATH: str = "aiperf_artifacts/logs/aiperf.log"
 
-# Default grace: how long after the server reports ready it may emit no log
-# output before the watchdog declares a hang / detokenizer stall. Measured from
-# the ready marker so the cold start is never counted. ``<= 0`` disables the
-# gate. Overridable via ``INFERENCE_OPTIMIZER_DETOK_STALL_GRACE_SEC``.
+# Default grace: how long after the server reports ready it may emit no log output before the watchdog declares a hang
+# / detokenizer stall.
 _DETOK_STALL_GRACE_SEC_DEFAULT: float = 1800.0
 
 
@@ -379,15 +270,7 @@ class _StreamCapture:
         text: bool,
         on_output: Callable[[], None] | None = None,
     ) -> None:
-        """Set up capture/mirror threads for a child's stdout and stderr.
-
-        Args:
-            proc: The child process whose pipes should be captured.
-            text: Whether the pipes are in text (``str``) or bytes mode.
-            on_output: Called once per observed unit of child output, from the
-                pump thread. Used as liveness evidence by callers that report
-                progress for a long step.
-        """
+        """Set up capture/mirror threads for a child's stdout and stderr."""
         self._text = text
         self._on_output = on_output
         self._stdout_chunks: list[str | bytes] = []
@@ -416,15 +299,7 @@ class _StreamCapture:
             thread.start()
 
     def finish(self, timeout: float = 2.0) -> tuple[str | bytes, str | bytes]:
-        """Join the capture threads and return the captured output.
-
-        Args:
-            timeout: Per-thread join timeout in seconds.
-
-        Returns:
-            A ``(stdout, stderr)`` tuple of the captured streams (``str`` or
-            ``bytes`` depending on the capture mode).
-        """
+        """Join the capture threads and return the captured output."""
         for thread in self._threads:
             thread.join(timeout=timeout)
         empty: str | bytes = "" if self._text else b""
@@ -443,24 +318,11 @@ class _StreamCapture:
             pass
 
     def _join(self, chunks: list[str | bytes]) -> str | bytes:
-        """Concatenate captured chunks using the appropriate empty separator.
-
-        Args:
-            chunks: Captured stdout or stderr chunks.
-
-        Returns:
-            The joined ``str`` or ``bytes`` output.
-        """
+        """Concatenate captured chunks using the appropriate empty separator."""
         return "".join(chunks) if self._text else b"".join(chunks)  # type: ignore[arg-type,return-value]
 
     def _pump(self, pipe, chunks: list[str | bytes], mirror) -> None:
-        """Read a pipe line-by-line, capturing and mirroring each line.
-
-        Args:
-            pipe: The child pipe to read from.
-            chunks: List that read chunks are appended to.
-            mirror: Parent stream the chunks are echoed to.
-        """
+        """Read a pipe line-by-line, capturing and mirroring each line."""
         try:
             while True:
                 chunk = pipe.readline()
@@ -476,12 +338,7 @@ class _StreamCapture:
                 pass
 
     def _mirror(self, chunk: str | bytes, mirror) -> None:
-        """Echo a captured chunk to the parent stream, ignoring errors.
-
-        Args:
-            chunk: The captured ``str``/``bytes`` chunk.
-            mirror: Parent stream to write to.
-        """
+        """Echo a captured chunk to the parent stream, ignoring errors."""
         try:
             if isinstance(chunk, bytes):
                 stream = getattr(mirror, "buffer", mirror)
@@ -496,28 +353,13 @@ class _StreamCapture:
 # Bytes read from the tail of ``server.log`` per scan.
 _SERVER_LOG_TAIL_BYTES: int = 65536
 
-# Glob (relative to the watched path's directory) for nested per-run server logs
-# Magpie writes when its wrapper ignores ``$SERVER_LOG`` and emits to a
-# ``benchmark_<framework>_<timestamp>/server.log`` subdir instead.
+# Glob (relative to the watched path's directory) for nested per-run server logs Magpie writes when its wrapper
+# ignores ``$SERVER_LOG`` and emits to a ``benchmark_<framework>_<timestamp>/server.log`` subdir instead.
 _NESTED_SERVER_LOG_GLOB: str = "benchmark_*/server.log"
 
 
 def _server_log_tail_has_marker(path: str) -> str | None:
-    """Return the death marker present in the tail of the single file ``path``,
-    else None.
-
-    Best-effort and never raises: a missing / unreadable log reads as "not
-    dead" (returns None).
-
-    Args:
-        path: Filesystem path to the server's ``server.log``.
-
-    Returns:
-        The first matched terminal engine/worker-init marker string if the log
-        tail contains one, otherwise None (including when the log is missing or
-        unreadable). Returning the marker (rather than a bare bool) lets the
-        watchdog report which fatal line tripped it instead of a placeholder.
-    """
+    """Return the death marker present in the tail of the single file ``path``, else None."""
     try:
         with open(path, "rb") as fh:
             try:
@@ -534,27 +376,7 @@ def _server_log_tail_has_marker(path: str) -> str | None:
 
 
 def _server_log_shows_death(path: str) -> str | None:
-    """Return the terminal engine/worker-init marker present in a server log,
-    else None.
-
-    Scans the watched ``path`` AND any nested ``benchmark_*/server.log`` files in
-    the same directory. The nested fallback covers Magpie wrappers that ignore
-    ``$SERVER_LOG`` and write the real server log to a per-run subdir, which
-    otherwise leaves the watchdog reading an empty/absent file forever.
-
-    Best-effort and never raises: a missing / unreadable log (server hasn't
-    written yet) reads as "not dead" so a slow cold start is never misjudged.
-    Returning the marker (rather than a bare bool) lets the watchdog report
-    which fatal line tripped it instead of a placeholder.
-
-    Args:
-        path: Filesystem path to the server's ``server.log``.
-
-    Returns:
-        The first matched terminal engine/worker-init marker string from any
-        candidate log tail, or None when none is present (including when no log
-        is present or readable).
-    """
+    """Return the terminal engine/worker-init marker present in a server log, else None."""
     marker = _server_log_tail_has_marker(path)
     if marker is not None:
         return marker
@@ -571,24 +393,7 @@ def _server_log_shows_death(path: str) -> str | None:
 
 
 def server_log_death_excerpt(path: str, *, max_chars: int = 1200) -> str | None:
-    """Return a short ``server.log`` excerpt around the first terminal
-    engine/worker-init marker, or ``None`` when no fatal marker is present.
-
-    Baseline / profile / explore failure classification calls this to surface
-    the real server-side root cause — e.g. vLLM's ``RuntimeError: Engine core
-    initialization failed`` — instead of the Magpie wrapper's generic
-    stdout/stderr tail. The excerpt keeps a couple of lines of context around
-    the marker. Best-effort: a missing / unreadable log returns ``None``.
-
-    Args:
-        path: Filesystem path to the server's ``server.log``.
-        max_chars: Maximum length of the returned excerpt; the tail is kept
-            when the excerpt is longer.
-
-    Returns:
-        A short multi-line excerpt around the first terminal init marker, or
-        ``None`` when no fatal marker is present.
-    """
+    """Return a short ``server.log`` excerpt around the first terminal engine/worker-init marker, or ``None`` when no fatal marker is present."""
     candidates = [path]
     try:
         base_dir = os.path.dirname(path) or "."
@@ -616,8 +421,7 @@ def server_log_death_excerpt(path: str, *, max_chars: int = 1200) -> str | None:
     return None
 
 
-# Name of the stamp written beside the caller's ``server.log`` the moment the
-# server first reports ready.
+# Name of the stamp written beside the caller's ``server.log`` the moment the server first reports ready.
 _READY_STAMP_NAME = "server_ready_at"
 
 
@@ -627,39 +431,7 @@ def _ready_stamp_path(server_log_path: str) -> Path:
 
 
 def _stamp_server_ready(server_log_path: str, boot_sec: float) -> None:
-    """Record, beside ``server_log_path``, that the server just reported ready.
-
-    Two numbers, because they answer two questions and one clock cannot answer
-    both. ``boot_sec`` is how long the round took to come up, measured from spawn
-    to this moment on one ``time.monotonic()`` reading in the process that
-    spawned the child. The wall-clock instant beside it only ever says *which
-    round* the stamp belongs to.
-
-    Keeping the boot a duration is what makes it safe to read across a process
-    boundary. On the Ray path the round runs inside an actor, possibly on another
-    host; subtracting the actor's wall-clock from the driver's would charge the
-    boot for whatever the two clocks disagree by, and a positive disagreement
-    inflates the boot and makes the budget gates refuse rounds that fit. A
-    duration crosses the boundary meaning the same thing on both sides -- the
-    same reason ``session_remaining_sec`` is passed to the actor as a duration
-    rather than as a deadline.
-
-    A file is used because it crosses that boundary without widening the round's
-    return value, and the round's output directory is already how post-mortem
-    evidence gets back (the caller reads the same directory's ``server.log`` to
-    classify server deaths).
-
-    Best effort: a round whose stamp cannot be written loses a measurement, which
-    callers already have to handle, and must not lose the round.
-
-    Args:
-        server_log_path: The ``<output_dir>/server.log`` path from the caller.
-        boot_sec: Seconds from spawn to this moment, on the spawning process's
-            monotonic clock. Required rather than defaulted: a caller that
-            omitted it would write a well-formed stamp claiming the round booted
-            instantly, which reads as a whole round of benchmark and is the one
-            wrong answer the two-field format exists to make impossible.
-    """
+    """Record, beside ``server_log_path``, that the server just reported ready."""
     try:
         _ready_stamp_path(server_log_path).write_text(
             f"{time.time():.3f} {max(0.0, float(boot_sec)):.3f}\n",
@@ -670,11 +442,7 @@ def _stamp_server_ready(server_log_path: str, boot_sec: float) -> None:
 
 
 def clear_server_ready_stamp(server_log_path: str) -> None:
-    """Drop any ready stamp an earlier round left in this output directory.
-
-    Args:
-        server_log_path: The ``<output_dir>/server.log`` path from the caller.
-    """
+    """Drop any ready stamp an earlier round left in this output directory."""
     try:
         _ready_stamp_path(server_log_path).unlink(missing_ok=True)
     except OSError as exc:
@@ -682,20 +450,7 @@ def clear_server_ready_stamp(server_log_path: str) -> None:
 
 
 def _read_ready_stamp(server_log_path: str) -> tuple[float, float] | None:
-    """Return a round's ``(ready_unix, boot_sec)``, or ``None`` when unrecorded.
-
-    Both fields are required. A stamp missing its boot is reported as no stamp at
-    all rather than as a boot of zero: zero is a legitimate boot, so it cannot
-    also stand for "not recorded", and reading it that way would hand the whole
-    round to the benchmark -- the figure every later variant is then admitted on.
-
-    Args:
-        server_log_path: The ``<output_dir>/server.log`` path from the caller.
-
-    Returns:
-        tuple[float, float] | None: The wall-clock instant the stamp was written
-        and the boot it measured, or ``None`` when no readable stamp exists.
-    """
+    """Return a round's ``(ready_unix, boot_sec)``, or ``None`` when unrecorded."""
     try:
         fields = _ready_stamp_path(server_log_path).read_text(encoding="utf-8").split()
         ready_unix = float(fields[0])
@@ -706,15 +461,7 @@ def _read_ready_stamp(server_log_path: str) -> tuple[float, float] | None:
 
 
 def server_ready_unix(server_log_path: str) -> float | None:
-    """Return when the server reported ready, or ``None`` when nothing recorded it.
-
-    Args:
-        server_log_path: The ``<output_dir>/server.log`` path from the caller.
-
-    Returns:
-        float | None: The wall-clock instant, or ``None`` when no stamp exists or
-        it is unreadable.
-    """
+    """Return when the server reported ready, or ``None`` when nothing recorded it."""
     stamp = _read_ready_stamp(server_log_path)
     return None if stamp is None else stamp[0]
 
@@ -725,29 +472,7 @@ def post_ready_runtime_sec(
     started_unix: float,
     runtime_sec: float,
 ) -> float | None:
-    """Return how long a round ran *after* its server was ready.
-
-    This is the part of a round's wall-clock that is the benchmark itself, with
-    boot, weight load, compile and graph capture excluded. It is what makes two
-    rounds comparable when one paid for a cold start and the other re-attached to
-    a server already up.
-
-    The round's wall-clock less the boot the stamp measured. The boot is a
-    duration taken on one clock, so this holds however far apart the writer and
-    the reader are; ``started_unix`` is only compared against the stamp's own
-    instant, to tell this round's stamp from one an earlier round left behind.
-
-    Args:
-        server_log_path: The ``<output_dir>/server.log`` path from the caller.
-        started_unix: When the round was spawned.
-        runtime_sec: The round's full wall-clock.
-
-    Returns:
-        float | None: Seconds after ready, bounded by the round's own runtime, or
-        ``None`` when the round never reported ready or the only stamp present
-        predates it (an earlier round's, left behind by a failed clear -- reading
-        it would report a cold round as though it had never booted).
-    """
+    """Return how long a round ran *after* its server was ready."""
     stamp = _read_ready_stamp(server_log_path)
     if stamp is None or stamp[0] < started_unix:
         return None
@@ -755,21 +480,7 @@ def post_ready_runtime_sec(
 
 
 def _resolve_scan_logs(server_log_path: str) -> list[str]:
-    """Return the log files to scan for markers, newest-nesting first.
-
-    The caller passes ``<output_dir>/server.log``, but the Magpie benchmark
-    scripts write their logs into a ``benchmark_<fw>_<ts>/`` subdir of
-    ``$RESULT_DIR``, so that exact path usually does not exist. Resolve the
-    nested location and pair each ``server.log`` with the sibling
-    ``benchmark_stderr.log`` that carries the eval-start marker (the patcher
-    echoes it to stderr, which never reaches ``server.log``).
-
-    Args:
-        server_log_path: The ``<output_dir>/server.log`` path from the caller.
-
-    Returns:
-        Existing log paths to scan; empty when none are present yet.
-    """
+    """Return the log files to scan for markers, newest-nesting first."""
     primary = Path(server_log_path)
     out: list[str] = []
     candidates = [primary]
@@ -778,8 +489,6 @@ def _resolve_scan_logs(server_log_path: str) -> list[str]:
     except OSError:
         pass
     for log in candidates:
-        # The AgentX client's own log sits under the benchmark workspace and is
-        # the only place its phase transitions appear.
         for name in (log, log.with_name(_EVAL_LOG_NAME), log.parent / _AGENTX_LOG_RELPATH):
             text = str(name)
             if text not in out and name.exists():
@@ -788,19 +497,7 @@ def _resolve_scan_logs(server_log_path: str) -> list[str]:
 
 
 class _LogScan(NamedTuple):
-    """What one pass over the resolved logs found in the bytes appended since the last.
-
-    Attributes:
-        saw_ready: A server-ready marker appeared.
-        saw_progress: A periodic decode-throughput line reported a non-zero
-            rate, so tokens were being produced during the interval whoever
-            logged them.
-        saw_eval_start: The accuracy eval announced itself.
-        grew: Some resolved log got longer, from any writer at all.
-        child_spoke: The benchmark body's own redirected stderr got longer,
-            which is output of the child being waited on that never reaches its
-            pipe.
-    """
+    """What one pass over the resolved logs found in the bytes appended since the last."""
 
     saw_ready: bool
     saw_progress: bool
@@ -812,20 +509,7 @@ class _LogScan(NamedTuple):
 
 
 class _IncrementScan(NamedTuple):
-    """What one file's newly appended bytes carried.
-
-    A named shape rather than a bare tuple because the marker set grows: the
-    phase boundaries were added here after the fact, and a caller unpacking by
-    position would have had to change with them.
-
-    Attributes:
-        offset: Byte offset now consumed, to seed the next scan.
-        saw_ready: A server-ready marker appeared.
-        saw_progress: A decode-throughput line reported a non-zero rate.
-        saw_eval_start: The accuracy eval announced itself.
-        saw_warmup_begin: AgentX entered its cold-cache warmup.
-        saw_measured_begin: AgentX opened the measured window.
-    """
+    """One log's scan result: the advanced offset, the markers seen, and the partial line to carry forward."""
 
     offset: int
     saw_ready: bool
@@ -836,33 +520,13 @@ class _IncrementScan(NamedTuple):
     residual: str = ""
 
 
-#: Cap on the carried-over tail. A writer that never emits a newline would
-#: otherwise grow this without bound; a marker longer than this is not one we
-#: match on.
+# Cap on the partial line carried between scans. A log that appends a very long line without a newline -- or none at
+# all -- must not let the buffer grow without bound; a marker is far shorter than this, so nothing real is lost.
 _RESIDUAL_MAX_CHARS = 8192
 
 
 def _stale_scan_log_sizes(server_log_path: str) -> dict[str, int]:
-    """Current byte length of each nested log that already exists at spawn.
-
-    Seeded as starting offsets so such a log contributes only what it grows by,
-    never what a previous attempt left in it.
-
-    Only the nested ``benchmark_*/`` workspaces, not the path the caller named.
-    That one the caller owns: it clears it when it means this round to start
-    clean, and a caller that means to attach to a server already up says so with
-    ``server_already_ready``. The nested ones are found by globbing a directory
-    the caller reuses, so nothing in them was asserted by anyone -- and a stale
-    ready line there would otherwise latch on the first poll and report a boot
-    that took minutes as one that took none.
-
-    Args:
-        server_log_path: The ``<output_dir>/server.log`` path from the caller.
-
-    Returns:
-        dict[str, int]: Per-path byte lengths; a path whose size cannot be read
-        is left out, so it is scanned from the start as an absent one would be.
-    """
+    """Current byte length of each nested log that already exists at spawn."""
     owned_dir = Path(server_log_path).parent
     sizes: dict[str, int] = {}
     for path in _resolve_scan_logs(server_log_path):
@@ -881,21 +545,7 @@ def _scan_logs_increment(
     offsets: dict[str, int],
     residuals: dict[str, str] | None = None,
 ) -> _LogScan:
-    """Scan every resolved log for markers, advancing ``offsets`` in place.
-
-    Args:
-        server_log_path: The ``<output_dir>/server.log`` path from the caller.
-        offsets: Per-path byte offsets already consumed; mutated in place.
-        residuals: Per-path unterminated tails carried from the previous scan;
-            mutated in place. Held per path rather than as one shared tail
-            because the resolved logs are written by different processes and
-            interleaving one's tail into another's next read would invent lines
-            neither of them wrote.
-
-    Returns:
-        _LogScan: The markers seen in the newly appended bytes, plus who — if
-        anyone — did the appending.
-    """
+    """Scan every resolved log for markers, advancing ``offsets`` (and ``residuals``, when given) in place."""
     saw_ready = saw_progress = saw_eval_start = grew = child_spoke = False
     saw_warmup_begin = saw_measured_begin = False
     for path in _resolve_scan_logs(server_log_path):
@@ -912,38 +562,11 @@ def _scan_logs_increment(
         if scan.offset > prev:
             grew = True
             child_spoke = child_spoke or Path(path).name == _EVAL_LOG_NAME
-    return _LogScan(
-        saw_ready,
-        saw_progress,
-        saw_eval_start,
-        grew,
-        child_spoke,
-        saw_warmup_begin,
-        saw_measured_begin,
-    )
+    return _LogScan(saw_ready, saw_progress, saw_eval_start, grew, child_spoke, saw_warmup_begin, saw_measured_begin)
 
 
 def _scan_server_log_increment(path: str, from_offset: int, residual: str = "") -> _IncrementScan:
-    """Incrementally scan the bytes appended to ``server.log`` since
-    ``from_offset`` for ready / generation-progress / eval-start markers.
-
-    Reading only the NEW tail (not the whole file) keeps the per-poll cost flat
-    and — crucially — makes "progress" mean *fresh* progress: a throughput line
-    written ten minutes ago that still sits in the file is read exactly once,
-    so a wedged server that stops appending lines correctly reads as "no new
-    progress" on subsequent polls. Handles truncation/rotation (size shrank
-    below the offset) by rescanning from the start. Best-effort: a missing /
-    unreadable log reads as "no new markers" and leaves the offset unchanged so
-    a slow cold start is never misjudged.
-
-    Args:
-        path: Filesystem path to the server's ``server.log``.
-        from_offset: Byte offset already consumed by a prior scan.
-
-    Returns:
-        _IncrementScan: The advanced offset plus which markers the newly read
-        bytes carried.
-    """
+    """Incrementally scan the bytes appended to ``server.log`` since ``from_offset`` for ready / generation-progress / eval-start markers."""
     try:
         size = os.path.getsize(path)
     except OSError:
@@ -952,7 +575,7 @@ def _scan_server_log_increment(path: str, from_offset: int, residual: str = "") 
     carried = residual
     if size < start:  # truncated / rotated — rescan from the top.
         start = 0
-        carried = ""  # the tail belonged to a file that no longer exists
+        carried = ""  # the bytes it belonged to are gone
     if size <= start:  # nothing new appended
         return _IncrementScan(start, False, False, False, residual=carried)
     try:
@@ -961,29 +584,16 @@ def _scan_server_log_increment(path: str, from_offset: int, residual: str = "") 
             chunk = fh.read().decode("utf-8", "ignore")
     except (OSError, ValueError):
         return _IncrementScan(from_offset, False, False, False, residual=carried)
-    # Splice the previous read's unterminated tail back on before matching. A
-    # marker straddling a read boundary appears in neither half, so without this
-    # it is not merely seen late -- it is never seen at all, and the phase it
-    # announced is silently attributed to the wrong window for the whole round.
+    # A poll lands wherever the writer happens to be, so a marker is routinely split across two reads. Prepending the
+    # previous tail and carrying the new one forward is what makes a marker findable exactly once, whole.
     chunk = carried + chunk
     tail_at = chunk.rfind("\n")
-    next_residual = "" if tail_at < 0 else chunk[tail_at + 1 :]
-    if tail_at < 0:
-        next_residual = chunk
+    next_residual = chunk if tail_at < 0 else chunk[tail_at + 1 :]
     next_residual = next_residual[-_RESIDUAL_MAX_CHARS:]
     saw_ready = any(marker in chunk for marker in _SERVER_READY_MARKERS)
-    # Progress is the rate on the periodic decode-throughput line, not the
-    # line's presence: some vLLM builds log ``Avg generation throughput: 0.0
-    # tokens/s`` on an idle engine, and an engine goes idle precisely when the
-    # client driving it wedges, so the marker alone lets the server vouch for
-    # the client that stopped asking it for tokens. Reusing the post-mortem
-    # estimator's parse keeps the frameworks the two recognise from drifting
-    # apart. A line whose rate it cannot read counts as no progress: this
-    # evidence only ever suppresses a stall accusation, and one suppressed by
-    # mistake is invisible, where a missing one is visible and answerable from
-    # the child's own redirected stderr. The stall gate is deliberately broader
-    # and keys on raw log activity (any new bytes); see
-    # :func:`_communicate_with_soft_deadline`.
+    # Progress is the rate on the periodic decode-throughput line, not the line's presence: some vLLM builds log ``Avg
+    # generation throughput: 0.0 tokens/s`` on an idle engine, and an engine goes idle precisely when the client
+    # driving it wedges, so the marker alone lets the server vouch for the client that stopped asking it for tokens.
     saw_progress = bool(parse_server_log_throughput(chunk))
     saw_eval_start = any(marker in chunk for marker in _EVAL_START_MARKERS)
     saw_warmup_begin = any(marker in chunk for marker in _AGENTX_WARMUP_BEGIN_MARKERS)
@@ -1000,76 +610,28 @@ def _scan_server_log_increment(path: str, from_offset: int, residual: str = "") 
 
 
 def session_deadline_to_remaining_sec(session_deadline_sec: float | None) -> float | None:
-    """Convert an in-process session deadline into seconds still left on it.
-
-    The pair of this and :func:`session_remaining_to_deadline_sec` is how a
-    session deadline crosses a process boundary. ``time.monotonic()`` has an
-    unspecified, per-process origin, so the absolute instant means nothing to a
-    reader in another process; a duration means the same thing everywhere.
-
-    Args:
-        session_deadline_sec: Absolute ``time.monotonic()`` instant at which the
-            session budget expires, or ``None`` when the budget is unbounded.
-
-    Returns:
-        Seconds left on the budget, or ``None`` when unbounded. Non-positive
-        when the deadline has already passed, which the receiving side is meant
-        to act on immediately rather than treat as "no budget given".
-    """
+    """Convert an in-process session deadline into seconds still left on it."""
     if session_deadline_sec is None:
         return None
     return float(session_deadline_sec) - time.monotonic()
 
 
 def session_remaining_to_deadline_sec(session_remaining_sec: float | None) -> float | None:
-    """Re-anchor a remaining session budget onto this process's monotonic clock.
-
-    The inverse of :func:`session_deadline_to_remaining_sec`. Whatever the trip
-    itself cost is forgiven: no clock is shared across the boundary to measure it
-    with, so the receiver starts a fresh window of the full duration. The
-    receiver can therefore run marginally past the sender's deadline, which is
-    the safe direction -- the alternative is guessing at the transit and charging
-    a round for time it never had.
-
-    Args:
-        session_remaining_sec: Seconds left on the session budget as measured by
-            the sender, or ``None`` when the budget is unbounded.
-
-    Returns:
-        An absolute ``time.monotonic()`` deadline usable in this process, or
-        ``None`` when unbounded.
-    """
+    """Re-anchor a remaining session budget onto this process's monotonic clock."""
     if session_remaining_sec is None:
         return None
     return time.monotonic() + float(session_remaining_sec)
 
 
-#: Kill switch for KV sampling. Collection is best-effort and cannot fail a
-#: round by construction, but a loop this central needs a way out of the path
-#: that does not require a redeploy. Set to ``0`` to disable.
+# Escape hatch for a round that must not pay even the cost of one HTTP GET every couple of seconds.
 _KV_METRICS_ENV = "INFERENCE_OPTIMIZER_KV_METRICS"
 
 
 def _build_kv_recorder(server_log_path: str | None, env: dict[str, str] | None) -> Any:
-    """Create the KV sampler for one round, or ``None`` when it does not apply.
+    """Build the KV-metrics recorder for this round, or ``None`` when it is off or cannot be built.
 
-    Gated on ``server_log_path`` because that is what marks a call as a served
-    benchmark rather than an arbitrary subprocess: a scriptable workload or a
-    helper command has no engine to scrape and no round-scoped place to put an
-    artifact.
-
-    Args:
-        server_log_path (str | None): The round's ``<output_dir>/server.log``.
-            Its parent is the round workspace and receives the artifact.
-        env (dict[str, str] | None): The child's environment. This is the
-            materialized config's ``benchmark.envs``, so it carries the
-            per-session ephemeral ``PORT`` the server actually bound -- the
-            default 8888 is only correct when nothing pinned one.
-
-    Returns:
-        Any: A recorder, or ``None`` when collection is off, inapplicable, or
-        could not be constructed. Never raises: a sampler that cannot be built
-        must not stop the benchmark it was going to watch.
+    Collection is strictly observational, so every failure here is swallowed: a round that produces a good benchmark
+    number and no KV metrics is a far better outcome than one that dies because a telemetry import went wrong.
     """
     if not server_log_path:
         return None
@@ -1082,40 +644,20 @@ def _build_kv_recorder(server_log_path: str | None, env: dict[str, str] | None) 
         return KvMetricsRecorder(
             poller=KvMetricsPoller(config_envs=dict(env or {})),
             output_path=str(workspace / KV_ARTIFACT_NAME),
-            # Self-sufficient on purpose: a consumer must be able to say which
-            # round produced this without joining against another file. The
-            # workspace directory name carries the variant, and the path under
-            # ``runs/`` carries the action and task that spawned it.
             scope={
                 "server_log_path": str(server_log_path),
                 "workspace": workspace.name,
                 "run_path": _run_relative_path(workspace),
-                # From the session directory, which the CLI does export. There
-                # is no INFERENCE_OPTIMIZER_SESSION_ID: nothing in the tree sets
-                # one, so reading it produced a field that was always empty.
-                "session": os.path.basename(
-                    os.environ.get("INFERENCE_OPTIMIZER_CURRENT_SESSION_DIR", "").rstrip("/\\")
-                ),
+                "session": os.path.basename(os.environ.get("INFERENCE_OPTIMIZER_CURRENT_SESSION_DIR", "").rstrip("/\\")),
             },
         )
-    except Exception:  # noqa: BLE001 - collection is never worth a failed round
-        # Warning, not debug: this is the difference between "no KV data because
-        # the engine had none" and "no KV data because nothing ever asked", and
-        # the artifact's absence cannot tell them apart.
+    except Exception:
         log.warning("kv_metrics: recorder could not be built; this round collects nothing", exc_info=True)
         return None
 
 
 def _run_relative_path(workspace: Path) -> str:
-    """Path of a round workspace relative to the session's ``runs/`` root.
-
-    Args:
-        workspace (Path): The round's output directory.
-
-    Returns:
-        str: e.g. ``explore/<task>/<variant>/<benchmark>``, or the bare
-        directory name when no ``runs`` component is present.
-    """
+    """Path of this round's workspace below ``runs/``, which is what the session breakdown keys rows by."""
     parts = workspace.parts
     if "runs" in parts:
         return "/".join(parts[parts.index("runs") + 1 :])
@@ -1137,31 +679,7 @@ def run_with_session_kill(
     on_output: Callable[[], None] | None = None,
     session_deadline_sec: float | None = None,
 ) -> subprocess.CompletedProcess:
-    """Run a subprocess in its own session and reap descendants on every exit path.
-
-    ``session_deadline_sec`` is an absolute ``time.monotonic()`` instant, unlike
-    ``soft_deadline_sec`` which is a relative duration. It is the session's own
-    wall-clock budget and is enforced in every phase, including the accuracy
-    eval -- the phase that retires ``soft_deadline_sec``. That distinction is the
-    reason it is a separate channel rather than a reuse of the soft deadline: the
-    eval-start boundary is meaningful for "is this variant abnormally slow" and
-    meaningless for "is the run out of time".
-
-    The cancel scope published by the dispatcher (:mod:`..cancel_channel`) is
-    watched for as long as the child lives, so an orchestrator that cancels the
-    action reaches the tree rather than just the coroutine awaiting this call.
-    Every cause that reaps the tree is reported as its own sentinel
-    ``returncode``, which is all a caller of a subprocess gets to tell them apart
-    by.
-
-    Args:
-        on_output: Called from a reader thread each time the child produces
-            output, so a caller can report a long step alive on the child's own
-            activity rather than on a timer.
-        session_deadline_sec: Absolute ``time.monotonic()`` instant at which the
-            session budget expires. Reaps the tree and returns
-            ``SESSION_TIME_EXHAUSTED_RETURNCODE``.
-    """
+    """Run a subprocess in its own session and reap descendants on every exit path."""
     if server_dead_grace_sec is None:
         try:
             server_dead_grace_sec = float(
@@ -1243,17 +761,7 @@ def run_with_session_kill(
 
 
 def _finish_capture(capture: _StreamCapture | None, *, text: bool) -> tuple[str | bytes, str | bytes]:
-    """Drain the capture threads of a reaped child, never returning ``None``.
-
-    Args:
-        capture: The stream capture to finish, or ``None`` when the child's
-            output was not captured.
-        text: Whether the streams are ``str`` (``True``) or ``bytes``, which
-            decides what an absent stream reads as.
-
-    Returns:
-        tuple[str | bytes, str | bytes]: The captured ``(stdout, stderr)``.
-    """
+    """Drain the capture threads of a reaped child, never returning ``None``."""
     empty: str | bytes = "" if text else b""
     if capture is None:
         return empty, empty
@@ -1265,14 +773,7 @@ def _finish_capture(capture: _StreamCapture | None, *, text: bool) -> tuple[str 
 
 
 class _ReapedByWatchdog(Exception):
-    """Internal base for a cause that reaps the tree and names itself.
-
-    None of these bubble past :func:`run_with_session_kill`: each is converted
-    to a ``CompletedProcess`` carrying the subclass's own ``returncode``, since
-    a returncode is the only thing that survives the trip back to a caller of a
-    subprocess. Subclasses build their own message and declare how much the
-    event is worth logging.
-    """
+    """Internal base for a cause that reaps the tree and names itself."""
 
     returncode: int = -1
     log_level: int = logging.WARNING
@@ -1284,12 +785,7 @@ class _SessionDeadlineExceeded(_ReapedByWatchdog):
     returncode = SESSION_TIME_EXHAUSTED_RETURNCODE
 
     def __init__(self, *, overrun_sec: float, elapsed_sec: float) -> None:
-        """Record how far past the session deadline the round got.
-
-        Args:
-            overrun_sec (float): Seconds past the session deadline at trip time.
-            elapsed_sec (float): Wall-clock elapsed for this round at trip time.
-        """
+        """Record how far past the session deadline the round got."""
         super().__init__(
             f"the session wall-clock budget was exhausted {overrun_sec:.1f}s ago (round elapsed={elapsed_sec:.1f}s)"
         )
@@ -1298,22 +794,12 @@ class _SessionDeadlineExceeded(_ReapedByWatchdog):
 
 
 class _OrchestratorCancelled(_ReapedByWatchdog):
-    """Internal sentinel: the orchestrator cancelled the action this child serves.
-
-    The cause is a decision taken outside the round -- a shutdown, or a budget
-    the dispatcher found spent -- which is why it carries the caller's reason
-    rather than a measurement of its own.
-    """
+    """Internal sentinel: the orchestrator cancelled the action this child serves."""
 
     returncode = ORCHESTRATOR_CANCELLED_RETURNCODE
 
     def __init__(self, *, reason: str, elapsed_sec: float) -> None:
-        """Record who asked for the stop and how far the round had got.
-
-        Args:
-            reason (str): Short cause from the canceller, e.g. ``shutdown_requested``.
-            elapsed_sec (float): Wall-clock elapsed for this round at trip time.
-        """
+        """Record who asked for the stop and how far the round had got."""
         super().__init__(
             f"the orchestrator cancelled this action ({reason or 'no reason given'}; round elapsed={elapsed_sec:.1f}s)"
         )
@@ -1328,21 +814,14 @@ class _SoftDeadlineExceeded(_ReapedByWatchdog):
     log_level = logging.INFO
 
     def __init__(self, *, deadline_sec: float, elapsed_sec: float) -> None:
-        """Record the deadline and actual elapsed time on the sentinel.
-
-        Args:
-            deadline_sec (float): The soft deadline that was exceeded.
-            elapsed_sec (float): The actual wall-clock elapsed at trip time.
-        """
+        """Record the deadline and actual elapsed time on the sentinel."""
         super().__init__(f"soft_deadline_sec={deadline_sec:.1f}s elapsed (actual={elapsed_sec:.1f}s)")
         self.deadline_sec = float(deadline_sec)
         self.elapsed_sec = float(elapsed_sec)
 
 
 class _ServerDeadDetected(_ReapedByWatchdog):
-    """Internal sentinel: the server-liveness watchdog saw a terminal engine /
-    worker init marker that persisted past the grace window.
-    """
+    """Internal sentinel: the server-liveness watchdog saw a terminal engine / worker init marker that persisted past the grace window."""
 
     returncode = SERVER_DEAD_RETURNCODE
 
@@ -1353,13 +832,7 @@ class _ServerDeadDetected(_ReapedByWatchdog):
         grace_sec: float,
         elapsed_sec: float,
     ) -> None:
-        """Build the error message describing the hung-after-death condition.
-
-        Args:
-            marker: Log marker that indicated the server init died.
-            grace_sec: Grace period the parent was allowed after the marker.
-            elapsed_sec: Actual wall-clock elapsed at trip time.
-        """
+        """Build the error message describing the hung-after-death condition."""
         super().__init__(
             f"server init died (marker={marker!r}) and the parent hung past "
             f"grace {grace_sec:.1f}s (elapsed={elapsed_sec:.1f}s)"
@@ -1370,9 +843,7 @@ class _ServerDeadDetected(_ReapedByWatchdog):
 
 
 class _ServerStalledDetected(_ReapedByWatchdog):
-    """Internal sentinel: the detokenizer-stall watchdog saw the server report
-    ready and then produce no generation progress for the grace window.
-    """
+    """Internal sentinel: the detokenizer-stall watchdog saw the server report ready and then produce no generation progress for the grace window."""
 
     returncode = DETOKENIZER_STALL_RETURNCODE
 
@@ -1382,13 +853,7 @@ class _ServerStalledDetected(_ReapedByWatchdog):
         grace_sec: float,
         elapsed_sec: float,
     ) -> None:
-        """Build the error message describing the ready-but-no-progress stall.
-
-        Args:
-            grace_sec: How long the ready server was allowed to produce no
-                generation progress before the watchdog tripped.
-            elapsed_sec: Actual wall-clock elapsed at trip time.
-        """
+        """Build the error message describing the ready-but-no-progress stall."""
         super().__init__(
             f"server reported ready but emitted no log output for "
             f"{grace_sec:.1f}s (hung engine / detokenizer stall; "
@@ -1412,28 +877,15 @@ def _communicate_with_soft_deadline(
     cancel_scope: CancelScope | None = None,
     kv_recorder: Any = None,
 ) -> tuple[str | bytes, str | bytes]:
-    """Communicate with a child while enforcing soft and server-log watchdogs.
-
-    ``kv_recorder`` is an optional KV-metrics collector
-    (:class:`._kv_metrics.KvMetricsRecorder`). It is duck-typed rather than
-    imported so this watchdog keeps no dependency on the collector: the
-    contract is ``note_phase(phase, mono)``, ``tick(mono)`` and
-    ``close(aborted=...)``, and ``None`` disables collection entirely. It rides
-    this loop because this is the only place that sees both the server-ready
-    marker and the eval-start marker, so it is the only place that can tell the
-    measured window from the boot and eval traffic around it -- and because a
-    sampler in a process of its own would contend for CPU with the very
-    benchmark being measured.
-    """
+    """Communicate with a child while enforcing soft and server-log watchdogs."""
     watchdog_active = bool(server_log_path) and (
         server_dead_grace_sec is not None and float(server_dead_grace_sec) > 0.0
     )
     stall_active = bool(server_log_path) and (detok_stall_grace_sec is not None and float(detok_stall_grace_sec) > 0.0)
     soft_active = soft_deadline_sec is not None and float(soft_deadline_sec) > 0.0
     session_active = session_deadline_sec is not None
-    # A cancel scope is polled like any other gate, so its presence rules out the
-    # single-wait fast paths below: a call that blocks until the child exits
-    # cannot notice a cancel that arrives while it is blocked.
+    # A cancel scope is polled like any other gate, so its presence rules out the single-wait fast paths below: a call
+    # that blocks until the child exits cannot notice a cancel that arrives while it is blocked.
     gated = soft_active or watchdog_active or stall_active or session_active or cancel_scope is not None
     if capture is None and not gated:
         return proc.communicate(timeout=hard_timeout)
@@ -1444,13 +896,8 @@ def _communicate_with_soft_deadline(
     deadline_sec = float(soft_deadline_sec) if soft_active else None
     grace_sec = float(server_dead_grace_sec) if watchdog_active else None
     stall_grace_sec = float(detok_stall_grace_sec) if stall_active else None
-    # When a ``server.log`` is available the soft deadline measures only the
-    # post-ready phase (clock starts at the server-ready marker, excluding boot /
-    # weight load / first-request JIT). Without a ``server.log`` it falls back to
-    # the from-spawn clock. Opt out with
-    # ``INFERENCE_OPTIMIZER_SOFT_DEADLINE_FROM_READY=0``.
-    # ``server_already_ready`` (warm reuse round) forces the from-spawn path
-    # since no ready marker is written, so the from-ready clock would never arm.
+    # When a ``server.log`` is available the soft deadline measures only the post-ready phase (clock starts at the
+    # server-ready marker, excluding boot / weight load / first-request JIT).
     soft_from_ready = (
         soft_active
         and bool(server_log_path)
@@ -1458,75 +905,52 @@ def _communicate_with_soft_deadline(
         and os.environ.get("INFERENCE_OPTIMIZER_SOFT_DEADLINE_FROM_READY", "1").strip().lower()
         not in {"0", "false", "no", "off"}
     )
-    # The log increment scan feeds the stall watchdog, the from-ready
-    # soft-deadline anchor, the eval-start boundary and the ready timestamp the
-    # caller prices later work off; run it once per slice whenever a log is
-    # present. Not narrowed to the watchdogs that consume it: tying it to
-    # ``stall_active`` let an unrelated knob
-    # (``INFERENCE_OPTIMIZER_DETOK_STALL_GRACE_SEC=0``) silently withdraw the
-    # boot/benchmark split for a whole session. It costs nothing where it did not
-    # already run, since without a gate this call never enters the loop at all.
+    # The log increment scan feeds the stall watchdog, the from-ready soft-deadline anchor, the eval-start boundary
+    # and the ready timestamp the caller prices later work off; run it once per slice whenever a log is present.
     scan_active = bool(server_log_path) and gated
     poll_interval = STOP_GATE_POLL_SECONDS
     start = time.monotonic()
     dead_marker_since: float | None = None
-    # Detokenizer-stall watchdog state: per-log byte offsets consumed so far,
-    # whether a ready marker has been seen, and the last time a log showed any
-    # new output (seeded to the ready time). The gate only arms once
-    # ``server_ready_since`` is set.
+    # Detokenizer-stall watchdog state: per-log byte offsets consumed so far, whether a ready marker has been seen,
+    # and the last time a log showed any new output (seeded to the ready time).
     scan_offsets: dict[str, int] = {}
     if scan_active:
-        # A reused output_dir can still hold a prior attempt's nested workspace,
-        # whose markers are not this round's. The workspace this round creates
-        # does not exist yet, so it is discovered later at offset zero, which is
-        # correct: all of its bytes are this round's.
+        # A reused output_dir can still hold a prior attempt's nested workspace, whose markers are not this round's.
         scan_offsets.update(_stale_scan_log_sizes(server_log_path))  # type: ignore[arg-type]
-    # Unterminated tails carried between scans, per path. Without them a marker
-    # landing across a read boundary is in neither half and is lost outright.
+    # Partial trailing line per log, carried into the next scan so a marker split across two reads is still found.
     scan_residuals: dict[str, str] = {}
-    # A warm-reuse round re-attaches to a server that is already up, so no ready
-    # marker is ever written and the phase would otherwise sit at ``boot`` for
-    # the whole round -- putting every measured sample in the one bucket that
-    # never enters a comparison. The caller telling us the server is ready is
-    # the same statement the marker would have made.
+    # A warm-reuse round re-attaches to a server that came up in an earlier round, so no ready marker will ever land in
+    # this process's scan window. Without this the phase would stay "boot" for the whole round and every sample would
+    # be filed under a phase the round never actually ran.
     if kv_recorder is not None and server_already_ready:
         kv_recorder.note_phase("measured", start)
     server_ready_since: float | None = None
     last_activity_at: float | None = None
-    # Latched once the accuracy eval starts: the soft deadline bounds the
-    # throughput phase only, so it is retired for the rest of the process.
+    # Latched once the accuracy eval starts: the soft deadline bounds the throughput phase only, so it is retired for
+    # the rest of the process.
     soft_deadline_suspended = False
-    # Distinguishes a child that finished from a gate that raised. The recorder
-    # is closed in the ``finally`` below so every exit path is covered: the five
-    # gate exceptions, the hard timeout, and the normal return. An unclosed
-    # window is the one failure a consumer cannot recover from -- it has no way
-    # to tell a round still running from one that died mid-window.
+    # Separates a child that finished from a gate that raised, so the recorder can mark an aborted round as such.
+    # Closing happens in the `finally` below, which is what covers every exit path: the five gate exceptions, the
+    # hard timeout, and the normal return. An unclosed window is the one failure a consumer cannot recover from --
+    # it has no way to tell a round still running from one that died mid-window.
     completed = False
     try:
         while True:
             now = time.monotonic()
             elapsed = now - start
-            # Session budget. Checked before every other gate and never suspended:
-            # unlike the soft deadline it makes no claim about the variant, so the
-            # eval-start boundary that retires the soft deadline does not apply. An
-            # accuracy eval that starts one minute before the run is out of time still
-            # has to stop.
+            # Session budget.
             if session_active and session_deadline_sec is not None and now >= session_deadline_sec:
                 raise _SessionDeadlineExceeded(
                     overrun_sec=now - float(session_deadline_sec),
                     elapsed_sec=elapsed,
                 )
-            # Orchestrator cancellation. Checked after the session deadline so a
-            # round that was already out of time keeps that reason: the budget is a
-            # fact about the run, while the cancel is only the dispatcher acting on
-            # it, and the more specific of the two is the one worth recording.
+            # Orchestrator cancellation.
             if cancel_scope is not None and cancel_scope.cancelled:
                 raise _OrchestratorCancelled(
                     reason=cancel_scope.reason,
                     elapsed_sec=elapsed,
                 )
-            # Advance the log scan, latching the server-ready, last-activity
-            # and eval-start signals.
+            # Advance the log scan, latching the server-ready, last-activity and eval-start signals.
             if scan_active:
                 scan = _scan_logs_increment(
                     server_log_path,  # type: ignore[arg-type]
@@ -1536,17 +960,12 @@ def _communicate_with_soft_deadline(
                 if scan.saw_ready and server_ready_since is None:
                     server_ready_since = now
                     last_activity_at = now  # start the silence clock at ready
-                    # Recorded for the caller, which prices later work off the
-                    # post-ready segment rather than the whole round: a pass that
-                    # re-attaches to this server pays none of the boot. Taken as
-                    # ``now - start`` so the boot is measured end to end on this
-                    # process's own clock, whatever host the caller reads it on.
+                    # Recorded for the caller, which prices later work off the post-ready segment rather than the whole
+                    # round: a pass that re-attaches to this server pays none of the boot.
                     _stamp_server_ready(server_log_path, now - start)  # type: ignore[arg-type]
-                    # Ready opens the measured window for a synthetic round,
-                    # which has no warmup marker of its own. AgentX corrects
-                    # this a moment later: aiperf announces its cold-cache
-                    # warmup right after the server comes up, so the handful of
-                    # samples in between carry the wrong label and no more.
+                    # Ready opens the measured window for a synthetic round, which has no warmup marker of its own.
+                    # AgentX corrects this a moment later, when aiperf announces its cold-cache warmup, so only the
+                    # handful of samples in between carry the wrong label.
                     if kv_recorder is not None:
                         kv_recorder.note_phase("measured", now)
                 if kv_recorder is not None:
@@ -1555,10 +974,8 @@ def _communicate_with_soft_deadline(
                     if scan.saw_measured_begin:
                         kv_recorder.note_phase("measured", now)
                     if scan.saw_eval_start:
-                        # Eval traffic is not the throughput benchmark: its
-                        # request shape is different and it would drag both
-                        # occupancy and hit rate toward numbers no comparison
-                        # should see.
+                        # Eval traffic is not the throughput benchmark: its request shape differs, and it would drag
+                        # both occupancy and hit rate toward numbers no cross-round comparison should see.
                         kv_recorder.note_phase("eval", now)
                 if scan.saw_eval_start and not soft_deadline_suspended:
                     soft_deadline_suspended = True
@@ -1567,38 +984,19 @@ def _communicate_with_soft_deadline(
                         "(it bounds the throughput phase only)",
                         float(deadline_sec or 0.0),
                     )
-                # Any new bytes count as liveness; only total silence trips the
-                # stall gate.
+                # Any new bytes count as liveness; only total silence trips the stall gate.
                 if scan.grew:
                     last_activity_at = now
-                # The liveness callback makes a narrower claim than the stall gate —
-                # that this child is working, not that something on the box is — so
-                # it takes narrower evidence: tokens flowing, or the child's own
-                # redirected stderr growing. A ``server.log`` that grew is neither.
-                # The server keeps logging while its benchmark client is wedged, and
-                # both vLLM and sglang write an access line per request, including
-                # the health probe the robustness agent issues on its own tick —
-                # which would let the monitor manufacture the evidence that
-                # suppresses its own stall accusation.
+                # The liveness callback makes a narrower claim than the stall gate — that this child is working, not that
+                # something on the box is — so it takes narrower evidence: tokens flowing, or the child's own redirected
+                # stderr growing.
                 if capture is not None and (scan.saw_progress or scan.child_spoke):
                     capture.note_output()
-            # KV sampling. Outside the ``scan_active`` guard because it reads the
-            # engine's HTTP endpoint, not the logs, and rate-limits itself on the
-            # monotonic clock: this loop's slice shrinks below its nominal 0.5s
-            # whenever a deadline bounds it, so counting passes would sample
-            # faster exactly when the run is closest to its limits.
-            #
-            # Held off until the server is up. The scrape is a blocking call, and
-            # before the engine binds its port every attempt is a refused
-            # connection paid for inside the loop -- during boot, which is
-            # precisely when the ready marker and the death watchdog need this
-            # loop to be responsive. Boot carries no traffic to measure anyway,
-            # and pool capacity is readable the moment the server answers.
+            # Held until the engine is actually up: scraping during boot only collects connection refusals, and on a
+            # warm-reuse round there is no boot to wait through.
             if kv_recorder is not None and (server_ready_since is not None or server_already_ready):
                 kv_recorder.tick(now)
-            # Soft deadline. With ``soft_from_ready`` the overtime clock is measured
-            # from the server-ready marker and stays dormant until ready; otherwise
-            # it is the from-spawn elapsed.
+            # Soft deadline.
             if soft_active and deadline_sec is not None and not soft_deadline_suspended:
                 if soft_from_ready:
                     if server_ready_since is not None:
@@ -1634,8 +1032,8 @@ def _communicate_with_soft_deadline(
                             grace_sec=stall_grace_sec,
                             elapsed_sec=elapsed,
                         )
-            # Slice bounded by every active remaining window so the right gate
-            # fires first; the child can still finish inside any slice.
+            # Slice bounded by every active remaining window so the right gate fires first; the child can still finish
+            # inside any slice.
             slice_sec = poll_interval
             if session_active and session_deadline_sec is not None:
                 slice_sec = min(slice_sec, float(session_deadline_sec) - now)


### PR DESCRIPTION
## Why

Nothing in Hyperloom has ever read how full the engine's KV pool is. A round can
spend its entire budget retracting requests and the breakdown reports only
"throughput low" — with the actual bottleneck invisible to the optimizer
choosing what to try next.

This matters more than it used to. On production AgentX traces the input length
median is ~62k tokens and p90 is ~339k, against a fixed 8192 on the synthetic
path, which moves KV from a background resource to the main constraint.

## What this produces

One `kv_metrics.json` per benchmark round, written into that round's workspace
next to `server.log`: phase-tagged samples, pool capacity, and the
retract/preemption counters. On an AgentX round it is joined by an
`agentx_timeline.jsonl` carrying the workload's own event stream. Both are added
to `PACKAGE_GLOBS`, since the round workspace is not otherwise reachable by the
session bundle.

Rows come from one of two collectors and `sample_source` says which. Where aiperf
is driving the workload it is already scraping the same endpoint, so its records
are used and this one stands down; everywhere else the watchdog collects.

**Breakdown integration is deliberately not in this PR.** The `telemetry.kv_cache`
aggregation is stacked on `feat/kv-metrics-sbd-section` and will follow once this
merges. This PR ships the raw artifact only.

## Design

**`/metrics`, not `server.log`.** The log cannot express the thing this is for.
Occupancy is two readings: tokens held by running requests (pressure) versus
tokens physically resident including what the prefix cache holds but would hand
back. A pool at 100% physical can be under no pressure at all — that is prefix
cache working — and only `kv_evictable_tokens`, which exists solely on
`/metrics`, separates them. On a measured saturated server the two read 0.85 and
0.91.

**Riding the existing watchdog loop, not a sampler process.** A sampler competing
for CPU would show up in the very latency numbers the round exists to measure.
The loop itself polls at 0.5s; scrapes are rate-limited on top of it to one
every 2s (`INFERENCE_OPTIMIZER_KV_SCRAPE_INTERVAL_SEC`), because a scrape is a
synchronous HTTP round trip plus a parse of the engine's whole exposition, and
the engine's gauges do not refresh anywhere near 0.5s -- most of those samples
would be the same numbers read again. That loop is also the only place that sees both the server-ready marker
and the eval-start marker, so it is the only place that can date the measured
window — and an engine process outlives that window by a wide margin. Boot
carries no traffic, warmup runs a deliberately cold cache, and the accuracy eval
drives request shapes unrelated to the benchmark. Averaged together they describe
no phase at all, so every sample carries its phase.

**AgentX needed no marker of ours.** aiperf already prints structured phase
transitions at NOTICE with millisecond stamps. Its log did have to be added to
the scan set explicitly — an AgentX workspace has no `benchmark_stderr.log`, so
those lines were simply unreachable.

**On AgentX rounds, aiperf's own scrapes are used instead.** aiperf scrapes the
engine's `/metrics` for its own purposes -- enabled by default, deriving the URL
from `--url` -- so every AgentX round was already doing it alongside this
collector. Its export is now read at close and the live poller backs off to one
scrape a minute, so the endpoint is not scraped twice to produce rows that get
discarded.

Its records are the better source besides. `SlimRecord` carries `benchmark_phase`,
stamped at collection time by the process that owns the phase transition, which
removes the boundary lag rather than correcting for it. It also carries
`request_sent_ns` and `endpoint_latency_ns`, so the scrape window is measured
rather than reconstructed.

The normalisation is not duplicated: `SlimRecord.metrics` is
`{name: [{labels, value}]}`, the same information `parse_prometheus_text`
produces, so records are rebuilt into that shape and go through the existing
`sample_from_families`. Per-rank assembly, the active/physical split and the
counter grouping are untouched, and the two sources cannot disagree about what a
number means.

Adoption replaces only the window aiperf actually covers, judged on time rather
than on the phase label. It starts after the server is up and exits before the
accuracy eval, so readings outside that span -- boot, and the whole eval phase --
are kept. The client asks for the `jsonl` format, which is the only one carrying
per-scrape records, and widens aiperf's own 333ms cadence to 2s to match.

**The watchdog path stays** because that export does not cover everything: there
is none for a synthetic benchmark, for boot, for the accuracy eval, or for a
round killed before aiperf flushed. Across 105 archived sessions and both
validation runs on crusoe, every round was synthetic.

**Phase boundaries come from aiperf's own stamps.** `phases.<name>.start_ns` is
recorded when the phase actually begins. The log line the watchdog would
otherwise grep for is written after the transition and read on the next poll, and
both lags land on the boundary -- so the samples either side of it were
systematically credited to the phase that had just ended, which is exactly where
the engine's behaviour changes most. The progress API was already being polled to
gate trace capture; it is now enabled on every round, its address published for
the watchdog to find, and polled alongside the `/metrics` scrape.

At close the rows are re-labelled from those stamps *and* the counter windows are
re-bracketed from each row's own raw per-series counters, so the phase totals move
with the boundary rather than only the labels. Adjacent phases share the reading
at their boundary, keeping the gap-free property the boundary scrapes give. A
`start_ns` that is not on the Unix epoch is rejected rather than trusted -- a
monotonic stamp would place every boundary in 1970 and sweep the round into one
phase -- and the artifact then reports `phase_source: log_markers`.

**The workload timeline, below the phase.** aiperf writes `profile_export.jsonl`
-- one record per request, with epoch-nanosecond `request_start_ns` /
`request_end_ns`, `x_correlation_id`, `conversation_id`, `turn_index` and
`x_request_id` -- at its default `--export-level records`. It has been landing in
`aiperf_artifacts/` on every AgentX round all along, next to the aggregate export
we were already reading. So the event stream needs no upstream change and no
added flag, only a reader.

At close we now emit `agentx_timeline.jsonl` beside the KV artifact:
`phase_start`/`phase_end` (from the progress API's authoritative bounds),
`trajectory_start`/`trajectory_end`, `turn_start`/`turn_end`, and
`request_start` / `first_token` / `request_end`, each carrying trajectory, turn
and request identity, time-ordered so it merges against the KV rows in one pass.
Each KV row also gets the exact set in flight during its own scrape window --
request and turn counts plus the live trajectory ids -- so "which trajectory was
running when the pool spiked" is answerable without doing the join.

`first_token` comes from the TTFT metric rather than `request_ack_ns`: the ack is
when the server accepted the request, and dating a decode-phase KV rise from it
would be wrong by the whole prefill.

Two scale guards. The correlation sweeps rather than scanning per row (a few
thousand rows against a few hundred thousand records is otherwise hundreds of
millions of comparisons in the path that finishes a round). And the request layer
is stride-sampled past a cap, since a long high-concurrency round would otherwise
outweigh every other artifact in the bundle; the phase, trajectory and turn layers
stay complete, the in-flight counts are computed from every record before any
sampling, and the summary says whether the stream was sampled.

**What this still does not do.** An exact counter total at a boundary needs the
client to quiesce, take one snapshot, and resume; aiperf exposes no such control,
so the boundary is exact to its stamp and the counter attribution to the scrape
interval either side of it.

**Nothing can fail a round.** Sampling exceptions are swallowed, an unwritable
artifact is logged at debug, and a poller that cannot reach the endpoint parks
itself rather than retrying twice a second for the whole round. Kill switch:
`INFERENCE_OPTIMIZER_KV_METRICS=0`.

**Nothing missing becomes zero.** These gauges legitimately read 0.0 — an idle
engine reports 0.0 for minutes — so absent stays `None` throughout, and poller
reachability is tri-state.

## Traps handled

Each of these produces plausible-looking wrong numbers rather than an error:

- `num_retracted_requests_total` (cumulative, 48) vs `num_retracted_reqs` (last
  batch, pid-labelled, 1). One word apart.
- Counters kept per label series, not summed flat, so an engine restart shows as
  a series resetting instead of a total going backwards.
- Hybrid pools take the max across subpool gauges, matching how SGLang's own
  scheduler judges pressure. Reading `full_token_usage` alone understates it.
- Port comes from the materialized config's `benchmark.envs.PORT`, which is a
  per-session ephemeral port, not a constant.

`sglang:cache_hit_rate` is deliberately **not** read: observed at 0.0 on a server
whose `cached_tokens_total` had already reached 4.6M, so it is not a cumulative
rate, and whether it is instantaneous or windowed is unresolved. A field nobody
can interpret is worse than an absent one.

## Watchdog changes

Kept deliberately small — it is a production loop:

- one optional duck-typed `kv_recorder`, `None` by default and then a strict
  no-op;
- one `tick` per pass, rate-limited on the monotonic clock (the slice shrinks
  below its nominal 0.5s near a deadline, so counting passes would sample
  fastest exactly when the run is most loaded), and held off until the server is
  up;
- phase notes at markers already being detected;
- the loop body wrapped in `try/finally`.

The `finally` is the part that matters. There was none, and the loop has seven
exits: five gate exceptions, the hard timeout, and the normal return. A window
that never closes is the one failure a consumer cannot recover from, because it
cannot tell a round still running from one that died mid-window.

`_scan_server_log_increment` now returns a NamedTuple instead of a 4-tuple — the
marker set grew here once and will again. Its existing test moves to attribute
access, and the truncation branch, reachable since it was written and never
covered, finally has a test.

## Two defects found by wiring it up

Both are about the scrape being a blocking call inside a watchdog, and neither
was reachable by unit tests:

- **The scrape honoured the ambient proxy.** `urlopen` reads `http_proxy`, so a
  loopback scrape on a corporate host routes through an external proxy — wrong
  by construction and slow enough to visibly stretch the loop.
- **It ran during boot.** Before the engine binds its port every attempt is a
  refused connection paid for inside the loop, during the phase when the ready
  marker and death watchdog most need it responsive. It broke a real test: a
  child talking only through its redirected stderr stopped being reported alive.
  Sampling now waits for the server, which costs nothing — boot has no traffic,
  and capacity is readable the moment the server answers. Warm-reuse rounds write
  no ready marker and are covered by `server_already_ready`.

## Prerequisite

SGLang exposes `/metrics` only with `--enable-metrics`; vLLM has it on by
default. Until that flag is set, this collects nothing and records
`available: false` — correctly, rather than reporting an idle pool. Measured
overhead of the flag is below noise (5×2 runs, the flagged arm 0.35% *higher*
than the control, against ~1.5% within-arm spread).

## Verification

Failure set on the touched suites is unchanged against `origin/main` (five
pre-existing WSL-dependent failures); 92 pass, including an end-to-end case that
runs a real round and asserts the artifact exists on disk. That last one covers
the gap this PR's final commit closes: the collector and the loop hook were both
built and tested while nothing ever constructed a recorder, so the feature
collected nothing with every test green.

Not yet validated against a live engine — the `/metrics` field names and values
come from expositions captured off MI355X nodes and used as fixtures, but
end-to-end confirmation waits on the flag above.

Refs: `kvcache-metrics-plan.md` §1.2, §3.2, §4.1, §4.3, §5.2, §6.1, §6.5, §7.4, §8.3, §8.5