### PR TITLE
fix(ci-e2e): budget queueing apart from running, and stop swallowing failed cancels

### DIFF
--- a/.github/scripts/ci-e2e-dispatch.sh
+++ b/.github/scripts/ci-e2e-dispatch.sh
@@ -22,11 +22,14 @@
 #   BASE_REPO_URL     base repo clone url
 #   MODEL_BASE        local model base dir (optional; backend fills if empty)
 #   POLL_INTERVAL_S   seconds between polls             (default 30)
-#   POLL_MAX          max polls before timeout          (default 120 => ~60min)
+#   POLL_MAX          default for QUEUE_MAX / RUN_MAX   (default 120 => ~60min)
+#   QUEUE_MAX         max polls waiting for a GPU slot  (default POLL_MAX)
+#   RUN_MAX           max polls once dispatched         (default POLL_MAX)
 #   KNOWLEDGE_STORE_MODE  explicit local|remote mode     (default local)
 #   KB_STORE_URL / KB_STORE_TOKEN  required together when mode=remote
 #   CI_E2E_PR_CHECK_BASE  base dir for per-PR checkouts (default /tmp/ci-e2e)
 #   CI_E2E_CACERT / CI_E2E_INSECURE   TLS to the API endpoint (CA bundle / skip-verify)
+#   CI_E2E_CURL_CONNECT_TIMEOUT_S / CI_E2E_CURL_MAX_TIME_S  HTTP bounds (default 5 / 20)
 #
 # Optional live commit status on the PR (all three required to enable):
 #   GH_STATUS_TOKEN   GitHub token with statuses:write (Actions: secrets.GITHUB_TOKEN)
@@ -46,6 +49,11 @@ TP="${TP:-1}"
 MAX_HOURS="${MAX_HOURS:-0.5}"
 POLL_INTERVAL_S="${POLL_INTERVAL_S:-30}"
 POLL_MAX="${POLL_MAX:-120}"
+# Waiting for a free GPU and running the optimizer are budgeted apart: a shared counter
+# lets an hours-long queue consume the run budget and then report the result as a run
+# timeout, which reads as "the tested code hung" when no GPU was ever allocated.
+QUEUE_MAX="${QUEUE_MAX:-$POLL_MAX}"
+RUN_MAX="${RUN_MAX:-$POLL_MAX}"
 KNOWLEDGE_STORE_MODE="${KNOWLEDGE_STORE_MODE:-local}"
 
 : "${E2E_API_BASE:?E2E_API_BASE is required}"
@@ -93,6 +101,14 @@ elif [ "${CI_E2E_INSECURE:-0}" = "1" ]; then
   tls=(-k)
 fi
 
+# ci-e2e.yml's cancel-in-progress gives this process ~10s between the runner's SIGINT
+# and its SIGKILL. Every call the cancel trap makes must be bounded or a hanging backend
+# — the case the cancel path exists for — eats the window before the workload is
+# reclaimed or the failure reported. The trap tightens both budgets further.
+CURL_CONNECT_S="${CI_E2E_CURL_CONNECT_TIMEOUT_S:-5}"
+CURL_MAX_S="${CI_E2E_CURL_MAX_TIME_S:-20}"
+IN_CANCEL_TRAP=0
+
 # ---- GitHub commit status (optional live status on the PR) ----------------
 # When GH_STATUS_TOKEN + GH_STATUS_REPO + GH_STATUS_SHA are set we publish a commit
 # status against the PR head sha and refresh it every STATUS_INTERVAL_S, so the PR's
@@ -104,7 +120,7 @@ gh_status_on() { [ -n "${GH_STATUS_TOKEN:-}" ] && [ -n "${GH_STATUS_REPO:-}" ] &
 post_status() { # state(pending|success|failure|error)  description
   gh_status_on || return 0
   local desc="${2:0:139}"
-  curl -sS -X POST \
+  curl -sS --connect-timeout "$CURL_CONNECT_S" --max-time "$CURL_MAX_S" -X POST \
     -H "Authorization: Bearer ${GH_STATUS_TOKEN}" \
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
@@ -245,19 +261,68 @@ last_push="$(date +%s)"
 
 # On cancellation (e.g. a newer commit via concurrency cancel-in-progress),
 # best-effort cancel the workload so we don't leak a GPU run.
-cleanup() { curl -sS "${tls[@]}" -X DELETE "$API/$UID_" "${auth[@]}" >/dev/null 2>&1 || true; }
-trap 'echo "[ci-e2e] cancelled; deleting workload $UID_"; post_status "error" "cancelled; uid=${UID_}; sha=${HEAD_SHA:0:12}"; cleanup; exit 1' INT TERM
+# A swallowed failure here is how a superseded or timed-out run leaks a workload: the
+# backend dispatches it hours later and it burns a full GPU slot nobody is watching.
+cleanup() {
+  local resp code attempt attempts=2
+  # On the trap path there is no room for a second round trip; the timeout paths have
+  # no deadline, so they keep the retry that rides out a backend blip.
+  if [ "$IN_CANCEL_TRAP" = 1 ]; then attempts=1; fi
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    resp="$(curl -sS "${tls[@]}" --connect-timeout "$CURL_CONNECT_S" --max-time "$CURL_MAX_S" \
+      -w $'\n%{http_code}' -X DELETE "$API/$UID_" "${auth[@]}" 2>&1 || true)"
+    # resp carries curl's stderr too; only the -w status line is bare digits.
+    code="$(printf '%s\n' "$resp" | grep -oE '^[0-9]{3}$' | tail -n1)"
+    case "$code" in
+      2*) echo "[ci-e2e] workload $UID_ cancelled (HTTP $code)"; return 0 ;;
+    esac
+    echo "[ci-e2e] cancel attempt $attempt/$attempts for $UID_ failed (HTTP ${code:-none}): $(printf '%s' "$resp" | sed '$d' | head -c 300)" >&2
+    if [ "$attempt" -lt "$attempts" ]; then sleep 2; fi
+  done
+  summary "⚠️ **workload \`$UID_\` was NOT reclaimed** (last HTTP ${code:-none}) — it may still be dispatched and hold a GPU. Cancel it manually."
+  return 1
+}
+on_cancel() {
+  # A SIGTERM arriving mid-handler must not restart the handler and spend the window twice.
+  trap '' INT TERM
+  IN_CANCEL_TRAP=1
+  CURL_CONNECT_S=2
+  CURL_MAX_S=3
+  echo "[ci-e2e] cancelled; deleting workload $UID_"
+  post_status "error" "cancelled; uid=${UID_}; sha=${HEAD_SHA:0:12}"
+  cleanup || true
+  exit 1
+}
+trap on_cancel INT TERM
 
 # ---- poll -----------------------------------------------------------------
 i=0
+queue_polls=0
+run_polls=0
+dispatched=0
 prev_phase=""
-while [ "$i" -lt "$POLL_MAX" ]; do
+while : ; do
   i=$((i + 1))
   detail="$(curl -sS "${tls[@]}" "$API/$UID_" "${auth[@]}" || true)"
   phase="$(printf '%s' "$detail" | jq -r '.orchestration.phase // "Unknown"' 2>/dev/null || echo Unknown)"
+  # A failed poll leaves $detail empty, and jq exits 0 printing nothing on empty input, so
+  # neither the `//` default nor the `||` fallback fires -- without this the empty phase
+  # latches `dispatched` and a still-queued workload is judged as a hung run.
+  phase="${phase:-Unknown}"
   jobref="$(printf '%s' "$detail" | jq -r '.dispatches[-1].platform_ref // "-"' 2>/dev/null || echo -)"
   node="$(printf '%s' "$detail" | jq -r '.dispatches[-1].nodes // "-"' 2>/dev/null || echo -)"
-  echo "[ci-e2e] poll $i/$POLL_MAX phase=$phase node=$node job=$jobref uid=$UID_"
+  # Unknown is a transient API read, not evidence of a slot; only a real phase latches.
+  case "$phase" in
+    Queued|Pending|Unknown) ;;
+    *) dispatched=1 ;;
+  esac
+  if [ "$dispatched" = 0 ]; then
+    queue_polls=$((queue_polls + 1))
+    echo "[ci-e2e] poll $i queue=$queue_polls/$QUEUE_MAX phase=$phase node=$node job=$jobref uid=$UID_"
+  else
+    run_polls=$((run_polls + 1))
+    echo "[ci-e2e] poll $i run=$run_polls/$RUN_MAX phase=$phase node=$node job=$jobref uid=$UID_"
+  fi
   # Announce phase transitions (from the orchestration conditions ledger).
   if [ "$phase" != "$prev_phase" ]; then
     cond="$(printf '%s' "$detail" | jq -r '.orchestration.conditions[-1] | "\(.time) \(.phase): \(.message)"' 2>/dev/null || echo "")"
@@ -278,6 +343,23 @@ while [ "$i" -lt "$POLL_MAX" ]; do
       report_upsert "❌ Failed"
       exit 1 ;;
   esac
+  if [ "$dispatched" = 0 ] && [ "$queue_polls" -ge "$QUEUE_MAX" ]; then
+    err="never dispatched: still waiting for a GPU after $((QUEUE_MAX * POLL_INTERVAL_S))s"
+    summary "❌ **FAIL (queue timeout)** — ${err}. session_id=\`$UID_\`"
+    summary "The tested commit was never run; the GPU pool had no free slot."
+    post_status "failure" "queue timeout; uid=${UID_}; sha=${HEAD_SHA:0:12}"
+    report_upsert "❌ Queue timeout"
+    cleanup || true
+    exit 1
+  fi
+  if [ "$dispatched" = 1 ] && [ "$run_polls" -ge "$RUN_MAX" ]; then
+    err="not terminal after $((RUN_MAX * POLL_INTERVAL_S))s of running"
+    summary "❌ **FAIL (run timeout)** — ${err}. session_id=\`$UID_\`"
+    post_status "failure" "run timeout; uid=${UID_}; sha=${HEAD_SHA:0:12}"
+    report_upsert "❌ Run timeout"
+    cleanup || true
+    exit 1
+  fi
   # Throttled live status: push at most once per STATUS_INTERVAL_S (default 5min).
   now_s="$(date +%s)"
   if [ $((now_s - last_push)) -ge "$STATUS_INTERVAL_S" ]; then
@@ -286,10 +368,3 @@ while [ "$i" -lt "$POLL_MAX" ]; do
   fi
   sleep "$POLL_INTERVAL_S"
 done
-
-err="not terminal after $((POLL_MAX * POLL_INTERVAL_S))s"
-summary "❌ **FAIL (timeout)** — ${err}. session_id=\`$UID_\`"
-post_status "failure" "timeout; uid=${UID_}; sha=${HEAD_SHA:0:12}"
-report_upsert "❌ Timeout"
-cleanup
-exit 1

--- a/.github/scripts/ci-e2e-dispatch.sh
+++ b/.github/scripts/ci-e2e-dispatch.sh
@@ -274,6 +274,9 @@ cleanup() {
     # resp carries curl's stderr too; only the -w status line is bare digits.
     code="$(printf '%s\n' "$resp" | grep -oE '^[0-9]{3}$' | tail -n1)"
     case "$code" in
+      # 202: the backend recorded the cancel but nothing confirmed the workload
+      # down, so it may still hold its GPUs. Retrying cannot change that answer.
+      202) summary "⚠️ **workload \`$UID_\` cancel recorded, stop NOT confirmed** (HTTP 202) — it may still hold a GPU."; return 0 ;;
       2*) echo "[ci-e2e] workload $UID_ cancelled (HTTP $code)"; return 0 ;;
     esac
     echo "[ci-e2e] cancel attempt $attempt/$attempts for $UID_ failed (HTTP ${code:-none}): $(printf '%s' "$resp" | sed '$d' | head -c 300)" >&2

--- a/.github/scripts/forge-ci-e2e-dispatch.sh
+++ b/.github/scripts/forge-ci-e2e-dispatch.sh
@@ -49,6 +49,14 @@ DEADLINE_SEC="${CI_E2E_DEADLINE_SEC:-$(awk -v h="$MAX_HOURS" -v s="$BOOTSTRAP_SL
   'BEGIN{printf "%d", h*3600 + s}')}"
 POLL_MAX="${POLL_MAX:-$(awk -v d="$DEADLINE_SEC" -v i="$POLL_INTERVAL_S" \
   'BEGIN{printf "%d", int((d + i - 1) / i) + 5}')}"
+# Waiting for a free GPU and running forge-loop are budgeted apart: a shared counter
+# lets an hours-long queue consume the run budget and then report the result as a run
+# timeout, which reads as "the tested code hung" when no GPU was ever allocated.
+# RUN_MAX is the budget DEADLINE_SEC belongs to; QUEUE_MAX only falls back to the same
+# poll count so a direct invocation has one, and forge-e2e.yml sets the real, far
+# shorter queue budget.
+QUEUE_MAX="${QUEUE_MAX:-$POLL_MAX}"
+RUN_MAX="${RUN_MAX:-$POLL_MAX}"
 IMAGE="${CI_E2E_IMAGE:-harbor.crusoe.primus-safe.amd.com/proxy/vllm/vllm-openai-rocm:v0.24.0}"
 
 summary() { echo "$*" | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"; }
@@ -59,6 +67,14 @@ if [ -n "${CI_E2E_CACERT:-}" ]; then
 elif [ "${CI_E2E_INSECURE:-0}" = "1" ]; then
   tls=(-k)
 fi
+
+# forge-e2e.yml's cancel-in-progress gives this process ~10s between the runner's
+# SIGINT and its SIGKILL. Every call the cancel trap makes must be bounded or a hanging
+# backend — the case the cancel path exists for — eats the window before the workload is
+# reclaimed or the failure reported. The trap tightens both budgets further.
+CURL_CONNECT_S="${CI_E2E_CURL_CONNECT_TIMEOUT_S:-5}"
+CURL_MAX_S="${CI_E2E_CURL_MAX_TIME_S:-20}"
+IN_CANCEL_TRAP=0
 
 STATUS_INTERVAL_S="${STATUS_INTERVAL_S:-300}"
 STATUS_CONTEXT="${STATUS_CONTEXT:-ci-e2e/kernelforge}"
@@ -73,7 +89,8 @@ gh_status_on() {
 post_status() { # state description
   gh_status_on || return 0
   local desc="${2:0:139}" code
-  code="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+  code="$(curl -sS --connect-timeout "$CURL_CONNECT_S" --max-time "$CURL_MAX_S" \
+    -o /dev/null -w '%{http_code}' -X POST \
     -H "Authorization: Bearer ${GH_STATUS_TOKEN}" \
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
@@ -184,7 +201,7 @@ body="$(jq -n \
    + (if $uname == "" then {} else {user_name:$uname} end)')"
 
 echo "[forge-ci-e2e] submitting: ref=$HEAD_REF sha=$HEAD_SHA gpus=$GPUS max_hours=$MAX_HOURS" \
-  "deadline=${DEADLINE_SEC}s poll=${POLL_MAX}x${POLL_INTERVAL_S}s workspace=$WORKSPACE"
+  "deadline=${DEADLINE_SEC}s queue=${QUEUE_MAX}x${POLL_INTERVAL_S}s run=${RUN_MAX}x${POLL_INTERVAL_S}s workspace=$WORKSPACE"
 resp="$(curl -sS "${tls[@]}" -w $'\n%{http_code}' -X POST "$API" \
   "${auth[@]}" -H "Content-Type: application/json" -d "$body")"
 code="$(printf '%s' "$resp" | tail -n1)"
@@ -205,18 +222,77 @@ echo "$UID_" > "${E2E_UID_FILE:-${RUNNER_TEMP:-/tmp}/forge_e2e_session_uid}" 2>/
 
 post_status "pending" "submitted; uid=${UID_}; ref=${HEAD_REF}; sha=${HEAD_SHA:0:12}"
 last_push="$(date +%s)"
-cleanup() { curl -sS "${tls[@]}" -X DELETE "$API/$UID_" "${auth[@]}" >/dev/null 2>&1 || true; }
-trap 'echo "[forge-ci-e2e] cancelled; deleting workload $UID_"; post_status "error" "cancelled; uid=${UID_}; sha=${HEAD_SHA:0:12}"; cleanup; exit 1' INT TERM
+# A swallowed failure here is how a superseded or timed-out run leaks a workload: the
+# backend dispatches it hours later and it burns a full GPU slot nobody is watching.
+cleanup() {
+  local resp code attempt attempts=2
+  # On the trap path there is no room for a second round trip; the timeout paths have
+  # no deadline, so they keep the retry that rides out a backend blip.
+  if [ "$IN_CANCEL_TRAP" = 1 ]; then attempts=1; fi
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    resp="$(curl -sS "${tls[@]}" --connect-timeout "$CURL_CONNECT_S" --max-time "$CURL_MAX_S" \
+      -w $'\n%{http_code}' -X DELETE "$API/$UID_" "${auth[@]}" 2>&1 || true)"
+    # resp carries curl's stderr too; only the -w status line is bare digits.
+    code="$(printf '%s\n' "$resp" | grep -oE '^[0-9]{3}$' | tail -n1)"
+    case "$code" in
+      2*) echo "[forge-ci-e2e] workload $UID_ cancelled (HTTP $code)"; return 0 ;;
+    esac
+    echo "[forge-ci-e2e] cancel attempt $attempt/$attempts for $UID_ failed (HTTP ${code:-none}): $(printf '%s' "$resp" | sed '$d' | head -c 300)" >&2
+    if [ "$attempt" -lt "$attempts" ]; then sleep 2; fi
+  done
+  summary "⚠️ **workload \`$UID_\` was NOT reclaimed** (last HTTP ${code:-none}) — it may still be dispatched and hold a GPU. Cancel it manually."
+  return 1
+}
+# A run timeout leaves a dispatched workload with on-cluster state, so it is kept by
+# default. A queue timeout has none — nothing was ever dispatched — and cancels
+# unconditionally instead; see the queue-timeout branch below.
+run_timeout_cleanup() {
+  if [ "${CI_E2E_DELETE_ON_TIMEOUT:-0}" = "1" ]; then
+    cleanup || true
+  else
+    summary "workload \`$UID_\` kept for triage"
+  fi
+}
+on_cancel() {
+  # A SIGTERM arriving mid-handler must not restart the handler and spend the window twice.
+  trap '' INT TERM
+  IN_CANCEL_TRAP=1
+  CURL_CONNECT_S=2
+  CURL_MAX_S=3
+  echo "[forge-ci-e2e] cancelled; deleting workload $UID_"
+  post_status "error" "cancelled; uid=${UID_}; sha=${HEAD_SHA:0:12}"
+  cleanup || true
+  exit 1
+}
+trap on_cancel INT TERM
 
 i=0
+queue_polls=0
+run_polls=0
+dispatched=0
 prev_phase=""
-while [ "$i" -lt "$POLL_MAX" ]; do
+while : ; do
   i=$((i + 1))
   detail="$(curl -sS "${tls[@]}" "$API/$UID_" "${auth[@]}" || true)"
   phase="$(printf '%s' "$detail" | jq -r '.orchestration.phase // "Unknown"' 2>/dev/null || echo Unknown)"
+  # A failed poll leaves $detail empty, and jq exits 0 printing nothing on empty input, so
+  # neither the `//` default nor the `||` fallback fires -- without this the empty phase
+  # latches `dispatched` and a still-queued workload is judged as a hung run.
+  phase="${phase:-Unknown}"
   jobref="$(printf '%s' "$detail" | jq -r '.dispatches[-1].platform_ref // "-"' 2>/dev/null || echo -)"
   node="$(printf '%s' "$detail" | jq -r '.dispatches[-1].nodes // "-"' 2>/dev/null || echo -)"
-  echo "[forge-ci-e2e] poll $i/$POLL_MAX phase=$phase node=$node job=$jobref uid=$UID_"
+  # Unknown is a transient API read, not evidence of a slot; only a real phase latches.
+  case "$phase" in
+    Queued|Pending|Unknown) ;;
+    *) dispatched=1 ;;
+  esac
+  if [ "$dispatched" = 0 ]; then
+    queue_polls=$((queue_polls + 1))
+    echo "[forge-ci-e2e] poll $i queue=$queue_polls/$QUEUE_MAX phase=$phase node=$node job=$jobref uid=$UID_"
+  else
+    run_polls=$((run_polls + 1))
+    echo "[forge-ci-e2e] poll $i run=$run_polls/$RUN_MAX phase=$phase node=$node job=$jobref uid=$UID_"
+  fi
   if [ "$phase" != "$prev_phase" ]; then
     echo "[forge-ci-e2e] phase ${prev_phase:-<start>} -> $phase"
     prev_phase="$phase"
@@ -236,6 +312,23 @@ while [ "$i" -lt "$POLL_MAX" ]; do
       report_upsert "❌ Failed"
       exit 1 ;;
   esac
+  if [ "$dispatched" = 0 ] && [ "$queue_polls" -ge "$QUEUE_MAX" ]; then
+    err="never dispatched: still waiting for a GPU after $((QUEUE_MAX * POLL_INTERVAL_S))s"
+    summary "❌ **FAIL (queue timeout)** — ${err}. session_id=\`$UID_\`"
+    summary "The tested commit was never run; the GPU pool had no free slot."
+    post_status "failure" "queue timeout; uid=${UID_}; sha=${HEAD_SHA:0:12}"
+    report_upsert "❌ Queue timeout"
+    cleanup || true
+    exit 1
+  fi
+  if [ "$dispatched" = 1 ] && [ "$run_polls" -ge "$RUN_MAX" ]; then
+    err="not terminal after $((RUN_MAX * POLL_INTERVAL_S))s of running"
+    summary "❌ **FAIL (run timeout)** — ${err}. session_id=\`$UID_\`"
+    post_status "failure" "run timeout; uid=${UID_}; sha=${HEAD_SHA:0:12}"
+    report_upsert "❌ Run timeout"
+    run_timeout_cleanup
+    exit 1
+  fi
   now_s="$(date +%s)"
   if [ $((now_s - last_push)) -ge "$STATUS_INTERVAL_S" ]; then
     post_status "pending" "running ${phase}; job=${jobref}; uid=${UID_}; sha=${HEAD_SHA:0:12}"
@@ -243,13 +336,3 @@ while [ "$i" -lt "$POLL_MAX" ]; do
   fi
   sleep "$POLL_INTERVAL_S"
 done
-
-summary "❌ **FAIL (timeout)** — workload did not reach terminal state. session_id=\`$UID_\`"
-post_status "failure" "timeout; uid=${UID_}; sha=${HEAD_SHA:0:12}"
-report_upsert "❌ Timeout"
-if [ "${CI_E2E_DELETE_ON_TIMEOUT:-0}" = "1" ]; then
-  cleanup
-else
-  summary "workload \`$UID_\` kept for triage"
-fi
-exit 1

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -178,8 +178,8 @@ jobs:
     # Self-hosted runner registered with the label `Hyperloom-e2e-ci`
     # (config.sh --labels Hyperloom-e2e-ci). Must reach github.com + the run API.
     runs-on: Hyperloom-e2e-ci
-    # Covers a full MAX_HOURS run + setup/baseline overhead.
-    timeout-minutes: 240
+    # Backstop only: QUEUE_MAX + RUN_MAX below must fire first.
+    timeout-minutes: 255
     steps:
       - name: Consume retest label
         if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'retest'
@@ -228,9 +228,14 @@ jobs:
           GH_STATUS_SHA: ${{ needs.resolve.outputs.head_sha }}
           GH_STATUS_DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           STATUS_INTERVAL_S: "300"
-          # Poll long enough to cover the run budget.
           POLL_INTERVAL_S: "60"
-          POLL_MAX: "220"
+          # Queueing for a GPU and running the optimizer are budgeted apart so a
+          # saturated pool reports "queue timeout" instead of consuming the run budget
+          # and reporting the tested commit as hung. RUN_MAX covers the observed
+          # 168-177min workload; the two together stay under timeout-minutes so the
+          # script, which names the cause, always fails before the job-level cutoff.
+          QUEUE_MAX: "40"
+          RUN_MAX: "195"
         run: |
           chmod +x .github/scripts/ci-e2e-dispatch.sh
           .github/scripts/ci-e2e-dispatch.sh

--- a/.github/workflows/forge-e2e.yml
+++ b/.github/workflows/forge-e2e.yml
@@ -245,6 +245,7 @@ jobs:
       group: forge-e2e-${{ needs.resolve.outputs.pr_number || needs.resolve.outputs.head_sha || needs.resolve.outputs.head_ref || github.ref }}
       cancel-in-progress: true
     runs-on: ${{ vars.FORGE_E2E_RUNNER_LABEL || 'Hyperloom-e2e-ci' }}
+    # Backstop only: QUEUE_MAX + RUN_MAX below must fire first.
     timeout-minutes: ${{ fromJSON(vars.FORGE_E2E_JOB_TIMEOUT_MIN || '240') }}
     steps:
       - name: Consume retest label
@@ -292,6 +293,13 @@ jobs:
           STATUS_CONTEXT: ci-e2e/kernelforge
           STATUS_INTERVAL_S: "300"
           POLL_INTERVAL_S: "60"
+          # Queueing for a GPU and running forge-loop are budgeted apart so a saturated
+          # pool reports "queue timeout" instead of consuming the run budget and
+          # reporting the tested commit as hung. RUN_MAX is left to the script so it
+          # keeps tracking MAX_HOURS + bootstrap slack (125 polls at the defaults
+          # below); 40 + 125 polls of 60s stay under the job timeout-minutes, so the
+          # script, which names the cause, always fails before the job-level cutoff.
+          QUEUE_MAX: ${{ vars.FORGE_E2E_QUEUE_MAX || '40' }}
           CI_E2E_BOOTSTRAP_SLACK_SEC: ${{ vars.FORGE_E2E_BOOTSTRAP_SLACK_SEC || '3600' }}
           CI_E2E_DELETE_ON_TIMEOUT: ${{ vars.FORGE_E2E_DELETE_ON_TIMEOUT || '0' }}
         run: |


### PR DESCRIPTION
## What was wrong

**One counter for two different waits.** `POLL_MAX` covered both waiting for a GPU and running the optimizer, so a saturated pool spent the run budget on the queue and then reported `not terminal after 13200s` — which reads as a hang in the tested commit.

Run [34190618492](https://github.com/AMD-AGI/Hyperloom/actions/runs/34190618492) spent **166 of its 220 polls in `phase=Queued`** and was failed 54 minutes into a workload that went on to **finish successfully 115 minutes later** (k8s Job `ci-pr-1414-34190618492-a7f21d57-a1`: `succeeded=1`, 171m, `crash_count 0`). The check never gave a verdict on the code.

**The cancel path hid why the pool was saturated.** `cleanup()` discarded the DELETE response, and that response is a 40x. The workload survives, the backend dispatches it hours after its GitHub run ended, and it holds a GPU for a full run nobody is watching.

Of 93 jobs dispatched 2026-09-07 → 09-08, **49 started after their run had already finished**, taking **96 of 204 GPU-slot-hours**. At 12:19Z all eight GPUs in the pool were held by workloads whose run had ended — none of them belonging to a live check.

## What this changes

- Queueing and running get **separate budgets and separate verdicts**, in both the `ci-e2e` and `forge-e2e` dispatchers. A red check now says whether the commit was ever given a GPU.
- A **queue timeout cancels unconditionally**. There is no on-cluster state to keep for triage when nothing was dispatched, and the workload would otherwise take a GPU for a full run once a slot freed.
- `cleanup()` **checks the status code**, retries once, and reports an unreclaimed workload instead of returning success.
- The cancel path is **bounded** so it can outlive neither the runner's grace period nor a hanging backend: `--connect-timeout`/`--max-time` on the DELETE and on `post_status`, a shorter retry, no retry at all from the signal trap, and the trap disarms itself so a SIGTERM mid-handler cannot re-enter it. Measured against a stubbed hanging backend: **6.4s wall, inside the ~10s SIGINT→SIGKILL window**.
- A poll whose `curl` failed left the phase **empty**, not `Unknown` — `jq` exits 0 printing nothing on empty input, so neither the `//` default nor the `|| echo` fallback fired. The empty phase fell through the `dispatched` latch and pinned the run budget on a workload still waiting for a GPU, on the first transient read of the several hundred a run makes.

## Verification

No bash test suite covers these scripts, so each behaviour was driven against a stubbed `curl`:

| Case | Result |
|---|---|
| 204 | reclaimed, one attempt, rc=0 |
| 403 | two attempts, `NOT reclaimed` summary, rc=1 |
| hanging backend | bounded by `--max-time`; pre-fix the stub was handed `--max-time=NONE` and slept 600s |
| SIGINT then SIGTERM 0.3s later | handler runs **once**, summary printed, 6.4s wall |
| poll 3 fails mid-queue | stays `queue=3/3 phase=Unknown`, verdict `queue timeout`, **DELETE sent** |

Plus `bash -n` on both scripts and `yaml.safe_load` on both workflows.

## What this does not fix

**The leak itself.** The DELETE still returns 40x and the workload still survives — this makes that loud and bounded rather than silent. Reclaiming the GPU needs the backend cancel to start succeeding; that is tracked separately.

Note this only takes effect for PRs whose branch carries it: `pull_request` loads the workflow from the PR head, so every other open PR keeps the old single budget until this is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)