### PR TITLE
feat(trace): per-LLM-call attribution, and the reports that read it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,7 @@ hyperloom = [
     # Release-contract shell installers + configs.
     "assets/*.sh",
     "assets/*.example",
+    "assets/*.yaml",
     "assets/configs/*.yaml",
     "assets/agentx/*.sh",
     "assets/agentx/*.py",

--- a/src/hyperloom/agents/kernel/tests/test_geak_runner_invocation_marker.py
+++ b/src/hyperloom/agents/kernel/tests/test_geak_runner_invocation_marker.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""GEAK is told who invoked it, because it also runs standalone."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from hyperloom.agents.kernel.tools.backends import geak_runner
+
+
+def _fake_popen(captured: dict) -> object:
+    def popen(cmd, **kwargs):  # noqa: ANN001, ANN003
+        captured["env"] = kwargs.get("env") or {}
+        return SimpleNamespace(
+            pid=1,
+            returncode=0,
+            communicate=lambda timeout=None: ("", ""),
+        )
+
+    return popen
+
+
+def test_geak_is_told_that_hyperloom_invoked_it(monkeypatch, tmp_path: Path):
+    """GEAK names its end-of-run report after the harness that drove the run.
+
+    Standalone GEAK and GEAK-as-KERNEL_AGENT answer different questions and their
+    numbers are not comparable, so the two must not produce identically-named
+    reports in a directory someone later reads without context.
+    """
+    runner = tmp_path / "interface" / "run_e2e.py"
+    runner.parent.mkdir(parents=True)
+    runner.write_text("")
+    monkeypatch.setenv("GEAK_E2E_RUNNER", str(runner))
+    monkeypatch.delenv("GEAK_INVOKED_BY", raising=False)
+
+    captured: dict = {}
+    monkeypatch.setattr(geak_runner.subprocess, "Popen", _fake_popen(captured))
+    (tmp_path / "result.json").write_text(json.dumps({"ok": True}))
+
+    geak_runner.call_geak({"model_path": "/m"}, tmp_path, timeout_s=120)
+
+    assert captured["env"]["GEAK_INVOKED_BY"] == "hyperloom"

--- a/src/hyperloom/agents/kernel/tools/backends/geak_runner.py
+++ b/src/hyperloom/agents/kernel/tools/backends/geak_runner.py
@@ -85,6 +85,10 @@ def call_geak(handoff: dict, output_dir: Path, *, timeout_s: int = 43200, python
     cmd = [py, runner, str(handoff_path), str(result_path)]
 
     env = dict(os.environ)
+    # Tell GEAK who is driving. It runs standalone too, and the two modes answer
+    # different questions, so its end-of-run report names itself hl_* rather than
+    # geak_* when this is set. A GEAK build that predates the marker ignores it.
+    env["GEAK_INVOKED_BY"] = "hyperloom"
     # ``timeout_s`` is authoritative: run_e2e.py reads GEAK_E2E_TIMEOUT_S to
     # self-stop before the outer subprocess kill. Split the inner SOFT deadline
     # from the outer HARD kill so run_e2e can flush result.json before SIGKILL.

--- a/src/hyperloom/common/llm_attribution.py
+++ b/src/hyperloom/common/llm_attribution.py
@@ -67,6 +67,7 @@ __all__ = [
     "CLAW_SESSION_ID_ENV",
     "DEFAULT_APPLICATION",
     "PRESETS",
+    "TASK_PATH_SEPARATOR",
     "attribution_context",
     "call_headers",
     "current_action",
@@ -75,7 +76,10 @@ __all__ = [
     "current_phase",
     "inject_env",
     "sdk_env_overlay",
+    "current_task_path",
+    "current_task_path_str",
     "set_current_phase",
+    "task_scope",
 ]
 
 # Publishing the phase here rather than threading it through every signature is
@@ -147,6 +151,63 @@ def current_action() -> str:
     return _current_action.get()
 
 
+# The task path is nested where the action is flat: one action fans out into
+# sub-agents, specialists and per-kernel attempts, and a report has to be able
+# to attribute a call to the leaf that made it. A context variable gives that
+# for free -- a child task sees its parent's path, pushes its own segment onto
+# it, and its siblings never observe the push.
+_current_task_path: contextvars.ContextVar[tuple[str, ...]] = contextvars.ContextVar(
+    "hyperloom_llm_attribution_task_path",
+    default=(),
+)
+
+TASK_PATH_SEPARATOR = "/"
+
+
+@contextlib.contextmanager
+def task_scope(segment: str) -> Iterator[None]:
+    """Push one segment onto the task path for the duration of a block.
+
+    Pushes rather than replaces, so nesting composes: a phase scope wrapping an
+    action scope wrapping a per-kernel scope yields
+    ``KERNEL_AGENT/kernel_opt/gemm_fp8``. An empty or all-separator segment is
+    dropped rather than producing a blank level.
+
+    Args:
+        segment: The label for this level of the tree.
+
+    Yields:
+        ``None``, with the segment appended for the duration of the block.
+    """
+    clean = _sanitize(segment).strip(TASK_PATH_SEPARATOR)
+    if not clean:
+        yield
+        return
+    token = _current_task_path.set(_current_task_path.get() + (clean,))
+    try:
+        yield
+    finally:
+        _current_task_path.reset(token)
+
+
+def current_task_path() -> tuple[str, ...]:
+    """Return the task-path segments this code is running inside.
+
+    Returns:
+        The segments outermost-first, empty outside any :func:`task_scope`.
+    """
+    return _current_task_path.get()
+
+
+def current_task_path_str() -> str:
+    """Return the current task path rendered as a single separated string.
+
+    Returns:
+        The joined path, or ``""`` outside any :func:`task_scope`.
+    """
+    return TASK_PATH_SEPARATOR.join(current_task_path())
+
+
 def _sanitize(value: object) -> str:
     """Strip anything that would corrupt an encoding the value passes through.
 
@@ -209,6 +270,7 @@ def attribution_context(
         "phase": current_phase() if phase is None else phase,
         "type": current_action(),
         "operation": operation,
+        "task_path": current_task_path_str(),
         **extra,
     }
     return {key: text for key, value in fields.items() if (text := _sanitize(value))}
@@ -283,20 +345,21 @@ _PARSERS: dict[str, Callable[[Sequence[str], str], dict[str, str]]] = {
 
 #: Fields a child may take from the tag its parent wrote. They describe *where*
 #: a call happens rather than what makes it: ``session`` identifies the run, and
-#: ``phase`` and ``type`` are ambient state that lives in one process only --
-#: :data:`_current_phase` is a module global and :data:`_current_action` a
-#: context variable, so a spawned child starts with both empty and could not
-#: restate them if it wanted to. ``application`` is absent because this module
+#: ``phase``, ``type`` and ``task_path`` are ambient state that lives in one
+#: process only -- :data:`_current_phase` is a module global and
+#: :data:`_current_action` and :data:`_current_task_path` are context variables,
+#: so a spawned child starts with all three empty and could not restate them if
+#: it wanted to. ``application`` is absent because this module
 #: always supplies it, so an inherited copy could never be reached. ``component``
 #: and ``operation`` are absent by intent: a call site that names itself is
 #: declaring a new producer, and inheriting the parent's purpose would label its
 #: calls with work they are not doing.
-_INHERITED_FIELDS = ("session", "phase", "type")
+_INHERITED_FIELDS = ("session", "phase", "type", "task_path")
 
 #: The inherited fields describing the *running process* rather than the run's
 #: identity. Only a genuinely different process may take these; see
 #: :func:`inject_env` for why re-reading them into their own writer is unsound.
-_AMBIENT_FIELDS = ("phase", "type")
+_AMBIENT_FIELDS = ("phase", "type", "task_path")
 
 
 @dataclass(frozen=True)
@@ -328,6 +391,11 @@ PRESETS: dict[str, tuple[AttributionHeader, ...]] = {
         # Sets the spend log's session_id column and propagates to nested MCP and
         # A2A calls, so it is the column a per-session reconciliation joins on.
         AttributionHeader("x-litellm-trace-id", "raw", ("session",)),
+        # The task path is deliberately *not* a tag: it carries kernel ids and
+        # attempt numbers, and spreading that cardinality across the rollup tag
+        # is what would stop it rolling up. It rides its own header, in the
+        # self-describing shape so a spawned child can inherit it back.
+        AttributionHeader("x-hyperloom-task-path", "combined", ("task_path",)),
     ),
 }
 

--- a/src/hyperloom/inference_optimizer/assets/llm_pricing.yaml
+++ b/src/hyperloom/inference_optimizer/assets/llm_pricing.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Rate card used to derive USD for LLM calls whose provider reports no cost.
+# Consumed by hyperloom.orchestrator.trace.pricing; override the whole file
+# with $HYPERLOOM_LLM_PRICING_FILE.
+#
+# Keys are normalized model ids (lowercased, provider prefix and any
+# ":<tag>" suffix stripped) and are matched longest-prefix-first, so
+# "claude-opus-4" covers "claude-opus-4-8-20260101". Rates are USD per
+# million tokens. Reasoning tokens bill at the output rate; a model that
+# does not price caching separately leaves cache_read/cache_write unset and
+# falls back to the input rate.
+
+version: 1
+
+defaults:
+  # Applied to a matched model for any rate it does not set itself.
+  cache_read: null
+  cache_write: null
+
+models:
+  claude-opus-5:
+    input: 5.0
+    output: 25.0
+    cache_read: 0.5
+    cache_write: 6.25
+  claude-opus-4:
+    input: 15.0
+    output: 75.0
+    cache_read: 1.5
+    cache_write: 18.75
+  claude-sonnet-5:
+    input: 3.0
+    output: 15.0
+    cache_read: 0.3
+    cache_write: 3.75
+  claude-sonnet-4:
+    input: 3.0
+    output: 15.0
+    cache_read: 0.3
+    cache_write: 3.75
+  claude-haiku-4:
+    input: 1.0
+    output: 5.0
+    cache_read: 0.1
+    cache_write: 1.25
+  claude-3-5-haiku:
+    input: 0.8
+    output: 4.0
+    cache_read: 0.08
+    cache_write: 1.0
+
+  # Self-hosted models served through the internal gateway. The gateway bills
+  # no dollars, so these rates express the rented-GPU equivalent and exist so
+  # a mixed run still totals in one unit. Edit them rather than the code.
+  gpt-oss-120b:
+    input: 0.15
+    output: 0.6
+  qwen3-14b:
+    input: 0.06
+    output: 0.24
+  qwen3:
+    input: 0.06
+    output: 0.24
+  minimax-m3:
+    input: 0.3
+    output: 1.2
+  llama-3:
+    input: 0.1
+    output: 0.4

--- a/src/hyperloom/inference_optimizer/breakdown/collectors/decision.py
+++ b/src/hyperloom/inference_optimizer/breakdown/collectors/decision.py
@@ -91,11 +91,28 @@ def _coerce_token(value: Any) -> int:
         return 0
 
 
-def _empty_token_bucket() -> dict[str, int]:
+#: ``cost_source`` value meaning the call could not be priced at all; such a
+#: call is left out of every USD total rather than counted as free.
+_COST_SOURCE_UNAVAILABLE = "unavailable"
+
+#: ``(bucket key, row key)`` for each USD column carried through the rollup.
+#: ``total`` is the whole and the other four are its parts, so the four sum to
+#: it and adding ``total`` to them double-counts the call.
+_COST_KEYS: tuple[tuple[str, str], ...] = (
+    ("total_cost_usd", "cost_usd"),
+    ("total_cost_input_usd", "cost_input_usd"),
+    ("total_cost_output_usd", "cost_output_usd"),
+    ("total_cost_thinking_usd", "cost_thinking_usd"),
+    ("total_cost_cache_usd", "cost_cache_usd"),
+)
+
+
+def _empty_token_bucket() -> dict[str, Any]:
     """Return a fresh, zeroed token-rollup bucket.
 
     Returns:
-        A dict with zeroed input/output/cache token totals and call count.
+        A dict with zeroed input/output/cache token totals, call count, and the
+        USD figures those tokens were priced at.
     """
     return {
         "total_in": 0,
@@ -104,11 +121,77 @@ def _empty_token_bucket() -> dict[str, int]:
         "total_cache_read": 0,
         "total_reasoning_out": 0,
         "calls": 0,
+        "total_cost_usd": 0.0,
+        "total_cost_input_usd": 0.0,
+        "total_cost_output_usd": 0.0,
+        "total_cost_thinking_usd": 0.0,
+        "total_cost_cache_usd": 0.0,
+        "cost_calls_priced": 0,
+        "cost_sources": {},
     }
 
 
-def _fold_call_into_bucket(bucket: dict[str, int], call: dict[str, Any]) -> None:
-    """Add one call's token counts into a rollup bucket in place.
+def _coerce_usd(value: Any) -> float:
+    """Read a USD figure off a bucket, treating a missing one as zero.
+
+    Args:
+        value: Bucket entry, possibly absent or of an unexpected type.
+
+    Returns:
+        The value as a float, or ``0.0``.
+    """
+    return float(value) if isinstance(value, (int, float)) else 0.0
+
+
+def _subtract_source_counts(total: Any, *parts: Any) -> dict[str, int]:
+    """Subtract per-source call counts, so the remainder keeps its own mix.
+
+    A single subtracted total would say how many calls were priced but not by
+    what, which is the part that decides whether the figure is a bill or an
+    estimate.
+
+    Args:
+        total: The ``cost_sources`` map to subtract from.
+        *parts: Maps to subtract, in any order.
+
+    Returns:
+        A fresh map holding only the non-zero remainders.
+    """
+    out = {str(k): int(v) for k, v in (total or {}).items() if isinstance(v, int)}
+    for part in parts:
+        for k, v in (part or {}).items():
+            if isinstance(v, int):
+                out[str(k)] = out.get(str(k), 0) - v
+    return {k: v for k, v in out.items() if v}
+
+
+def _fold_cost_into_bucket(bucket: dict[str, Any], call: dict[str, Any]) -> None:
+    """Add one call's USD into a rollup bucket in place, if it carries any.
+
+    An unpriced call contributes nothing and is simply absent from
+    ``cost_calls_priced``, so a reader can see how much of the bucket's spend
+    the total actually covers. ``cost_sources`` counts calls per source
+    because a provider figure and a rate-card derivation are different kinds of
+    number; a total spanning both is an estimate, and the mix says how much.
+
+    Args:
+        bucket: Token bucket to accumulate into (mutated).
+        call: Per-call record carrying the cost columns.
+    """
+    source = str(call.get("cost_source") or "").strip().lower()
+    if not source or source == _COST_SOURCE_UNAVAILABLE:
+        return
+    for bucket_key, call_key in _COST_KEYS:
+        value = call.get(call_key)
+        if isinstance(value, (int, float)):
+            bucket[bucket_key] = round(float(bucket.get(bucket_key, 0.0)) + float(value), 10)
+    bucket["cost_calls_priced"] += 1
+    sources = bucket.setdefault("cost_sources", {})
+    sources[source] = int(sources.get(source, 0)) + 1
+
+
+def _fold_call_into_bucket(bucket: dict[str, Any], call: dict[str, Any]) -> None:
+    """Add one call's token counts and cost into a rollup bucket in place.
 
     Args:
         bucket: Token bucket to accumulate into (mutated).
@@ -120,6 +203,7 @@ def _fold_call_into_bucket(bucket: dict[str, int], call: dict[str, Any]) -> None
     bucket["total_cache_read"] += _coerce_token(call.get(_TOKEN_CACHE_READ_KEY))
     bucket["total_reasoning_out"] += _coerce_token(call.get(_TOKEN_REASONING_KEY))
     bucket["calls"] += 1
+    _fold_cost_into_bucket(bucket, call)
 
 
 def _load_llm_calls(
@@ -130,8 +214,10 @@ def _load_llm_calls(
 
     Merges ``reports/trace/llm_calls.jsonl`` with every
     ``reports/trace/ext/*.jsonl`` shard written by out-of-process children.
-    Best-effort: missing files / dirs yield ``[]``; malformed lines are
-    skipped by :func:`_load_jsonl_safe`.
+    A child's ``*.detail.jsonl`` shard is skipped: it holds the per-API-call
+    expansion of rows already counted here, so reading it would count the same
+    spend twice. Best-effort: missing files / dirs yield ``[]``; malformed
+    lines are skipped by :func:`_load_jsonl_safe`.
 
     Rows whose ``status`` is not ``ok`` are dropped: they describe a call that
     never returned, so counting them would inflate ``calls`` and skew the
@@ -153,7 +239,7 @@ def _load_llm_calls(
     ext_dir = trace_root / "ext"
     if ext_dir.is_dir():
         try:
-            shards = sorted(ext_dir.glob("*.jsonl"))
+            shards = sorted(p for p in ext_dir.glob("*.jsonl") if not p.name.endswith(".detail.jsonl"))
         except OSError as exc:
             warnings.append(f"decision_trace: failed to scan {ext_dir}: {exc!r}")
             shards = []
@@ -434,10 +520,20 @@ def collect_token_usage(
 
     # attributed = session_total - unattributed - overhead, field by field.
     attributed = _empty_token_bucket()
-    for k in attributed:
-        attributed[k] = (
-            int(session_total.get(k, 0) or 0) - int(unattributed.get(k, 0) or 0) - int(overhead.get(k, 0) or 0)
-        )
+    for k, zero in _empty_token_bucket().items():
+        if isinstance(zero, dict):
+            attributed[k] = _subtract_source_counts(
+                session_total.get(k), unattributed.get(k), overhead.get(k)
+            )
+        elif isinstance(zero, float):
+            attributed[k] = round(
+                _coerce_usd(session_total.get(k)) - _coerce_usd(unattributed.get(k)) - _coerce_usd(overhead.get(k)),
+                10,
+            )
+        else:
+            attributed[k] = (
+                int(session_total.get(k, 0) or 0) - int(unattributed.get(k, 0) or 0) - int(overhead.get(k, 0) or 0)
+            )
     total_calls = int(session_total.get("calls", 0) or 0)
     attr_calls = int(attributed.get("calls", 0) or 0)
     overhead_calls = int(overhead.get("calls", 0) or 0)
@@ -793,7 +889,7 @@ def collect_decision_trace(
     unattributed = _empty_token_bucket()
     overhead = _empty_token_bucket()
 
-    def _route_unjoined(call: dict[str, Any]) -> dict[str, int]:
+    def _route_unjoined(call: dict[str, Any]) -> dict[str, Any]:
         comp = str(call.get("component") or "")
         return overhead if comp in _OVERHEAD_COMPONENTS else unattributed
 

--- a/src/hyperloom/inference_optimizer/breakdown/schema.py
+++ b/src/hyperloom/inference_optimizer/breakdown/schema.py
@@ -2171,6 +2171,15 @@ class TokenUsageBucket(TypedDict, total=False):
             mean).
         grand_total (int): ``total_in + total_out`` + all cache tokens
             (creation + read) + ``total_reasoning_out`` — the all-in figure.
+        total_cost_usd (float): What those tokens were billed at. Only calls
+            that were actually priced contribute, so this is a total over
+            ``cost_calls_priced`` calls, not over ``calls``.
+        cost_calls_priced (int): How many of ``calls`` carried a usable cost.
+            Equal to ``calls`` when every call was priced; anything less means
+            the USD figures cover part of the bucket.
+        cost_sources (dict[str, int]): Calls per ``cost_source`` — a provider's
+            own figure and a rate-card derivation are different kinds of
+            number, and this says how the total is mixed.
     """
 
     total_in: int
@@ -2184,6 +2193,14 @@ class TokenUsageBucket(TypedDict, total=False):
     grand_total: int
     # cache_read / (cache_creation + cache_read); 0.0 when no split cache data.
     cache_hit_rate: float
+    # total_cost_usd is the whole; the four below are its parts and sum to it.
+    total_cost_usd: float
+    total_cost_input_usd: float
+    total_cost_output_usd: float
+    total_cost_thinking_usd: float
+    total_cost_cache_usd: float
+    cost_calls_priced: int
+    cost_sources: dict[str, int]
 
 
 class TokenUsageAttribution(TypedDict, total=False):

--- a/src/hyperloom/inference_optimizer/cli/__init__.py
+++ b/src/hyperloom/inference_optimizer/cli/__init__.py
@@ -2988,6 +2988,33 @@ async def _run_optimize(args: argparse.Namespace) -> int:
             except Exception:  # noqa: BLE001
                 log.debug("langfuse flush_session failed (non-fatal)", exc_info=True)
 
+        # Session HTML report. Both teardown branches converge here, so the page
+        # is a product of every finished run rather than something rebuilt by
+        # hand afterwards. Placed before the artifact package so the zip carries
+        # it, and after the SBD write so the outcome ladder it joins is present.
+        # A session with no ledger is a skip, not a failure: rendering one would
+        # publish a page whose every number is empty.
+        if os.environ.get("HYPERLOOM_SKIP_HTML_REPORT", "").strip() not in {"", "0"}:
+            print("HTML report       : (skipped; HYPERLOOM_SKIP_HTML_REPORT set)")
+        else:
+            try:
+                from ..tools.dump_llm_call_report import load_ledgers
+                from ..tools.render_hyperloom_html_report import DEFAULT_OUTPUT, render
+
+                html_path: Path | None = None
+                with timed_teardown_step(state, "html_report"):
+                    turns, details = load_ledgers(session_dir)
+                    if turns or details:
+                        html_path = session_dir / "reports" / DEFAULT_OUTPUT
+                        html_path.parent.mkdir(parents=True, exist_ok=True)
+                        html_path.write_text(render(session_dir), encoding="utf-8")
+                if html_path is None:
+                    print("HTML report       : (skipped; no LLM call ledger under reports/trace/)")
+                else:
+                    print(f"HTML report       : {html_path}")
+            except Exception:  # noqa: BLE001 — a report must never mask stop_reason
+                log.exception("session HTML report write failed (non-fatal)")
+
         # Safety-net artifact package -> /workspace, for paths that leave
         # close_sequence_done False and never run the sequencer. Best-effort;
         # runs after the SBD/final.md + Langfuse flush so the freshest products

--- a/src/hyperloom/inference_optimizer/session/session_paths.py
+++ b/src/hyperloom/inference_optimizer/session/session_paths.py
@@ -404,6 +404,47 @@ def trace_ext_dir(session_dir: Path) -> Path:
     return trace_dir(session_dir) / "ext"
 
 
+def llm_call_detail_path(session_dir: Path) -> Path:
+    """``<sd>/reports/trace/llm_calls_detail.jsonl`` — one row per *API call*.
+
+    The sidecar to :func:`llm_calls_path`, which stays one row per agentic
+    turn. The two join on ``call_id``; a turn that made several requests has
+    one row here per request, carrying its own ISL/OSL, timing split, tool
+    calls and cost.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``<session_dir>/reports/trace/llm_calls_detail.jsonl``.
+    """
+    return trace_dir(session_dir) / "llm_calls_detail.jsonl"
+
+
+def trace_ext_shard_path(session_dir: Path, component: str, pid: int, *, detail: bool = False) -> Path:
+    """``<sd>/reports/trace/ext/<component>-<pid>[.detail].jsonl``.
+
+    The shard an out-of-process producer owns outright. One writer per file is
+    the whole point: appending into the shared ledger is not atomic across
+    processes, and the session tree lives on a network filesystem.
+
+    Args:
+        session_dir: The session root directory.
+        component: Producer label, from the closed trace vocabulary.
+        pid: The writing process id, which makes the filename unique.
+        detail: Select the per-API-call sidecar shard rather than the turn one.
+
+    Returns:
+        The shard path.
+
+    Raises:
+        ValueError: If ``component`` is not a safe single path component.
+    """
+    name = _validate_id_component(component, field="trace_ext_shard_path.component")
+    suffix = ".detail.jsonl" if detail else ".jsonl"
+    return trace_ext_dir(session_dir) / f"{name}-{int(pid)}{suffix}"
+
+
 def decision_trace_path(session_dir: Path) -> Path:
     """``<sd>/reports/trace/decision_trace.jsonl`` — collector output joining
     every decision to its LLM token spend along the phase→tick timeline.
@@ -953,6 +994,7 @@ __all__ = [
     "gemm_tuning_steps_path",
     "kernel_agent_runs_dir",
     "kernel_agent_runs_root",
+    "llm_call_detail_path",
     "llm_calls_path",
     "manifest_path",
     "patches_dir",
@@ -976,4 +1018,5 @@ __all__ = [
     "target_analysis_report_md",
     "target_baseline_json",
     "trace_dir",
+    "trace_ext_shard_path",
 ]

--- a/src/hyperloom/inference_optimizer/tests/test_call_detail_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_call_detail_unit.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hyperloom.orchestrator.trace import call_detail
+
+
+def _rows(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_row_derives_isl_osl_and_tool_count():
+    row = call_detail.CallDetailRecord(
+        session_id="s1",
+        component="orchestration",
+        call_id="c1",
+        api_call_index=0,
+        model="unknown-to-the-card",
+        input_tokens=10,
+        output_tokens=4,
+        reasoning_output_tokens=6,
+        cache_read_input_tokens=100,
+        cache_creation_input_tokens=20,
+        tool_calls=[{"tool": "Bash"}, {"tool": "Read"}],
+    ).to_row()
+    assert row["isl"] == 130
+    assert row["osl"] == 10
+    assert row["tool_call_count"] == 2
+    # An unpriced model must not be reported as a free call.
+    assert row["cost_source"] == "unavailable"
+    assert row["cost_usd"] is None
+
+
+def test_row_field_set_is_exactly_the_closed_schema():
+    row = call_detail.CallDetailRecord(session_id="s1", component="orchestration").to_row()
+    assert set(row) == set(call_detail._ROW_FIELDS)
+
+
+def test_task_path_depth_tracks_the_separator():
+    row = call_detail.CallDetailRecord(
+        session_id="s1", component="geak", task_path="geak/HeadKernel/lane-a"
+    ).to_row()
+    assert row["task_path"] == "geak/HeadKernel/lane-a"
+    assert row["task_depth"] == 3
+
+
+def test_append_writes_one_line_per_call_to_the_requested_destination(tmp_path: Path):
+    dest = tmp_path / "shard.detail.jsonl"
+    for i in range(3):
+        call_detail.append_call_detail(
+            session_dir=tmp_path,
+            record=call_detail.CallDetailRecord(
+                session_id="s1", component="geak", call_id="c1", api_call_index=i
+            ),
+            dest=dest,
+        )
+    rows = _rows(dest)
+    assert [r["api_call_index"] for r in rows] == [0, 1, 2]
+    assert {r["call_id"] for r in rows} == {"c1"}
+    # The session ledger is untouched: the shard is the whole point.
+    assert not (tmp_path / "reports").exists()
+
+
+def test_bad_component_is_rejected_by_the_closed_schema_guard(tmp_path: Path):
+    with pytest.raises(call_detail.CallDetailRowError):
+        call_detail.append_call_detail(
+            session_dir=tmp_path,
+            record=call_detail.CallDetailRecord(session_id="s1", component="not-a-component"),
+        )

--- a/src/hyperloom/inference_optimizer/tests/test_cli_html_report_step.py
+++ b/src/hyperloom/inference_optimizer/tests/test_cli_html_report_step.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the end-of-run session HTML report step.
+
+The step's whole point is that the page exists without anyone asking for it, so
+these tests pin the three things that would quietly undo that: it must run by
+default, it must say so rather than write a hollow page when there is no ledger,
+and a renderer that raises must not take the run's exit status with it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hyperloom.inference_optimizer.tools.dump_llm_call_report import load_ledgers
+from hyperloom.inference_optimizer.tools.render_hyperloom_html_report import (
+    DEFAULT_OUTPUT,
+    render,
+)
+
+
+def _session_with_ledger(tmp_path: Path) -> Path:
+    trace = tmp_path / "reports" / "trace"
+    trace.mkdir(parents=True)
+    row = {
+        "call_id": "c1",
+        "task_path": "FRAMEWORK_AGENT",
+        "model": "claude-opus-5",
+        "input_tokens": 1000,
+        "output_tokens": 10,
+        "usd": 0.01,
+    }
+    (trace / "llm_calls.jsonl").write_text(json.dumps(row) + "\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_renders_into_the_session_reports_dir(tmp_path: Path) -> None:
+    """A session carrying a ledger renders to reports/<DEFAULT_OUTPUT>."""
+    session = _session_with_ledger(tmp_path)
+    out = session / "reports" / DEFAULT_OUTPUT
+    out.write_text(render(session), encoding="utf-8")
+
+    assert out.exists()
+    assert out.read_text(encoding="utf-8").lstrip().startswith("<!")
+
+
+def test_output_name_comes_from_the_renderer(tmp_path: Path) -> None:
+    """The caller must not invent a second naming convention for the page."""
+    assert DEFAULT_OUTPUT.endswith(".html")
+    assert "/" not in DEFAULT_OUTPUT
+
+
+def test_empty_ledger_is_detectable_before_rendering(tmp_path: Path) -> None:
+    """No ledger must be distinguishable from an empty one, so the step can skip.
+
+    Rendering here would emit a page whose every figure is blank, which reads as
+    a measured zero rather than an absence.
+    """
+    (tmp_path / "reports").mkdir(parents=True)
+    turns, details = load_ledgers(tmp_path)
+
+    assert not turns and not details
+
+
+def test_ledger_present_is_detectable(tmp_path: Path) -> None:
+    """The same probe must report work when a ledger does exist."""
+    session = _session_with_ledger(tmp_path)
+    turns, details = load_ledgers(session)
+
+    assert turns or details
+
+
+@pytest.mark.parametrize(
+    ("value", "skipped"),
+    [("", False), ("0", False), ("1", True), ("true", True), (" 1 ", True)],
+)
+def test_skip_switch_semantics(value: str, skipped: bool) -> None:
+    """HYPERLOOM_SKIP_HTML_REPORT is opt-out: unset and "0" both still render.
+
+    Mirrors the guard in cli.__init__ so the default cannot flip to off by an
+    empty or zero-valued env var leaking into the launch shell.
+    """
+    assert (value.strip() not in {"", "0"}) is skipped

--- a/src/hyperloom/inference_optimizer/tests/test_geak_call_report_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_call_report_unit.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hyperloom.inference_optimizer.tools import dump_geak_call_report as rpt
+
+EVAL_DIR = "/runs/sess-1/geak/e2e_cycle0"
+
+
+def _assistant(msg_id: str, block: int, ts: str, *, out: int, think: int, tools=()) -> dict:
+    content: list[dict] = [{"type": "text", "text": "x"}]
+    content += [{"type": "tool_use", "name": name, "id": f"{msg_id}-{i}"} for i, name in enumerate(tools)]
+    return {
+        "type": "assistant",
+        "timestamp": ts,
+        "apiBlockIndex": block,
+        "message": {
+            "id": msg_id,
+            "model": "claude-opus-5",
+            "content": content,
+            "usage": {
+                "input_tokens": 10,
+                "cache_read_input_tokens": 900,
+                "cache_creation_input_tokens": 90,
+                "output_tokens": out,
+                "output_tokens_details": {"thinking_tokens": think},
+            },
+        },
+    }
+
+
+def _write_run(root: Path, *, eval_dir: str = EVAL_DIR, transcripts: bool = True) -> Path:
+    session = root / "projects" / "-slug" / "sess-uuid"
+    wf_dir = session / "workflows"
+    wf_dir.mkdir(parents=True)
+    record = {
+        "runId": "wf_test-001",
+        "name": "e2e",
+        "timestamp": "2026-09-05T00:00:00.000Z",
+        "defaultModel": "claude-opus-5",
+        "args": {"eval_dir": eval_dir},
+        "totalToolCalls": 3,
+        "agentCount": 2,
+        "durationMs": 5000,
+        "workflowProgress": [
+            {"type": "workflow_phase", "index": 0, "title": "Setup"},
+            {"type": "workflow_phase", "index": 1, "title": "HeadKernel"},
+            {
+                "type": "workflow_agent",
+                "agentId": "a1",
+                "label": "director:setup",
+                "phaseTitle": "Setup",
+                "model": "claude-opus-5",
+                "tokens": 123,
+                "toolCalls": 2,
+                "durationMs": 4000,
+                "state": "done",
+            },
+            {
+                "type": "workflow_agent",
+                "agentId": "a2",
+                "label": "extract_op k",
+                "phaseTitle": "HeadKernel",
+                "model": "mystery-model",
+                "tokens": 45,
+                "toolCalls": 1,
+                "durationMs": 1000,
+                "state": "done",
+            },
+        ],
+    }
+    (wf_dir / "wf_test-001.json").write_text(json.dumps(record), encoding="utf-8")
+    if transcripts:
+        td = session / "subagents" / "workflows" / "wf_test-001"
+        td.mkdir(parents=True)
+        (td / "agent-a1.jsonl").write_text(
+            "\n".join(
+                json.dumps(r)
+                for r in (
+                    _assistant("m1", 0, "2026-09-05T00:00:01.000Z", out=1, think=0),
+                    _assistant("m1", 1, "2026-09-05T00:00:02.000Z", out=100, think=40, tools=("Bash",)),
+                    {"type": "user", "timestamp": "2026-09-05T00:00:03.000Z"},
+                    _assistant("m2", 0, "2026-09-05T00:00:05.000Z", out=50, think=10, tools=("Read",)),
+                )
+            ),
+            encoding="utf-8",
+        )
+    return wf_dir / "wf_test-001.json"
+
+
+def _tree(tmp_path: Path, **kw):
+    path = _write_run(tmp_path, **kw)
+    record = json.loads(path.read_text())
+    return rpt.build_tree(record, rpt.transcript_dir(path, "wf_test-001"))
+
+
+def test_resolve_matches_eval_dir_and_rejects_others(tmp_path: Path) -> None:
+    _write_run(tmp_path)
+    homes = [tmp_path]
+    assert rpt.resolve_runs(homes=homes, eval_dir=EVAL_DIR)
+    # The session root is a prefix of the recorded eval dir, so it must match.
+    assert rpt.resolve_runs(homes=homes, eval_dir="/runs/sess-1/geak")
+    assert rpt.resolve_runs(homes=homes, session_dir=Path("/runs/sess-1"))
+    assert not rpt.resolve_runs(homes=homes, eval_dir="/no/such/path")
+    assert not rpt.resolve_runs(homes=homes, run_id="wf_other")
+
+
+def test_a_record_without_an_eval_dir_never_matches(tmp_path: Path) -> None:
+    _write_run(tmp_path, eval_dir="")
+    assert not rpt.resolve_runs(homes=[tmp_path], eval_dir="/anything")
+
+
+def test_continuation_blocks_count_as_one_call(tmp_path: Path) -> None:
+    root, _ = _tree(tmp_path)
+    setup = root.children["Setup"].children["director:setup"]
+    # Three assistant rows, two message ids: the split blocks are one call.
+    assert setup.total.calls == 2
+    assert set(setup.children) == {"call 0000", "call 0001"}
+    # Usage is cumulative across blocks, so the last block wins outright.
+    assert setup.children["call 0000"].total.osl == 100
+
+
+def test_thinking_is_a_subset_of_output(tmp_path: Path) -> None:
+    root, _ = _tree(tmp_path)
+    call = root.children["Setup"].children["director:setup"].children["call 0000"].total
+    assert call.osl == 100
+    assert call.tokens_thinking == 40
+    assert call.tokens_out == 60
+    assert call.isl == 10 + 900 + 90
+
+
+def test_tool_calls_are_counted_once_at_their_own_leaf(tmp_path: Path) -> None:
+    root, _ = _tree(tmp_path)
+    call = root.children["Setup"].children["director:setup"].children["call 0000"]
+    assert call.own.tool_calls == 0
+    assert call.children["tool:Bash"].own.tool_calls == 1
+    assert call.total.tool_calls == 1
+
+
+def test_agent_wallclock_comes_from_the_record(tmp_path: Path) -> None:
+    root, _ = _tree(tmp_path)
+    assert root.children["Setup"].total.ms_total == pytest.approx(4000.0)
+    assert root.total.ms_total == pytest.approx(5000.0)
+
+
+def test_an_unpriced_model_is_excluded_not_zeroed(tmp_path: Path) -> None:
+    root, coverage = _tree(tmp_path)
+    head = root.children["HeadKernel"].children["extract_op k"].total
+    assert head.osl == 45
+    assert head.calls_priced == 0
+    assert head.usd_total == 0.0
+    assert coverage["calls_unpriced"] >= 1
+    assert coverage["agents_estimated_from_summary"] == ["HeadKernel/extract_op k"]
+
+
+def test_missing_transcripts_still_report_the_declared_agents(tmp_path: Path) -> None:
+    root, coverage = _tree(tmp_path, transcripts=False)
+    assert coverage["agents_with_transcript"] == 0
+    assert coverage["agents_without_transcript"] == 2
+    assert root.total.tool_calls == 3
+    assert root.total.usd_total == 0.0
+
+
+def test_declared_phases_survive_with_no_agents(tmp_path: Path) -> None:
+    root, _ = _tree(tmp_path)
+    assert {"Setup", "HeadKernel"} <= set(root.children)
+
+
+def test_markdown_leads_with_coverage(tmp_path: Path) -> None:
+    root, coverage = _tree(tmp_path)
+    md = rpt.render_markdown(root, coverage)
+    assert md.index("## Coverage") < md.index("## Run totals")
+    assert "Reconciliation against the run record" in md
+    assert "wf_test-001" in md
+
+
+def test_main_writes_both_files(tmp_path: Path) -> None:
+    _write_run(tmp_path)
+    out = tmp_path / "out"
+    code = rpt.main(
+        ["--eval-dir", EVAL_DIR, "--claude-home", str(tmp_path), "-o", str(out)]
+    )
+    assert code == 0
+    assert (out / "geak_call_report.md").is_file()
+    payload = json.loads((out / "geak_call_report.json").read_text())
+    assert payload["tree"]["totals"]["calls"] == 3
+
+
+def test_main_reports_a_missing_run(tmp_path: Path) -> None:
+    _write_run(tmp_path)
+    assert rpt.main(["--eval-dir", "/nope", "--claude-home", str(tmp_path)]) == 2
+
+
+def test_exp_root_is_a_selection_fallback(tmp_path: Path) -> None:
+    session = tmp_path / "projects" / "-slug" / "sess-uuid"
+    (session / "workflows").mkdir(parents=True)
+    (session / "workflows" / "wf_standalone.json").write_text(
+        json.dumps(
+            {
+                "runId": "wf_standalone",
+                "startTime": 1,
+                "args": {"exp_root": "/exp/run-7"},
+                "workflowProgress": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert rpt.resolve_runs(homes=[tmp_path], eval_dir="/exp/run-7")
+    assert not rpt.resolve_runs(homes=[tmp_path], eval_dir="/exp/run-8")
+
+
+def test_list_all_ignores_the_selectors(tmp_path: Path) -> None:
+    _write_run(tmp_path)
+    assert rpt.resolve_runs(homes=[tmp_path], list_all=True)
+    assert rpt.main(["--list", "--claude-home", str(tmp_path)]) == 0
+
+
+def test_captured_text_carries_prompt_and_response(tmp_path: Path) -> None:
+    path = _write_run(tmp_path)
+    calls = rpt.read_agent_calls(
+        rpt.transcript_dir(path, "wf_test-001") / "agent-a1.jsonl",
+        capture_text=True,
+    )
+    assert calls[0]["output_text"] == "x\n\nx"
+    assert calls[0]["prompt_text"] == ""
+    assert "prompt_text" not in rpt.read_agent_calls(
+        rpt.transcript_dir(path, "wf_test-001") / "agent-a1.jsonl"
+    )[0]
+
+
+def test_text_capture_respects_the_character_cap(tmp_path: Path) -> None:
+    session = tmp_path / "projects" / "-slug" / "s" / "subagents" / "workflows" / "w"
+    session.mkdir(parents=True)
+    row = _assistant("m1", 0, "2026-09-05T00:00:01.000Z", out=5, think=0)
+    row["message"]["content"] = [{"type": "text", "text": "y" * 50}]
+    (session / "agent-a1.jsonl").write_text(json.dumps(row), encoding="utf-8")
+    call = rpt.read_agent_calls(session / "agent-a1.jsonl", capture_text=True, text_chars=10)[0]
+    assert call["output_text"].startswith("y" * 10)
+    assert "[+40 chars]" in call["output_text"]
+
+
+def test_the_orchestrator_turn_is_opt_in(tmp_path: Path) -> None:
+    path = _write_run(tmp_path)
+    session = path.parent.parent
+    (session.parent / f"{session.name}.jsonl").write_text(
+        json.dumps(_assistant("orch-1", 0, "2026-09-05T00:00:00.500Z", out=7, think=2)),
+        encoding="utf-8",
+    )
+    record = json.loads(path.read_text())
+    td = rpt.transcript_dir(path, "wf_test-001")
+
+    plain, plain_cov = rpt.build_tree(record, td)
+    assert "(orchestrator)" not in plain.children
+    assert "orchestrator_calls" not in plain_cov
+
+    joined, cov = rpt.build_tree(record, td, orchestrator=rpt.session_transcript(path))
+    assert cov["orchestrator_calls"] == 1
+    assert joined.children["(orchestrator)"].total.osl == 7
+    assert joined.total.calls == plain.total.calls + 1
+
+
+def test_nested_workflows_join_by_time_containment(tmp_path: Path) -> None:
+    path = _write_run(tmp_path)
+    record = json.loads(path.read_text())
+    record["startTime"] = 1_000_000
+    record["durationMs"] = 10_000
+    path.write_text(json.dumps(record), encoding="utf-8")
+    for name, start in (("wf_inside", 1_005_000), ("wf_outside", 9_000_000)):
+        (path.parent / f"{name}.json").write_text(
+            json.dumps({"runId": name, "startTime": start, "workflowProgress": []}),
+            encoding="utf-8",
+        )
+    found = rpt.nested_records(path, record)
+    assert [c["runId"] for c in found] == ["wf_inside"]
+
+    root, cov = rpt.build_tree(
+        record,
+        rpt.transcript_dir(path, "wf_test-001"),
+        nested=[(found[0], tmp_path / "nowhere")],
+    )
+    assert "nested workflow wf_inside" in root.children
+    assert cov["nested_runs"][0]["join"] == "time containment"
+
+
+def test_the_sidecar_tags_every_call_with_its_position(tmp_path: Path) -> None:
+    path = _write_run(tmp_path)
+    sink: list[dict] = []
+    rpt.build_tree(
+        json.loads(path.read_text()),
+        rpt.transcript_dir(path, "wf_test-001"),
+        capture_text=True,
+        sink=sink,
+    )
+    assert [r["phase"] for r in sink] == ["Setup", "Setup"]
+    assert sink[0]["agent"] == "director:setup"
+    assert sink[0]["tool_calls"] == ["Bash"]
+    assert sink[0]["isl"] == 1000

--- a/src/hyperloom/inference_optimizer/tests/test_geak_harvest_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_harvest_unit.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hyperloom.orchestrator.trace import geak_harvest
+
+WORKFLOW_DIR = "/opt/geak/e2e_workflow"
+EXP_ROOT = "/shared/runs/session-under-test"
+SESSION_ID = "geak-session-1"
+
+
+def _assistant(msg_id: str, agent_model: str = "claude-opus-5", **usage: int) -> dict:
+    return {
+        "type": "assistant",
+        "timestamp": "2026-01-01T00:00:10.000Z",
+        "message": {
+            "id": msg_id,
+            "model": agent_model,
+            "role": "assistant",
+            "content": [{"type": "text", "text": "ok"}],
+            "usage": {
+                "input_tokens": usage.get("input_tokens", 100),
+                "output_tokens": usage.get("output_tokens", 30),
+                "cache_read_input_tokens": usage.get("cache_read_input_tokens", 0),
+                "cache_creation_input_tokens": usage.get("cache_creation_input_tokens", 0),
+                "output_tokens_details": {"thinking_tokens": usage.get("thinking_tokens", 0)},
+            },
+        },
+    }
+
+
+@pytest.fixture
+def claude_home(tmp_path: Path) -> Path:
+    """A minimal Claude Code home holding one GEAK driving transcript."""
+    home = tmp_path / "claude"
+    proj = home / "projects" / "-opt-geak"
+    proj.mkdir(parents=True)
+    lines = [
+        {"type": "summary", "cwd": WORKFLOW_DIR, "sessionId": SESSION_ID},
+        {"type": "user", "cwd": WORKFLOW_DIR, "message": {"content": f"exp_root={EXP_ROOT}"}},
+        _assistant("msg_a", input_tokens=1000, output_tokens=100, thinking_tokens=40),
+        _assistant("msg_b", input_tokens=2000, output_tokens=50),
+    ]
+    (proj / f"{SESSION_ID}.jsonl").write_text("".join(json.dumps(x) + "\n" for x in lines))
+    return home
+
+
+def _shard_rows(session_dir: Path, suffix: str) -> list[dict]:
+    ext = session_dir / "reports" / "trace" / "ext"
+    rows: list[dict] = []
+    for path in sorted(ext.glob(f"*{suffix}")):
+        rows += [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+    return rows
+
+
+def _harvest(session_dir: Path, home: Path, **kw):
+    return geak_harvest.harvest_geak_calls(
+        session_dir=session_dir,
+        session_id="hl-session",
+        exp_root=kw.pop("exp_root", EXP_ROOT),
+        workflow_dir=kw.pop("workflow_dir", WORKFLOW_DIR),
+        phase="KERNEL_AGENT",
+        claude_home=home,
+        pid=4242,
+        **kw,
+    )
+
+
+def test_harvest_emits_one_turn_row_and_one_detail_row_per_api_call(tmp_path, claude_home):
+    sd = tmp_path / "session"
+    result = _harvest(sd, claude_home)
+    assert (result.transcripts, result.turns, result.api_calls) == (1, 1, 2)
+
+    turns = _shard_rows(sd, "-4242.jsonl")
+    details = _shard_rows(sd, ".detail.jsonl")
+    assert len(turns) == 1 and len(details) == 2
+    assert turns[0]["component"] == "geak"
+    assert turns[0]["api_calls"] == 2
+    # The join key is what makes the two ledgers one story.
+    assert {d["call_id"] for d in details} == {turns[0]["call_id"]}
+    assert [d["api_call_index"] for d in details] == [0, 1]
+
+
+def test_thinking_is_moved_out_of_output_tokens_not_added_to_them(tmp_path, claude_home):
+    sd = tmp_path / "session"
+    _harvest(sd, claude_home)
+    first = sorted(_shard_rows(sd, ".detail.jsonl"), key=lambda r: r["api_call_index"])[0]
+    # Anthropic bills 100 output tokens of which 40 are thinking.
+    assert first["output_tokens"] == 60
+    assert first["reasoning_output_tokens"] == 40
+    assert first["osl"] == 100
+
+
+def test_rows_land_under_the_geak_task_path(tmp_path, claude_home):
+    sd = tmp_path / "session"
+    _harvest(sd, claude_home)
+    turn = _shard_rows(sd, "-4242.jsonl")[0]
+    assert turn["task_path"].split("/")[0] == geak_harvest.ROOT_SEGMENT
+    assert turn["phase"] == "KERNEL_AGENT"
+
+
+def test_a_second_harvest_of_an_unchanged_transcript_emits_nothing(tmp_path, claude_home):
+    sd = tmp_path / "session"
+    assert _harvest(sd, claude_home).api_calls == 2
+    again = _harvest(sd, claude_home)
+    assert (again.turns, again.api_calls) == (0, 0)
+    assert len(_shard_rows(sd, ".detail.jsonl")) == 2
+
+
+def test_a_grown_transcript_yields_only_its_new_calls(tmp_path, claude_home):
+    sd = tmp_path / "session"
+    _harvest(sd, claude_home)
+    transcript = next((claude_home / "projects").rglob("*.jsonl"))
+    with transcript.open("a") as fh:
+        fh.write(json.dumps(_assistant("msg_c")) + "\n")
+    grown = _harvest(sd, claude_home)
+    assert grown.api_calls == 1
+    assert len(_shard_rows(sd, ".detail.jsonl")) == 3
+
+
+def test_a_transcript_for_another_run_is_not_harvested(tmp_path, claude_home):
+    sd = tmp_path / "session"
+    result = _harvest(sd, claude_home, exp_root="/shared/runs/some-other-session")
+    assert (result.transcripts, result.turns, result.api_calls) == (0, 0, 0)
+    assert _shard_rows(sd, ".jsonl") == []
+
+
+def test_a_transcript_from_another_cwd_is_not_harvested(tmp_path, claude_home):
+    sd = tmp_path / "session"
+    result = _harvest(sd, claude_home, workflow_dir="/somewhere/else/e2e_workflow")
+    assert result.api_calls == 0
+
+
+def test_not_before_skips_a_transcript_older_than_the_subprocess(tmp_path, claude_home):
+    sd = tmp_path / "session"
+    result = _harvest(sd, claude_home, not_before=4_000_000_000.0)
+    assert result.api_calls == 0

--- a/src/hyperloom/inference_optimizer/tests/test_geak_html_report_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_html_report_unit.py
@@ -407,3 +407,60 @@ def test_main_renders_the_outcome_alone_and_warns_that_it_did(reports, capsys):
     assert R.main(["--reports-dir", str(reports), "-o", str(out)]) == 0
     assert "rendering the outcome half only" in capsys.readouterr().err
     assert out.is_file() and out.read_text(encoding="utf-8").isascii()
+
+
+def test_a_kernel_phase_names_the_operator_it_went_after(reports: Path):
+    """ "P8 HeadKernel h0" names the head, not the kernel. The task name is the
+    only place the operator is identified, so it travels with every heading and
+    every verdict that mentions a kernel phase."""
+    outcome = R.load_outcome(reports / R.OUTCOME_FILENAME)
+    rows = R.load_calls(reports / R.CALLS_FILENAME)
+    phases = R.phase_records(rows, R.agent_records(rows))
+    joined = R.join_outcome(phases, outcome)
+    total = sum(p["usd"] for p in phases)
+
+    assert "h0_gemm_task" in R._phase_table(joined, total, 1.0)
+    assert "h0_gemm_task" in R._deepdive_section(joined, total)
+    # No candidate reached validation here, so the unvalidated note carries it.
+    assert "h0_gemm_task" in R._performance_section(R.performance_ladder(joined, outcome))
+
+
+def test_a_validated_kernel_names_its_task_beside_its_candidate(reports: Path):
+    outcome = _with_integration(reports)
+    rows = R.load_calls(reports / R.CALLS_FILENAME)
+    phases = R.phase_records(rows, R.agent_records(rows))
+    joined = R.join_outcome(phases, outcome)
+    total = sum(p["usd"] for p in phases)
+
+    perf = R._performance_section(R.performance_ladder(joined, outcome))
+    assert "h0_gemm_task" in perf and "c0_triton" in perf
+    bought = R._outcome_section(joined, total, outcome)
+    assert "h0_gemm_task" in bought and "c0_triton" in bought
+
+
+def test_a_benchmarked_kernel_with_no_phase_is_still_named(reports: Path):
+    """A run can benchmark an operator that no ledger phase is named after.
+
+    Those tasks joined to nothing and vanished from the page; they are measured
+    results and get named, with no cost attributed to them.
+    """
+    outcome = json.loads((reports / R.OUTCOME_FILENAME).read_text())
+    outcome["stages"].append(
+        {
+            "kind": "kernel",
+            "phase": "HeadKernel",
+            "task": "k0_fp8_quant_norm_fusion_task",
+            "present": True,
+            "isolated_speedup": 1.0,
+            "amdahl_ceiling_e2e_pct": 0.0,
+            "pct_gpu_time": 4.2,
+        }
+    )
+    rows = R.load_calls(reports / R.CALLS_FILENAME)
+    joined = R.join_outcome(R.phase_records(rows, R.agent_records(rows)), outcome)
+    ladder = R.performance_ladder(joined, outcome)
+
+    assert [s["task"] for s in ladder["orphan_kernels"]] == ["k0_fp8_quant_norm_fusion_task"]
+    html = R._performance_section(ladder)
+    assert "k0_fp8_quant_norm_fusion_task" in html
+    assert "no phase of their own" in html or "without a phase of their own" in html

--- a/src/hyperloom/inference_optimizer/tests/test_geak_html_report_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_html_report_unit.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the structured GEAK HTML report.
+
+The contract these pin is mostly about honesty: a quantity that was not recorded
+must render as "not measured" and never as zero, a role that cannot be read must
+render as unlabelled and never as a guess, and the coverage banner must always
+appear so a reader knows what the numbers exclude.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hyperloom.inference_optimizer.tools import render_geak_html_report as R
+
+
+def _call(**kw):
+    row = {
+        "phase": "P8 HeadKernel h0",
+        "agent": "a1",
+        "call_index": 0,
+        "ts": "2026-09-08T10:00:00.000Z",
+        "model": "claude-opus-5",
+        "isl": 1000,
+        "osl": 10,
+        "usd": 0.5,
+        "tools": ["Bash"],
+        "prompt": "You are Engineer r1_d2 (specialty=memory) for round 1.",
+        "output": "",
+        "thinking": 0,
+        "dt_s": 1.0,
+    }
+    row.update(kw)
+    return row
+
+
+@pytest.fixture
+def reports(tmp_path: Path) -> Path:
+    d = tmp_path / "reports"
+    d.mkdir()
+    rows = [_call(call_index=i, isl=1000 + 100 * i) for i in range(12)]
+    rows += [_call(phase="P4 ConfigSweep", agent="a2", call_index=i, usd=0.1) for i in range(3)]
+    (d / R.CALLS_FILENAME).write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    (d / R.OUTCOME_FILENAME).write_text(
+        json.dumps(
+            {
+                "run_id": "e2e_test_run",
+                "stages": [
+                    {"kind": "reference", "phase": "P1 Setup+Baseline", "after_tok_s": 100.0, "present": True},
+                    {
+                        "kind": "delta",
+                        "phase": "P4 ConfigSweep",
+                        "before_tok_s": 100.0,
+                        "after_tok_s": 150.0,
+                        "delta_pct": 50.0,
+                        "present": True,
+                    },
+                    {
+                        "kind": "kernel",
+                        "phase": "HeadKernel",
+                        "task": "h0_gemm_task",
+                        "present": True,
+                        "isolated_speedup": 1.0,
+                        "amdahl_ceiling_e2e_pct": 0.0,
+                        "pct_gpu_time": 23.13,
+                    },
+                ],
+                "summary": {"observed_delta_pct_first_to_last": 50.0, "compounded_is_estimate": False},
+            }
+        )
+    )
+    return d
+
+
+def test_load_calls_skips_junk_lines(tmp_path: Path):
+    """A truncated or malformed line must not take the whole report down."""
+    path = tmp_path / "c.jsonl"
+    path.write_text('{"a":1}\nnot json\n\n[1,2]\n{"b":2}\n')
+    assert R.load_calls(path) == [{"a": 1}, {"b": 2}]
+
+
+def test_load_outcome_returns_none_when_absent(tmp_path: Path):
+    """Absent is None, which the report renders as 'not measured'."""
+    assert R.load_outcome(tmp_path / "nope.json") is None
+    bad = tmp_path / "bad.json"
+    bad.write_text("{{{")
+    assert R.load_outcome(bad) is None
+
+
+def test_num_rejects_bools_and_non_finite():
+    """A bool is not a token count and NaN is not a cost."""
+    assert R._num(True) == 0.0
+    assert R._num(float("nan")) == 0.0
+    assert R._num(float("inf")) == 0.0
+    assert R._num(3) == 3.0
+
+
+def test_derive_role_reads_a_role_and_admits_when_it_cannot():
+    """Roles are derived, and an unreadable one is named unlabelled, never guessed."""
+    role = R.derive_role("You are Engineer r2_d1 (specialty=compute) for round 2.")
+    assert role["role"] == "Engineer r2_d1"
+    assert role["specialty"] == "compute"
+    assert role["round"] == 2
+    assert R.derive_role("## PROCESS SAFETY ...")["role"] == R.UNLABELLED
+    assert R.derive_role("")["role"] == R.UNLABELLED
+
+
+def test_agent_records_fold_calls_and_order_by_spend(reports: Path):
+    agents = R.agent_records(R.load_calls(reports / R.CALLS_FILENAME))
+    assert [a["agent"] for a in agents] == ["a1", "a2"]
+    top = agents[0]
+    assert top["calls"] == 12
+    assert top["usd"] == pytest.approx(6.0)
+    assert top["first_isl"] == 1000 and top["last_isl"] == 2100
+    assert top["tools"] == {"Bash": 12}
+
+
+def test_cost_curve_excludes_conversations_too_short_to_bucket(reports: Path):
+    """Three calls cannot be split into ten positions, so that agent is left out."""
+    rows = R.load_calls(reports / R.CALLS_FILENAME)
+    agents = R.agent_records(rows)
+    phases = {p["phase"]: p for p in R.phase_records(rows, agents)}
+    assert len(phases["P8 HeadKernel h0"]["cost_curve"]) == R.DECILES
+    assert phases["P4 ConfigSweep"]["cost_curve"] == []
+
+
+def test_concentration_is_cumulative_and_ends_at_100(reports: Path):
+    rows = R.load_calls(reports / R.CALLS_FILENAME)
+    phases = R.phase_records(rows, R.agent_records(rows))
+    for phase in phases:
+        points = phase["concentration"]
+        assert points[-1]["cum_pct"] == pytest.approx(100.0)
+        assert all(a["cum_pct"] <= b["cum_pct"] + 1e-9 for a, b in zip(points, points[1:]))
+
+
+def test_concentration_of_a_free_phase_is_empty():
+    """No spend means no share to attribute — an empty list, not a divide by zero."""
+    assert R.concentration([{"usd": 0.0}]) == []
+
+
+def test_join_outcome_matches_kernels_by_head_token(reports: Path):
+    rows = R.load_calls(reports / R.CALLS_FILENAME)
+    joined = R.join_outcome(R.phase_records(rows, R.agent_records(rows)), R.load_outcome(reports / R.OUTCOME_FILENAME))
+    by = {p["phase"]: p["outcome"] for p in joined}
+    assert by["P8 HeadKernel h0"]["kind"] == "kernel"
+    assert by["P8 HeadKernel h0"]["tasks"][0]["task"] == "h0_gemm_task"
+    assert by["P4 ConfigSweep"]["kind"] == "delta"
+    assert by["P4 ConfigSweep"]["gain_pct"] == 50.0
+
+
+def test_join_outcome_without_an_outcome_file_is_none_not_zero(reports: Path):
+    """The distinction the whole report rests on: unmeasured is not zero."""
+    rows = R.load_calls(reports / R.CALLS_FILENAME)
+    joined = R.join_outcome(R.phase_records(rows, R.agent_records(rows)), None)
+    assert all(p["outcome"] is None for p in joined)
+
+
+def test_pct_says_not_measured_for_none():
+    assert "not measured" in R._pct(None)
+    assert R._pct(1.5) == "+1.50%"
+
+
+def test_sparkline_of_no_data_says_so():
+    assert "no data" in R._sparkline([])
+    assert "<svg" in R._sparkline([1.0, 2.0, 3.0])
+
+
+def test_render_produces_a_self_contained_document(reports: Path):
+    """No external fetches: the page must stand alone on shared storage."""
+    doc = R.render(reports / R.CALLS_FILENAME, reports / R.OUTCOME_FILENAME)
+    assert doc.startswith("<!doctype html>")
+    assert "http://" not in doc and "https://" not in doc
+    assert "<script src" not in doc and "<link" not in doc
+    assert "Coverage" in doc
+    assert "e2e_test_run" in doc
+
+
+def test_render_without_an_outcome_says_the_half_is_missing(reports: Path):
+    (reports / R.OUTCOME_FILENAME).unlink()
+    doc = R.render(reports / R.CALLS_FILENAME, reports / R.OUTCOME_FILENAME)
+    assert "Not available" in doc
+    assert "what each phase cost but not what it bought" in doc
+
+
+def test_unlabelled_agents_are_flagged_in_coverage(tmp_path: Path):
+    d = tmp_path / "reports"
+    d.mkdir()
+    rows = [_call(prompt="## PROCESS SAFETY", call_index=i) for i in range(3)]
+    (d / R.CALLS_FILENAME).write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    doc = R.render(d / R.CALLS_FILENAME, d / R.OUTCOME_FILENAME)
+    assert R.UNLABELLED in doc
+    assert "could not be given a role" in doc
+
+
+def test_coverage_counts_unpriced_and_untimed_calls(tmp_path: Path):
+    rows = [_call(usd=0, dt_s=0), _call(call_index=1)]
+    agents = R.agent_records(rows)
+    cov = R.coverage(rows, agents)
+    assert cov["unpriced_calls"] == 1 and cov["untimed_calls"] == 1
+
+
+def test_agent_key_is_dom_safe(reports: Path):
+    rows = R.load_calls(reports / R.CALLS_FILENAME)
+    for agent in R.agent_records(rows):
+        key = R.agent_key(agent)
+        assert key.replace("_", "").replace("-", "").isalnum()
+
+
+def test_call_payload_is_capped_and_reports_the_remainder(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(R, "MAX_CALLS_EMBEDDED", 2)
+    rows = [_call(call_index=i) for i in range(5)]
+    agents = R.agent_records(rows)
+    assert len(agents[0]["rows"]) == 2
+    assert agents[0]["rows_truncated"] == 3
+    assert '"more":3' in R._agent_payload(agents)
+
+
+def test_main_writes_the_file(reports: Path, tmp_path: Path, capsys):
+    out = tmp_path / "out" / "r.html"
+    assert R.main(["--reports-dir", str(reports), "-o", str(out)]) == 0
+    assert out.is_file() and out.stat().st_size > 1000
+    assert "wrote" in capsys.readouterr().out
+
+
+def test_main_refuses_a_directory_with_no_ledger(tmp_path: Path, capsys):
+    assert R.main(["--reports-dir", str(tmp_path)]) == 2
+    assert R.CALLS_FILENAME in capsys.readouterr().err

--- a/src/hyperloom/inference_optimizer/tests/test_geak_html_report_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_html_report_unit.py
@@ -277,3 +277,71 @@ def test_rendered_document_is_pure_ascii(reports: Path):
 def test_esc_folds_non_ascii_to_entities():
     assert R._esc("a—b") == "a&#8212;b"
     assert R._esc("<b>") == "&lt;b&gt;"
+
+
+def _with_integration(reports: Path, **over) -> dict:
+    outcome = json.loads((reports / R.OUTCOME_FILENAME).read_text())
+    integ = {
+        "candidate": "c0_triton",
+        "isolated_speedup": 1.3143,
+        "e2e_delta_pct": 3.538,
+        "e2e_throughput_tok_s": 6078.752,
+        "amdahl_ceiling_pct": 5.86,
+        "gate": "stack",
+        "gsm8k_ref": 0.89,
+        "gsm8k_cand": 0.89,
+        "reason": "provisional stack, authoritative call deferred",
+    }
+    integ.update(over)
+    for stage in outcome["stages"]:
+        if stage.get("kind") == "kernel":
+            stage["integration"] = integ
+    (reports / R.OUTCOME_FILENAME).write_text(json.dumps(outcome))
+    return outcome
+
+
+def test_a_validated_kernel_beats_the_opbench_ceiling(reports: Path):
+    """The A/B of a kernel the run wrote is the result; the ceiling is a bound.
+
+    opbench races library backends, so an unbeaten incumbent records 1.0000x and
+    a 0.00% ceiling -- which says nothing about the candidate the run authored.
+    Reading only the ceiling reports a real measured win as nothing.
+    """
+    outcome = _with_integration(reports)
+    rows = R.load_calls(reports / R.CALLS_FILENAME)
+    joined = R.join_outcome(R.phase_records(rows, R.agent_records(rows)), outcome)
+    kernel = next(p["outcome"] for p in joined if p["outcome"] and p["outcome"]["kind"] == "kernel")
+    assert kernel["gain_pct"] == pytest.approx(3.538)
+
+
+def test_the_opbench_ceiling_is_used_when_nothing_was_validated(reports: Path):
+    outcome = R.load_outcome(reports / R.OUTCOME_FILENAME)
+    rows = R.load_calls(reports / R.CALLS_FILENAME)
+    joined = R.join_outcome(R.phase_records(rows, R.agent_records(rows)), outcome)
+    kernel = next(p["outcome"] for p in joined if p["outcome"] and p["outcome"]["kind"] == "kernel")
+    assert kernel["gain_pct"] == pytest.approx(0.0)
+
+
+def test_a_validated_kernel_renders_its_gain_and_its_caveat(reports: Path):
+    """The harness's own verdict travels with the number, caveats included."""
+    outcome = _with_integration(reports)
+    rows = R.load_calls(reports / R.CALLS_FILENAME)
+    joined = R.join_outcome(R.phase_records(rows, R.agent_records(rows)), outcome)
+    html = R._performance_section(R.performance_ladder(joined, outcome))
+    assert "+3.54%" in html
+    assert "end to end" in html
+    assert "c0_triton" in html
+    assert "gsm8k 0.89" in html
+    assert "provisional stack" in html
+    assert "no measured end-to-end throughput" not in html
+
+
+def test_a_validated_kernel_shows_cost_per_percent(reports: Path):
+    outcome = _with_integration(reports)
+    rows = R.load_calls(reports / R.CALLS_FILENAME)
+    phases = R.phase_records(rows, R.agent_records(rows))
+    joined = R.join_outcome(phases, outcome)
+    total = sum(p["usd"] for p in phases)
+    html = R._outcome_section(joined, total, outcome)
+    assert "+3.54%" in html
+    assert "measured A/B of the kernel this run wrote" in html

--- a/src/hyperloom/inference_optimizer/tests/test_geak_html_report_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_html_report_unit.py
@@ -363,3 +363,47 @@ def test_grid_columns_can_shrink_and_scroll_rather_than_overlap(reports):
         head = body.index(header)
         opener = body.rindex("<table>", 0, head)
         assert body[:opener].rstrip().endswith('<div class="scroll">'), header
+
+
+def test_a_run_whose_ledger_was_lost_still_gets_its_outcome_page(reports):
+    """The ledger and the outcome have different lifetimes; losing one is not losing both.
+
+    Claude Code writes the ledger into a config home the run does not own, so a
+    run can finish, measure a real result, and have no ledger left. That run's
+    measured outcome is still worth a page.
+    """
+    (reports / "geak_calls.jsonl").unlink()
+    html = R.render(reports / "geak_calls.jsonl", reports / "geak_outcome.json", None)
+    assert "no ledger" in html
+    # Never a dollar figure, a call count or a token total: those would be zeros
+    # standing in for numbers that are simply absent.
+    assert "Total spend" not in html and "$0.00" not in html
+    assert "Cost per +1%" not in html
+    # The empty spend sections are omitted, not rendered headed and rowless.
+    for gone in ('id="phases"', 'id="deep"', 'id="delegate"'):
+        assert gone not in html
+    # It says which file it read, and does not credit the one it did not.
+    assert "geak_outcome.json</code>" in html
+    assert "geak_calls.jsonl</code>" not in html
+    # The measured half is reported in full.
+    assert "P4 ConfigSweep" in html
+
+
+def test_load_calls_treats_a_missing_ledger_as_empty_not_fatal(tmp_path):
+    """A missing ledger is a fact about durability, not a parse error."""
+    assert R.load_calls(tmp_path / "absent.jsonl") == []
+
+
+def test_main_needs_one_of_the_two_files_and_says_which_are_missing(tmp_path, capsys):
+    """Both files absent is the only case with nothing to render."""
+    assert R.main(["--reports-dir", str(tmp_path), "-o", str(tmp_path / "x.html")]) == 2
+    assert "neither" in capsys.readouterr().err
+
+
+def test_main_renders_the_outcome_alone_and_warns_that_it_did(reports, capsys):
+    """Rendering half a report is a warning, not a silent success or a failure."""
+    (reports / "geak_calls.jsonl").unlink()
+    out = reports / "outcome_only.html"
+    assert R.main(["--reports-dir", str(reports), "-o", str(out)]) == 0
+    assert "rendering the outcome half only" in capsys.readouterr().err
+    assert out.is_file() and out.read_text(encoding="utf-8").isascii()

--- a/src/hyperloom/inference_optimizer/tests/test_geak_html_report_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_html_report_unit.py
@@ -230,3 +230,50 @@ def test_main_writes_the_file(reports: Path, tmp_path: Path, capsys):
 def test_main_refuses_a_directory_with_no_ledger(tmp_path: Path, capsys):
     assert R.main(["--reports-dir", str(tmp_path)]) == 2
     assert R.CALLS_FILENAME in capsys.readouterr().err
+
+
+def test_performance_ladder_ranks_measured_gains_only(reports: Path):
+    """Share is a stage's own tok/s gain over the summed measured gains."""
+    rows = R.load_calls(reports / R.CALLS_FILENAME)
+    joined = R.join_outcome(R.phase_records(rows, R.agent_records(rows)), R.load_outcome(reports / R.OUTCOME_FILENAME))
+    ladder = R.performance_ladder(joined, R.load_outcome(reports / R.OUTCOME_FILENAME))
+    kinds = [s["kind"] for s in ladder["steps"]]
+    assert kinds == ["reference", "delta"]
+    delta = ladder["steps"][1]
+    assert delta["abs_gain"] == pytest.approx(50.0)
+    assert delta["share"] == pytest.approx(1.0)
+    assert delta["usd"] == pytest.approx(0.3)
+    assert [p["phase"] for p in ladder["kernels"]] == ["P8 HeadKernel h0"]
+
+
+def test_performance_ladder_without_an_outcome_is_empty(reports: Path):
+    rows = R.load_calls(reports / R.CALLS_FILENAME)
+    joined = R.join_outcome(R.phase_records(rows, R.agent_records(rows)), None)
+    assert R.performance_ladder(joined, None) == {}
+
+
+def test_performance_section_says_unmeasured_rather_than_zero():
+    html = R._performance_section({})
+    assert "not the same as zero" in html
+    assert "0.00%" not in html
+
+
+def test_performance_section_renders_the_ladder(reports: Path):
+    rows = R.load_calls(reports / R.CALLS_FILENAME)
+    outcome = R.load_outcome(reports / R.OUTCOME_FILENAME)
+    joined = R.join_outcome(R.phase_records(rows, R.agent_records(rows)), outcome)
+    html = R._performance_section(R.performance_ladder(joined, outcome))
+    assert "+50.00%" in html
+    assert "baseline" in html
+    assert "no measured end-to-end throughput" in html
+
+
+def test_rendered_document_is_pure_ascii(reports: Path):
+    """A mis-decoded em dash is unreadable and gives the reader no clue why."""
+    doc = R.render(reports / R.CALLS_FILENAME, reports / R.OUTCOME_FILENAME)
+    assert doc.isascii()
+
+
+def test_esc_folds_non_ascii_to_entities():
+    assert R._esc("a—b") == "a&#8212;b"
+    assert R._esc("<b>") == "&lt;b&gt;"

--- a/src/hyperloom/inference_optimizer/tests/test_geak_html_report_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_html_report_unit.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import pytest
 
+from hyperloom.inference_optimizer.tools import _report_agents as A
+from hyperloom.inference_optimizer.tools._report_html import sparkline
 from hyperloom.inference_optimizer.tools import render_geak_html_report as R
 
 
@@ -166,8 +168,8 @@ def test_pct_says_not_measured_for_none():
 
 
 def test_sparkline_of_no_data_says_so():
-    assert "no data" in R._sparkline([])
-    assert "<svg" in R._sparkline([1.0, 2.0, 3.0])
+    assert "no data" in sparkline([])
+    assert "<svg" in sparkline([1.0, 2.0, 3.0])
 
 
 def test_render_produces_a_self_contained_document(reports: Path):
@@ -212,7 +214,8 @@ def test_agent_key_is_dom_safe(reports: Path):
 
 
 def test_call_payload_is_capped_and_reports_the_remainder(tmp_path: Path, monkeypatch):
-    monkeypatch.setattr(R, "MAX_CALLS_EMBEDDED", 2)
+    # The cap lives in the shared deep-dive module both reports render through.
+    monkeypatch.setattr(A, "MAX_CALLS_EMBEDDED", 2)
     rows = [_call(call_index=i) for i in range(5)]
     agents = R.agent_records(rows)
     assert len(agents[0]["rows"]) == 2

--- a/src/hyperloom/inference_optimizer/tests/test_geak_html_report_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_geak_html_report_unit.py
@@ -345,3 +345,21 @@ def test_a_validated_kernel_shows_cost_per_percent(reports: Path):
     html = R._outcome_section(joined, total, outcome)
     assert "+3.54%" in html
     assert "measured A/B of the kernel this run wrote" in html
+
+
+def test_grid_columns_can_shrink_and_scroll_rather_than_overlap(reports):
+    """The per-phase blocks sit in a grid; grid items must be allowed to shrink.
+
+    A grid item defaults to ``min-width:auto``, so a table full of ``nowrap``
+    cells refuses to shrink below its min-content width and paints over the
+    column beside it. The fix is two halves and both must hold: let the item
+    shrink, and give the table its own scroll container so an genuinely wide
+    table scrolls inside its column instead of across its neighbour.
+    """
+    assert ".grid2>*{min-width:0}" in R.CSS
+    html = R.render(reports / "geak_calls.jsonl", reports / "geak_outcome.json", None)
+    body = html.split('<div class="grid2">', 1)[1]
+    for header in ("<th>Position</th>", "<th>Agents</th>", "<th>Tool</th>"):
+        head = body.index(header)
+        opener = body.rindex("<table>", 0, head)
+        assert body[:opener].rstrip().endswith('<div class="scroll">'), header

--- a/src/hyperloom/inference_optimizer/tests/test_hyperloom_html_report_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_hyperloom_html_report_unit.py
@@ -232,3 +232,113 @@ def test_unrelated_rows_without_call_ids_still_count_separately() -> None:
     root, _ = build_tree([a, b], [])
     assert root.roll_up().calls == 2
     assert root.roll_up().isl == 107
+
+
+def test_agent_identity_uses_the_task_path_and_the_recorded_role():
+    """A specialist's conversation is its instance, not its turn."""
+    agent, role = H.agent_identity(_call(task_path="specialist/abc123/turn-7", component="specialist"))
+    assert agent == "specialist/abc123"
+    assert role == "specialist"
+
+    agent, role = H.agent_identity(_call(task_path="critic", component="critic", role="critic"))
+    assert (agent, role) == ("critic", "critic")
+
+
+def test_agent_identity_never_invents_a_role_from_the_id():
+    """An id is an id. With nothing recorded and nothing to fall back on, say so."""
+    _, role = H.agent_identity(_call(task_path="specialist/abc123/turn-1", component="specialist", role=None))
+    assert role == "specialist"
+    _, role = H.agent_identity({"task_path": "lone", "component": "lone"})
+    assert role == H.UNLABELLED
+
+
+def test_normalise_renumbers_position_within_each_conversation():
+    """The position curve must measure position in a conversation, not in the session."""
+    rows = [
+        _call(task_path="specialist/a/turn-3", turn=3, api_call_index=1),
+        _call(task_path="specialist/a/turn-1", turn=1, api_call_index=1),
+        _call(task_path="specialist/b/turn-9", turn=9, api_call_index=1),
+    ]
+    out = H.normalise(rows)
+    by_agent = {}
+    for row in out:
+        by_agent.setdefault(row["agent"], []).append(row["call_index"])
+    assert by_agent["specialist/a"] == [0, 1]
+    assert by_agent["specialist/b"] == [0]
+
+
+def test_normalise_puts_thinking_beside_output_not_inside_it():
+    """Hyperloom's ledger convention, the inverse of GEAK's. Getting it wrong double-counts."""
+    (row,) = H.normalise([_call(osl=0, output_tokens=100, reasoning_output_tokens=40)])
+    assert row["thinking"] == 40
+    assert row["osl"] == 140
+
+
+def test_role_falls_back_to_the_geak_prompt_only_when_nothing_recorded_one():
+    """Grafted GEAK rows carry a prompt and no role; the derivation matches GEAK's own page."""
+    assert H.hyperloom_role_of([{"role": "critic", "prompt": "You are the director."}])["role"] == "critic"
+    assert H.hyperloom_role_of([{"prompt": "You are the director. PHASE=setup."}])["role"] == "director"
+    assert H.hyperloom_role_of([{"prompt": ""}])["role"] == H.UNLABELLED
+
+
+def test_geak_eval_dir_reads_the_record_and_requires_the_directory(tmp_path: Path):
+    """A path the run recorded but that is not there is not an eval dir."""
+    sd = tmp_path / "sess"
+    (sd / "geak").mkdir(parents=True)
+    (sd / "geak" / "result.json").write_text(json.dumps({"eval_dir": str(sd / "geak" / "gone")}), encoding="utf-8")
+    assert H.geak_eval_dir(sd) is None
+
+    (sd / "geak" / "e2e_cycle0").mkdir()
+    (sd / "geak" / "result.json").write_text(
+        json.dumps({"eval_dir": str(sd / "geak" / "e2e_cycle0")}), encoding="utf-8"
+    )
+    assert H.geak_eval_dir(sd) == sd / "geak" / "e2e_cycle0"
+
+
+def test_graft_replaces_the_harvested_rows_rather_than_adding_to_them(tmp_path: Path):
+    """The harvested rows and GEAK's own describe the same calls; keeping both bills twice."""
+    sd = tmp_path / "sess"
+    reports = sd / "geak" / "e2e_cycle0" / "reports"
+    reports.mkdir(parents=True)
+    (sd / "geak" / "result.json").write_text(
+        json.dumps({"eval_dir": str(sd / "geak" / "e2e_cycle0")}), encoding="utf-8"
+    )
+    _write(
+        reports / H.GEAK_LEDGER,
+        [{"phase": "P8 HeadKernel h0", "agent": "a1", "call_index": 0, "usd": 4.0, "isl": 10, "osl": 1}],
+    )
+    rows = [
+        {"phase": "KERNEL_AGENT", "agent": "geak/runner", "component": "geak", "usd": 9.0},
+        {"phase": "PRELUDE", "agent": "baseline", "component": "orchestration", "usd": 1.0},
+    ]
+    out, status = H.graft_geak(sd, rows)
+
+    assert status["grafted"] is True
+    assert status["dropped_harvested"] == 1
+    assert [r["phase"] for r in out if r["component"] == "geak"] == ["KERNEL_AGENT / P8 HeadKernel h0"]
+    assert sum(r["usd"] for r in out) == 5.0
+
+
+def test_graft_that_finds_no_ledger_changes_nothing_and_says_why(tmp_path: Path):
+    """A run whose GEAK ledger did not survive keeps its harvested rows and an explanation."""
+    sd = tmp_path / "sess"
+    (sd / "geak" / "e2e_cycle0" / "reports").mkdir(parents=True)
+    (sd / "geak" / "result.json").write_text(
+        json.dumps({"eval_dir": str(sd / "geak" / "e2e_cycle0")}), encoding="utf-8"
+    )
+    rows = [{"phase": "KERNEL_AGENT", "agent": "geak/runner", "component": "geak", "usd": 9.0}]
+    out, status = H.graft_geak(sd, rows)
+
+    assert out == rows
+    assert status["grafted"] is False
+    assert H.GEAK_LEDGER in status["reason"]
+
+
+def test_the_page_carries_the_deep_dive_and_the_delegation_signals(session: Path):
+    """Both pages answer the same questions inside a phase, so both must render them."""
+    html = H.render(session)
+    for heading in ("Cost by position in the conversation", "Agents, most expensive first"):
+        assert heading in html
+    assert 'id="delegate"' in html
+    assert "const AGENTS=" in html
+    assert "no GEAK eval directory is named" in html

--- a/src/hyperloom/inference_optimizer/tests/test_hyperloom_html_report_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_hyperloom_html_report_unit.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the Hyperloom session HTML report.
+
+The report's value is that a reader can trust a number on it, so the tests are
+mostly about honesty rather than layout: an unmeasured outcome must not render
+as zero, an unpriced call must not be counted as free, and gain must reach a
+phase only through the declared source map.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hyperloom.inference_optimizer.tools import render_hyperloom_html_report as H
+
+
+def _write(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+
+
+def _call(**over) -> dict:
+    row = {
+        "call_id": "c1",
+        "phase": "FRAMEWORK_AGENT",
+        "task_path": "explore/attempt-1",
+        "model": "claude-opus-5",
+        "isl": 1000,
+        "osl": 100,
+        "input_tokens": 900,
+        "output_tokens": 100,
+        "cache_read_input_tokens": 100,
+        "cost_usd": 0.5,
+        "cost_source": "priced",
+        "latency_ms": 2000,
+        "api_call_index": 1,
+        "turn": 1,
+        "tool_call_count": 1,
+    }
+    row.update(over)
+    return row
+
+
+@pytest.fixture()
+def session(tmp_path: Path) -> Path:
+    """A minimal but realistic session: two phases, a detailed turn and a bare one."""
+    sd = tmp_path / "model" / "20260101T000000Z-abcd1234"
+    trace = sd / "reports" / "trace"
+    _write(
+        trace / "llm_calls.jsonl",
+        [
+            _call(call_id="t1"),
+            _call(call_id="t2", phase="PRELUDE", task_path="baseline", cost_usd=0.25),
+        ],
+    )
+    # t1 expanded into two API calls; t2 did not, so it is counted from its turn row.
+    _write(
+        trace / "llm_calls_detail.jsonl",
+        [
+            _call(call_id="t1", api_call_index=1, cost_usd=0.30),
+            _call(call_id="t1", api_call_index=2, cost_usd=0.40, isl=2000),
+        ],
+    )
+    (sd / H.BREAKDOWN_FILENAME).write_text(
+        json.dumps(
+            {
+                "metadata": {"session": {"session_id": "sess-42", "code_revision": "abc1234"}},
+                "model_info": {"model_type": "qwen3"},
+                "outcome": {
+                    "baseline": {"throughput_tok_s_per_gpu": 100.0},
+                    "final": {"throughput_tok_s_per_gpu": 120.0, "gain_pct": 20.0, "action_path": ["explore:x"]},
+                    "status": "completed",
+                    "stop_reason": "target_reached",
+                    "stage_reached": "close",
+                    "validation": {
+                        "unattributed_gain_pct": 0.0,
+                        "reconciliation_gap_pct": 0.0,
+                        "attribution": {
+                            "available": True,
+                            "by_source": {"framework_agent": {"keep_count": 1, "total_gain_pct": 20.0}},
+                        },
+                    },
+                },
+                "phase_timeline": [
+                    {"phase": "FRAMEWORK_AGENT", "action": "env", "decision": "KEEP", "key_metric": 120.0},
+                    {"phase": "PRELUDE", "action": "baseline", "decision": "KEEP", "key_metric": 100.0},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return sd
+
+
+def test_spend_is_counted_once_per_call_not_once_per_turn(session: Path):
+    """A detailed turn is counted from its detail rows only; a bare turn from itself."""
+    turns, details = H.load_ledgers(session)
+    rows = H.call_rows(turns, details)
+    assert len(rows) == 3  # two detail rows for t1, plus t2 which had none
+    assert round(sum(H.num(r["cost_usd"]) for r in rows), 6) == 0.95
+
+
+def test_a_phase_the_map_does_not_cover_is_unattributed_not_credited(session: Path):
+    """PRELUDE spends real money and is credited with no gain, and the page says so."""
+    page = H.render(session)
+    turns, details = H.load_ledgers(session)
+    root, _ = H.build_tree(turns, details)
+    joined = H.join_gain(H.phase_records(root), H.outcome_ladder(H.load_breakdown(session / H.BREAKDOWN_FILENAME)))
+    by_phase = {r["phase"]: r for r in joined}
+    assert by_phase["FRAMEWORK_AGENT"]["gain_pct"] == 20.0
+    assert by_phase["FRAMEWORK_AGENT"]["source"] == "framework_agent"
+    assert by_phase["PRELUDE"]["gain_pct"] is None
+    assert "not attributed" in page
+
+
+def test_a_missing_breakdown_says_not_recorded_rather_than_zero(session: Path):
+    """No outcome file must never render as a 0% gain."""
+    (session / H.BREAKDOWN_FILENAME).unlink()
+    page = H.render(session)
+    assert "not recorded" in page
+    assert "+0.00%" not in page
+
+
+def test_unpriced_calls_are_declared_a_floor(session: Path):
+    """A call with no price is excluded from the total and confessed in the banner."""
+    trace = session / "reports" / "trace"
+    _write(
+        trace / "llm_calls.jsonl",
+        [_call(call_id="t1"), _call(call_id="t3", cost_source="unavailable", cost_usd=0.0)],
+    )
+    turns, details = H.load_ledgers(session)
+    _, cov = H.build_tree(turns, details)
+    assert cov["calls_unpriced"] >= 1
+    assert "left out of the USD total" in H.render(session)
+
+
+def test_growth_curve_drops_buckets_too_small_to_have_a_median():
+    """A single call is not a median, so its bucket is not plotted."""
+    rows = [_call(api_call_index=1, isl=10) for _ in range(3)] + [_call(api_call_index=2, isl=99)]
+    curve = H.growth_curve(rows)
+    assert [point["index"] for point in curve] == [1]
+    assert curve[0]["isl_median"] == 10
+
+
+def test_model_mix_orders_by_spend(session: Path):
+    """The dearest model is first, and an unrecorded model is named, not dropped."""
+    mix = H.model_mix([_call(model="a", cost_usd=1.0), _call(model=None, cost_usd=2.0)])
+    assert [entry["model"] for entry in mix] == ["unrecorded", "a"]
+
+
+def test_identity_prefers_what_the_run_recorded(session: Path):
+    """The recorded session id wins over the directory name it happens to sit in."""
+    ident = H.session_identity(session, H.load_breakdown(session / H.BREAKDOWN_FILENAME))
+    assert ident["session_id"] == "sess-42"
+    assert ident["model"] == "qwen3"
+    assert H.session_identity(session, None)["session_id"] == session.name
+
+
+def test_the_page_is_pure_ascii_and_self_contained(session: Path):
+    """It is read off shared storage through viewers that ignore the charset."""
+    page = H.render(session)
+    assert page.isascii()
+    assert "http://" not in page and "https://" not in page
+    assert page.startswith("<!doctype html>")
+
+
+def test_every_phase_of_the_session_appears_not_just_the_kernel_one(session: Path):
+    """The point of this report: a session's bill is not spent in one phase."""
+    page = H.render(session)
+    assert "FRAMEWORK_AGENT" in page and "PRELUDE" in page
+
+
+def test_main_refuses_a_session_with_no_ledger(tmp_path: Path, capsys):
+    """Exit 2 and say why, rather than writing a confident empty page."""
+    assert H.main(["--session-dir", str(tmp_path), "-o", str(tmp_path / "x.html")]) == 2
+    assert "no llm_calls.jsonl" in capsys.readouterr().err
+
+
+def test_main_writes_the_page(session: Path, tmp_path: Path):
+    """The CLI writes where it is told and reports the size."""
+    out = tmp_path / "out" / "report.html"
+    assert H.main(["--session-dir", str(session), "-o", str(out)]) == 0
+    assert out.read_text(encoding="utf-8").startswith("<!doctype html>")

--- a/src/hyperloom/inference_optimizer/tests/test_hyperloom_html_report_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_hyperloom_html_report_unit.py
@@ -17,6 +17,8 @@ from pathlib import Path
 import pytest
 
 from hyperloom.inference_optimizer.tools import render_hyperloom_html_report as H
+from hyperloom.inference_optimizer.tools.dump_llm_call_report import build_tree
+from hyperloom.inference_optimizer.tools.render_hyperloom_html_report import call_rows
 
 
 def _write(path: Path, rows: list[dict]) -> None:
@@ -186,3 +188,47 @@ def test_main_writes_the_page(session: Path, tmp_path: Path):
     out = tmp_path / "out" / "report.html"
     assert H.main(["--session-dir", str(session), "-o", str(out)]) == 0
     assert out.read_text(encoding="utf-8").startswith("<!doctype html>")
+
+
+def test_turn_and_detail_without_call_ids_are_one_call_not_two() -> None:
+    """A producer that wrote no call id must not have its calls counted twice.
+
+    The specialist and critic backends recorded neither the turn row's
+    ``call_id`` nor the detail row's. Joining on the raw field made the detail
+    row look orphaned and its turn look undetailed, so the same API call landed
+    in the totals twice -- observed on a real session as 11,898,833 input
+    tokens counted a second time.
+    """
+    turn = {
+        "session_id": "s1",
+        "task_path": "specialist/abc/turn-1",
+        "turn": 1,
+        "phase": "PRELUDE",
+        "input_tokens": 100,
+        "output_tokens": 10,
+        "cost_usd": None,
+    }
+    detail = dict(turn)
+    detail["api_call_index"] = None
+
+    root, cov = build_tree([turn], [detail])
+    totals = root.roll_up()
+
+    assert totals.calls == 1, "the turn and its detail row are one API call"
+    assert totals.isl == 100
+    assert totals.osl == 10
+    assert cov["detail_rows_orphaned"] == 0
+    assert cov["turns_with_detail"] == 1
+    assert cov["turns_without_detail"] == 0
+
+    assert len(call_rows([turn], [detail])) == 1, "the flat row list must agree with the tree"
+
+
+def test_unrelated_rows_without_call_ids_still_count_separately() -> None:
+    """The fallback join must key on the turn, not lump every id-less row together."""
+    a = {"session_id": "s1", "task_path": "specialist/abc/turn-1", "turn": 1, "input_tokens": 100}
+    b = {"session_id": "s1", "task_path": "specialist/xyz/turn-1", "turn": 1, "input_tokens": 7}
+
+    root, _ = build_tree([a, b], [])
+    assert root.roll_up().calls == 2
+    assert root.roll_up().isl == 107

--- a/src/hyperloom/inference_optimizer/tests/test_llm_call_report_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_llm_call_report_unit.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hyperloom.inference_optimizer.tools import dump_llm_call_report as rpt
+
+
+def _turn(call_id: str, phase: str, task_path: str, **kw) -> dict:
+    row = {
+        "session_id": "s1",
+        "component": "orchestration",
+        "call_id": call_id,
+        "phase": phase,
+        "task_path": task_path,
+        "model": "m",
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "reasoning_output_tokens": 5,
+        "latency_ms": 1000,
+        "cost_usd": 1.0,
+        "cost_input_usd": 0.6,
+        "cost_output_usd": 0.3,
+        "cost_thinking_usd": 0.1,
+        "cost_source": "derived",
+        "status": "ok",
+    }
+    row.update(kw)
+    return row
+
+
+def _detail(call_id: str, index: int, phase: str, task_path: str, **kw) -> dict:
+    row = {
+        "session_id": "s1",
+        "component": "orchestration",
+        "call_id": call_id,
+        "api_call_index": index,
+        "phase": phase,
+        "task_path": task_path,
+        "model": "m",
+        "isl": 100,
+        "osl": 25,
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "reasoning_output_tokens": 5,
+        "latency_ms": 500,
+        "thinking_ms": 100,
+        "output_ms": 400,
+        "cost_usd": 0.5,
+        "cost_source": "derived",
+        "tool_calls": [{"tool": "Bash"}],
+        "status": "ok",
+    }
+    row.update(kw)
+    return row
+
+
+def _write(session_dir: Path, turns: list[dict], details: list[dict], ext: dict | None = None) -> None:
+    trace = session_dir / "reports" / "trace"
+    (trace / "ext").mkdir(parents=True, exist_ok=True)
+    (trace / "llm_calls.jsonl").write_text("".join(json.dumps(r) + "\n" for r in turns))
+    (trace / "llm_calls_detail.jsonl").write_text("".join(json.dumps(r) + "\n" for r in details))
+    for name, rows in (ext or {}).items():
+        (trace / "ext" / name).write_text("".join(json.dumps(r) + "\n" for r in rows))
+
+
+def test_a_detailed_turn_is_counted_from_its_detail_rows_only(tmp_path: Path):
+    sd = tmp_path / "s"
+    _write(
+        sd,
+        [_turn("c1", "PROFILE", "profile/plan")],
+        [_detail("c1", 0, "PROFILE", "profile/plan"), _detail("c1", 1, "PROFILE", "profile/plan")],
+    )
+    root, coverage = rpt.build_tree(*rpt.load_ledgers(sd))
+    assert root.total.calls == 2
+    assert root.total.turns == 1
+    # 2 x 0.5, not 2 x 0.5 + the turn's own 1.0.
+    assert root.total.usd_total == pytest.approx(1.0)
+    assert coverage["turns_with_detail"] == 1
+    assert coverage["turns_without_detail"] == 0
+
+
+def test_an_undetailed_turn_is_counted_once_from_the_turn_row(tmp_path: Path):
+    sd = tmp_path / "s"
+    _write(sd, [_turn("c1", "PROFILE", "profile/plan")], [])
+    root, coverage = rpt.build_tree(*rpt.load_ledgers(sd))
+    assert root.total.calls == 1
+    assert root.total.usd_total == pytest.approx(1.0)
+    # ISL/OSL are absent from a turn row and derived on the detail writer's rule.
+    assert root.total.isl == 100
+    assert root.total.osl == 25
+    assert coverage["turns_without_detail"] == 1
+
+
+def test_the_tree_nests_by_phase_then_by_task_path_segment(tmp_path: Path):
+    sd = tmp_path / "s"
+    _write(sd, [_turn("c1", "KERNEL_AGENT", "geak/HeadKernel/lane-a")], [])
+    root, _ = rpt.build_tree(*rpt.load_ledgers(sd))
+    node = root.children["KERNEL_AGENT"].children["geak"].children["HeadKernel"].children["lane-a"]
+    assert node.total.calls == 1
+    assert root.children["KERNEL_AGENT"].total.usd_total == pytest.approx(1.0)
+
+
+def test_a_parent_total_is_the_sum_of_its_children(tmp_path: Path):
+    sd = tmp_path / "s"
+    _write(
+        sd,
+        [_turn("c1", "EXPLORE", "explore/a"), _turn("c2", "EXPLORE", "explore/b")],
+        [],
+    )
+    root, _ = rpt.build_tree(*rpt.load_ledgers(sd))
+    explore = root.children["EXPLORE"].children["explore"]
+    assert explore.total.usd_total == pytest.approx(
+        sum(k.total.usd_total for k in explore.children.values())
+    )
+
+
+def test_rows_with_no_phase_or_path_get_their_own_labelled_node(tmp_path: Path):
+    sd = tmp_path / "s"
+    _write(sd, [_turn("c1", "", "")], [])
+    root, _ = rpt.build_tree(*rpt.load_ledgers(sd))
+    assert root.children[rpt.UNPHASED].children[rpt.UNPATHED].total.calls == 1
+
+
+def test_an_unpriced_call_is_excluded_from_cost_and_flagged_in_coverage(tmp_path: Path):
+    sd = tmp_path / "s"
+    _write(
+        sd,
+        [
+            _turn("c1", "PROFILE", "p"),
+            _turn("c2", "PROFILE", "p", cost_source="unavailable", cost_usd=None),
+        ],
+        [],
+    )
+    root, coverage = rpt.build_tree(*rpt.load_ledgers(sd))
+    assert root.total.calls == 2
+    assert root.total.calls_priced == 1
+    assert root.total.usd_total == pytest.approx(1.0)
+    assert coverage["calls_unpriced"] == 1
+
+
+def test_ext_shards_are_split_into_turn_and_detail_streams(tmp_path: Path):
+    sd = tmp_path / "s"
+    _write(
+        sd,
+        [],
+        [],
+        ext={
+            "geak-7.jsonl": [_turn("g1", "KERNEL_AGENT", "geak/HeadKernel", component="geak")],
+            "geak-7.detail.jsonl": [
+                _detail("g1", 0, "KERNEL_AGENT", "geak/HeadKernel", component="geak")
+            ],
+        },
+    )
+    root, coverage = rpt.build_tree(*rpt.load_ledgers(sd))
+    # One turn, expanded into one API call -- not two calls.
+    assert root.total.calls == 1
+    assert root.total.turns == 1
+    assert coverage["turns_with_detail"] == 1
+    assert rpt._has_node(root, "geak")
+
+
+def test_a_detail_row_with_no_turn_row_is_counted_and_reported_as_an_orphan(tmp_path: Path):
+    sd = tmp_path / "s"
+    _write(sd, [], [_detail("gone", 0, "PROFILE", "p")])
+    root, coverage = rpt.build_tree(*rpt.load_ledgers(sd))
+    assert root.total.calls == 1
+    assert coverage["detail_rows_orphaned"] == 1
+
+
+def test_markdown_names_the_missing_geak_subtree(tmp_path: Path):
+    sd = tmp_path / "s"
+    _write(sd, [_turn("c1", "PROFILE", "p")], [])
+    root, coverage = rpt.build_tree(*rpt.load_ledgers(sd))
+    md = rpt.render_markdown("s", root, coverage)
+    assert "no `geak` subtree is present" in md
+
+
+def test_trimming_the_tree_does_not_change_any_total(tmp_path: Path):
+    sd = tmp_path / "s"
+    _write(sd, [_turn("c1", "KERNEL_AGENT", "geak/HeadKernel/lane-a/kernel-3")], [])
+    root, _ = rpt.build_tree(*rpt.load_ledgers(sd))
+    before = root.total.as_dict()
+    rpt._trim(root, 0, 2)
+    root.roll_up()
+    assert root.total.as_dict() == before
+    assert root.children["KERNEL_AGENT"].children["geak"].children == {}
+
+
+def test_main_writes_both_artifacts(tmp_path: Path, monkeypatch):
+    sd = tmp_path / "s"
+    _write(sd, [_turn("c1", "PROFILE", "p")], [])
+    monkeypatch.delenv("USER_DATA_PATH", raising=False)
+    assert rpt.main(["-s", str(sd)]) == 0
+    payload = json.loads((sd / "reports" / "llm_call_report.json").read_text())
+    assert payload["tree"]["totals"]["calls"] == 1
+    assert (sd / "reports" / "llm_call_report.md").read_text().startswith("# LLM call report")
+
+
+def test_main_refuses_a_session_with_no_ledger(tmp_path: Path):
+    (tmp_path / "empty").mkdir()
+    assert rpt.main(["-s", str(tmp_path / "empty")]) == 2
+
+
+def test_a_truncated_final_line_is_skipped_not_fatal(tmp_path: Path):
+    sd = tmp_path / "s"
+    _write(sd, [_turn("c1", "PROFILE", "p")], [])
+    path = sd / "reports" / "trace" / "llm_calls.jsonl"
+    path.write_text(path.read_text() + '{"session_id": "s1", "compo')
+    root, _ = rpt.build_tree(*rpt.load_ledgers(sd))
+    assert root.total.calls == 1

--- a/src/hyperloom/inference_optimizer/tests/test_llm_trace_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_llm_trace_unit.py
@@ -193,3 +193,48 @@ def test_llm_trace_langfuse_mirror_failure_swallowed(tmp_path: Path, monkeypatch
     record = llm_trace.LLMCallRecord(session_id="s3", component="forge")
     # Must not raise even though the Langfuse mirror blows up.
     llm_trace.append_llm_call(session_dir=tmp_path, record=record)
+
+
+def test_widened_row_carries_the_cost_timing_and_path_columns(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(llm_trace, "_now_iso", lambda **_: "2026-01-01T00:00:00Z")
+    monkeypatch.setattr(llm_trace, "get_emitter", lambda _session_dir: None, raising=False)
+
+    row = llm_trace.LLMCallRecord(
+        session_id="s1",
+        component="orchestration",
+        task_path="KERNEL_AGENT/geak/HeadKernel",
+        api_calls=3,
+        tool_call_count=7,
+        ttft_ms=120,
+        thinking_ms=300,
+        output_ms=900,
+        stop_reason="end_turn",
+    ).to_row()
+    assert row["task_path"] == "KERNEL_AGENT/geak/HeadKernel"
+    assert row["task_depth"] == 3
+    assert (row["api_calls"], row["tool_call_count"]) == (3, 7)
+    assert (row["ttft_ms"], row["thinking_ms"], row["output_ms"]) == (120, 300, 900)
+    assert row["stop_reason"] == "end_turn"
+    assert set(row) == set(llm_trace._ROW_FIELDS)
+
+
+def test_an_unpriced_row_keeps_cost_none_rather_than_zero():
+    row = llm_trace.LLMCallRecord(
+        session_id="s1", component="orchestration", model="not-on-the-rate-card"
+    ).to_row()
+    assert row["cost_source"] == "unavailable"
+    assert row["cost_usd"] is None
+
+
+def test_append_honours_an_explicit_destination(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(llm_trace, "get_emitter", lambda _session_dir: None, raising=False)
+    dest = tmp_path / "ext" / "geak-9.jsonl"
+    llm_trace.append_llm_call(
+        session_dir=tmp_path,
+        record=llm_trace.LLMCallRecord(session_id="s1", component="geak"),
+        dest=dest,
+    )
+    assert len(dest.read_text().splitlines()) == 1
+    # Writing into the shared ledger from an out-of-process producer is what
+    # the dest argument exists to avoid.
+    assert not (tmp_path / "reports" / "trace" / "llm_calls.jsonl").exists()

--- a/src/hyperloom/inference_optimizer/tests/test_parse_usage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_parse_usage_unit.py
@@ -256,6 +256,50 @@ def test_parse_turn_usages_none_when_no_per_message_usage(tmp_path):
     assert pu.parse_claude_stream_json_turn_usages(log) == []
 
 
+def test_parse_turn_usages_carries_call_id_and_model(tmp_path):
+    """Identity travels with the counters: the row is priceable and joinable."""
+    log = tmp_path / "p.log"
+    log.write_text(
+        '{"type": "assistant", "message": {"id": "msg_1", "model": "claude-opus-5", '
+        '"usage": {"input_tokens": 10, "output_tokens": 1}}}\n'
+        '{"type": "assistant", "message": {"id": "msg_2", "model": "claude-opus-5", '
+        '"usage": {"input_tokens": 20, "output_tokens": 2}}}\n'
+        '{"type": "result", "usage": {"output_tokens": 500}}\n',
+        encoding="utf-8",
+    )
+    usages = pu.parse_claude_stream_json_turn_usages(log)
+    assert [u["call_id"] for u in usages] == ["msg_1", "msg_2"]
+    assert [u["model"] for u in usages] == ["claude-opus-5", "claude-opus-5"]
+
+
+def test_parse_turn_usages_omits_identity_keys_the_log_does_not_name(tmp_path):
+    """A missing model is an absent key, never an empty string that prices to 0."""
+    log = tmp_path / "p.log"
+    log.write_text(
+        '{"type": "assistant", "message": {"id": "msg_1", "usage": {"input_tokens": 10}}}\n',
+        encoding="utf-8",
+    )
+    (usage,) = pu.parse_claude_stream_json_turn_usages(log)
+    assert usage["call_id"] == "msg_1"
+    assert "model" not in usage
+
+
+def test_parse_turn_usages_identity_survives_block_collapse(tmp_path):
+    """The kept line of a multi-block response is the one carrying identity."""
+    block = (
+        '{{"type": "assistant", "message": {{"id": "msg_1", "model": "claude-opus-5", '
+        '"content": [{{"type": "{kind}"}}], "usage": {{"input_tokens": 10}}}}}}\n'
+    )
+    log = tmp_path / "p.log"
+    log.write_text(
+        block.format(kind="thinking") + block.format(kind="text"),
+        encoding="utf-8",
+    )
+    (usage,) = pu.parse_claude_stream_json_turn_usages(log)
+    assert usage["call_id"] == "msg_1"
+    assert usage["model"] == "claude-opus-5"
+
+
 # ---- parse_claude_stream_json_tool_calls ----
 
 

--- a/src/hyperloom/inference_optimizer/tests/test_pricing_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_pricing_unit.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hyperloom.orchestrator.trace import pricing
+
+
+@pytest.fixture(autouse=True)
+def _fresh_rates(monkeypatch, tmp_path: Path):
+    """Point pricing at a small, known rate card for every test here."""
+    card = tmp_path / "rates.yaml"
+    card.write_text(
+        "version: 1\n"
+        "defaults:\n"
+        "  cache_read: null\n"
+        "  cache_write: null\n"
+        "models:\n"
+        "  test-model:\n"
+        "    input: 1.0\n"
+        "    output: 10.0\n"
+        "    cache_read: 0.1\n"
+        "    cache_write: 2.0\n"
+        "  plain-model:\n"
+        "    input: 3.0\n"
+        "    output: 6.0\n"
+    )
+    monkeypatch.setenv("HYPERLOOM_LLM_PRICING_FILE", str(card))
+    pricing.load_rates(refresh=True)
+    yield
+    monkeypatch.delenv("HYPERLOOM_LLM_PRICING_FILE", raising=False)
+    pricing.load_rates(refresh=True)
+
+
+def test_normalize_model_strips_provider_prefix_and_tag():
+    assert pricing.normalize_model("Anthropic/Claude-Opus-5:thinking") == "claude-opus-5"
+    assert pricing.normalize_model(None) == ""
+
+
+def test_longest_prefix_match_wins():
+    assert pricing.rates_for("test-model-20260101").input == 1.0
+    assert pricing.rates_for("nothing-like-this") is None
+
+
+def test_derived_total_is_the_sum_of_its_parts():
+    cost = pricing.resolve_cost(
+        model="test-model",
+        tokens={
+            "input_tokens": 1_000_000,
+            "output_tokens": 1_000_000,
+            "reasoning_output_tokens": 1_000_000,
+            "cache_read_input_tokens": 1_000_000,
+            "cache_creation_input_tokens": 1_000_000,
+        },
+    )
+    assert cost.source == pricing.SOURCE_DERIVED
+    assert cost.input_usd == pytest.approx(1.0)
+    assert cost.output_usd == pytest.approx(10.0)
+    # Reasoning bills at the output rate, and is its own bucket.
+    assert cost.thinking_usd == pytest.approx(10.0)
+    assert cost.cache_usd == pytest.approx(2.1)
+    assert cost.total_usd == pytest.approx(
+        cost.input_usd + cost.output_usd + cost.thinking_usd + cost.cache_usd
+    )
+
+
+def test_unset_cache_rates_fall_back_to_the_input_rate():
+    cost = pricing.resolve_cost(
+        model="plain-model",
+        tokens={"cache_read_input_tokens": 1_000_000, "cache_creation_input_tokens": 1_000_000},
+    )
+    assert cost.cache_usd == pytest.approx(6.0)
+
+
+def test_provider_figure_wins_and_the_split_only_attributes_it():
+    cost = pricing.resolve_cost(
+        model="test-model",
+        tokens={"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+        provider_usd=110.0,
+    )
+    assert cost.source == pricing.SOURCE_PROVIDER
+    assert cost.total_usd == pytest.approx(110.0)
+    # Card says 1.0 in / 10.0 out; the provider's total is split in that ratio.
+    assert cost.input_usd == pytest.approx(10.0)
+    assert cost.output_usd == pytest.approx(100.0)
+
+
+def test_provider_figure_survives_an_unknown_model_without_a_split():
+    cost = pricing.resolve_cost(model="who-knows", tokens={"input_tokens": 5}, provider_usd=0.25)
+    assert cost.source == pricing.SOURCE_PROVIDER
+    assert cost.total_usd == pytest.approx(0.25)
+    assert cost.input_usd is None
+
+
+def test_unknown_model_and_no_provider_figure_is_unavailable():
+    cost = pricing.resolve_cost(model="who-knows", tokens={"input_tokens": 5})
+    assert cost.source == pricing.SOURCE_UNAVAILABLE
+    assert cost.total_usd is None
+    assert not cost.available

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_runner_helpers_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_runner_helpers_unit.py
@@ -405,3 +405,57 @@ def test_patch_path_within_bases_rejects_outside_paths(tmp_path):
     assert sr._patch_path_within_bases(Path("/etc/passwd"), bases) is False
     assert sr._patch_path_within_bases(worktree / ".." / "escape.patch", bases) is False
     assert sr._patch_path_within_bases(tmp_path / "sibling.patch", bases) is False
+
+
+# ---- specialist per-call join key ----
+
+
+def _trace_rows(session_dir):
+    """Return the (turn rows, detail rows) a traced specialist turn wrote."""
+    trace = session_dir / "reports" / "trace"
+    def _read(name):
+        path = trace / name
+        if not path.exists():
+            return []
+        return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    return _read("llm_calls.jsonl"), _read("llm_calls_detail.jsonl")
+
+
+def test_specialist_turn_keeps_the_backend_call_id(tmp_path):
+    """A backend that stamps a real id keeps it on both halves of the ledger."""
+    r = _runner(session_dir=tmp_path)
+    r._trace_specialist_llm_call(
+        task_id="task-a",
+        turn=3,
+        metadata={"input_tokens": 5, "output_tokens": 7, "call_id": "msg_real", "model": "claude-opus-5"},
+    )
+    turns, _ = _trace_rows(tmp_path)
+    assert [t["call_id"] for t in turns] == ["msg_real"]
+    assert [t["model"] for t in turns] == ["claude-opus-5"]
+
+
+def test_specialist_turn_synthesizes_a_join_key_when_the_backend_omits_one(tmp_path):
+    """Without this the detail rows orphan and drop out of every rollup."""
+    r = _runner(session_dir=tmp_path)
+    r._trace_specialist_llm_call(
+        task_id="task-b", turn=2, metadata={"input_tokens": 5, "output_tokens": 9}
+    )
+    turns, details = _trace_rows(tmp_path)
+    assert [t["call_id"] for t in turns] == ["task-b:turn-2"]
+    # The join, which is the point: every detail row reaches its turn row.
+    assert details and {d["call_id"] for d in details} == {"task-b:turn-2"}
+
+
+def test_specialist_turn_does_not_mutate_the_backend_usage_dict(tmp_path):
+    """The single-turn caller passes the backend's own dict straight through."""
+    r = _runner(session_dir=tmp_path)
+    usage = {"input_tokens": 5}
+    r._trace_specialist_llm_call(task_id="task-c", turn=1, metadata=usage)
+    assert usage == {"input_tokens": 5}
+
+
+def test_specialist_turn_without_token_counters_writes_nothing(tmp_path):
+    r = _runner(session_dir=tmp_path)
+    r._trace_specialist_llm_call(task_id="task-d", turn=1, metadata={"model": "claude-opus-5"})
+    turns, details = _trace_rows(tmp_path)
+    assert turns == [] and details == []

--- a/src/hyperloom/inference_optimizer/tools/_report_agents.py
+++ b/src/hyperloom/inference_optimizer/tools/_report_agents.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""The per-phase deep dive shared by the GEAK and Hyperloom HTML reports.
+
+Both reports answer the same question one level down from "which phase cost the
+most": *inside* an expensive phase, where did the money actually go? The answer
+is the same four panels either way -- how cost moves as a conversation grows,
+how few agents carry the total, what tools the work consisted of, and the agent
+roster with every agent drillable to its own API calls -- so the machinery lives
+here once and a number means the same thing on either page.
+
+The two ledgers are not the same shape, so callers normalise their rows into the
+small record this module works on before calling anything here:
+
+======================  =========================================================
+key                     meaning
+======================  =========================================================
+``phase``               the phase the call belongs to
+``agent``               a stable id for the conversation the call is part of
+``call_index``          position of the call within that conversation, from 0
+``ts``                  ISO timestamp
+``isl`` / ``osl``       input (with cache) and output tokens
+``thinking``            thinking tokens; a subset of ``osl`` or beside it, per ledger
+``usd``                 derived cost
+``dt_s``                seconds attributed to the call, 0 when not recorded
+``tools``               list of tool names invoked by the call
+``model``               model id
+``prompt``              first 400-odd characters of what the model was handed
+======================  =========================================================
+
+Identity is the one thing the two ledgers genuinely disagree on, so it is
+injected rather than assumed. GEAK's ledger carries prompt text and no label, so
+it recovers a role with a regex; Hyperloom's carries a ``role`` field that is
+populated for some components and empty for others, so it falls back to the
+task path. Callers pass a ``role_of`` resolver and this module never guesses:
+an agent whose role could not be established is :data:`UNLABELLED`, and the
+coverage banner is expected to say how many those were.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import statistics
+from collections import defaultdict
+from typing import Any, Callable
+
+from hyperloom.inference_optimizer.tools._report_html import bar as _bar
+from hyperloom.inference_optimizer.tools._report_html import esc as _esc
+from hyperloom.inference_optimizer.tools._report_html import fmt_hms as _hms
+from hyperloom.inference_optimizer.tools._report_html import fmt_int as _int
+from hyperloom.inference_optimizer.tools._report_html import fmt_usd as _usd
+from hyperloom.inference_optimizer.tools._report_html import num as _num
+from hyperloom.inference_optimizer.tools._report_html import sparkline as _sparkline
+
+#: An agent whose role could not be established from the ledger. Never a guess.
+UNLABELLED = "unlabelled"
+
+# A conversation is split into this many equal position buckets to show how cost
+# moves as context accumulates. Ten is enough to see the trend and few enough to read.
+DECILES = 10
+# Agents shorter than this have too few calls for a position curve to mean anything.
+MIN_CALLS_FOR_CURVE = 10
+# Per-agent call rows embedded for the drill-down. The ledger stays the full record;
+# this only bounds the size of the HTML.
+MAX_CALLS_EMBEDDED = 400
+
+#: A ``role_of`` resolver: given an agent's calls, name it. Must not guess.
+RoleResolver = Callable[[list[dict[str, Any]]], dict[str, Any]]
+
+
+def agent_records(rows: list[dict[str, Any]], role_of: RoleResolver) -> list[dict[str, Any]]:
+    """Fold the call rows into one record per (phase, agent), ordered by spend.
+
+    Args:
+        rows: Normalised call rows.
+        role_of: Resolver handed the agent's calls in order; returns at least a
+            ``role`` key, optionally ``specialty``, ``round`` and ``derived``.
+
+    Returns:
+        One record per agent, most expensive first.
+    """
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[(str(row.get("phase", "")), str(row.get("agent", "")))].append(row)
+
+    agents: list[dict[str, Any]] = []
+    for (phase, agent), calls in grouped.items():
+        calls.sort(key=lambda r: (_num(r.get("call_index")), str(r.get("ts", ""))))
+        isls = [_num(c.get("isl")) for c in calls]
+        tools: dict[str, int] = defaultdict(int)
+        for call in calls:
+            for tool in call.get("tools") or []:
+                tools[tool if isinstance(tool, str) else json.dumps(tool)[:40]] += 1
+        usd = sum(_num(c.get("usd")) for c in calls)
+        seconds = sum(_num(c.get("dt_s")) for c in calls)
+        identity = {"role": UNLABELLED, "specialty": None, "round": None, "derived": True}
+        identity.update(role_of(calls) or {})
+        agents.append(
+            {
+                "phase": phase,
+                "agent": agent,
+                "calls": len(calls),
+                "usd": usd,
+                "seconds": seconds,
+                "isl": sum(isls),
+                "osl": sum(_num(c.get("osl")) for c in calls),
+                "thinking": sum(_num(c.get("thinking")) for c in calls),
+                "tool_calls": sum(tools.values()),
+                "tools": dict(sorted(tools.items(), key=lambda kv: -kv[1])),
+                "first_isl": isls[0] if isls else 0.0,
+                "last_isl": isls[-1] if isls else 0.0,
+                "median_isl": statistics.median(isls) if isls else 0.0,
+                "usd_per_call": usd / len(calls) if calls else 0.0,
+                "started": str(calls[0].get("ts", "")) if calls else "",
+                "models": sorted({str(c.get("model")) for c in calls if c.get("model")}),
+                **identity,
+                "rows": calls[:MAX_CALLS_EMBEDDED],
+                "rows_truncated": max(0, len(calls) - MAX_CALLS_EMBEDDED),
+            }
+        )
+    agents.sort(key=lambda a: -a["usd"])
+    return agents
+
+
+def phase_records(rows: list[dict[str, Any]], agents: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """One record per phase, with the agent roster that produced its spend."""
+    by_phase: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for agent in agents:
+        by_phase[agent["phase"]].append(agent)
+
+    calls_by_phase: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        calls_by_phase[str(row.get("phase", ""))].append(row)
+
+    phases: list[dict[str, Any]] = []
+    for phase, roster in by_phase.items():
+        calls = calls_by_phase[phase]
+        stamps = sorted(str(c.get("ts", "")) for c in calls if c.get("ts"))
+        tools: dict[str, int] = defaultdict(int)
+        for agent in roster:
+            for tool, count in agent["tools"].items():
+                tools[tool] += count
+        phases.append(
+            {
+                "phase": phase,
+                "agents": len(roster),
+                "calls": len(calls),
+                "usd": sum(a["usd"] for a in roster),
+                "seconds": sum(a["seconds"] for a in roster),
+                "isl": sum(a["isl"] for a in roster),
+                "osl": sum(a["osl"] for a in roster),
+                "tool_calls": sum(a["tool_calls"] for a in roster),
+                "tools": dict(sorted(tools.items(), key=lambda kv: -kv[1])),
+                "first_ts": stamps[0] if stamps else "",
+                "last_ts": stamps[-1] if stamps else "",
+                "roster": roster,
+                "cost_curve": cost_curve(roster),
+                "concentration": concentration(roster),
+            }
+        )
+    phases.sort(key=lambda p: -p["usd"])
+    return phases
+
+
+def cost_curve(roster: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Spend and median ISL by position within a conversation.
+
+    Every agent is stretched onto the same 0-9 scale, so this answers "does a call
+    get more expensive the longer its conversation runs?" without being dominated by
+    whichever agent happened to run longest. Agents too short to bucket are excluded,
+    and the count of those is reported so the exclusion is visible.
+    """
+    spend: dict[int, float] = defaultdict(float)
+    islers: dict[int, list[float]] = defaultdict(list)
+    counts: dict[int, int] = defaultdict(int)
+    used = 0
+    for agent in roster:
+        calls = agent["rows"]
+        total = len(calls)
+        if total < MIN_CALLS_FOR_CURVE:
+            continue
+        used += 1
+        for index, call in enumerate(calls):
+            bucket = min(DECILES - 1, int(DECILES * index / total))
+            spend[bucket] += _num(call.get("usd"))
+            islers[bucket].append(_num(call.get("isl")))
+            counts[bucket] += 1
+    if not used:
+        return []
+    return [
+        {
+            "decile": bucket,
+            "usd": spend[bucket],
+            "calls": counts[bucket],
+            "median_isl": statistics.median(islers[bucket]) if islers[bucket] else 0.0,
+        }
+        for bucket in range(DECILES)
+    ]
+
+
+def concentration(roster: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Cumulative share of phase spend as agents are added most-expensive first."""
+    total = sum(a["usd"] for a in roster)
+    if total <= 0:
+        return []
+    running = 0.0
+    points: list[dict[str, Any]] = []
+    for rank, agent in enumerate(sorted(roster, key=lambda a: -a["usd"]), start=1):
+        running += agent["usd"]
+        points.append({"rank": rank, "cum_pct": running / total * 100.0})
+    return points
+
+
+def delegation_signals(agents: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Per-agent signals bearing on 'could a smaller model have done this?'.
+
+    These are observations, not a recommendation. A low output-per-call agent spent
+    its budget reading rather than writing; a single-tool agent ran a mechanical loop.
+    Both are reasons to *look* at an agent, and neither is evidence on its own that a
+    cheaper model would have reached the same result.
+    """
+    signals: list[dict[str, Any]] = []
+    for agent in agents:
+        calls = max(1, agent["calls"])
+        signals.append(
+            {
+                "phase": agent["phase"],
+                "agent": agent["agent"],
+                "role": agent["role"],
+                "usd": agent["usd"],
+                "calls": agent["calls"],
+                "osl_per_call": agent["osl"] / calls,
+                "isl_per_call": agent["isl"] / calls,
+                "output_share": (agent["osl"] / agent["isl"]) if agent["isl"] else None,
+                "tool_variety": len(agent["tools"]),
+                "top_tool": next(iter(agent["tools"]), None),
+                "thinking": agent["thinking"],
+            }
+        )
+    signals.sort(key=lambda s: -s["usd"])
+    return signals
+
+
+def unlabelled_count(agents: list[dict[str, Any]]) -> int:
+    """How many agents could not be given a role. For the coverage banner."""
+    return sum(1 for a in agents if a["role"] == UNLABELLED)
+
+
+def anatomy_html(phase: dict[str, Any]) -> str:
+    """Where inside a phase the cost is actually incurred."""
+    curve = phase["cost_curve"]
+    conc = phase["concentration"]
+    blocks: list[str] = []
+
+    if curve:
+        spend = [c["usd"] for c in curve]
+        isls = [c["median_isl"] for c in curve]
+        total = sum(spend) or 1.0
+        rows = "".join(
+            f"<tr><td>{c['decile'] * 10}&ndash;{c['decile'] * 10 + 10}%</td>"
+            f"<td>{c['calls']:,}</td><td>{_int(c['median_isl'])}</td>"
+            f"<td>{_usd(c['usd'])}{_bar(c['usd'] / max(spend))}</td>"
+            f"<td>{c['usd'] / total * 100:.1f}%</td></tr>"
+            for c in curve
+        )
+        growth = (isls[-1] / isls[0]) if isls and isls[0] else None
+        lede = (
+            f"Each call re-sends the conversation so far, so the input grows as an agent works. "
+            f"Median input goes from {_int(isls[0])} tokens in the first tenth of a conversation to "
+            f"{_int(isls[-1])} in the last"
+            + (f", a {growth:.2f}x growth" if growth else "")
+            + f"; the last tenth costs {spend[-1] / total * 100:.1f}% of the phase against "
+            f"{spend[0] / total * 100:.1f}% for the first."
+        )
+        blocks.append(
+            "<div><h3>Cost by position in the conversation</h3>"
+            f'<p class="lede">{_esc(lede)}</p>'
+            '<div class="scroll"><table><thead><tr><th>Position</th><th>Calls</th><th>Median ISL</th>'
+            "<th>Spend</th><th>Share</th></tr></thead>"
+            f"<tbody>{rows}</tbody></table></div>"
+            f'<p class="mut">Median input tokens across the conversation:</p>{_sparkline(isls)}</div>'
+        )
+    else:
+        blocks.append(
+            "<div><h3>Cost by position in the conversation</h3>"
+            f'<p class="none">Not shown: no agent in this phase ran {MIN_CALLS_FOR_CURVE} or more calls, '
+            "which is too few for a position curve to mean anything.</p></div>"
+        )
+
+    if conc:
+
+        def agents_to(pct: float) -> int:
+            for point in conc:
+                if point["cum_pct"] >= pct:
+                    return point["rank"]
+            return len(conc)
+
+        half, most = agents_to(50.0), agents_to(80.0)
+        rows = "".join(
+            f"<tr><td>top {p['rank']}</td><td>{p['cum_pct']:.1f}%{_bar(p['cum_pct'] / 100)}</td></tr>"
+            for p in conc
+            if p["rank"] in {1, 3, 5, 10, 20, max(1, len(conc) // 2), len(conc)}
+        )
+        blocks.append(
+            "<div><h3>How concentrated the spend is</h3>"
+            f'<p class="lede">{half} of this phase\'s {len(conc)} agents account for half its cost, and '
+            f"{most} account for 80%. Ranked most expensive first.</p>"
+            '<div class="scroll"><table><thead><tr><th>Agents</th><th>Cumulative share</th></tr></thead>'
+            f"<tbody>{rows}</tbody></table></div></div>"
+        )
+
+    if phase["tools"]:
+        total_tools = sum(phase["tools"].values()) or 1
+        rows = "".join(
+            f"<tr><td><code>{_esc(name)}</code></td><td>{count:,}</td>"
+            f"<td>{count / total_tools * 100:.1f}%{_bar(count / max(phase['tools'].values()))}</td></tr>"
+            for name, count in list(phase["tools"].items())[:10]
+        )
+        blocks.append(
+            "<div><h3>What the agents actually did</h3>"
+            f'<p class="lede">{total_tools:,} tool calls across {phase["calls"]:,} API calls '
+            f"({total_tools / max(1, phase['calls']):.2f} per call). A phase dominated by one tool is "
+            "running a mechanical loop; a varied mix is exploratory work.</p>"
+            '<div class="scroll"><table><thead><tr><th>Tool</th><th>Calls</th><th>Share</th></tr></thead>'
+            f"<tbody>{rows}</tbody></table></div></div>"
+        )
+    return f'<div class="grid2">{"".join(blocks)}</div>'
+
+
+def agent_key(agent: dict[str, Any]) -> str:
+    """A DOM-safe id for an agent's drill-down panel."""
+    raw = f"{agent['phase']}-{agent['agent']}"
+    return re.sub(r"[^A-Za-z0-9_-]", "_", raw)
+
+
+def roster_html(phase: dict[str, Any]) -> str:
+    """Every agent in the phase, ranked by spend, each drillable down to its calls."""
+    total = phase["usd"] or 1.0
+    peak = max((a["usd"] for a in phase["roster"]), default=1.0) or 1.0
+    rows: list[str] = []
+    for agent in phase["roster"]:
+        key = agent_key(agent)
+        tag = (
+            f'<span class="tag">{_esc(agent["role"])}</span>'
+            if agent["role"] != UNLABELLED
+            else f'<span class="tag q">{UNLABELLED}</span>'
+        )
+        if agent["specialty"]:
+            tag += f'<span class="tag q">{_esc(agent["specialty"])}</span>'
+        growth = f"{agent['last_isl'] / agent['first_isl']:.2f}x" if agent["first_isl"] else "-"
+        rows.append(
+            f"<tr><td><code>{_esc(agent['agent'][:12])}</code>{tag}</td>"
+            f"<td>{agent['calls']:,}</td>"
+            f"<td>{_usd(agent['usd'])}{_bar(agent['usd'] / peak)}</td>"
+            f"<td>{agent['usd'] / total * 100:.1f}%</td>"
+            f"<td>{_usd(agent['usd_per_call'])}</td>"
+            f"<td>{_hms(agent['seconds'])}</td>"
+            f"<td>{_int(agent['median_isl'])}</td>"
+            f"<td>{growth}</td>"
+            f"<td>{_int(agent['osl'])}</td>"
+            f"<td>{agent['tool_calls']:,}</td>"
+            f'<td><button class="drill" onclick="drill(\'{key}\',this)">calls</button></td></tr>'
+            f'<tr><td colspan="11" style="padding:0">'
+            f'<div class="calls" id="calls-{key}" hidden></div></td></tr>'
+        )
+    return (
+        '<div class="scroll"><table><thead><tr><th>Agent</th><th>Calls</th><th>Cost</th><th>Share</th>'
+        "<th>$/call</th><th>Recorded time</th><th>Median ISL</th><th>ISL growth</th><th>Output</th>"
+        f"<th>Tools</th><th></th></tr></thead><tbody>{''.join(rows)}</tbody></table></div>"
+    )
+
+
+def deepdive_html(
+    joined: list[dict[str, Any]],
+    total_usd: float,
+    code_of: Callable[[dict[str, Any]], str] | None = None,
+    lede: str | None = None,
+    extra_of: Callable[[dict[str, Any]], str] | None = None,
+) -> str:
+    """One collapsible block per phase, expensive first, the top two open by default.
+
+    Args:
+        joined: Phase records, most expensive first.
+        total_usd: The bill the shares are taken against.
+        code_of: Optional extra label for a phase heading -- GEAK uses it to name
+            the kernel a HeadKernel phase went after, which the phase name omits.
+        lede: Optional replacement for the introductory paragraph.
+        extra_of: Optional extra panel appended inside a phase block, after the
+            roster -- the Hyperloom report uses it for its task-path tree.
+    """
+    blocks: list[str] = []
+    for rank, phase in enumerate(joined):
+        share = phase["usd"] / total_usd * 100 if total_usd else 0.0
+        window = ""
+        if phase["first_ts"] and phase["last_ts"]:
+            window = f"{phase['first_ts'][11:19]}&ndash;{phase['last_ts'][11:19]} UTC"
+        code = code_of(phase) if code_of else ""
+        blocks.append(
+            f"<details{' open' if rank < 2 else ''}>"
+            f"<summary><span>{_esc(phase['phase'])}"
+            + (f" <code>{_esc(code)}</code>" if code else "")
+            + "</span>"
+            f'<span class="r">{_usd(phase["usd"])} | {share:.1f}% of spend | '
+            f"{phase['agents']} agents | {phase['calls']:,} calls | "
+            f"{_int(phase['isl'])} in / {_int(phase['osl'])} out"
+            + (f" | {window}" if window else "")
+            + "</span></summary>"
+            f'<div class="body">{anatomy_html(phase)}<h3>Agents, most expensive first</h3>'
+            f"{roster_html(phase)}{extra_of(phase) if extra_of else ''}</div>"
+            "</details>"
+        )
+    intro = lede or (
+        "Expand a phase to see where its money went: how cost moves as a conversation grows, how "
+        "few agents carry the total, what tools the work actually consisted of, and the full agent "
+        "roster. Any agent row opens into its own API calls."
+    )
+    return f'<h2 id="deep">Inside each phase</h2><p class="lede">{intro}</p>' + "".join(blocks)
+
+
+def delegation_html(signals: list[dict[str, Any]], limit: int = 20) -> str:
+    """Signals bearing on 'could a cheaper model have done this?' -- signals, not a verdict."""
+    rows = "".join(
+        f"<tr><td><code>{_esc(s['agent'][:12])}</code>"
+        + (f'<span class="tag">{_esc(s["role"])}</span>' if s["role"] != UNLABELLED else "")
+        + f"</td><td>{_esc(s['phase'])}</td><td>{_usd(s['usd'])}</td><td>{s['calls']:,}</td>"
+        f"<td>{_int(s['isl_per_call'])}</td><td>{_int(s['osl_per_call'])}</td>"
+        + (
+            f"<td>{s['output_share'] * 100:.3f}%</td>"
+            if s["output_share"] is not None
+            else '<td><span class="none">n/a</span></td>'
+        )
+        + f"<td>{s['tool_variety']}</td><td><code>{_esc(s['top_tool'] or '-')}</code></td></tr>"
+        for s in signals[:limit]
+    )
+    return (
+        '<h2 id="delegate">Signals for delegating work to a cheaper model</h2>'
+        '<p class="lede">These are observations, not a recommendation. An agent that reads far more '
+        "than it writes spent its budget on context rather than reasoning, and one that uses a single "
+        "tool repeatedly is running a mechanical loop. Both are reasons to <em>look</em> at an agent; "
+        "neither is evidence that a smaller model would have reached the same result. The only way to "
+        "know that is to run the arm and compare the measured throughput.</p>"
+        '<div class="scroll"><table><thead><tr><th>Agent</th><th>Phase</th><th>Cost</th><th>Calls</th>'
+        "<th>Input/call</th><th>Output/call</th><th>Output share</th><th>Tool variety</th>"
+        f"<th>Main tool</th></tr></thead><tbody>{rows}</tbody></table></div>"
+        f'<p class="mut">Showing the {min(limit, len(signals))} most expensive agents of {len(signals)}.</p>'
+    )
+
+
+def agent_payload(agents: list[dict[str, Any]]) -> str:
+    """The per-call rows the drill-down renders, keyed by DOM id."""
+    payload = {
+        agent_key(a): {
+            "more": a["rows_truncated"],
+            "rows": [
+                {
+                    "i": int(_num(r.get("call_index"))),
+                    "ts": r.get("ts"),
+                    "isl": _num(r.get("isl")),
+                    "osl": _num(r.get("osl")),
+                    "think": _num(r.get("thinking")),
+                    "dt": _num(r.get("dt_s")),
+                    "usd": _num(r.get("usd")),
+                    "tools": [t for t in (r.get("tools") or []) if isinstance(t, str)],
+                    "prompt": (r.get("prompt") or "")[:400],
+                }
+                for r in a["rows"]
+            ],
+        }
+        for a in agents
+    }
+    return json.dumps(payload, separators=(",", ":")).replace("</", "<\\/")
+
+
+def drill_js(ledger_name: str) -> str:
+    """The drill-down script. ``ledger_name`` is the file a capped table points at."""
+    return """
+function fmtUsd(v){return v==null?'-':'$'+Number(v).toFixed(4);}
+function fmtInt(v){return v==null?'-':Number(v).toLocaleString();}
+function drill(key,btn){
+  var host=document.getElementById('calls-'+key);
+  if(host.dataset.built){host.hidden=!host.hidden;btn.textContent=host.hidden?'calls':'hide';return;}
+  var a=AGENTS[key];
+  var h='<table><thead><tr><th>#</th><th>time</th><th>ISL</th><th>OSL</th><th>think</th>'
+       +'<th>secs</th><th>USD</th><th>tools</th><th style="text-align:left">first line of prompt</th>'
+       +'</tr></thead><tbody>';
+  a.rows.forEach(function(r){
+    var p=(r.prompt||'').split('\\n').find(function(x){return x.trim();})||'';
+    h+='<tr><td>'+r.i+'</td><td class="mono">'+(r.ts||'').slice(11,19)+'</td><td>'+fmtInt(r.isl)
+      +'</td><td>'+fmtInt(r.osl)+'</td><td>'+fmtInt(r.think)+'</td><td>'+(r.dt==null?'-':r.dt.toFixed(1))
+      +'</td><td>'+fmtUsd(r.usd)+'</td><td>'+(r.tools||[]).join(', ')
+      +'</td><td class="pw" title="'+p.replace(/"/g,'&quot;').slice(0,400)+'">'+p.slice(0,110)+'</td></tr>';
+  });
+  h+='</tbody></table>';
+  if(a.more){h+='<p class="mut" style="padding:8px 10px;margin:0">'+a.more
+    +' further calls are in LEDGER_NAME; this table is capped so the page stays loadable.</p>';}
+  host.innerHTML=h;host.dataset.built='1';host.hidden=false;btn.textContent='hide';
+}
+""".replace("LEDGER_NAME", ledger_name)

--- a/src/hyperloom/inference_optimizer/tools/_report_html.py
+++ b/src/hyperloom/inference_optimizer/tools/_report_html.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Formatting and page chrome shared by the HTML run reports.
+
+Two reports render the same kind of document -- a GEAK run
+(:mod:`render_geak_html_report`) and a Hyperloom session
+(:mod:`render_hyperloom_html_report`) -- and a reader who opens both should not
+have to work out whether "$1,234.56" means the same thing on each page. The
+formatters and the stylesheet therefore live here once rather than being copied,
+so the two pages cannot drift into disagreeing about how a number is written.
+
+Nothing here decides what to say; it only decides how a value is spelled. The
+one rule that carries meaning is in :func:`fmt_pct`: ``None`` renders as "not
+measured" rather than as zero, because "we did not measure it" and "it was
+nothing" are different claims and a report that conflates them is lying.
+"""
+
+from __future__ import annotations
+
+import html
+from typing import Any
+
+
+def num(value: Any) -> float:
+    """Coerce a ledger value to a float, treating anything unusable as 0.0.
+
+    A bool is not a token count and NaN is not a cost, so both are rejected
+    rather than summed: ``True`` would otherwise add 1 to a total and a single
+    NaN would poison every total it touches.
+
+    Args:
+        value: A value off a JSON row.
+
+    Returns:
+        The value as a float, or ``0.0`` when it is not a finite number.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0.0
+    if value != value or value in (float("inf"), float("-inf")):  # NaN / inf
+        return 0.0
+    return float(value)
+
+
+def esc(value: Any) -> str:
+    """HTML-escape, and fold every non-ASCII character to a numeric entity.
+
+    The page is written UTF-8 and declares it, but it gets opened from shared
+    storage, out of archives and through viewers that ignore the declaration --
+    and a mis-decoded em dash renders as mojibake with no clue as to why. Pure
+    ASCII bytes cannot be mis-decoded, so the document is kept pure ASCII and
+    anything outside it travels as an entity the browser resolves itself.
+    """
+    text = html.escape(str(value), quote=True)
+    if text.isascii():
+        return text
+    return "".join(ch if ord(ch) < 128 else f"&#{ord(ch)};" for ch in text)
+
+
+def fmt_usd(value: Any) -> str:
+    number = num(value)
+    return f"${number:,.2f}" if number >= 0.01 or number == 0 else f"${number:,.4f}"
+
+
+def fmt_int(value: Any) -> str:
+    return f"{int(num(value)):,}"
+
+
+def fmt_hms(seconds: Any) -> str:
+    total = int(num(seconds))
+    return f"{total // 3600}:{total % 3600 // 60:02d}:{total % 60:02d}"
+
+
+def fmt_pct(value: Any, digits: int = 2) -> str:
+    """Format a percentage, or say plainly that it was never measured."""
+    if value is None:
+        return '<span class="none">not measured</span>'
+    return f"{num(value):+.{digits}f}%"
+
+
+def bar(fraction: float, tone: str = "spend") -> str:
+    width = max(0.0, min(100.0, fraction * 100.0))
+    return f'<span class="bar {tone}"><i style="width:{width:.2f}%"></i></span>'
+
+
+def sparkline(values: list[float], width: int = 220, height: int = 44) -> str:
+    """A dependency-free inline SVG line. Empty input renders nothing, not a flat line."""
+    if not values:
+        return '<span class="none">no data</span>'
+    top = max(values)
+    bottom = min(values)
+    span = (top - bottom) or 1.0
+    step = width / max(1, len(values) - 1)
+    points = " ".join(
+        f"{index * step:.1f},{height - (value - bottom) / span * (height - 6) - 3:.1f}"
+        for index, value in enumerate(values)
+    )
+    return (
+        f'<svg class="spark" viewBox="0 0 {width} {height}" width="{width}" height="{height}" '
+        f'preserveAspectRatio="none" role="img"><polyline points="{points}"/></svg>'
+    )
+
+
+CSS = """
+:root{--bg:#fbfbfa;--fg:#1c1b19;--mut:#6b6862;--line:#e3e0da;--card:#fff;
+--accent:#2d6cdf;--good:#1a7f4b;--bad:#b3261e;--warn:#8a6d00;--spend:#2d6cdf;--time:#8a5cd0;}
+@media (prefers-color-scheme:dark){:root{--bg:#16161a;--fg:#eceae6;--mut:#9d9a94;--line:#2e2e34;
+--card:#1d1d22;--accent:#7aa5f5;--good:#5cc98d;--bad:#f0857c;--warn:#e0be4e;--spend:#7aa5f5;--time:#b394ea;}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--fg);
+font:14px/1.55 ui-sans-serif,-apple-system,"Segoe UI",Roboto,sans-serif}
+.wrap{max-width:1180px;margin:0 auto;padding:28px 20px 80px}
+h1{font-size:23px;margin:0 0 4px}h2{font-size:18px;margin:38px 0 6px;padding-top:14px;border-top:1px solid var(--line)}
+h3{font-size:15px;margin:20px 0 6px}
+.sub{color:var(--mut);margin:0 0 18px}
+.lede{color:var(--mut);margin:0 0 14px;max-width:80ch}
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:10px;margin:16px 0}
+.card{background:var(--card);border:1px solid var(--line);border-radius:9px;padding:11px 13px}
+.card .k{color:var(--mut);font-size:11px;text-transform:uppercase;letter-spacing:.05em}
+.card .v{font-size:20px;font-weight:600;margin-top:3px}
+.card .n{color:var(--mut);font-size:11.5px;margin-top:2px}
+.note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--warn);
+border-radius:7px;padding:11px 14px;margin:14px 0}
+.note b{display:block;margin-bottom:3px}
+.note ul{margin:6px 0 0;padding-left:20px}.note li{margin:2px 0}
+table{border-collapse:collapse;width:100%;margin:10px 0;font-size:13px}
+th,td{text-align:right;padding:6px 9px;border-bottom:1px solid var(--line);white-space:nowrap}
+th:first-child,td:first-child{text-align:left;white-space:normal}
+th{color:var(--mut);font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.04em}
+tbody tr:hover{background:color-mix(in srgb,var(--accent) 7%,transparent)}
+.scroll{overflow-x:auto}
+.bar{display:inline-block;width:74px;height:7px;background:var(--line);border-radius:4px;
+overflow:hidden;vertical-align:middle;margin-left:7px}
+.bar i{display:block;height:100%;background:var(--spend)}
+.bar.time i{background:var(--time)}
+tr.ref td{background:var(--card)}
+.good{color:var(--good)}.bad{color:var(--bad)}.none{color:var(--mut);font-style:italic}
+.mut{color:var(--mut)}
+.spark{display:block;margin-top:4px}
+.spark polyline{fill:none;stroke:var(--accent);stroke-width:1.8;vector-effect:non-scaling-stroke}
+code,.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px}
+details{background:var(--card);border:1px solid var(--line);border-radius:9px;margin:10px 0;padding:0}
+summary{cursor:pointer;padding:11px 14px;font-weight:600;list-style:none;display:flex;
+justify-content:space-between;gap:14px;align-items:baseline}
+summary::-webkit-details-marker{display:none}
+summary::before{content:"\\25b8";color:var(--mut);margin-right:8px;transition:transform .15s}
+details[open]>summary::before{transform:rotate(90deg);display:inline-block}
+summary .r{color:var(--mut);font-weight:500;font-size:12.5px}
+.body{padding:0 14px 14px}
+.grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:18px}
+/* Grid items default to min-width:auto, so a nowrap table refuses to shrink below its
+   min-content width and bleeds over the next column. Let the item shrink, and let the
+   table scroll inside its own column instead of over its neighbour. */
+.grid2>*{min-width:0}
+.grid2 .scroll{max-width:100%}
+.tag{display:inline-block;background:color-mix(in srgb,var(--accent) 13%,transparent);
+color:var(--accent);border-radius:4px;padding:0 6px;font-size:11px;margin-left:5px}
+.tag.q{background:color-mix(in srgb,var(--mut) 16%,transparent);color:var(--mut)}
+nav{position:sticky;top:0;background:var(--bg);border-bottom:1px solid var(--line);
+padding:9px 0;margin-bottom:10px;z-index:5;font-size:13px}
+nav a{color:var(--accent);text-decoration:none;margin-right:16px}
+nav a:hover{text-decoration:underline}
+.calls{max-height:420px;overflow:auto;border:1px solid var(--line);border-radius:7px;margin-top:8px}
+.calls table{margin:0}.calls th{position:sticky;top:0;background:var(--card)}
+button.drill{background:none;border:1px solid var(--line);border-radius:5px;color:var(--accent);
+cursor:pointer;font-size:11.5px;padding:2px 8px}
+button.drill:hover{border-color:var(--accent)}
+.pw{max-width:56ch;overflow:hidden;text-overflow:ellipsis;color:var(--mut);font-size:11.5px}
+"""

--- a/src/hyperloom/inference_optimizer/tools/dump_geak_call_report.py
+++ b/src/hyperloom/inference_optimizer/tools/dump_geak_call_report.py
@@ -1,0 +1,1130 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Render a GEAK run as a phase -> agent -> API call -> tool call tree.
+
+GEAK issues almost no LLM calls of its own: ``interface/run_e2e.py`` opens one
+``ClaudeSDKClient`` and hands a single prompt to Claude Code, which executes
+``e2e_workflow/e2e_workflow.js`` -- a Workflow script that already declares its
+phases and already tags every ``agent()`` call with ``{phase, label}``. Claude
+Code persists that structure, so this module reads it rather than asking GEAK
+to write a ledger it has no way to fill:
+
+* ``<claude_home>/projects/<slug>/<session>/workflows/wf_*.json`` -- the run
+  record: ``phases``, ``args`` (carrying ``eval_dir``), ``result``, and a
+  ``workflowProgress`` array whose ``workflow_agent`` entries name every agent
+  with its label, phase, ``agentId``, model, tokens, tool calls and duration.
+* ``<session>/subagents/workflows/<runId>/agent-<agentId>.jsonl`` -- one row
+  per API call, with the ``usage`` counters and the ``tool_use`` blocks.
+
+Usage::
+
+    python3 dump_geak_call_report.py --eval-dir /path/to/geak/e2e_cycle0
+    python3 dump_geak_call_report.py --run-id wf_ec8b57b0-1a7 --max-depth 3
+
+Writes ``geak_call_report.md`` and ``geak_call_report.json`` to
+``$USER_DATA_PATH/reports/<runId>/`` unless ``--output-dir`` says otherwise.
+
+Three properties matter more than the totals:
+
+* Assistant rows sharing a ``message.id`` are one API call split per content
+  block, and their ``usage`` is cumulative -- counted once, from the last
+  block, or the report overstates output by roughly the block count.
+* GEAK's ``thinking_tokens`` are a **subset** of ``output_tokens``, not an
+  addend beside them (the opposite of Hyperloom's own ledger), so OSL is
+  ``output_tokens`` alone.
+* Claude Code records no cost, so every figure here is derived from the
+  shipped rate card. An unpriced model is excluded from the USD total rather
+  than counted as free.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+_HERE = Path(__file__).resolve()
+for _parent in _HERE.parents:
+    if (_parent / "hyperloom").is_dir():
+        sys.path.insert(0, str(_parent))
+        break
+
+from hyperloom.inference_optimizer.tools.dump_llm_call_report import (  # noqa: E402
+    Node,
+    _render_rows,
+    _trim,
+)
+from hyperloom.orchestrator.trace.pricing import resolve_cost  # noqa: E402
+
+WORKFLOW_GLOB = "projects/*/*/workflows/wf_*.json"
+AGENT_ENTRY = "workflow_agent"
+PHASE_ENTRY = "workflow_phase"
+TIMING_INFERRED = "inferred"
+
+
+def claude_homes(extra: Iterable[Path] = ()) -> list[Path]:
+    """List the Claude Code home directories to search for run records.
+
+    Archived GEAK runs live under whichever account drove them, so the caller
+    can name additional roots; the configured home is always searched first.
+
+    Args:
+        extra: Additional roots supplied on the command line.
+
+    Returns:
+        Existing home directories, in search order, without duplicates.
+    """
+    seen: dict[str, Path] = {}
+    configured = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
+    ordered = [Path(configured)] if configured else []
+    ordered.append(Path.home() / ".claude")
+    ordered.extend(Path(p) for p in extra)
+    for home in ordered:
+        try:
+            resolved = home.expanduser().resolve()
+        except OSError:
+            continue
+        if resolved.is_dir():
+            seen.setdefault(str(resolved), resolved)
+    return list(seen.values())
+
+
+def find_run_records(homes: Iterable[Path]) -> Iterator[tuple[Path, dict[str, Any]]]:
+    """Yield every workflow run record found beneath *homes*.
+
+    Args:
+        homes: Claude Code home directories.
+
+    Yields:
+        ``(path, record)`` for each readable ``wf_*.json``.
+    """
+    for home in homes:
+        for path in sorted(home.glob(WORKFLOW_GLOB)):
+            try:
+                record = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            if isinstance(record, dict) and record.get("runId"):
+                yield path, record
+
+
+def _record_paths(record: dict[str, Any]) -> list[str]:
+    """Return the run directories a record names, most specific first.
+
+    A Hyperloom-driven run is identified by ``eval_dir``; a standalone one is
+    usually reached for by its ``exp_root``, which is the directory the caller
+    actually has to hand.
+
+    Args:
+        record: A workflow run record.
+
+    Returns:
+        Distinct directory strings, ``eval_dir`` before ``exp_root``.
+    """
+    found: list[str] = []
+    for key in ("eval_dir", "exp_root"):
+        for holder in (record.get("args"), record.get("result")):
+            if not isinstance(holder, dict):
+                continue
+            value = holder.get(key)
+            if isinstance(value, str) and value.strip():
+                cleaned = value.strip().rstrip("/")
+                if cleaned not in found:
+                    found.append(cleaned)
+    return found
+
+
+def _record_eval_dir(record: dict[str, Any]) -> str:
+    """Return the run directory a record is best identified by.
+
+    Args:
+        record: A workflow run record.
+
+    Returns:
+        The most specific recorded directory, or ``""``.
+    """
+    paths = _record_paths(record)
+    return paths[0] if paths else ""
+
+
+def resolve_runs(
+    *,
+    homes: Iterable[Path],
+    eval_dir: str | None = None,
+    run_id: str | None = None,
+    session_dir: Path | None = None,
+    list_all: bool = False,
+) -> list[tuple[Path, dict[str, Any]]]:
+    """Find the run records matching a selector, newest first.
+
+    Matching is an identity check on ``args.eval_dir``, not an mtime or cwd
+    heuristic: a Hyperloom session joins through its ``geak/e2e_cycle*`` dir
+    and a standalone run through its experiment dir.
+
+    Args:
+        homes: Claude Code home directories to search.
+        eval_dir: The GEAK eval dir to match, exactly or as a prefix.
+        run_id: A ``wf_...`` run id to match instead.
+        session_dir: A Hyperloom session root whose ``geak/`` subtree supplies
+            the eval dir.
+        list_all: Return every readable record, ignoring the selectors.
+
+    Returns:
+        Matching ``(path, record)`` pairs, newest ``timestamp`` first.
+    """
+    wanted = (eval_dir or "").strip().rstrip("/")
+    if not wanted and session_dir is not None:
+        wanted = str(session_dir.resolve() / "geak")
+    hits: list[tuple[Path, dict[str, Any]]] = []
+    for path, record in find_run_records(homes):
+        if run_id and record.get("runId") != run_id:
+            continue
+        if wanted:
+            if not any(
+                found == wanted or found.startswith(wanted + "/") or wanted.startswith(found + "/")
+                for found in _record_paths(record)
+            ):
+                continue
+        elif not run_id and not list_all:
+            continue
+        hits.append((path, record))
+    return sorted(hits, key=lambda pr: str(pr[1].get("timestamp") or ""), reverse=True)
+
+
+def _ts_ms(value: Any) -> float | None:
+    """Parse an ISO-8601 timestamp into epoch milliseconds.
+
+    Args:
+        value: A timestamp string from a transcript row.
+
+    Returns:
+        Epoch milliseconds, or ``None`` when unparseable.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp() * 1000.0
+    except ValueError:
+        return None
+
+
+def _tool_uses(message: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract the tool_use blocks of one assistant message.
+
+    Args:
+        message: The ``message`` object of a transcript row.
+
+    Returns:
+        One ``{tool, tool_use_id}`` mapping per tool_use block.
+    """
+    blocks = message.get("content")
+    if not isinstance(blocks, list):
+        return []
+    return [
+        {"tool": b.get("name") or "?", "tool_use_id": b.get("id")}
+        for b in blocks
+        if isinstance(b, dict) and b.get("type") == "tool_use"
+    ]
+
+
+def _has_thinking(message: dict[str, Any]) -> bool:
+    """Report whether an assistant message carries a thinking block.
+
+    Args:
+        message: The ``message`` object of a transcript row.
+
+    Returns:
+        ``True`` when any content block is of type ``thinking``.
+    """
+    blocks = message.get("content")
+    return isinstance(blocks, list) and any(isinstance(b, dict) and b.get("type") == "thinking" for b in blocks)
+
+
+def _block_text(blocks: Any, kinds: tuple[str, ...], limit: int) -> str:
+    """Join the text carried by content blocks of the given kinds.
+
+    Args:
+        blocks: A message's ``content``.
+        kinds: Block types to keep, e.g. ``("text", "thinking")``.
+        limit: Per-block character cap; ``0`` means uncapped.
+
+    Returns:
+        The joined text, blocks separated by blank lines.
+    """
+    if not isinstance(blocks, list):
+        return str(blocks)[:limit] if limit and isinstance(blocks, str) else ""
+    out: list[str] = []
+    for b in blocks:
+        if not isinstance(b, dict) or b.get("type") not in kinds:
+            continue
+        text = b.get("text") or b.get("thinking") or b.get("content") or ""
+        if not isinstance(text, str):
+            text = json.dumps(text)
+        if limit and len(text) > limit:
+            text = text[:limit] + f"... [+{len(text) - limit} chars]"
+        out.append(text)
+    return "\n\n".join(out)
+
+
+def read_agent_calls(path: Path, *, capture_text: bool = False, text_chars: int = 4000) -> list[dict[str, Any]]:
+    """Read one agent transcript into normalized per-API-call rows.
+
+    Rows sharing a ``message.id`` are the same API call split across content
+    blocks with cumulative usage, so they collapse to the highest
+    ``apiBlockIndex`` while their tool_use blocks are unioned. Latency is the
+    gap from the previous transcript row -- a tool_result timestamp is when
+    the tool finished, so that gap approximates API time rather than tool time.
+
+    Args:
+        path: An ``agent-<agentId>.jsonl`` transcript.
+        capture_text: Also carry the prompt and response text of each call.
+        text_chars: Per-block character cap for captured text; ``0`` is uncapped.
+
+    Returns:
+        Normalized rows in the field vocabulary
+        :class:`~hyperloom.inference_optimizer.tools.dump_llm_call_report.Totals`
+        consumes, ordered by timestamp.
+    """
+    grouped: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    prev_ts: float | None = None
+    gap_for: dict[str, float] = {}
+    pending: list[str] = []
+    for line in _iter_lines(path):
+        row_ts = _ts_ms(line.get("timestamp"))
+        message = line.get("message")
+        if capture_text and line.get("type") == "user" and isinstance(message, dict):
+            # What the model was handed since it last spoke: the agent prompt on
+            # the first call, tool results after that. The full context is ISL;
+            # this is the increment that provoked the call.
+            text = _block_text(message.get("content"), ("text", "tool_result"), text_chars)
+            if text:
+                pending.append(text)
+        if line.get("type") == "assistant" and isinstance(message, dict) and message.get("usage"):
+            key = str(message.get("id") or f"anon-{len(order)}")
+            entry = grouped.get(key)
+            if entry is None:
+                entry = {
+                    "block": -1,
+                    "message": message,
+                    "ts": row_ts,
+                    "tools": [],
+                    "thinking_block": False,
+                    "prompt": "\n\n".join(pending),
+                    "output": [],
+                    "thinking": [],
+                }
+                pending = []
+                grouped[key] = entry
+                order.append(key)
+                if prev_ts is not None and row_ts is not None:
+                    gap_for[key] = max(0.0, row_ts - prev_ts)
+            block = int(line.get("apiBlockIndex") or 0)
+            if block >= entry["block"]:
+                entry["block"] = block
+                entry["message"] = message
+            if row_ts is not None:
+                entry["ts"] = row_ts
+            entry["tools"].extend(_tool_uses(message))
+            entry["thinking_block"] = entry["thinking_block"] or _has_thinking(message)
+            if capture_text:
+                for kind, key in (("text", "output"), ("thinking", "thinking")):
+                    text = _block_text(message.get("content"), (kind,), text_chars)
+                    if text:
+                        entry[key].append(text)
+        if row_ts is not None:
+            prev_ts = row_ts
+
+    calls: list[dict[str, Any]] = []
+    for index, key in enumerate(order):
+        entry = grouped[key]
+        call = _normalize_call(
+            message=entry["message"],
+            message_id=key,
+            index=index,
+            ts_ms=entry["ts"],
+            latency_ms=gap_for.get(key),
+            tools=entry["tools"],
+            thinking_block=entry["thinking_block"],
+        )
+        if capture_text:
+            call["prompt_text"] = entry["prompt"]
+            call["output_text"] = "\n\n".join(entry["output"])
+            call["thinking_text"] = "\n\n".join(entry["thinking"])
+        calls.append(call)
+    return calls
+
+
+def _iter_lines(path: Path) -> Iterator[dict[str, Any]]:
+    """Yield the parseable JSON objects of a JSONL file.
+
+    Args:
+        path: File to read.
+
+    Yields:
+        Each decoded object; malformed lines are skipped.
+    """
+    try:
+        handle = path.open("r", encoding="utf-8")
+    except OSError:
+        return
+    with handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(obj, dict):
+                yield obj
+
+
+def _normalize_call(
+    *,
+    message: dict[str, Any],
+    message_id: str,
+    index: int,
+    ts_ms: float | None,
+    latency_ms: float | None,
+    tools: list[dict[str, Any]],
+    thinking_block: bool,
+) -> dict[str, Any]:
+    """Project one API call onto the report's row vocabulary.
+
+    Args:
+        message: The assistant message carrying the final cumulative usage.
+        message_id: The provider ``message.id``, the call's identity.
+        index: Zero-based position within the agent.
+        ts_ms: Completion time in epoch milliseconds.
+        latency_ms: Inferred wall-clock for the call.
+        tools: The tool_use blocks the call emitted.
+        thinking_block: Whether the response contained a thinking block.
+
+    Returns:
+        A row ready for :meth:`Totals.add_call`.
+    """
+    usage = message.get("usage") or {}
+    raw_out = int(usage.get("output_tokens") or 0)
+    thinking = int((usage.get("output_tokens_details") or {}).get("thinking_tokens") or 0)
+    thinking = max(0, min(thinking, raw_out))
+    row: dict[str, Any] = {
+        "call_id": message_id,
+        "api_call_index": index,
+        "model": message.get("model"),
+        "stop_reason": message.get("stop_reason"),
+        "input_tokens": int(usage.get("input_tokens") or 0),
+        "cache_read_input_tokens": int(usage.get("cache_read_input_tokens") or 0),
+        "cache_creation_input_tokens": int(usage.get("cache_creation_input_tokens") or 0),
+        # thinking_tokens are part of output_tokens here, so the plain-output
+        # counter is the remainder. Adding them would double-bill the split.
+        "output_tokens": raw_out - thinking,
+        "reasoning_output_tokens": thinking,
+        "thinking_block": thinking_block,
+        "tool_calls": tools,
+        "ts_ms": ts_ms,
+        "status": "ok",
+    }
+    row["isl"] = row["input_tokens"] + row["cache_read_input_tokens"] + row["cache_creation_input_tokens"]
+    row["osl"] = raw_out
+    if latency_ms is not None:
+        row["latency_ms"] = latency_ms
+        row["timing_source"] = TIMING_INFERRED
+    cost = resolve_cost(model=row["model"], tokens=row)
+    row.update(
+        {
+            "cost_usd": cost.total_usd,
+            "cost_input_usd": cost.input_usd,
+            "cost_output_usd": cost.output_usd,
+            "cost_thinking_usd": cost.thinking_usd,
+            "cost_cache_usd": cost.cache_usd,
+            "cost_source": cost.source,
+        }
+    )
+    return row
+
+
+def transcript_dir(record_path: Path, run_id: str) -> Path:
+    """Locate the per-agent transcripts belonging to a run record.
+
+    Args:
+        record_path: Path of the ``wf_*.json`` record.
+        run_id: The record's ``runId``.
+
+    Returns:
+        The ``subagents/workflows/<runId>`` directory, which may not exist.
+    """
+    return record_path.parent.parent / "subagents" / "workflows" / run_id
+
+
+def _phase_order(progress: Iterable[Any]) -> list[str]:
+    """Return the declared phase titles in execution order.
+
+    Args:
+        progress: The ``workflowProgress`` array.
+
+    Returns:
+        Phase titles, first appearance order preserved.
+    """
+    titles: list[str] = []
+    for entry in progress:
+        if isinstance(entry, dict) and entry.get("type") == PHASE_ENTRY:
+            title = str(entry.get("title") or "").strip()
+            if title and title not in titles:
+                titles.append(title)
+    return titles
+
+
+def _agent_entries(progress: Iterable[Any]) -> list[dict[str, Any]]:
+    """Return the latest state of every agent named in the progress array.
+
+    An agent is reported repeatedly as it advances, so the last entry for an
+    ``agentId`` is the one that carries its final tokens and duration.
+
+    Args:
+        progress: The ``workflowProgress`` array.
+
+    Returns:
+        One entry per agent, in first-appearance order.
+    """
+    latest: dict[str, dict[str, Any]] = {}
+    for entry in progress:
+        if not isinstance(entry, dict) or entry.get("type") != AGENT_ENTRY:
+            continue
+        key = str(entry.get("agentId") or entry.get("label") or len(latest))
+        latest[key] = {**latest.get(key, {}), **entry}
+    return list(latest.values())
+
+
+def session_transcript(record_path: Path) -> Path:
+    """Locate the orchestrator conversation that launched a run.
+
+    ``run_e2e.py`` opens one ``ClaudeSDKClient`` and sends a single prompt; that
+    conversation is a sibling ``<session-uuid>.jsonl`` of the session directory.
+
+    Args:
+        record_path: Path of the ``wf_*.json`` record.
+
+    Returns:
+        The session transcript, which may not exist.
+    """
+    session = record_path.parent.parent
+    return session.parent / f"{session.name}.jsonl"
+
+
+def nested_records(record_path: Path, record: dict[str, Any]) -> list[dict[str, Any]]:
+    """Find workflow records that ran inside this one's window.
+
+    A nested ``workflow()`` registers its own record and Claude Code writes no
+    parent link, so containment in the same session is the only join available.
+    It is reported as such rather than presented as an identity match.
+
+    Args:
+        record_path: Path of the parent ``wf_*.json`` record.
+        record: The parsed parent record.
+
+    Returns:
+        Parsed child records, in start order.
+    """
+    start = float(record.get("startTime") or 0.0)
+    end = start + float(record.get("durationMs") or 0.0)
+    if not start:
+        return []
+    found: list[dict[str, Any]] = []
+    for path in sorted(record_path.parent.glob("wf_*.json")):
+        if path == record_path:
+            continue
+        try:
+            child = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        child_start = float(child.get("startTime") or 0.0)
+        if child_start and start <= child_start <= end:
+            child["_path"] = str(path)
+            found.append(child)
+    return sorted(found, key=lambda c: float(c.get("startTime") or 0.0))
+
+
+def build_tree(
+    record: dict[str, Any],
+    transcripts: Path,
+    *,
+    orchestrator: Path | None = None,
+    nested: Iterable[tuple[dict[str, Any], Path]] = (),
+    capture_text: bool = False,
+    text_chars: int = 4000,
+    sink: list[dict[str, Any]] | None = None,
+) -> tuple[Node, dict[str, Any]]:
+    """Place every API call under phase -> agent and roll the totals up.
+
+    Args:
+        record: A parsed ``wf_*.json`` run record.
+        transcripts: Directory holding ``agent-<agentId>.jsonl``.
+        orchestrator: The session transcript of the conversation that launched
+            the run, folded in as its own node when given.
+        nested: ``(record, transcripts)`` pairs for workflows that ran inside
+            this one, grafted as sub-agents.
+        capture_text: Carry each call's prompt and response text.
+        text_chars: Per-block character cap for captured text.
+        sink: When given, every call is appended to it as a flat row carrying
+            its phase and agent, for the per-call sidecar.
+
+    Returns:
+        ``(root, coverage)``, where *coverage* records what the totals omit:
+        agents whose transcript is missing, unpriced calls, and the record's
+        own summary figures for reconciliation.
+    """
+    progress = record.get("workflowProgress")
+    progress = progress if isinstance(progress, list) else []
+    agents = _agent_entries(progress)
+    root = Node(name=str(record.get("runId") or record.get("workflowName") or "geak"))
+    for title in _phase_order(progress):
+        root.child(title)
+
+    coverage: dict[str, Any] = {
+        "run_id": record.get("runId"),
+        "workflow": record.get("workflowName") or record.get("name"),
+        "timestamp": record.get("timestamp"),
+        "default_model": record.get("defaultModel"),
+        "eval_dir": _record_eval_dir(record),
+        "agents_declared": len(agents),
+        "agents_with_transcript": 0,
+        "agents_without_transcript": 0,
+        "agents_estimated_from_summary": [],
+        "transcript_dir": str(transcripts),
+        "record_totals": {
+            "tokens": record.get("totalTokens"),
+            "tool_calls": record.get("totalToolCalls"),
+            "duration_ms": record.get("durationMs"),
+            "agents": record.get("agentCount"),
+        },
+    }
+
+    seen_labels: dict[str, int] = {}
+    for entry in agents:
+        phase = str(entry.get("phaseTitle") or "").strip() or "(no phase)"
+        label = str(entry.get("label") or entry.get("agentId") or "(unlabelled)")
+        agent_id = str(entry.get("agentId") or "")
+        # One label can name several agents -- a retry, or a fan-out the script
+        # did not number. Merging them would hide the retry and collide their
+        # call indices, so each gets its own node.
+        ordinal = seen_labels[label] = seen_labels.get(label, 0) + 1
+        node = root.child(phase).child(label if ordinal == 1 else f"{label} #{ordinal}")
+        path = transcripts / f"agent-{agent_id}.jsonl" if agent_id else Path()
+        calls = read_agent_calls(path, capture_text=capture_text, text_chars=text_chars) if path.is_file() else []
+        if calls:
+            coverage["agents_with_transcript"] += 1
+            for call in calls:
+                _place_call(node, call)
+                _record_flat(sink, call, phase=phase, agent=node.name, agent_id=agent_id)
+        else:
+            coverage["agents_without_transcript"] += 1
+            coverage["agents_estimated_from_summary"].append(f"{phase}/{label}")
+            _place_summary(node, entry)
+        # durationMs is measured by the runtime; the inferred per-call gaps are
+        # not, so the agent's wall-clock comes from the record either way.
+        node.own.ms_total += _agent_ms(entry, node)
+
+    for child, child_dir in nested:
+        child_root, child_cov = build_tree(
+            child,
+            child_dir,
+            capture_text=capture_text,
+            text_chars=text_chars,
+            sink=sink,
+        )
+        child_root.name = f"nested workflow {child.get('runId')}"
+        root.children[child_root.name] = child_root
+        coverage.setdefault("nested_runs", []).append(
+            {
+                "run_id": child.get("runId"),
+                "agents": child_cov["agents_declared"],
+                "calls": child_cov["calls_counted"],
+                "join": "time containment",
+            }
+        )
+
+    if orchestrator is not None and orchestrator.is_file():
+        calls = read_agent_calls(orchestrator, capture_text=capture_text, text_chars=text_chars)
+        node = root.child("(orchestrator)").child("SDK conversation")
+        for call in calls:
+            _place_call(node, call)
+            _record_flat(sink, call, phase="(orchestrator)", agent="SDK conversation", agent_id="")
+        coverage["orchestrator_calls"] = len(calls)
+        coverage["orchestrator_transcript"] = str(orchestrator)
+
+    total = root.roll_up()
+    coverage.update(
+        {
+            "calls_counted": total.calls,
+            "calls_unpriced": total.calls - total.calls_priced,
+            "calls_untimed": total.calls - total.calls_timed,
+            "tool_calls": total.tool_calls,
+            "cost_sources": dict(sorted(total.cost_sources.items())),
+            "models": dict(sorted(total.models.items(), key=lambda kv: (-kv[1], kv[0]))),
+        }
+    )
+    return root, coverage
+
+
+def _agent_ms(entry: dict[str, Any], node: Node) -> float:
+    """Return the agent's wall-clock, preferring the runtime's own figure.
+
+    Args:
+        entry: The ``workflow_agent`` progress entry.
+        node: The agent node, whose children carry inferred per-call gaps.
+
+    Returns:
+        Milliseconds to attribute to the agent, minus what its calls already
+        hold, so the roll-up equals the recorded duration rather than doubling.
+    """
+    recorded = float(entry.get("durationMs") or 0.0)
+    if recorded <= 0:
+        return node.own.ms_total
+    inferred = sum(kid.roll_up().ms_total for kid in node.children.values())
+    return max(0.0, recorded - inferred)
+
+
+def _record_flat(
+    sink: list[dict[str, Any]] | None,
+    call: dict[str, Any],
+    *,
+    phase: str,
+    agent: str,
+    agent_id: str,
+) -> None:
+    """Append one call to the flat per-call sidecar, tagged with its position.
+
+    Args:
+        sink: The accumulator, or ``None`` to skip.
+        call: A normalized API-call row.
+        phase: The phase the call belongs to.
+        agent: The agent node's name.
+        agent_id: The agent's Claude Code id, blank for the orchestrator.
+    """
+    if sink is None:
+        return
+    row = {"phase": phase, "agent": agent, "agent_id": agent_id, **call}
+    row["tool_calls"] = [t.get("tool") for t in (call.get("tool_calls") or [])]
+    sink.append(row)
+
+
+def _place_call(node: Node, call: dict[str, Any]) -> None:
+    """Attach one API call, and its tool invocations, beneath an agent node.
+
+    Tool calls are counted on their own child nodes so the tree bottoms out at
+    tool names without the API-call row counting them a second time.
+
+    Args:
+        node: The agent node.
+        call: A normalized API-call row.
+    """
+    tools = call.get("tool_calls") or []
+    leaf = node.child(f"call {int(call.get('api_call_index') or 0):04d}")
+    leaf.own.add_call({**call, "tool_calls": [], "tool_call_count": 0})
+    for tool in tools:
+        leaf.child(f"tool:{tool.get('tool') or '?'}").own.tool_calls += 1
+
+
+def _place_summary(node: Node, entry: dict[str, Any]) -> None:
+    """Record an agent whose transcript is missing, from the progress entry.
+
+    The entry reports a token total with no input/output split and no model, so
+    the spend is visible in the tree but stays out of the USD total instead of
+    being priced on a guess.
+
+    Args:
+        node: The agent node.
+        entry: The ``workflow_agent`` progress entry.
+    """
+    node.own.add_call(
+        {
+            "model": entry.get("model"),
+            "isl": 0,
+            "osl": int(float(entry.get("tokens") or 0)),
+            "tool_call_count": int(float(entry.get("toolCalls") or 0)),
+            "cost_source": "unavailable",
+            "status": str(entry.get("state") or "ok"),
+        }
+    )
+
+
+_COLUMNS = (
+    "| Node | Calls | Share | ISL | OSL | Tok in | Tok think | Tok out | "
+    "s total | s think | s out | USD | USD think | USD out | Tools |"
+)
+_RULE = "| " + " | ".join(["---"] * 15) + " |"
+
+
+def coverage_lines(coverage: dict[str, Any]) -> list[str]:
+    """Render the coverage section that precedes every number.
+
+    Args:
+        coverage: The dict returned by :func:`build_tree`.
+
+    Returns:
+        Markdown lines.
+    """
+    rec = coverage.get("record_totals") or {}
+    missing = coverage.get("agents_estimated_from_summary") or []
+    lines = [
+        "## Coverage — read before quoting a number",
+        "",
+        "| Limit | Detail |",
+        "| --- | --- |",
+        "| Cost | Derived from the shipped rate card. Claude Code records no "
+        "provider cost, so no figure here is provider-reported. |",
+        f"| Unpriced calls | {coverage.get('calls_unpriced', 0):,} of "
+        f"{coverage.get('calls_counted', 0):,} excluded from the USD total, "
+        "never counted as free. |",
+        "| Per-call time | Inferred from consecutive message timestamps; an "
+        "agent's first call absorbs its queue wait. Agent wall-clock is the "
+        "runtime's own `durationMs`. |",
+        "| Thinking time | Not recorded anywhere. Thinking *tokens* are exact; "
+        "thinking *seconds* are 0 by construction. |",
+        "| Thinking tokens | A subset of `output_tokens` in these transcripts, "
+        "so OSL is output alone, not output + thinking. |",
+        f"| Agents without a transcript | {len(missing)} of "
+        f"{coverage.get('agents_declared', 0)} — token totals shown, no split, "
+        "unpriced. |",
+        "| Agents in parallel | The summed agent durations exceed the run's "
+        "wall-clock wherever the script fanned out; the record's `durationMs` "
+        "is the wall-clock. |",
+        f"| Nested workflows | {_nested_note(coverage)} |",
+        f"| Orchestrator conversation | {_orchestrator_note(coverage)} |",
+        "",
+        "### Reconciliation against the run record",
+        "",
+        "| Figure | Record | Leaf-derived |",
+        "| --- | --- | --- |",
+        f"| Tokens, excluding cache | {_fmt(rec.get('tokens'))} | {coverage.get('_leaf_tokens_nocache', 0):,} |",
+        f"| Tokens, including cache | - | {coverage.get('_leaf_tokens', 0):,} |",
+        f"| Tool calls | {_fmt(rec.get('tool_calls'))} | {coverage.get('tool_calls', 0):,} |",
+        f"| Duration | {_hours(rec.get('duration_ms'))} wall-clock | "
+        f"{_hours(coverage.get('_leaf_ms'))} summed over agents |",
+        f"| Agents | {_fmt(rec.get('agents'))} | {coverage.get('agents_declared', 0):,} |",
+        "",
+        "Tool calls, agent count and per-agent duration reconcile exactly. The "
+        "record's token figure does not, and is not expected to: it sums the "
+        "`tokens` field of the progress entries, a streamed snapshot that lands "
+        "on either side of the transcript sums agent by agent. The transcripts "
+        "are authoritative for tokens.",
+        "",
+    ]
+    if missing:
+        lines += ["Agents estimated from the summary entry:", ""]
+        lines += [f"* `{name}`" for name in missing]
+        lines.append("")
+    return lines
+
+
+def _nested_note(coverage: dict[str, Any]) -> str:
+    """Describe how any nested workflow records were joined.
+
+    Args:
+        coverage: The coverage dict.
+
+    Returns:
+        A table cell.
+    """
+    nested = coverage.get("nested_runs") or []
+    if not nested:
+        return (
+            "None found in this session's window. Every agent here is a direct `agent()` call of the top-level script."
+        )
+    ids = ", ".join(f"`{n['run_id']}` ({n['calls']:,} calls)" for n in nested)
+    return (
+        f"{len(nested)} grafted as sub-agents: {ids}. Claude Code writes no "
+        "parent link, so the join is time containment within the same session, "
+        "not an identity match."
+    )
+
+
+def _orchestrator_note(coverage: dict[str, Any]) -> str:
+    """Describe whether the launching SDK conversation is included.
+
+    Args:
+        coverage: The coverage dict.
+
+    Returns:
+        A table cell.
+    """
+    if "orchestrator_calls" not in coverage:
+        return (
+            "Excluded. `run_e2e.py`'s own `ClaudeSDKClient` turn is not counted; "
+            "pass `--include-orchestrator` to fold it in."
+        )
+    return f"Included — {coverage['orchestrator_calls']:,} calls."
+
+
+def _fmt(value: Any) -> str:
+    """Format a possibly-absent integer for a table cell.
+
+    Args:
+        value: The value to render.
+
+    Returns:
+        A grouped integer, or ``"-"``.
+    """
+    return f"{int(value):,}" if isinstance(value, (int, float)) else "-"
+
+
+def _hours(ms: Any) -> str:
+    """Format milliseconds as hours.
+
+    Args:
+        ms: Milliseconds, possibly absent.
+
+    Returns:
+        A short hours string, or ``"-"``.
+    """
+    return f"{float(ms) / 3_600_000.0:,.2f} h" if isinstance(ms, (int, float)) else "-"
+
+
+def render_markdown(root: Node, coverage: dict[str, Any]) -> str:
+    """Render the whole GEAK report as markdown.
+
+    Args:
+        root: The rolled-up tree.
+        coverage: The coverage dict from :func:`build_tree`.
+
+    Returns:
+        The markdown document.
+    """
+    t = root.total
+    coverage["_leaf_tokens"] = t.isl + t.osl
+    coverage["_leaf_tokens_nocache"] = t.tokens_in + t.osl
+    coverage["_leaf_ms"] = t.ms_total
+    lines = [
+        f"# GEAK call report — `{coverage.get('run_id')}`",
+        "",
+        f"* workflow: `{coverage.get('workflow')}`",
+        f"* started: `{coverage.get('timestamp')}`",
+        f"* eval dir: `{coverage.get('eval_dir') or '(none recorded)'}`",
+        f"* default model: `{coverage.get('default_model')}`",
+        "",
+    ]
+    lines += coverage_lines(coverage)
+    lines += [
+        "## Run totals",
+        "",
+        "| Metric | Value |",
+        "| --- | --- |",
+        f"| API calls | {t.calls:,} |",
+        f"| Tool calls | {t.tool_calls:,} |",
+        f"| ISL | {t.isl:,} |",
+        f"| OSL | {t.osl:,} |",
+        f"| Tokens — input | {t.tokens_in:,} |",
+        f"| Tokens — thinking | {t.tokens_thinking:,} |",
+        f"| Tokens — output (visible) | {t.tokens_out:,} |",
+        f"| Tokens — cache write / read | {t.tokens_cache_write:,} / {t.tokens_cache_read:,} |",
+        f"| Wall-clock | {_hours(t.ms_total)} |",
+        f"| USD (derived) | ${t.usd_total:,.4f} |",
+        f"| Calls priced | {t.calls_priced:,} / {t.calls:,} |",
+        "",
+        "## Phase -> agent -> API call -> tool call",
+        "",
+        _COLUMNS,
+        _RULE,
+    ]
+    _render_rows(root, 0, None, lines)
+    lines += ["", "## Models", "", "| Model | Calls |", "| --- | --- |"]
+    for model, count in (coverage.get("models") or {}).items():
+        lines.append(f"| `{model}` | {count:,} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def join_hyperloom(root: Node, session_dir: Path, coverage: dict[str, Any]) -> Node:
+    """Nest the GEAK tree inside the Hyperloom session that drove it.
+
+    The session's own ledgers supply the outer phases. Rows the GEAK harvester
+    already recovered into the session's ``ext`` shard are dropped first: they
+    describe the same calls this tree reads from the transcripts, and keeping
+    both would bill the run twice.
+
+    Args:
+        root: The rolled-up GEAK tree.
+        session_dir: The Hyperloom session root.
+        coverage: The GEAK coverage dict, annotated in place.
+
+    Returns:
+        The combined root.
+    """
+    from hyperloom.inference_optimizer.tools.dump_llm_call_report import (
+        build_tree as hl_build_tree,
+        load_ledgers,
+    )
+
+    turns, details = load_ledgers(session_dir)
+    dropped = sum(1 for r in turns + details if str(r.get("component") or "") == "geak")
+    turns = [r for r in turns if str(r.get("component") or "") != "geak"]
+    details = [r for r in details if str(r.get("component") or "") != "geak"]
+    outer, hl_coverage = hl_build_tree(turns, details)
+    outer.name = session_dir.name
+    # GEAK *is* the kernel-agent phase, so it belongs under that node whether or
+    # not the session's own ledger has any rows there -- a session that never
+    # harvested GEAK has the phase missing, not empty.
+    host = outer.child("KERNEL_AGENT")
+    root.name = f"GEAK {coverage.get('run_id')}"
+    host.children[root.name] = root
+    outer.roll_up()
+    coverage["hyperloom_session"] = str(session_dir)
+    coverage["hyperloom_geak_rows_dropped"] = dropped
+    coverage["hyperloom_phases"] = sorted(outer.children)
+    coverage["hyperloom_coverage"] = hl_coverage
+    return outer
+
+
+def _output_dir(run_id: str, explicit: Path | None) -> Path:
+    """Pick where the report is written.
+
+    Args:
+        run_id: The workflow run id, used as the leaf directory.
+        explicit: ``--output-dir``, when given.
+
+    Returns:
+        The directory to write into.
+    """
+    if explicit is not None:
+        return explicit
+    base = os.environ.get("USER_DATA_PATH", "").strip()
+    return (Path(base) if base else Path.cwd()) / "reports" / run_id
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Argument vector; defaults to ``sys.argv``.
+
+    Returns:
+        Parsed arguments.
+    """
+    p = argparse.ArgumentParser(description="Render a GEAK phase/agent/call report.")
+    sel = p.add_argument_group("run selection (one required)")
+    sel.add_argument("--eval-dir", default=None, help="GEAK eval dir the run was pointed at")
+    sel.add_argument("--run-id", default=None, help="Workflow run id, e.g. wf_ec8b57b0-1a7")
+    sel.add_argument("--session-dir", type=Path, default=None, help="Hyperloom session root")
+    p.add_argument(
+        "--claude-home",
+        type=Path,
+        action="append",
+        default=[],
+        help="Extra Claude Code home to search (repeatable)",
+    )
+    p.add_argument("--join-hyperloom", type=Path, default=None, help="Nest under this session's phases")
+    p.add_argument("--output-dir", "-o", type=Path, default=None, help="Where to write the report")
+    p.add_argument("--max-depth", type=int, default=0, help="Trim the tree to this depth (0 = no limit)")
+    p.add_argument(
+        "--list",
+        action="store_true",
+        help="List runs and exit; with no selector, lists every record found",
+    )
+    p.add_argument(
+        "--include-orchestrator",
+        action="store_true",
+        help="Also count the SDK conversation that launched the run",
+    )
+    p.add_argument(
+        "--include-text",
+        action="store_true",
+        help="Write geak_calls.jsonl carrying each call's prompt and response",
+    )
+    p.add_argument(
+        "--text-chars",
+        type=int,
+        default=4000,
+        help="Per-block character cap for captured text (0 = uncapped)",
+    )
+    p.add_argument(
+        "--no-nested",
+        action="store_true",
+        help="Do not graft workflows that ran inside this one's window",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point.
+
+    Args:
+        argv: Argument vector; defaults to ``sys.argv``.
+
+    Returns:
+        ``0`` on success, ``2`` when no run record matches the selector.
+    """
+    args = _parse_args(argv)
+    if not (args.eval_dir or args.run_id or args.session_dir or args.list):
+        print("one of --eval-dir, --run-id or --session-dir is required", file=sys.stderr)
+        return 2
+    hits = resolve_runs(
+        homes=claude_homes(args.claude_home),
+        eval_dir=args.eval_dir,
+        run_id=args.run_id,
+        session_dir=args.session_dir,
+        list_all=args.list and not (args.eval_dir or args.run_id or args.session_dir),
+    )
+    if not hits:
+        print("no workflow record found for that selector", file=sys.stderr)
+        return 2
+    if args.list:
+        for path, record in hits:
+            print(f"{record.get('runId')}\t{record.get('timestamp')}\t{_record_eval_dir(record) or '-'}\t{path}")
+        return 0
+
+    path, record = hits[0]
+    run_id = str(record.get("runId"))
+    children = [] if args.no_nested else nested_records(path, record)
+    calls: list[dict[str, Any]] = []
+    root, coverage = build_tree(
+        record,
+        transcript_dir(path, run_id),
+        orchestrator=session_transcript(path) if args.include_orchestrator else None,
+        nested=[(c, transcript_dir(Path(c["_path"]), str(c.get("runId")))) for c in children],
+        capture_text=args.include_text,
+        text_chars=args.text_chars,
+        sink=calls,
+    )
+    coverage["record_path"] = str(path)
+    coverage["candidates"] = [
+        {"run_id": r.get("runId"), "timestamp": r.get("timestamp"), "path": str(p)} for p, r in hits
+    ]
+    if args.max_depth:
+        _trim(root, 0, args.max_depth)
+        root.roll_up()
+    if args.join_hyperloom is not None:
+        root = join_hyperloom(root, args.join_hyperloom, coverage)
+
+    out_dir = _output_dir(run_id, args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    md_path = out_dir / "geak_call_report.md"
+    json_path = out_dir / "geak_call_report.json"
+    if args.include_text:
+        calls_path = out_dir / "geak_calls.jsonl"
+        with calls_path.open("w", encoding="utf-8") as fh:
+            for row in calls:
+                fh.write(json.dumps(row) + "\n")
+        coverage["calls_sidecar"] = str(calls_path)
+    md_path.write_text(render_markdown(root, coverage), encoding="utf-8")
+    json_path.write_text(
+        json.dumps({"coverage": coverage, "tree": root.as_dict()}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        f"wrote {md_path} and {json_path} "
+        f"({root.total.calls:,} calls, {root.total.tool_calls:,} tool calls, "
+        f"${root.total.usd_total:,.4f})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/hyperloom/inference_optimizer/tools/dump_llm_call_report.py
+++ b/src/hyperloom/inference_optimizer/tools/dump_llm_call_report.py
@@ -376,6 +376,30 @@ def _segments(row: dict[str, Any]) -> list[str]:
     return [phase] + (parts or [UNPATHED])
 
 
+def call_identity(row: dict[str, Any]) -> str:
+    """Return the key that joins a turn row to its per-API-call detail rows.
+
+    ``call_id`` is the join key whenever the producer wrote one. Some backends
+    -- the specialist and critic runners, on sessions recorded before they
+    learned to emit one -- write no ``call_id`` on *either* side. Falling back
+    to the empty string there silently breaks the join in the worst possible
+    way: the detail row looks orphaned, its turn row looks undetailed, and the
+    same API call is counted twice. The session, task path and turn number
+    identify a turn uniquely and are present on both sides, so they are the
+    fallback.
+
+    Args:
+        row: A turn or detail row.
+
+    Returns:
+        An opaque key; equal keys mean the same turn.
+    """
+    call_id = row.get("call_id")
+    if call_id:
+        return f"id:{call_id}"
+    return "key:{}|{}|{}".format(row.get("session_id"), row.get("task_path"), row.get("turn"))
+
+
 def build_tree(turns: Iterable[dict[str, Any]], details: Iterable[dict[str, Any]]) -> tuple[Node, dict[str, Any]]:
     """Place every call in the phase -> task tree and roll the totals up.
 
@@ -393,7 +417,7 @@ def build_tree(turns: Iterable[dict[str, Any]], details: Iterable[dict[str, Any]
     """
     turns = list(turns)
     details = list(details)
-    detailed_ids = {str(r.get("call_id")) for r in details if r.get("call_id")}
+    detailed_ids = {call_identity(r) for r in details}
 
     root = Node(name="session")
     coverage: dict[str, Any] = {
@@ -410,15 +434,15 @@ def build_tree(turns: Iterable[dict[str, Any]], details: Iterable[dict[str, Any]
             node = node.child(seg)
         return node
 
-    turn_ids = {str(r.get("call_id")) for r in turns if r.get("call_id")}
+    turn_ids = {call_identity(r) for r in turns}
     for row in details:
         place(row).own.add_call(row)
-        if str(row.get("call_id") or "") not in turn_ids:
+        if call_identity(row) not in turn_ids:
             coverage["detail_rows_orphaned"] += 1
     for row in turns:
         node = place(row)
         node.own.turns += 1
-        if str(row.get("call_id") or "") in detailed_ids:
+        if call_identity(row) in detailed_ids:
             coverage["turns_with_detail"] += 1
         else:
             coverage["turns_without_detail"] += 1

--- a/src/hyperloom/inference_optimizer/tools/dump_llm_call_report.py
+++ b/src/hyperloom/inference_optimizer/tools/dump_llm_call_report.py
@@ -1,0 +1,731 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Render the per-LLM-call report for a session as a phase -> task tree.
+
+Reads the two ledgers written during a run -- ``llm_calls.jsonl`` (one row per
+agentic turn) and its ``llm_calls_detail.jsonl`` sidecar (one row per real API
+call) -- plus every out-of-process ``ext/`` shard, including the GEAK spend the
+harvester recovers. Rows are placed in a tree by ``phase`` then by the segments
+of ``task_path``, and every node reports the roll-up of the calls beneath it:
+call counts, ISL/OSL, tokens (input / thinking / output / cache), wall-clock
+(total / thinking / output), USD (total / thinking / output) and tool calls,
+each against its share of its parent.
+
+Usage::
+
+    python -m hyperloom.inference_optimizer.tools.dump_llm_call_report \\
+        --session-dir /shared/hyperloom-sessions/<user>/<sid>
+
+Writes ``llm_call_report.md`` and ``llm_call_report.json`` to
+``$USER_DATA_PATH/reports/<session-id>/`` unless ``--output-dir`` says
+otherwise.
+
+Two properties matter more than the totals themselves:
+
+* A turn with no detail rows is still counted, once, from the turn row. A turn
+  that has detail rows is counted **only** from them, so the same spend is
+  never added twice.
+* An unpriced call is left out of the USD total rather than counted as free,
+  and the coverage section says how many such calls there were. A partial total
+  presented as a total is worse than no total.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+log = logging.getLogger("dump_llm_call_report")
+
+#: Separator used inside the ledgers' flat ``task_path`` string.
+PATH_SEPARATOR = "/"
+
+#: ``cost_source`` value meaning the call could not be priced at all.
+COST_UNAVAILABLE = "unavailable"
+
+#: ``timing_source`` value meaning the thinking/output split was estimated from
+#: the token ratio rather than measured off stream events.
+TIMING_APPORTIONED = "apportioned"
+
+#: Node label for rows that carry no ``phase``.
+UNPHASED = "(no phase)"
+
+#: Node label for rows that carry no ``task_path``.
+UNPATHED = "(no task path)"
+
+_TOKEN_FIELDS = (
+    ("input_tokens", "tokens_in"),
+    ("output_tokens", "tokens_out"),
+    ("reasoning_output_tokens", "tokens_thinking"),
+    ("cache_creation_input_tokens", "tokens_cache_write"),
+    ("cache_read_input_tokens", "tokens_cache_read"),
+)
+
+_TIME_FIELDS = (
+    ("latency_ms", "ms_total"),
+    ("thinking_ms", "ms_thinking"),
+    ("output_ms", "ms_output"),
+)
+
+_COST_FIELDS = (
+    ("cost_usd", "usd_total"),
+    ("cost_input_usd", "usd_input"),
+    ("cost_output_usd", "usd_output"),
+    ("cost_thinking_usd", "usd_thinking"),
+    ("cost_cache_usd", "usd_cache"),
+)
+
+
+def _num(value: Any) -> float:
+    """Read a numeric ledger field, treating a missing one as zero.
+
+    Args:
+        value: Ledger field value, possibly ``None`` or of a foreign type.
+
+    Returns:
+        The value as a float, or ``0.0``.
+    """
+    return float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else 0.0
+
+
+@dataclass
+class Totals:
+    """Roll-up of every API call beneath one node of the report tree."""
+
+    calls: int = 0
+    turns: int = 0
+    tool_calls: int = 0
+    isl: int = 0
+    osl: int = 0
+    tokens_in: int = 0
+    tokens_out: int = 0
+    tokens_thinking: int = 0
+    tokens_cache_write: int = 0
+    tokens_cache_read: int = 0
+    ms_total: float = 0.0
+    ms_thinking: float = 0.0
+    ms_output: float = 0.0
+    usd_total: float = 0.0
+    usd_input: float = 0.0
+    usd_output: float = 0.0
+    usd_thinking: float = 0.0
+    usd_cache: float = 0.0
+    calls_priced: int = 0
+    calls_timed: int = 0
+    calls_apportioned: int = 0
+    errors: int = 0
+    models: dict[str, int] = field(default_factory=dict)
+    cost_sources: dict[str, int] = field(default_factory=dict)
+
+    def add_call(self, row: dict[str, Any]) -> None:
+        """Fold one API call (or an undetailed turn) into this roll-up.
+
+        Args:
+            row: A ledger row from either the detail sidecar or the turn ledger.
+        """
+        self.calls += 1
+        for src, dst in _TOKEN_FIELDS:
+            setattr(self, dst, getattr(self, dst) + int(_num(row.get(src))))
+        isl = row.get("isl")
+        osl = row.get("osl")
+        # Turn rows carry no ISL/OSL: they are derived here on the same rule
+        # the detail writer uses, so a mixed tree stays comparable.
+        self.isl += (
+            int(_num(isl))
+            if isl is not None
+            else (
+                int(_num(row.get("input_tokens")))
+                + int(_num(row.get("cache_read_input_tokens")))
+                + int(_num(row.get("cache_creation_input_tokens")))
+            )
+        )
+        self.osl += (
+            int(_num(osl))
+            if osl is not None
+            else (int(_num(row.get("output_tokens"))) + int(_num(row.get("reasoning_output_tokens"))))
+        )
+        for src, dst in _TIME_FIELDS:
+            setattr(self, dst, getattr(self, dst) + _num(row.get(src)))
+        if row.get("latency_ms") is not None:
+            self.calls_timed += 1
+        if str(row.get("timing_source") or "").strip().lower() == TIMING_APPORTIONED:
+            self.calls_apportioned += 1
+        source = str(row.get("cost_source") or "").strip().lower()
+        if source and source != COST_UNAVAILABLE:
+            for src, dst in _COST_FIELDS:
+                setattr(self, dst, getattr(self, dst) + _num(row.get(src)))
+            self.calls_priced += 1
+            self.cost_sources[source] = self.cost_sources.get(source, 0) + 1
+        tools = row.get("tool_calls")
+        if isinstance(tools, list):
+            self.tool_calls += len(tools)
+        else:
+            self.tool_calls += int(_num(row.get("tool_call_count")))
+        if str(row.get("status") or "ok").strip().lower() not in ("", "ok"):
+            self.errors += 1
+        model = str(row.get("model") or "").strip()
+        if model:
+            self.models[model] = self.models.get(model, 0) + 1
+
+    def merge(self, other: "Totals") -> None:
+        """Add a child's roll-up into this one.
+
+        Args:
+            other: The child roll-up to absorb.
+        """
+        for name in (
+            "calls",
+            "turns",
+            "tool_calls",
+            "isl",
+            "osl",
+            "tokens_in",
+            "tokens_out",
+            "tokens_thinking",
+            "tokens_cache_write",
+            "tokens_cache_read",
+            "ms_total",
+            "ms_thinking",
+            "ms_output",
+            "usd_total",
+            "usd_input",
+            "usd_output",
+            "usd_thinking",
+            "usd_cache",
+            "calls_priced",
+            "calls_timed",
+            "calls_apportioned",
+            "errors",
+        ):
+            setattr(self, name, getattr(self, name) + getattr(other, name))
+        for src, dst in ((other.models, self.models), (other.cost_sources, self.cost_sources)):
+            for k, v in src.items():
+                dst[k] = dst.get(k, 0) + v
+
+    def as_dict(self) -> dict[str, Any]:
+        """Project to a JSON-safe dict with the derived averages included.
+
+        Returns:
+            The roll-up, with USD rounded to cents-of-a-cent and per-call means.
+        """
+        out: dict[str, Any] = {
+            "calls": self.calls,
+            "turns": self.turns,
+            "tool_calls": self.tool_calls,
+            "isl": self.isl,
+            "osl": self.osl,
+            "tokens_in": self.tokens_in,
+            "tokens_thinking": self.tokens_thinking,
+            "tokens_out": self.tokens_out,
+            "tokens_cache_write": self.tokens_cache_write,
+            "tokens_cache_read": self.tokens_cache_read,
+            "tokens_total": self.isl + self.osl,
+            "ms_total": round(self.ms_total, 1),
+            "ms_thinking": round(self.ms_thinking, 1),
+            "ms_output": round(self.ms_output, 1),
+            "usd_total": round(self.usd_total, 6),
+            "usd_input": round(self.usd_input, 6),
+            "usd_output": round(self.usd_output, 6),
+            "usd_thinking": round(self.usd_thinking, 6),
+            "usd_cache": round(self.usd_cache, 6),
+            "calls_priced": self.calls_priced,
+            "calls_timed": self.calls_timed,
+            "calls_apportioned": self.calls_apportioned,
+            "errors": self.errors,
+            "cost_sources": dict(sorted(self.cost_sources.items())),
+            "models": dict(sorted(self.models.items(), key=lambda kv: (-kv[1], kv[0]))),
+        }
+        if self.calls:
+            out["mean_isl"] = round(self.isl / self.calls, 1)
+            out["mean_osl"] = round(self.osl / self.calls, 1)
+        if self.calls_timed:
+            out["mean_ms"] = round(self.ms_total / self.calls_timed, 1)
+        return out
+
+
+@dataclass
+class Node:
+    """One node of the phase -> task -> subtask tree."""
+
+    name: str
+    children: dict[str, "Node"] = field(default_factory=dict)
+    own: Totals = field(default_factory=Totals)
+    total: Totals = field(default_factory=Totals)
+
+    def child(self, name: str) -> "Node":
+        """Return (creating if needed) the child node called *name*.
+
+        Args:
+            name: Path segment.
+
+        Returns:
+            The child node.
+        """
+        node = self.children.get(name)
+        if node is None:
+            node = Node(name=name)
+            self.children[name] = node
+        return node
+
+    def roll_up(self) -> Totals:
+        """Recompute ``total`` from ``own`` plus every descendant.
+
+        Returns:
+            This node's inclusive roll-up.
+        """
+        total = Totals()
+        total.merge(self.own)
+        for kid in self.children.values():
+            total.merge(kid.roll_up())
+        self.total = total
+        return total
+
+    def as_dict(self) -> dict[str, Any]:
+        """Project the subtree to JSON, heaviest child first.
+
+        Returns:
+            A nested dict of ``{name, totals, own, children}``.
+        """
+        kids = sorted(self.children.values(), key=lambda n: (-n.total.usd_total, -n.total.calls, n.name))
+        return {
+            "name": self.name,
+            "totals": self.total.as_dict(),
+            "own": self.own.as_dict() if self.own.calls else None,
+            "children": [k.as_dict() for k in kids],
+        }
+
+
+def read_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    """Yield each parseable object from a JSONL ledger.
+
+    A truncated final line is normal for a run that was killed, so a bad line
+    is skipped rather than aborting the whole report.
+
+    Args:
+        path: Ledger file; a missing file yields nothing.
+
+    Yields:
+        One row dict per readable line.
+    """
+    if not path.is_file():
+        return
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(row, dict):
+                yield row
+
+
+def load_ledgers(session_dir: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Load every turn row and every detail row for a session.
+
+    Both the in-process ledgers and the ``ext/`` shards written by
+    out-of-process children (GEAK above all) are read; the ``.detail.jsonl``
+    shards are the per-API-call side of the same pair.
+
+    Args:
+        session_dir: The session root directory.
+
+    Returns:
+        ``(turn_rows, detail_rows)``.
+    """
+    from hyperloom.inference_optimizer.session.session_paths import (
+        llm_call_detail_path,
+        llm_calls_path,
+        trace_ext_dir,
+    )
+
+    turns = list(read_jsonl(llm_calls_path(session_dir)))
+    details = list(read_jsonl(llm_call_detail_path(session_dir)))
+    ext = trace_ext_dir(session_dir)
+    if ext.is_dir():
+        for shard in sorted(ext.glob("*.jsonl")):
+            if shard.name.endswith(".detail.jsonl"):
+                details.extend(read_jsonl(shard))
+            else:
+                turns.extend(read_jsonl(shard))
+    return turns, details
+
+
+def _segments(row: dict[str, Any]) -> list[str]:
+    """Return the tree path a row belongs under, phase first.
+
+    Args:
+        row: A turn or detail row.
+
+    Returns:
+        Path segments, always at least one deep.
+    """
+    phase = str(row.get("phase") or "").strip() or UNPHASED
+    raw = str(row.get("task_path") or "").strip()
+    parts = [p for p in raw.split(PATH_SEPARATOR) if p] if raw else []
+    return [phase] + (parts or [UNPATHED])
+
+
+def build_tree(turns: Iterable[dict[str, Any]], details: Iterable[dict[str, Any]]) -> tuple[Node, dict[str, Any]]:
+    """Place every call in the phase -> task tree and roll the totals up.
+
+    A turn that expanded into detail rows contributes only those rows; a turn
+    with none is counted once from the turn row itself, so nothing is double
+    counted and nothing is dropped.
+
+    Args:
+        turns: Turn-level rows.
+        details: Per-API-call rows.
+
+    Returns:
+        ``(root, coverage)`` where *coverage* records what the totals do not
+        cover: undetailed turns, unpriced and untimed calls, apportioned splits.
+    """
+    turns = list(turns)
+    details = list(details)
+    detailed_ids = {str(r.get("call_id")) for r in details if r.get("call_id")}
+
+    root = Node(name="session")
+    coverage: dict[str, Any] = {
+        "turns_total": len(turns),
+        "turns_with_detail": 0,
+        "turns_without_detail": 0,
+        "detail_rows": len(details),
+        "detail_rows_orphaned": 0,
+    }
+
+    def place(row: dict[str, Any]) -> Node:
+        node = root
+        for seg in _segments(row):
+            node = node.child(seg)
+        return node
+
+    turn_ids = {str(r.get("call_id")) for r in turns if r.get("call_id")}
+    for row in details:
+        place(row).own.add_call(row)
+        if str(row.get("call_id") or "") not in turn_ids:
+            coverage["detail_rows_orphaned"] += 1
+    for row in turns:
+        node = place(row)
+        node.own.turns += 1
+        if str(row.get("call_id") or "") in detailed_ids:
+            coverage["turns_with_detail"] += 1
+        else:
+            coverage["turns_without_detail"] += 1
+            node.own.add_call(row)
+
+    total = root.roll_up()
+    coverage["calls_counted"] = total.calls
+    coverage["calls_unpriced"] = total.calls - total.calls_priced
+    coverage["calls_untimed"] = total.calls - total.calls_timed
+    coverage["calls_timing_apportioned"] = total.calls_apportioned
+    coverage["cost_sources"] = dict(sorted(total.cost_sources.items()))
+    return root, coverage
+
+
+def _pct(part: float, whole: float) -> str:
+    """Format *part* as a percentage of *whole*.
+
+    Args:
+        part: Numerator.
+        whole: Denominator; zero yields a dash.
+
+    Returns:
+        A short percentage string, or ``"-"``.
+    """
+    return f"{100.0 * part / whole:.1f}%" if whole else "-"
+
+
+def _share(node: Totals, parent: Totals | None) -> str:
+    """Format a node's share of its parent, by cost where cost is known.
+
+    An unpriced run would show a dash in every row, which says nothing about
+    where the work went, so the share falls back to call count there.
+
+    Args:
+        node: The node's roll-up.
+        parent: The parent's roll-up; ``None`` at the root.
+
+    Returns:
+        A percentage string.
+    """
+    if parent is None:
+        return "100.0%"
+    if parent.usd_total:
+        return _pct(node.usd_total, parent.usd_total)
+    return _pct(node.calls, parent.calls)
+
+
+def _render_rows(node: Node, depth: int, parent: Totals | None, out: list[str]) -> None:
+    """Append one markdown table row per node, depth-first.
+
+    Args:
+        node: Subtree root to render.
+        depth: Indentation depth (0 = session).
+        parent: The parent's roll-up, for the share column.
+        out: Line accumulator (mutated).
+    """
+    t = node.total
+    indent = "&nbsp;" * 4 * depth
+    label = f"{indent}{'└ ' if depth else ''}`{node.name}`"
+    out.append(
+        "| "
+        + " | ".join(
+            [
+                label,
+                str(t.calls),
+                _share(t, parent),
+                f"{t.isl:,}",
+                f"{t.osl:,}",
+                f"{t.tokens_in:,}",
+                f"{t.tokens_thinking:,}",
+                f"{t.tokens_out:,}",
+                f"{t.ms_total / 1000.0:,.1f}",
+                f"{t.ms_thinking / 1000.0:,.1f}",
+                f"{t.ms_output / 1000.0:,.1f}",
+                f"{t.usd_total:,.4f}",
+                f"{t.usd_thinking:,.4f}",
+                f"{t.usd_output:,.4f}",
+                str(t.tool_calls),
+            ]
+        )
+        + " |"
+    )
+    for kid in sorted(node.children.values(), key=lambda n: (-n.total.usd_total, -n.total.calls, n.name)):
+        _render_rows(kid, depth + 1, t, out)
+
+
+def _has_node(node: Node, name: str) -> bool:
+    """Report whether any node in the subtree carries *name*.
+
+    Args:
+        node: Subtree root.
+        name: Segment to look for.
+
+    Returns:
+        ``True`` when the segment appears anywhere beneath (or at) *node*.
+    """
+    if node.name == name:
+        return True
+    return any(_has_node(kid, name) for kid in node.children.values())
+
+
+def render_markdown(session_id: str, root: Node, coverage: dict[str, Any]) -> str:
+    """Render the whole report as markdown.
+
+    Args:
+        session_id: Session identifier, for the heading.
+        root: The rolled-up tree.
+        coverage: The coverage dict from :func:`build_tree`.
+
+    Returns:
+        The markdown document.
+    """
+    t = root.total
+    lines = [
+        f"# LLM call report — `{session_id}`",
+        "",
+        "## Session totals",
+        "",
+        "| Metric | Value |",
+        "| --- | --- |",
+        f"| API calls | {t.calls:,} |",
+        f"| Agentic turns | {t.turns:,} |",
+        f"| Tool calls | {t.tool_calls:,} |",
+        f"| ISL (input sequence length) | {t.isl:,} |",
+        f"| OSL (output sequence length) | {t.osl:,} |",
+        f"| Tokens — input | {t.tokens_in:,} |",
+        f"| Tokens — thinking | {t.tokens_thinking:,} |",
+        f"| Tokens — output (visible) | {t.tokens_out:,} |",
+        f"| Tokens — cache write / read | {t.tokens_cache_write:,} / {t.tokens_cache_read:,} |",
+        f"| Time — total | {t.ms_total / 1000.0:,.1f} s |",
+        f"| Time — thinking | {t.ms_thinking / 1000.0:,.1f} s |",
+        f"| Time — output | {t.ms_output / 1000.0:,.1f} s |",
+        f"| Cost — total | ${t.usd_total:,.4f} |",
+        f"| Cost — input / cache | ${t.usd_input:,.4f} / ${t.usd_cache:,.4f} |",
+        f"| Cost — thinking | ${t.usd_thinking:,.4f} |",
+        f"| Cost — output | ${t.usd_output:,.4f} |",
+        f"| Failed calls | {t.errors:,} |",
+        "",
+        "Thinking tokens sit beside the visible output tokens, not inside them: "
+        "`OSL` is output + thinking, and the cost total is input + output + "
+        "thinking + cache.",
+        "",
+        "## Phase → task → subtask tree",
+        "",
+        "| Node | Calls | $ share | ISL | OSL | Tok in | Tok think | Tok out "
+        "| Time s | Think s | Out s | $ total | $ think | $ out | Tools |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    _render_rows(root, 0, None, lines)
+
+    lines += ["", "## Models", "", "| Model | Calls |", "| --- | ---: |"]
+    for model, count in sorted(t.models.items(), key=lambda kv: (-kv[1], kv[0])):
+        lines.append(f"| `{model}` | {count:,} |")
+    if not t.models:
+        lines.append("| _(no model recorded)_ | 0 |")
+
+    lines += ["", "## Coverage", "", "What the numbers above do and do not cover.", ""]
+    unpriced = int(coverage.get("calls_unpriced", 0))
+    untimed = int(coverage.get("calls_untimed", 0))
+    apportioned = int(coverage.get("calls_timing_apportioned", 0))
+    lines += [
+        f"- **Priced:** {t.calls_priced:,} of {t.calls:,} calls carry a cost. "
+        + (
+            f"**{unpriced:,} do not and are excluded from every USD figure** — the totals are a floor, not the bill."
+            if unpriced
+            else "Every call is priced."
+        ),
+        f"- **Cost sources:** {coverage.get('cost_sources') or '(none)'} — a provider figure is the charge itself; "
+        "a derived one is the shipped rate card applied to the token counts.",
+        f"- **Timed:** {t.calls_timed:,} of {t.calls:,} calls carry a latency."
+        + (f" {untimed:,} do not." if untimed else ""),
+        f"- **Thinking/output split:** {apportioned:,} call(s) had it apportioned from the token ratio rather than "
+        "measured off stream events; read those two columns as estimates.",
+        f"- **Turns:** {coverage.get('turns_with_detail', 0):,} of {coverage.get('turns_total', 0):,} expanded into "
+        f"per-call detail rows; the other {coverage.get('turns_without_detail', 0):,} are each counted once from the "
+        "turn row alone, so their per-call breakdown is the turn's aggregate.",
+    ]
+    orphans = int(coverage.get("detail_rows_orphaned", 0))
+    if orphans:
+        lines.append(
+            f"- **Orphans:** {orphans:,} detail row(s) join to no turn row — usually a child shard whose turn row "
+            "was written by a process that did not finish."
+        )
+    if not _has_node(root, "geak"):
+        lines.append(
+            "- **GEAK:** no `geak` subtree is present. If this run invoked the kernel agent, its spend "
+            "(historically the majority of a session's bill) was not harvested."
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _resolve_output_dir(session_dir: Path, explicit: Path | None) -> Path:
+    """Pick where the report is written.
+
+    Args:
+        session_dir: The session root directory.
+        explicit: ``--output-dir``, when given.
+
+    Returns:
+        The directory to write into.
+    """
+    if explicit is not None:
+        return explicit
+    base = os.environ.get("USER_DATA_PATH", "").strip()
+    if base:
+        return Path(base) / "reports" / session_dir.name
+    return session_dir / "reports"
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Argument vector; defaults to ``sys.argv``.
+
+    Returns:
+        Parsed arguments.
+    """
+    p = argparse.ArgumentParser(description="Render a Hyperloom per-LLM-call report.")
+    p.add_argument("--session-dir", "-s", required=True, type=Path, help="Session root directory")
+    p.add_argument("--output-dir", "-o", type=Path, default=None, help="Where to write the report")
+    p.add_argument("--max-depth", type=int, default=0, help="Trim the tree to this depth (0 = no limit)")
+    return p.parse_args(argv)
+
+
+def _collapse(node: Node) -> None:
+    """Fold every descendant's own calls into *node*, then drop the descendants.
+
+    The point of trimming is a shorter table, not a smaller total, so the
+    dropped levels' spend has to survive as the surviving node's own.
+
+    Args:
+        node: The node to collapse into.
+    """
+    for kid in node.children.values():
+        _collapse(kid)
+        node.own.merge(kid.own)
+    node.children.clear()
+
+
+def _trim(node: Node, depth: int, limit: int) -> None:
+    """Drop children below *limit*, keeping their totals folded into the parent.
+
+    Args:
+        node: Subtree root.
+        depth: Current depth.
+        limit: Maximum depth to keep; ``0`` disables trimming.
+    """
+    if limit and depth >= limit:
+        _collapse(node)
+        return
+    for kid in node.children.values():
+        _trim(kid, depth + 1, limit)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point.
+
+    Args:
+        argv: Argument vector; defaults to ``sys.argv``.
+
+    Returns:
+        ``0`` on success, ``2`` when the session directory has no ledger.
+    """
+    logging.basicConfig(
+        level=os.environ.get("HYPERLOOM_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    args = _parse_args(argv)
+    session_dir = args.session_dir
+    if not session_dir.is_dir():
+        log.error("session dir not found: %s", session_dir)
+        return 2
+
+    turns, details = load_ledgers(session_dir)
+    if not turns and not details:
+        log.error("no LLM ledger rows under %s/reports/trace", session_dir)
+        return 2
+
+    root, coverage = build_tree(turns, details)
+    if args.max_depth:
+        _trim(root, 0, args.max_depth)
+        root.roll_up()
+
+    out_dir = _resolve_output_dir(session_dir, args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    md_path = out_dir / "llm_call_report.md"
+    json_path = out_dir / "llm_call_report.json"
+    md_path.write_text(render_markdown(session_dir.name, root, coverage))
+    json_path.write_text(
+        json.dumps(
+            {"session_id": session_dir.name, "coverage": coverage, "tree": root.as_dict()},
+            indent=2,
+            sort_keys=False,
+        )
+        + "\n"
+    )
+    log.info(
+        "wrote %s and %s (%d calls, %d turns, $%.4f)",
+        md_path,
+        json_path,
+        root.total.calls,
+        root.total.turns,
+        root.total.usd_total,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
+++ b/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
@@ -382,7 +382,18 @@ def join_outcome(phases: list[dict[str, Any]], outcome: dict[str, Any] | None) -
 
 
 def _esc(value: Any) -> str:
-    return html.escape("" if value is None else str(value), quote=True)
+    """HTML-escape, and fold every non-ASCII character to a numeric entity.
+
+    The page is written UTF-8 and declares it, but it gets opened from shared
+    storage, out of archives and through viewers that ignore the declaration --
+    and a mis-decoded em dash renders as mojibake with no clue as to why. Pure
+    ASCII bytes cannot be mis-decoded, so the document is kept pure ASCII and
+    anything outside it travels as an entity the browser resolves itself.
+    """
+    text = html.escape(str(value), quote=True)
+    if text.isascii():
+        return text
+    return "".join(ch if ord(ch) < 128 else f"&#{ord(ch)};" for ch in text)
 
 
 def _usd(value: Any) -> str:
@@ -461,6 +472,7 @@ tbody tr:hover{background:color-mix(in srgb,var(--accent) 7%,transparent)}
 overflow:hidden;vertical-align:middle;margin-left:7px}
 .bar i{display:block;height:100%;background:var(--spend)}
 .bar.time i{background:var(--time)}
+tr.ref td{background:var(--card)}
 .good{color:var(--good)}.bad{color:var(--bad)}.none{color:var(--mut);font-style:italic}
 .mut{color:var(--mut)}
 .spark{display:block;margin-top:4px}
@@ -554,7 +566,7 @@ def _coverage_section(cov: dict[str, Any], outcome: dict[str, Any] | None) -> st
     )
     items = "".join(f"<li>{_esc(c)}</li>" for c in caveats)
     return (
-        '<div class="note"><b>Coverage &mdash; read this before quoting a number</b>'
+        '<div class="note"><b>Coverage - read this before quoting a number</b>'
         f"<div>{cov['calls']:,} API calls across {cov['agents']} agents and {cov['phases']} phases, "
         f"model{'s' if len(cov['models']) != 1 else ''} {_esc(', '.join(cov['models']) or 'not recorded')}."
         f"</div><ul>{items}</ul></div>"
@@ -567,15 +579,26 @@ def _headline_cards(cov: dict[str, Any], outcome: dict[str, Any] | None) -> str:
     per_pct = None
     if observed and _num(observed) > 0:
         per_pct = cov["usd"] / _num(observed)
-    cards = [
+    base = summary.get("reference_baseline_tok_s")
+    final = summary.get("last_measured_after_tok_s")
+    cards = []
+    if observed is not None:
+        cards.append(("Throughput gained", _pct(observed), "measured, first stage to last"))
+    if base and final:
+        cards.append(
+            (
+                "Throughput",
+                f"{_int(base)} -&gt; {_int(final)}",
+                "tok/s, baseline to last measured stage",
+            )
+        )
+    cards += [
         ("Total spend", _usd(cov["usd"]), f"{cov['calls']:,} API calls"),
         ("Input tokens", _int(cov["isl"]), f"{cov['isl'] / max(1, cov['isl'] + cov['osl']) * 100:.1f}% of all tokens"),
         ("Output tokens", _int(cov["osl"]), "what the model actually wrote"),
         ("Recorded wall time", _hms(cov["wall_seconds"]), "sum of per-call durations"),
         ("Tool calls", _int(cov["tool_calls"]), "shell, file and monitor actions"),
     ]
-    if observed is not None:
-        cards.append(("Throughput gained", _pct(observed), "measured, first to last stage"))
     if per_pct is not None:
         cards.append(("Cost per +1%", _usd(per_pct), "whole-run average"))
     body = "".join(
@@ -615,7 +638,7 @@ def _outcome_section(joined: list[dict[str, Any]], total_usd: float, outcome: di
             gate = out.get("gate")
             bought = (
                 f'<span class="{tone}">{_pct(out["gain_pct"])}</span> '
-                f'<span class="mut">({_int(out["before_tok_s"])} &rarr; {_int(out["after_tok_s"])} tok/s'
+                f'<span class="mut">({_int(out["before_tok_s"])} -&gt; {_int(out["after_tok_s"])} tok/s'
                 + (f", gate {_esc(gate)}" if gate else "")
                 + ")</span>"
             )
@@ -635,8 +658,7 @@ def _outcome_section(joined: list[dict[str, Any]], total_usd: float, outcome: di
             )
             tone = "good" if ceiling > 0 else "bad"
             bought = (
-                f'<span class="{tone}">{ceiling:+.2f}%</span> '
-                f'<span class="mut">end-to-end ceiling &mdash; {detail}</span>'
+                f'<span class="{tone}">{ceiling:+.2f}%</span> <span class="mut">end-to-end ceiling - {detail}</span>'
             )
             efficiency = '<span class="none">n/a</span>' if ceiling <= 0 else _usd(phase["usd"] / ceiling)
         rows.append(
@@ -672,6 +694,137 @@ def _outcome_section(joined: list[dict[str, Any]], total_usd: float, outcome: di
         '<div class="scroll"><table><thead><tr><th>Phase</th><th>Cost</th><th>Share</th>'
         "<th>Measured result</th><th>Cost per +1%</th></tr></thead>"
         f"<tbody>{''.join(rows)}</tbody></table></div>{estimate_note}"
+    )
+
+
+def performance_ladder(joined: list[dict[str, Any]], outcome: dict[str, Any] | None) -> dict[str, Any]:
+    """Order the measured stages the way the run walked them, and rank the gains.
+
+    Every figure here is a throughput the run measured and wrote down. A stage's
+    share is its own tok/s gain over the summed tok/s gains of the stages that
+    measured one -- arithmetic on recorded numbers, not an attribution model, and
+    it deliberately does not equal the end-to-end figure, because the handoff
+    seams between stages lose some of it. Kernel stages carry an Amdahl ceiling
+    instead of a throughput, and a stage that measured nothing stays empty.
+    """
+    if outcome is None:
+        return {}
+    steps: list[dict[str, Any]] = []
+    for stage in outcome.get("stages") or []:
+        kind = stage.get("kind")
+        if kind == "reference":
+            steps.append(
+                {
+                    "kind": "reference",
+                    "phase": str(stage.get("phase", "")),
+                    "after": _num(stage.get("after_tok_s")),
+                    "mode": stage.get("measurement_mode"),
+                }
+            )
+        elif kind == "delta":
+            before, after = _num(stage.get("before_tok_s")), _num(stage.get("after_tok_s"))
+            steps.append(
+                {
+                    "kind": "delta",
+                    "phase": str(stage.get("phase", "")),
+                    "before": before,
+                    "after": after,
+                    "abs_gain": after - before,
+                    "pct": _num(stage.get("delta_pct")),
+                    "gate": stage.get("gate"),
+                    "mode": stage.get("measurement_mode"),
+                }
+            )
+    total_gain = sum(s["abs_gain"] for s in steps if s["kind"] == "delta" and s["abs_gain"] > 0)
+    for step in steps:
+        if step["kind"] == "delta":
+            step["share"] = step["abs_gain"] / total_gain if total_gain else None
+    costed = {p["phase"]: p["usd"] for p in joined}
+    for step in steps:
+        step["usd"] = costed.get(step["phase"])
+    kernel_only = [p for p in joined if p["outcome"] and p["outcome"]["kind"] == "kernel"]
+    silent = [p["phase"] for p in joined if p["outcome"] is None]
+    return {
+        "steps": steps,
+        "total_gain": total_gain,
+        "kernels": kernel_only,
+        "silent": silent,
+        "summary": outcome.get("summary") or {},
+    }
+
+
+def _performance_section(ladder: dict[str, Any]) -> str:
+    """Which phase made the run faster, and by how much."""
+    if not ladder:
+        return (
+            '<h2 id="perf">What each phase contributed to throughput</h2>'
+            f'<p class="lede">Not available: no <code>{OUTCOME_FILENAME}</code> beside the ledger. '
+            "Every phase's contribution is unmeasured, which is not the same as zero, so none is "
+            "shown.</p>"
+        )
+    summary = ladder["summary"]
+    rows = []
+    for step in ladder["steps"]:
+        cost = _usd(step["usd"]) if step["usd"] is not None else '<span class="none">not billed</span>'
+        if step["kind"] == "reference":
+            rows.append(
+                f'<tr class="ref"><td><b>{_esc(step["phase"])}</b></td>'
+                f'<td colspan="2"><span class="mut">baseline</span></td>'
+                f"<td><b>{_int(step['after'])}</b> tok/s</td>"
+                f'<td colspan="2"><span class="mut">the number every later gain is measured '
+                f"against{' (' + _esc(step['mode']) + ')' if step.get('mode') else ''}</span></td>"
+                f"<td>{cost}</td></tr>"
+            )
+            continue
+        tone = "good" if step["pct"] > 0 else "bad" if step["pct"] < 0 else "mut"
+        share = step.get("share")
+        share_cell = f"{share * 100:.1f}%{_bar(share)}" if share is not None else '<span class="none">n/a</span>'
+        gate = f' <span class="mut">gate {_esc(step["gate"])}</span>' if step.get("gate") else ""
+        rows.append(
+            f"<tr><td><b>{_esc(step['phase'])}</b>{gate}</td>"
+            f"<td>{_int(step['before'])}</td><td>{_int(step['after'])}</td>"
+            f'<td class="{tone}"><b>{step["pct"]:+.2f}%</b></td>'
+            f"<td>+{_int(step['abs_gain'])} tok/s</td>"
+            f"<td>{share_cell}</td><td>{cost}</td></tr>"
+        )
+    notes = []
+    if ladder["kernels"]:
+        detail = "; ".join(
+            f"{_esc(p['phase'])} {_num(max((_num(t['amdahl_ceiling_e2e_pct']) for t in (p['outcome'].get('tasks') or []) if t['present']), default=0.0)):+.2f}%"
+            for p in ladder["kernels"]
+        )
+        notes.append(
+            f"<b>The kernel phases contributed no measured end-to-end throughput.</b> Their "
+            f"best kernels came out at 1.0000x against the reference, so the Amdahl ceiling on "
+            f"an end-to-end gain is {detail}. That is a measured result, not a missing one: the "
+            f"work ran, was benchmarked, and did not beat what was already there."
+        )
+    if ladder["silent"]:
+        notes.append(
+            "<b>Phases with no throughput measurement of their own:</b> "
+            + ", ".join(f"<code>{_esc(p)}</code>" for p in ladder["silent"])
+            + ". They profile, strategise or hand off rather than ending on a benchmark, so "
+            "nothing here is attributed to them either way."
+        )
+    if summary.get("compounded_is_estimate"):
+        notes.append(
+            "<b>The shares do not add up to the end-to-end figure, and should not.</b> "
+            f"Measured end to end: {_pct(summary.get('observed_delta_pct_first_to_last'))} "
+            f"({_num(summary.get('observed_speedup_first_to_last')):.4f}x, "
+            f"{_int(summary.get('reference_baseline_tok_s'))} -&gt; "
+            f"{_int(summary.get('last_measured_after_tok_s'))} tok/s). Multiplying the per-phase "
+            f"gains would give {_num(summary.get('compounded_speedup')):.4f}x. The gap is the "
+            "handoff seams: a phase does not always start from where the previous one finished."
+        )
+    note_html = "".join(f'<p class="lede">{n}</p>' for n in notes)
+    return (
+        '<h2 id="perf">What each phase contributed to throughput</h2>'
+        '<p class="lede">Read in run order. Every tok/s here was measured by the run at a phase '
+        "boundary and written to its own artifacts; share is a phase's tok/s gain over the summed "
+        "gains of the phases that measured one.</p>"
+        '<div class="scroll"><table><thead><tr><th>Phase</th><th>From</th><th>To</th>'
+        "<th>Gain</th><th>Absolute</th><th>Share of measured gain</th><th>Cost</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table></div>{note_html}"
     )
 
 
@@ -809,10 +962,10 @@ def _deepdive_section(joined: list[dict[str, Any]], total_usd: float) -> str:
         blocks.append(
             f"<details{' open' if rank < 2 else ''}>"
             f"<summary><span>{_esc(phase['phase'])}</span>"
-            f'<span class="r">{_usd(phase["usd"])} &middot; {share:.1f}% of spend &middot; '
-            f"{phase['agents']} agents &middot; {phase['calls']:,} calls &middot; "
+            f'<span class="r">{_usd(phase["usd"])} | {share:.1f}% of spend | '
+            f"{phase['agents']} agents | {phase['calls']:,} calls | "
             f"{_int(phase['isl'])} in / {_int(phase['osl'])} out"
-            + (f" &middot; {window}" if window else "")
+            + (f" | {window}" if window else "")
             + "</span></summary>"
             f'<div class="body">{_anatomy(phase)}<h3>Agents, most expensive first</h3>{_roster(phase)}</div>'
             "</details>"
@@ -893,7 +1046,7 @@ def _phase_table(joined: list[dict[str, Any]], total_usd: float, total_isl: floa
     return (
         '<h2 id="phases">Spend by phase</h2>'
         '<p class="lede">Ranked by cost. Input tokens carry almost all of it: every call re-sends the '
-        "conversation, so a phase’s bill tracks how long its agents talked, not how much they wrote.</p>"
+        "conversation, so a phase's bill tracks how long its agents talked, not how much they wrote.</p>"
         '<div class="scroll"><table><thead><tr><th>Phase</th><th>Agents</th><th>Calls</th><th>Cost</th>'
         "<th>Share</th><th>Input</th><th>Input share</th><th>Output</th><th>Recorded time</th>"
         f"<th>Tools</th><th>$/call</th></tr></thead><tbody>{rows}</tbody></table></div>"
@@ -909,9 +1062,10 @@ def render(calls_path: Path, outcome_path: Path, title: str | None = None) -> st
     joined = join_outcome(phases, outcome)
     cov = coverage(rows, agents)
     signals = delegation_signals(agents)
+    ladder = performance_ladder(joined, outcome)
 
     run_id = (outcome or {}).get("run_id") or calls_path.parent.parent.name
-    heading = title or "GEAK run — where the time and the money went"
+    heading = title or "GEAK run - where the time and the money went"
     generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
     return f"""<!doctype html>
@@ -920,13 +1074,14 @@ def render(calls_path: Path, outcome_path: Path, title: str | None = None) -> st
 <title>{_esc(heading)}</title><style>{CSS}</style></head>
 <body><div class="wrap">
 <h1>{_esc(heading)}</h1>
-<p class="sub">Run <code>{_esc(run_id)}</code> &middot; generated {generated} from
+<p class="sub">Run <code>{_esc(run_id)}</code> | generated {generated} from
 <code>{_esc(calls_path.name)}</code>
 {"and <code>" + _esc(outcome_path.name) + "</code>" if outcome else ""}</p>
-<nav><a href="#bought">What it bought</a><a href="#phases">Spend by phase</a>
+<nav><a href="#perf">Throughput</a><a href="#bought">Cost vs result</a><a href="#phases">Spend by phase</a>
 <a href="#deep">Inside each phase</a><a href="#delegate">Delegation signals</a></nav>
 {_headline_cards(cov, outcome)}
 {_coverage_section(cov, outcome)}
+{_performance_section(ladder)}
 {_outcome_section(joined, cov["usd"], outcome)}
 {_phase_table(joined, cov["usd"], cov["isl"])}
 {_deepdive_section(joined, cov["usd"])}

--- a/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
+++ b/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
@@ -495,7 +495,12 @@ summary::before{content:"\\25b8";color:var(--mut);margin-right:8px;transition:tr
 details[open]>summary::before{transform:rotate(90deg);display:inline-block}
 summary .r{color:var(--mut);font-weight:500;font-size:12.5px}
 .body{padding:0 14px 14px}
-.grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:18px}
+.grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:18px}
+/* Grid items default to min-width:auto, so a nowrap table refuses to shrink below its
+   min-content width and bleeds over the next column. Let the item shrink, and let the
+   table scroll inside its own column instead of over its neighbour. */
+.grid2>*{min-width:0}
+.grid2 .scroll{max-width:100%}
 .tag{display:inline-block;background:color-mix(in srgb,var(--accent) 13%,transparent);
 color:var(--accent);border-radius:4px;padding:0 6px;font-size:11px;margin-left:5px}
 .tag.q{background:color-mix(in srgb,var(--mut) 16%,transparent);color:var(--mut)}
@@ -935,8 +940,9 @@ def _anatomy(phase: dict[str, Any]) -> str:
         blocks.append(
             "<div><h3>Cost by position in the conversation</h3>"
             f'<p class="lede">{_esc(lede)}</p>'
-            "<table><thead><tr><th>Position</th><th>Calls</th><th>Median ISL</th><th>Spend</th>"
-            f"<th>Share</th></tr></thead><tbody>{rows}</tbody></table>"
+            '<div class="scroll"><table><thead><tr><th>Position</th><th>Calls</th><th>Median ISL</th>'
+            "<th>Spend</th><th>Share</th></tr></thead>"
+            f"<tbody>{rows}</tbody></table></div>"
             f'<p class="mut">Median input tokens across the conversation:</p>{_sparkline(isls)}</div>'
         )
     else:
@@ -964,8 +970,8 @@ def _anatomy(phase: dict[str, Any]) -> str:
             "<div><h3>How concentrated the spend is</h3>"
             f'<p class="lede">{half} of this phase\'s {len(conc)} agents account for half its cost, and '
             f"{most} account for 80%. Ranked most expensive first.</p>"
-            f"<table><thead><tr><th>Agents</th><th>Cumulative share</th></tr></thead>"
-            f"<tbody>{rows}</tbody></table></div>"
+            '<div class="scroll"><table><thead><tr><th>Agents</th><th>Cumulative share</th></tr></thead>'
+            f"<tbody>{rows}</tbody></table></div></div>"
         )
 
     if phase["tools"]:
@@ -980,8 +986,8 @@ def _anatomy(phase: dict[str, Any]) -> str:
             f'<p class="lede">{total_tools:,} tool calls across {phase["calls"]:,} API calls '
             f"({total_tools / max(1, phase['calls']):.2f} per call). A phase dominated by one tool is "
             "running a mechanical loop; a varied mix is exploratory work.</p>"
-            f"<table><thead><tr><th>Tool</th><th>Calls</th><th>Share</th></tr></thead>"
-            f"<tbody>{rows}</tbody></table></div>"
+            '<div class="scroll"><table><thead><tr><th>Tool</th><th>Calls</th><th>Share</th></tr></thead>'
+            f"<tbody>{rows}</tbody></table></div></div>"
         )
     return f'<div class="grid2">{"".join(blocks)}</div>'
 

--- a/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
+++ b/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
@@ -696,9 +696,10 @@ def _outcome_section(
         else:
             tasks = out.get("tasks") or []
             measured = [t for t in tasks if t["present"]]
-            ab = [t["integration"] for t in tasks if t.get("integration")]
+            ab = [t for t in tasks if t.get("integration")]
             if ab:
-                best = max(ab, key=lambda i: _num(i.get("e2e_delta_pct")))
+                best_task = max(ab, key=lambda t: _num(t["integration"].get("e2e_delta_pct")))
+                best = best_task["integration"]
                 delta = _num(best.get("e2e_delta_pct"))
                 tone = "good" if delta > 0 else "bad" if delta < 0 else "mut"
                 gate = best.get("gate")
@@ -707,7 +708,8 @@ def _outcome_section(
                 )
                 bought = (
                     f'<span class="{tone}">{delta:+.2f}%</span> <span class="mut">end-to-end, '
-                    f"measured A/B of the kernel this run wrote "
+                    f"measured A/B of the kernel this run wrote for "
+                    f"<code>{_esc(best_task.get('task'))}</code> "
                     f"({_esc(best.get('candidate'))}, {_num(best.get('isolated_speedup')):.4f}x isolated, "
                     f"{acc}"
                     + (f", gate {_esc(gate)}" if gate else "")
@@ -830,11 +832,21 @@ def performance_ladder(joined: list[dict[str, Any]], outcome: dict[str, Any] | N
     for step in steps:
         step["usd"] = costed.get(step["phase"])
     kernel_only = [p for p in joined if p["outcome"] and p["outcome"]["kind"] == "kernel"]
+    # Kernel tasks the ledger has no phase for. A run can benchmark an operator
+    # without a "P<n> HeadKernel <head>" phase existing to join it to, and those
+    # tasks would otherwise vanish from the page entirely.
+    attributed = {t["task"] for p in kernel_only for t in (p["outcome"].get("tasks") or []) if t.get("task")}
+    orphans = [
+        stage
+        for stage in outcome.get("stages") or []
+        if isinstance(stage, dict) and stage.get("kind") == "kernel" and stage.get("task") not in attributed
+    ]
     silent = [p["phase"] for p in joined if p["outcome"] is None]
     return {
         "steps": steps,
         "total_gain": total_gain,
         "kernels": kernel_only,
+        "orphan_kernels": orphans,
         "silent": silent,
         "summary": outcome.get("summary") or {},
     }
@@ -879,21 +891,22 @@ def _performance_section(ladder: dict[str, Any], no_ledger: bool = False) -> str
         )
     notes = []
     validated = [
-        (p, i)
+        (p, best)
         for p in ladder["kernels"]
-        for i in [
+        for best in [
             max(
-                (t["integration"] for t in (p["outcome"].get("tasks") or []) if t.get("integration")),
-                key=lambda x: _num(x.get("e2e_delta_pct")),
+                (t for t in (p["outcome"].get("tasks") or []) if t.get("integration")),
+                key=lambda t: _num(t["integration"].get("e2e_delta_pct")),
                 default=None,
             )
         ]
-        if i
+        if best
     ]
     unvalidated = [
         p for p in ladder["kernels"] if not any(t.get("integration") for t in (p["outcome"].get("tasks") or []))
     ]
-    for phase, integ in validated:
+    for phase, best_task in validated:
+        integ = best_task["integration"]
         delta = _num(integ.get("e2e_delta_pct"))
         tone = "good" if delta > 0 else "bad"
         reason = integ.get("reason")
@@ -908,7 +921,11 @@ def _performance_section(ladder: dict[str, Any], no_ledger: bool = False) -> str
             + "</span> end to end.</b> "
         )
         body = (
-            "The run wrote its own candidate (" + _esc(integ.get("candidate")) + "), served it "
+            "The kernel is <code>"
+            + _esc(best_task.get("task"))
+            + "</code>. The run wrote its own candidate ("
+            + _esc(integ.get("candidate"))
+            + "), served it "
             "against the reference and measured " + _int(integ.get("e2e_throughput_tok_s")) + " tok/s "
             "-- " + f"{_num(integ.get('isolated_speedup')):.4f}" + "x on the kernel in isolation, "
             "against a " + f"{_num(integ.get('amdahl_ceiling_pct')):.2f}" + "% ceiling. Accuracy was "
@@ -922,7 +939,10 @@ def _performance_section(ladder: dict[str, Any], no_ledger: bool = False) -> str
         notes.append(head + body + tail)
     if unvalidated:
         detail = "; ".join(
-            f"{_esc(p['phase'])} {max((_num(t['amdahl_ceiling_e2e_pct']) for t in (p['outcome'].get('tasks') or []) if t['present']), default=0.0):+.2f}%"
+            f"{_esc(p['phase'])} ("
+            + ", ".join(f"<code>{_esc(t['task'])}</code>" for t in (p["outcome"].get("tasks") or []) if t.get("task"))
+            + ") "
+            + f"{max((_num(t['amdahl_ceiling_e2e_pct']) for t in (p['outcome'].get('tasks') or []) if t['present']), default=0.0):+.2f}%"
             for p in unvalidated
         )
         notes.append(
@@ -931,6 +951,24 @@ def _performance_section(ladder: dict[str, Any], no_ledger: bool = False) -> str
             "incumbent stayed fastest, so the Amdahl ceiling on any gain is "
             f"{detail}. That is a measured result, not a missing one: the work ran, was "
             "benchmarked, and did not beat what was already there."
+        )
+    if ladder.get("orphan_kernels"):
+        detail = "; ".join(
+            f"<code>{_esc(s.get('task'))}</code> "
+            + (
+                f"{_num(s.get('isolated_speedup')):.4f}x isolated, "
+                f"{_num(s.get('pct_gpu_time')):.2f}% GPU time, "
+                f"ceiling {_num(s.get('amdahl_ceiling_e2e_pct')):+.2f}%"
+                if s.get("present")
+                else "never benchmarked"
+            )
+            for s in ladder["orphan_kernels"]
+        )
+        notes.append(
+            "<b>Kernels the run benchmarked without a phase of their own:</b> "
+            + detail
+            + ". No phase in the LLM ledger is named after them, so nothing here is attributed "
+            "to them either way -- they are named because they are part of this run's kernel work."
         )
     if ladder["silent"]:
         notes.append(
@@ -1095,7 +1133,9 @@ def _deepdive_section(joined: list[dict[str, Any]], total_usd: float) -> str:
             window = f"{phase['first_ts'][11:19]}&ndash;{phase['last_ts'][11:19]} UTC"
         blocks.append(
             f"<details{' open' if rank < 2 else ''}>"
-            f"<summary><span>{_esc(phase['phase'])}</span>"
+            f"<summary><span>{_esc(phase['phase'])}"
+            + (f" <code>{_esc(_kernel_tasks(phase))}</code>" if _kernel_tasks(phase) else "")
+            + "</span>"
             f'<span class="r">{_usd(phase["usd"])} | {share:.1f}% of spend | '
             f"{phase['agents']} agents | {phase['calls']:,} calls | "
             f"{_int(phase['isl'])} in / {_int(phase['osl'])} out"
@@ -1166,10 +1206,25 @@ def _agent_payload(agents: list[dict[str, Any]]) -> str:
     return json.dumps(payload, separators=(",", ":")).replace("</", "<\\/")
 
 
+def _kernel_tasks(phase: dict[str, Any]) -> str:
+    """The kernel task names behind a HeadKernel phase, or "" for any other phase.
+
+    "P8 HeadKernel h0" names the head, not the operator it went after. The task
+    ("h0_gemm_a8w8_blockscale_task") is the only place the kernel is named, so
+    every heading that carries a kernel phase carries the task with it.
+    """
+    out = phase.get("outcome") or {}
+    if out.get("kind") != "kernel":
+        return ""
+    return ", ".join(str(t["task"]) for t in (out.get("tasks") or []) if t.get("task"))
+
+
 def _phase_table(joined: list[dict[str, Any]], total_usd: float, total_isl: float) -> str:
     peak = max((p["usd"] for p in joined), default=1.0) or 1.0
     rows = "".join(
-        f"<tr><td><b>{_esc(p['phase'])}</b></td><td>{p['agents']}</td><td>{p['calls']:,}</td>"
+        f"<tr><td><b>{_esc(p['phase'])}</b>"
+        + (f'<div class="mut"><code>{_esc(_kernel_tasks(p))}</code></div>' if _kernel_tasks(p) else "")
+        + f"</td><td>{p['agents']}</td><td>{p['calls']:,}</td>"
         f"<td>{_usd(p['usd'])}{_bar(p['usd'] / peak)}</td>"
         f"<td>{p['usd'] / total_usd * 100 if total_usd else 0:.1f}%</td>"
         f"<td>{_int(p['isl'])}</td><td>{p['isl'] / total_isl * 100 if total_isl else 0:.1f}%</td>"

--- a/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
+++ b/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
@@ -39,7 +39,6 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import statistics
 import sys
 from collections import defaultdict
 from datetime import datetime, timezone
@@ -54,7 +53,21 @@ from hyperloom.inference_optimizer.tools._report_html import fmt_int as _int
 from hyperloom.inference_optimizer.tools._report_html import fmt_pct as _pct
 from hyperloom.inference_optimizer.tools._report_html import fmt_usd as _usd
 from hyperloom.inference_optimizer.tools._report_html import num as _num
-from hyperloom.inference_optimizer.tools._report_html import sparkline as _sparkline
+from hyperloom.inference_optimizer.tools._report_agents import (
+    DECILES,
+    MAX_CALLS_EMBEDDED,
+    MIN_CALLS_FOR_CURVE,
+    UNLABELLED,
+    agent_key,
+    agent_payload as _agent_payload,
+    concentration,
+    cost_curve,
+    delegation_html as _delegation_section,
+    delegation_signals,
+    drill_js,
+    phase_records,
+)
+from hyperloom.inference_optimizer.tools import _report_agents as _agents
 
 CALLS_FILENAME = "geak_calls.jsonl"
 OUTCOME_FILENAME = "geak_outcome.json"
@@ -66,16 +79,9 @@ DEFAULT_OUTPUT = "geak_report.html"
 ROLE_RE = re.compile(r"You are (?:the )?([A-Za-z][\w \-/]{0,48}?)(?:[.,\n(]|\s+for\s|\s+committing\s)")
 SPECIALTY_RE = re.compile(r"specialty=(\w+)")
 ROUND_RE = re.compile(r"\br(\d+)_d(\d+)\b")
-UNLABELLED = "unlabelled"
 
-# A conversation is split into this many equal position buckets to show how cost
-# moves as context accumulates. Ten is enough to see the trend and few enough to read.
-DECILES = 10
-# Agents shorter than this have too few calls for a position curve to mean anything.
-MIN_CALLS_FOR_CURVE = 10
-# Per-agent call rows embedded for the drill-down. The ledger stays the full record;
-# this only bounds the size of the HTML.
-MAX_CALLS_EMBEDDED = 400
+#: The drill-down script, pointed at this report's own ledger file.
+JS = drill_js(CALLS_FILENAME)
 
 
 def load_calls(path: Path) -> list[dict[str, Any]]:
@@ -128,137 +134,33 @@ def derive_role(prompt: str) -> dict[str, Any]:
         "derived": True,
     }
 
+def _role_of(calls: list[dict[str, Any]]) -> dict[str, Any]:
+    """Name an agent from the first prompt of its conversation.
+
+    GEAK's ledger carries no label, so the role is recovered from the role
+    sentence every GEAK prompt opens with. See :func:`derive_role`.
+    """
+    return derive_role(str(calls[0].get("prompt", "")) if calls else "")
+
 
 def agent_records(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Fold the call rows into one record per (phase, agent), ordered by spend."""
-    grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
-    for row in rows:
-        grouped[(str(row.get("phase", "")), str(row.get("agent", "")))].append(row)
-
-    agents: list[dict[str, Any]] = []
-    for (phase, agent), calls in grouped.items():
-        calls.sort(key=lambda r: (_num(r.get("call_index")), str(r.get("ts", ""))))
-        isls = [_num(c.get("isl")) for c in calls]
-        tools: dict[str, int] = defaultdict(int)
-        for call in calls:
-            for tool in call.get("tools") or []:
-                tools[tool if isinstance(tool, str) else json.dumps(tool)[:40]] += 1
-        usd = sum(_num(c.get("usd")) for c in calls)
-        seconds = sum(_num(c.get("dt_s")) for c in calls)
-        agents.append(
-            {
-                "phase": phase,
-                "agent": agent,
-                "calls": len(calls),
-                "usd": usd,
-                "seconds": seconds,
-                "isl": sum(isls),
-                "osl": sum(_num(c.get("osl")) for c in calls),
-                "thinking": sum(_num(c.get("thinking")) for c in calls),
-                "tool_calls": sum(tools.values()),
-                "tools": dict(sorted(tools.items(), key=lambda kv: -kv[1])),
-                "first_isl": isls[0] if isls else 0.0,
-                "last_isl": isls[-1] if isls else 0.0,
-                "median_isl": statistics.median(isls) if isls else 0.0,
-                "usd_per_call": usd / len(calls) if calls else 0.0,
-                "started": str(calls[0].get("ts", "")) if calls else "",
-                "models": sorted({str(c.get("model")) for c in calls if c.get("model")}),
-                **derive_role(str(calls[0].get("prompt", "")) if calls else ""),
-                "rows": calls[:MAX_CALLS_EMBEDDED],
-                "rows_truncated": max(0, len(calls) - MAX_CALLS_EMBEDDED),
-            }
-        )
-    agents.sort(key=lambda a: -a["usd"])
-    return agents
+    return _agents.agent_records(rows, _role_of)
 
 
-def phase_records(rows: list[dict[str, Any]], agents: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """One record per phase, with the agent roster that produced its spend."""
-    by_phase: dict[str, list[dict[str, Any]]] = defaultdict(list)
-    for agent in agents:
-        by_phase[agent["phase"]].append(agent)
-
-    calls_by_phase: dict[str, list[dict[str, Any]]] = defaultdict(list)
-    for row in rows:
-        calls_by_phase[str(row.get("phase", ""))].append(row)
-
-    phases: list[dict[str, Any]] = []
-    for phase, roster in by_phase.items():
-        calls = calls_by_phase[phase]
-        stamps = sorted(str(c.get("ts", "")) for c in calls if c.get("ts"))
-        tools: dict[str, int] = defaultdict(int)
-        for agent in roster:
-            for tool, count in agent["tools"].items():
-                tools[tool] += count
-        phases.append(
-            {
-                "phase": phase,
-                "agents": len(roster),
-                "calls": len(calls),
-                "usd": sum(a["usd"] for a in roster),
-                "seconds": sum(a["seconds"] for a in roster),
-                "isl": sum(a["isl"] for a in roster),
-                "osl": sum(a["osl"] for a in roster),
-                "tool_calls": sum(a["tool_calls"] for a in roster),
-                "tools": dict(sorted(tools.items(), key=lambda kv: -kv[1])),
-                "first_ts": stamps[0] if stamps else "",
-                "last_ts": stamps[-1] if stamps else "",
-                "roster": roster,
-                "cost_curve": cost_curve(roster),
-                "concentration": concentration(roster),
-            }
-        )
-    phases.sort(key=lambda p: -p["usd"])
-    return phases
+def _anatomy(phase: dict[str, Any]) -> str:
+    """Where inside a phase the cost is actually incurred."""
+    return _agents.anatomy_html(phase)
 
 
-def cost_curve(roster: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Spend and median ISL by position within a conversation.
-
-    Every agent is stretched onto the same 0-9 scale, so this answers "does a call
-    get more expensive the longer its conversation runs?" without being dominated by
-    whichever agent happened to run longest. Agents too short to bucket are excluded,
-    and the count of those is reported so the exclusion is visible.
-    """
-    spend: dict[int, float] = defaultdict(float)
-    islers: dict[int, list[float]] = defaultdict(list)
-    counts: dict[int, int] = defaultdict(int)
-    used = 0
-    for agent in roster:
-        calls = agent["rows"]
-        total = len(calls)
-        if total < MIN_CALLS_FOR_CURVE:
-            continue
-        used += 1
-        for index, call in enumerate(calls):
-            bucket = min(DECILES - 1, int(DECILES * index / total))
-            spend[bucket] += _num(call.get("usd"))
-            islers[bucket].append(_num(call.get("isl")))
-            counts[bucket] += 1
-    if not used:
-        return []
-    return [
-        {
-            "decile": bucket,
-            "usd": spend[bucket],
-            "calls": counts[bucket],
-            "median_isl": statistics.median(islers[bucket]) if islers[bucket] else 0.0,
-        }
-        for bucket in range(DECILES)
-    ]
+def _roster(phase: dict[str, Any]) -> str:
+    """Every agent in the phase, ranked by spend, each drillable down to its calls."""
+    return _agents.roster_html(phase)
 
 
-def concentration(roster: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Cumulative share of phase spend as agents are added most-expensive first."""
-    total = sum(a["usd"] for a in roster)
-    if total <= 0:
-        return []
-    running = 0.0
-    points: list[dict[str, Any]] = []
-    for rank, agent in enumerate(sorted(roster, key=lambda a: -a["usd"]), start=1):
-        running += agent["usd"]
-        points.append({"rank": rank, "cum_pct": running / total * 100.0})
-    return points
+def _deepdive_section(joined: list[dict[str, Any]], total_usd: float) -> str:
+    """One collapsible block per phase, each headed with the kernel it went after."""
+    return _agents.deepdive_html(joined, total_usd, code_of=_kernel_tasks)
 
 
 def coverage(rows: list[dict[str, Any]], agents: list[dict[str, Any]]) -> dict[str, Any]:
@@ -282,36 +184,6 @@ def coverage(rows: list[dict[str, Any]], agents: list[dict[str, Any]]) -> dict[s
         "tool_calls": sum(len(r.get("tools") or []) for r in rows),
         "wall_seconds": sum(_num(r.get("dt_s")) for r in rows),
     }
-
-
-def delegation_signals(agents: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Per-agent signals bearing on 'could a smaller model have done this?'.
-
-    These are observations, not a recommendation. A low output-per-call agent spent
-    its budget reading rather than writing; a single-tool agent ran a mechanical loop.
-    Both are reasons to *look* at an agent, and neither is evidence on its own that a
-    cheaper model would have reached the same result.
-    """
-    signals: list[dict[str, Any]] = []
-    for agent in agents:
-        calls = max(1, agent["calls"])
-        signals.append(
-            {
-                "phase": agent["phase"],
-                "agent": agent["agent"],
-                "role": agent["role"],
-                "usd": agent["usd"],
-                "calls": agent["calls"],
-                "osl_per_call": agent["osl"] / calls,
-                "isl_per_call": agent["isl"] / calls,
-                "output_share": (agent["osl"] / agent["isl"]) if agent["isl"] else None,
-                "tool_variety": len(agent["tools"]),
-                "top_tool": next(iter(agent["tools"]), None),
-                "thinking": agent["thinking"],
-            }
-        )
-    signals.sort(key=lambda s: -s["usd"])
-    return signals
 
 
 def join_outcome(phases: list[dict[str, Any]], outcome: dict[str, Any] | None) -> list[dict[str, Any]]:
@@ -397,31 +269,6 @@ def join_outcome(phases: list[dict[str, Any]], outcome: dict[str, Any] | None) -
                 }
         joined.append({**phase, "outcome": found})
     return joined
-
-
-JS = """
-function fmtUsd(v){return v==null?'-':'$'+Number(v).toFixed(4);}
-function fmtInt(v){return v==null?'-':Number(v).toLocaleString();}
-function drill(key,btn){
-  var host=document.getElementById('calls-'+key);
-  if(host.dataset.built){host.hidden=!host.hidden;btn.textContent=host.hidden?'calls':'hide';return;}
-  var a=AGENTS[key];
-  var h='<table><thead><tr><th>#</th><th>time</th><th>ISL</th><th>OSL</th><th>think</th>'
-       +'<th>secs</th><th>USD</th><th>tools</th><th style="text-align:left">first line of prompt</th>'
-       +'</tr></thead><tbody>';
-  a.rows.forEach(function(r){
-    var p=(r.prompt||'').split('\\n').find(function(x){return x.trim();})||'';
-    h+='<tr><td>'+r.i+'</td><td class="mono">'+(r.ts||'').slice(11,19)+'</td><td>'+fmtInt(r.isl)
-      +'</td><td>'+fmtInt(r.osl)+'</td><td>'+fmtInt(r.think)+'</td><td>'+(r.dt==null?'-':r.dt.toFixed(1))
-      +'</td><td>'+fmtUsd(r.usd)+'</td><td>'+(r.tools||[]).join(', ')
-      +'</td><td class="pw" title="'+p.replace(/"/g,'&quot;').slice(0,400)+'">'+p.slice(0,110)+'</td></tr>';
-  });
-  h+='</tbody></table>';
-  if(a.more){h+='<p class="mut" style="padding:8px 10px;margin:0">'+a.more
-    +' further calls are in geak_calls.jsonl; this table is capped so the page stays loadable.</p>';}
-  host.innerHTML=h;host.dataset.built='1';host.hidden=false;btn.textContent='hide';
-}
-"""
 
 
 def _coverage_section(cov: dict[str, Any], outcome: dict[str, Any] | None) -> str:
@@ -871,213 +718,6 @@ def _performance_section(ladder: dict[str, Any], no_ledger: bool = False) -> str
         "<th>Gain</th><th>Absolute</th><th>Share of measured gain</th><th>Cost</th></tr></thead>"
         f"<tbody>{''.join(rows)}</tbody></table></div>{note_html}"
     )
-
-
-def _anatomy(phase: dict[str, Any]) -> str:
-    """Where inside a phase the cost is actually incurred."""
-    curve = phase["cost_curve"]
-    conc = phase["concentration"]
-    blocks: list[str] = []
-
-    if curve:
-        spend = [c["usd"] for c in curve]
-        isls = [c["median_isl"] for c in curve]
-        total = sum(spend) or 1.0
-        rows = "".join(
-            f"<tr><td>{c['decile'] * 10}&ndash;{c['decile'] * 10 + 10}%</td>"
-            f"<td>{c['calls']:,}</td><td>{_int(c['median_isl'])}</td>"
-            f"<td>{_usd(c['usd'])}{_bar(c['usd'] / max(spend))}</td>"
-            f"<td>{c['usd'] / total * 100:.1f}%</td></tr>"
-            for c in curve
-        )
-        growth = (isls[-1] / isls[0]) if isls and isls[0] else None
-        lede = (
-            f"Each call re-sends the conversation so far, so the input grows as an agent works. "
-            f"Median input goes from {_int(isls[0])} tokens in the first tenth of a conversation to "
-            f"{_int(isls[-1])} in the last"
-            + (f", a {growth:.2f}x growth" if growth else "")
-            + f"; the last tenth costs {spend[-1] / total * 100:.1f}% of the phase against "
-            f"{spend[0] / total * 100:.1f}% for the first."
-        )
-        blocks.append(
-            "<div><h3>Cost by position in the conversation</h3>"
-            f'<p class="lede">{_esc(lede)}</p>'
-            '<div class="scroll"><table><thead><tr><th>Position</th><th>Calls</th><th>Median ISL</th>'
-            "<th>Spend</th><th>Share</th></tr></thead>"
-            f"<tbody>{rows}</tbody></table></div>"
-            f'<p class="mut">Median input tokens across the conversation:</p>{_sparkline(isls)}</div>'
-        )
-    else:
-        blocks.append(
-            "<div><h3>Cost by position in the conversation</h3>"
-            f'<p class="none">Not shown: no agent in this phase ran {MIN_CALLS_FOR_CURVE} or more calls, '
-            "which is too few for a position curve to mean anything.</p></div>"
-        )
-
-    if conc:
-
-        def agents_to(pct: float) -> int:
-            for point in conc:
-                if point["cum_pct"] >= pct:
-                    return point["rank"]
-            return len(conc)
-
-        half, most = agents_to(50.0), agents_to(80.0)
-        rows = "".join(
-            f"<tr><td>top {p['rank']}</td><td>{p['cum_pct']:.1f}%{_bar(p['cum_pct'] / 100)}</td></tr>"
-            for p in conc
-            if p["rank"] in {1, 3, 5, 10, 20, max(1, len(conc) // 2), len(conc)}
-        )
-        blocks.append(
-            "<div><h3>How concentrated the spend is</h3>"
-            f'<p class="lede">{half} of this phase\'s {len(conc)} agents account for half its cost, and '
-            f"{most} account for 80%. Ranked most expensive first.</p>"
-            '<div class="scroll"><table><thead><tr><th>Agents</th><th>Cumulative share</th></tr></thead>'
-            f"<tbody>{rows}</tbody></table></div></div>"
-        )
-
-    if phase["tools"]:
-        total_tools = sum(phase["tools"].values()) or 1
-        rows = "".join(
-            f"<tr><td><code>{_esc(name)}</code></td><td>{count:,}</td>"
-            f"<td>{count / total_tools * 100:.1f}%{_bar(count / max(phase['tools'].values()))}</td></tr>"
-            for name, count in list(phase["tools"].items())[:10]
-        )
-        blocks.append(
-            "<div><h3>What the agents actually did</h3>"
-            f'<p class="lede">{total_tools:,} tool calls across {phase["calls"]:,} API calls '
-            f"({total_tools / max(1, phase['calls']):.2f} per call). A phase dominated by one tool is "
-            "running a mechanical loop; a varied mix is exploratory work.</p>"
-            '<div class="scroll"><table><thead><tr><th>Tool</th><th>Calls</th><th>Share</th></tr></thead>'
-            f"<tbody>{rows}</tbody></table></div></div>"
-        )
-    return f'<div class="grid2">{"".join(blocks)}</div>'
-
-
-def _roster(phase: dict[str, Any]) -> str:
-    """Every agent in the phase, ranked by spend, each drillable down to its calls."""
-    total = phase["usd"] or 1.0
-    peak = max((a["usd"] for a in phase["roster"]), default=1.0) or 1.0
-    rows: list[str] = []
-    for agent in phase["roster"]:
-        key = agent_key(agent)
-        tag = (
-            f'<span class="tag">{_esc(agent["role"])}</span>'
-            if agent["role"] != UNLABELLED
-            else f'<span class="tag q">{UNLABELLED}</span>'
-        )
-        if agent["specialty"]:
-            tag += f'<span class="tag q">{_esc(agent["specialty"])}</span>'
-        growth = f"{agent['last_isl'] / agent['first_isl']:.2f}x" if agent["first_isl"] else "-"
-        rows.append(
-            f"<tr><td><code>{_esc(agent['agent'][:12])}</code>{tag}</td>"
-            f"<td>{agent['calls']:,}</td>"
-            f"<td>{_usd(agent['usd'])}{_bar(agent['usd'] / peak)}</td>"
-            f"<td>{agent['usd'] / total * 100:.1f}%</td>"
-            f"<td>{_usd(agent['usd_per_call'])}</td>"
-            f"<td>{_hms(agent['seconds'])}</td>"
-            f"<td>{_int(agent['median_isl'])}</td>"
-            f"<td>{growth}</td>"
-            f"<td>{_int(agent['osl'])}</td>"
-            f"<td>{agent['tool_calls']:,}</td>"
-            f'<td><button class="drill" onclick="drill(\'{key}\',this)">calls</button></td></tr>'
-            f'<tr><td colspan="11" style="padding:0">'
-            f'<div class="calls" id="calls-{key}" hidden></div></td></tr>'
-        )
-    return (
-        '<div class="scroll"><table><thead><tr><th>Agent</th><th>Calls</th><th>Cost</th><th>Share</th>'
-        "<th>$/call</th><th>Recorded time</th><th>Median ISL</th><th>ISL growth</th><th>Output</th>"
-        f"<th>Tools</th><th></th></tr></thead><tbody>{''.join(rows)}</tbody></table></div>"
-    )
-
-
-def agent_key(agent: dict[str, Any]) -> str:
-    """A DOM-safe id for an agent's drill-down panel."""
-    raw = f"{agent['phase']}-{agent['agent']}"
-    return re.sub(r"[^A-Za-z0-9_-]", "_", raw)
-
-
-def _deepdive_section(joined: list[dict[str, Any]], total_usd: float) -> str:
-    """One collapsible block per phase, expensive first, the top two open by default."""
-    blocks: list[str] = []
-    for rank, phase in enumerate(joined):
-        share = phase["usd"] / total_usd * 100 if total_usd else 0.0
-        window = ""
-        if phase["first_ts"] and phase["last_ts"]:
-            window = f"{phase['first_ts'][11:19]}&ndash;{phase['last_ts'][11:19]} UTC"
-        blocks.append(
-            f"<details{' open' if rank < 2 else ''}>"
-            f"<summary><span>{_esc(phase['phase'])}"
-            + (f" <code>{_esc(_kernel_tasks(phase))}</code>" if _kernel_tasks(phase) else "")
-            + "</span>"
-            f'<span class="r">{_usd(phase["usd"])} | {share:.1f}% of spend | '
-            f"{phase['agents']} agents | {phase['calls']:,} calls | "
-            f"{_int(phase['isl'])} in / {_int(phase['osl'])} out"
-            + (f" | {window}" if window else "")
-            + "</span></summary>"
-            f'<div class="body">{_anatomy(phase)}<h3>Agents, most expensive first</h3>{_roster(phase)}</div>'
-            "</details>"
-        )
-    return (
-        '<h2 id="deep">Inside each phase</h2>'
-        '<p class="lede">Expand a phase to see where its money went: how cost moves as a conversation '
-        "grows, how few agents carry the total, what tools the work actually consisted of, and the "
-        "full agent roster. Any agent row opens into its own API calls.</p>" + "".join(blocks)
-    )
-
-
-def _delegation_section(signals: list[dict[str, Any]], limit: int = 20) -> str:
-    """Signals bearing on 'could a cheaper model have done this?' -- signals, not a verdict."""
-    rows = "".join(
-        f"<tr><td><code>{_esc(s['agent'][:12])}</code>"
-        + (f'<span class="tag">{_esc(s["role"])}</span>' if s["role"] != UNLABELLED else "")
-        + f"</td><td>{_esc(s['phase'])}</td><td>{_usd(s['usd'])}</td><td>{s['calls']:,}</td>"
-        f"<td>{_int(s['isl_per_call'])}</td><td>{_int(s['osl_per_call'])}</td>"
-        + (
-            f"<td>{s['output_share'] * 100:.3f}%</td>"
-            if s["output_share"] is not None
-            else '<td><span class="none">n/a</span></td>'
-        )
-        + f"<td>{s['tool_variety']}</td><td><code>{_esc(s['top_tool'] or '-')}</code></td></tr>"
-        for s in signals[:limit]
-    )
-    return (
-        '<h2 id="delegate">Signals for delegating work to a cheaper model</h2>'
-        '<p class="lede">These are observations, not a recommendation. An agent that reads far more '
-        "than it writes spent its budget on context rather than reasoning, and one that uses a single "
-        "tool repeatedly is running a mechanical loop. Both are reasons to <em>look</em> at an agent; "
-        "neither is evidence that a smaller model would have reached the same result. The only way to "
-        "know that is to run the arm and compare the measured throughput.</p>"
-        '<div class="scroll"><table><thead><tr><th>Agent</th><th>Phase</th><th>Cost</th><th>Calls</th>'
-        "<th>Input/call</th><th>Output/call</th><th>Output share</th><th>Tool variety</th>"
-        f"<th>Main tool</th></tr></thead><tbody>{rows}</tbody></table></div>"
-        f'<p class="mut">Showing the {min(limit, len(signals))} most expensive agents of {len(signals)}.</p>'
-    )
-
-
-def _agent_payload(agents: list[dict[str, Any]]) -> str:
-    """The per-call rows the drill-down renders, keyed by DOM id."""
-    payload = {
-        agent_key(a): {
-            "more": a["rows_truncated"],
-            "rows": [
-                {
-                    "i": int(_num(r.get("call_index"))),
-                    "ts": r.get("ts"),
-                    "isl": _num(r.get("isl")),
-                    "osl": _num(r.get("osl")),
-                    "think": _num(r.get("thinking")),
-                    "dt": _num(r.get("dt_s")),
-                    "usd": _num(r.get("usd")),
-                    "tools": [t for t in (r.get("tools") or []) if isinstance(t, str)],
-                    "prompt": (r.get("prompt") or "")[:400],
-                }
-                for r in a["rows"]
-            ],
-        }
-        for a in agents
-    }
-    return json.dumps(payload, separators=(",", ":")).replace("</", "<\\/")
 
 
 def _kernel_tasks(phase: dict[str, Any]) -> str:

--- a/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
+++ b/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
@@ -37,7 +37,6 @@ Usage::
 from __future__ import annotations
 
 import argparse
-import html
 import json
 import re
 import statistics
@@ -46,6 +45,16 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+from hyperloom.inference_optimizer.tools._report_html import CSS  # noqa: F401
+from hyperloom.inference_optimizer.tools._report_html import bar as _bar
+from hyperloom.inference_optimizer.tools._report_html import esc as _esc
+from hyperloom.inference_optimizer.tools._report_html import fmt_hms as _hms
+from hyperloom.inference_optimizer.tools._report_html import fmt_int as _int
+from hyperloom.inference_optimizer.tools._report_html import fmt_pct as _pct
+from hyperloom.inference_optimizer.tools._report_html import fmt_usd as _usd
+from hyperloom.inference_optimizer.tools._report_html import num as _num
+from hyperloom.inference_optimizer.tools._report_html import sparkline as _sparkline
 
 CALLS_FILENAME = "geak_calls.jsonl"
 OUTCOME_FILENAME = "geak_outcome.json"
@@ -103,15 +112,6 @@ def load_outcome(path: Path) -> dict[str, Any] | None:
     except (OSError, json.JSONDecodeError):
         return None
     return data if isinstance(data, dict) else None
-
-
-def _num(value: Any) -> float:
-    """Coerce to float, treating anything non-numeric as 0.0 for summation."""
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return 0.0
-    if value != value or value in (float("inf"), float("-inf")):  # NaN / inf
-        return 0.0
-    return float(value)
 
 
 def derive_role(prompt: str) -> dict[str, Any]:
@@ -398,132 +398,6 @@ def join_outcome(phases: list[dict[str, Any]], outcome: dict[str, Any] | None) -
         joined.append({**phase, "outcome": found})
     return joined
 
-
-def _esc(value: Any) -> str:
-    """HTML-escape, and fold every non-ASCII character to a numeric entity.
-
-    The page is written UTF-8 and declares it, but it gets opened from shared
-    storage, out of archives and through viewers that ignore the declaration --
-    and a mis-decoded em dash renders as mojibake with no clue as to why. Pure
-    ASCII bytes cannot be mis-decoded, so the document is kept pure ASCII and
-    anything outside it travels as an entity the browser resolves itself.
-    """
-    text = html.escape(str(value), quote=True)
-    if text.isascii():
-        return text
-    return "".join(ch if ord(ch) < 128 else f"&#{ord(ch)};" for ch in text)
-
-
-def _usd(value: Any) -> str:
-    number = _num(value)
-    return f"${number:,.2f}" if number >= 0.01 or number == 0 else f"${number:,.4f}"
-
-
-def _int(value: Any) -> str:
-    return f"{int(_num(value)):,}"
-
-
-def _hms(seconds: Any) -> str:
-    total = int(_num(seconds))
-    return f"{total // 3600}:{total % 3600 // 60:02d}:{total % 60:02d}"
-
-
-def _pct(value: Any, digits: int = 2) -> str:
-    """Format a percentage, or say plainly that it was never measured."""
-    if value is None:
-        return '<span class="none">not measured</span>'
-    return f"{_num(value):+.{digits}f}%"
-
-
-def _bar(fraction: float, tone: str = "spend") -> str:
-    width = max(0.0, min(100.0, fraction * 100.0))
-    return f'<span class="bar {tone}"><i style="width:{width:.2f}%"></i></span>'
-
-
-def _sparkline(values: list[float], width: int = 220, height: int = 44) -> str:
-    """A dependency-free inline SVG line. Empty input renders nothing, not a flat line."""
-    if not values:
-        return '<span class="none">no data</span>'
-    top = max(values)
-    bottom = min(values)
-    span = (top - bottom) or 1.0
-    step = width / max(1, len(values) - 1)
-    points = " ".join(
-        f"{index * step:.1f},{height - (value - bottom) / span * (height - 6) - 3:.1f}"
-        for index, value in enumerate(values)
-    )
-    return (
-        f'<svg class="spark" viewBox="0 0 {width} {height}" width="{width}" height="{height}" '
-        f'preserveAspectRatio="none" role="img"><polyline points="{points}"/></svg>'
-    )
-
-
-CSS = """
-:root{--bg:#fbfbfa;--fg:#1c1b19;--mut:#6b6862;--line:#e3e0da;--card:#fff;
---accent:#2d6cdf;--good:#1a7f4b;--bad:#b3261e;--warn:#8a6d00;--spend:#2d6cdf;--time:#8a5cd0;}
-@media (prefers-color-scheme:dark){:root{--bg:#16161a;--fg:#eceae6;--mut:#9d9a94;--line:#2e2e34;
---card:#1d1d22;--accent:#7aa5f5;--good:#5cc98d;--bad:#f0857c;--warn:#e0be4e;--spend:#7aa5f5;--time:#b394ea;}}
-*{box-sizing:border-box}
-body{margin:0;background:var(--bg);color:var(--fg);
-font:14px/1.55 ui-sans-serif,-apple-system,"Segoe UI",Roboto,sans-serif}
-.wrap{max-width:1180px;margin:0 auto;padding:28px 20px 80px}
-h1{font-size:23px;margin:0 0 4px}h2{font-size:18px;margin:38px 0 6px;padding-top:14px;border-top:1px solid var(--line)}
-h3{font-size:15px;margin:20px 0 6px}
-.sub{color:var(--mut);margin:0 0 18px}
-.lede{color:var(--mut);margin:0 0 14px;max-width:80ch}
-.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:10px;margin:16px 0}
-.card{background:var(--card);border:1px solid var(--line);border-radius:9px;padding:11px 13px}
-.card .k{color:var(--mut);font-size:11px;text-transform:uppercase;letter-spacing:.05em}
-.card .v{font-size:20px;font-weight:600;margin-top:3px}
-.card .n{color:var(--mut);font-size:11.5px;margin-top:2px}
-.note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--warn);
-border-radius:7px;padding:11px 14px;margin:14px 0}
-.note b{display:block;margin-bottom:3px}
-.note ul{margin:6px 0 0;padding-left:20px}.note li{margin:2px 0}
-table{border-collapse:collapse;width:100%;margin:10px 0;font-size:13px}
-th,td{text-align:right;padding:6px 9px;border-bottom:1px solid var(--line);white-space:nowrap}
-th:first-child,td:first-child{text-align:left;white-space:normal}
-th{color:var(--mut);font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.04em}
-tbody tr:hover{background:color-mix(in srgb,var(--accent) 7%,transparent)}
-.scroll{overflow-x:auto}
-.bar{display:inline-block;width:74px;height:7px;background:var(--line);border-radius:4px;
-overflow:hidden;vertical-align:middle;margin-left:7px}
-.bar i{display:block;height:100%;background:var(--spend)}
-.bar.time i{background:var(--time)}
-tr.ref td{background:var(--card)}
-.good{color:var(--good)}.bad{color:var(--bad)}.none{color:var(--mut);font-style:italic}
-.mut{color:var(--mut)}
-.spark{display:block;margin-top:4px}
-.spark polyline{fill:none;stroke:var(--accent);stroke-width:1.8;vector-effect:non-scaling-stroke}
-code,.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px}
-details{background:var(--card);border:1px solid var(--line);border-radius:9px;margin:10px 0;padding:0}
-summary{cursor:pointer;padding:11px 14px;font-weight:600;list-style:none;display:flex;
-justify-content:space-between;gap:14px;align-items:baseline}
-summary::-webkit-details-marker{display:none}
-summary::before{content:"\\25b8";color:var(--mut);margin-right:8px;transition:transform .15s}
-details[open]>summary::before{transform:rotate(90deg);display:inline-block}
-summary .r{color:var(--mut);font-weight:500;font-size:12.5px}
-.body{padding:0 14px 14px}
-.grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:18px}
-/* Grid items default to min-width:auto, so a nowrap table refuses to shrink below its
-   min-content width and bleeds over the next column. Let the item shrink, and let the
-   table scroll inside its own column instead of over its neighbour. */
-.grid2>*{min-width:0}
-.grid2 .scroll{max-width:100%}
-.tag{display:inline-block;background:color-mix(in srgb,var(--accent) 13%,transparent);
-color:var(--accent);border-radius:4px;padding:0 6px;font-size:11px;margin-left:5px}
-.tag.q{background:color-mix(in srgb,var(--mut) 16%,transparent);color:var(--mut)}
-nav{position:sticky;top:0;background:var(--bg);border-bottom:1px solid var(--line);
-padding:9px 0;margin-bottom:10px;z-index:5;font-size:13px}
-nav a{color:var(--accent);text-decoration:none;margin-right:16px}
-nav a:hover{text-decoration:underline}
-.calls{max-height:420px;overflow:auto;border:1px solid var(--line);border-radius:7px;margin-top:8px}
-.calls table{margin:0}.calls th{position:sticky;top:0;background:var(--card)}
-button.drill{background:none;border:1px solid var(--line);border-radius:5px;color:var(--accent);
-cursor:pointer;font-size:11.5px;padding:2px 8px}
-button.drill:hover{border-color:var(--accent)}
-.pw{max-width:56ch;overflow:hidden;text-overflow:ellipsis;color:var(--mut);font-size:11.5px}
-"""
 
 JS = """
 function fmtUsd(v){return v==null?'-':'$'+Number(v).toFixed(4);}

--- a/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
+++ b/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
@@ -362,9 +362,17 @@ def join_outcome(phases: list[dict[str, Any]], outcome: dict[str, Any] | None) -
                 measured = [s for s in stages if s.get("present")]
                 found = {
                     "kind": "kernel",
-                    "gain_pct": max((_num(s.get("amdahl_ceiling_e2e_pct")) for s in measured), default=None)
-                    if measured
-                    else None,
+                    # The end-to-end A/B of a kernel the run wrote is the real
+                    # result when there is one; the opbench ceiling is only the
+                    # upper bound that applies when nothing was validated.
+                    "gain_pct": max(
+                        (_num(s["integration"].get("e2e_delta_pct")) for s in stages if s.get("integration")),
+                        default=(
+                            max((_num(s.get("amdahl_ceiling_e2e_pct")) for s in measured), default=None)
+                            if measured
+                            else None
+                        ),
+                    ),
                     "tasks": [
                         {
                             "task": s.get("task"),
@@ -373,6 +381,7 @@ def join_outcome(phases: list[dict[str, Any]], outcome: dict[str, Any] | None) -
                             "amdahl_ceiling_e2e_pct": s.get("amdahl_ceiling_e2e_pct"),
                             "pct_gpu_time": s.get("pct_gpu_time"),
                             "winner_backend": s.get("winner_backend"),
+                            "integration": s.get("integration"),
                         }
                         for s in stages
                     ],
@@ -646,6 +655,32 @@ def _outcome_section(joined: list[dict[str, Any]], total_usd: float, outcome: di
         else:
             tasks = out.get("tasks") or []
             measured = [t for t in tasks if t["present"]]
+            ab = [t["integration"] for t in tasks if t.get("integration")]
+            if ab:
+                best = max(ab, key=lambda i: _num(i.get("e2e_delta_pct")))
+                delta = _num(best.get("e2e_delta_pct"))
+                tone = "good" if delta > 0 else "bad" if delta < 0 else "mut"
+                gate = best.get("gate")
+                acc = (
+                    "accuracy held" if _num(best.get("gsm8k_cand")) >= _num(best.get("gsm8k_ref")) else "accuracy fell"
+                )
+                bought = (
+                    f'<span class="{tone}">{delta:+.2f}%</span> <span class="mut">end-to-end, '
+                    f"measured A/B of the kernel this run wrote "
+                    f"({_esc(best.get('candidate'))}, {_num(best.get('isolated_speedup')):.4f}x isolated, "
+                    f"{acc}"
+                    + (f", gate {_esc(gate)}" if gate else "")
+                    + f"; ceiling was {_num(best.get('amdahl_ceiling_pct')):.2f}%)</span>"
+                )
+                efficiency = _usd(phase["usd"] / delta) if delta > 0 else '<span class="none">n/a</span>'
+                rows.append(
+                    f"<tr><td><b>{_esc(phase['phase'])}</b></td>"
+                    f"<td>{_usd(phase['usd'])}{_bar(share)}</td>"
+                    f"<td>{share * 100:.1f}%</td>"
+                    f'<td style="text-align:left">{bought}</td>'
+                    f"<td>{efficiency}</td></tr>"
+                )
+                continue
             ceiling = max((_num(t["amdahl_ceiling_e2e_pct"]) for t in measured), default=0.0)
             detail = ", ".join(
                 f"{_esc(t['task'])}: "
@@ -788,16 +823,59 @@ def _performance_section(ladder: dict[str, Any]) -> str:
             f"<td>{share_cell}</td><td>{cost}</td></tr>"
         )
     notes = []
-    if ladder["kernels"]:
+    validated = [
+        (p, i)
+        for p in ladder["kernels"]
+        for i in [
+            max(
+                (t["integration"] for t in (p["outcome"].get("tasks") or []) if t.get("integration")),
+                key=lambda x: _num(x.get("e2e_delta_pct")),
+                default=None,
+            )
+        ]
+        if i
+    ]
+    unvalidated = [
+        p for p in ladder["kernels"] if not any(t.get("integration") for t in (p["outcome"].get("tasks") or []))
+    ]
+    for phase, integ in validated:
+        delta = _num(integ.get("e2e_delta_pct"))
+        tone = "good" if delta > 0 else "bad"
+        reason = integ.get("reason")
+        head = (
+            "<b>"
+            + _esc(phase["phase"])
+            + " shipped a kernel and measured "
+            + '<span class="'
+            + tone
+            + '">'
+            + f"{delta:+.2f}%"
+            + "</span> end to end.</b> "
+        )
+        body = (
+            "The run wrote its own candidate (" + _esc(integ.get("candidate")) + "), served it "
+            "against the reference and measured " + _int(integ.get("e2e_throughput_tok_s")) + " tok/s "
+            "-- " + f"{_num(integ.get('isolated_speedup')):.4f}" + "x on the kernel in isolation, "
+            "against a " + f"{_num(integ.get('amdahl_ceiling_pct')):.2f}" + "% ceiling. Accuracy was "
+            "checked rather than assumed: gsm8k "
+            + f"{_num(integ.get('gsm8k_ref')):.2f}"
+            + " -&gt; "
+            + f"{_num(integ.get('gsm8k_cand')):.2f}"
+            + "."
+        )
+        tail = (" The harness recorded this verdict as <em>" + _esc(reason) + "</em>") if reason else ""
+        notes.append(head + body + tail)
+    if unvalidated:
         detail = "; ".join(
-            f"{_esc(p['phase'])} {_num(max((_num(t['amdahl_ceiling_e2e_pct']) for t in (p['outcome'].get('tasks') or []) if t['present']), default=0.0)):+.2f}%"
-            for p in ladder["kernels"]
+            f"{_esc(p['phase'])} {max((_num(t['amdahl_ceiling_e2e_pct']) for t in (p['outcome'].get('tasks') or []) if t['present']), default=0.0):+.2f}%"
+            for p in unvalidated
         )
         notes.append(
-            f"<b>The kernel phases contributed no measured end-to-end throughput.</b> Their "
-            f"best kernels came out at 1.0000x against the reference, so the Amdahl ceiling on "
-            f"an end-to-end gain is {detail}. That is a measured result, not a missing one: the "
-            f"work ran, was benchmarked, and did not beat what was already there."
+            "<b>The other kernel phases contributed no measured end-to-end throughput.</b> No "
+            "candidate they wrote reached an end-to-end A/B, and among the library backends the "
+            "incumbent stayed fastest, so the Amdahl ceiling on any gain is "
+            f"{detail}. That is a measured result, not a missing one: the work ran, was "
+            "benchmarked, and did not beat what was already there."
         )
     if ladder["silent"]:
         notes.append(

--- a/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
+++ b/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
@@ -70,8 +70,17 @@ MAX_CALLS_EMBEDDED = 400
 
 
 def load_calls(path: Path) -> list[dict[str, Any]]:
-    """Read the ledger, skipping lines that are not JSON objects."""
+    """Read the ledger, skipping lines that are not JSON objects.
+
+    A missing ledger is empty, not fatal. Claude Code writes the ledger into a
+    config home the run does not own, so a run whose home was a container overlay
+    can finish, measure a real result, and still have no ledger left to read. That
+    run's outcome is still worth a page; the page just has to say the cost half is
+    gone rather than imply the phases were free.
+    """
     rows: list[dict[str, Any]] = []
+    if not path.is_file():
+        return rows
     with path.open(encoding="utf-8") as handle:
         for line in handle:
             line = line.strip()
@@ -544,6 +553,15 @@ function drill(key,btn){
 def _coverage_section(cov: dict[str, Any], outcome: dict[str, Any] | None) -> str:
     """The banner that says what these numbers are and are not. Always rendered."""
     caveats: list[str] = []
+    if not cov["calls"]:
+        # Zero calls and zero dollars mean the ledger is gone, not that the run
+        # was free. Say which, at the top, before any number is read.
+        caveats.append(
+            f"No {CALLS_FILENAME} was found, so this run's LLM ledger is not available and every cost, "
+            f"token and wall-clock figure below is absent rather than zero. Claude Code writes that "
+            f"ledger into its own config home; if that home was a container overlay it died with the "
+            f"container. What the run measured survived, and is reported in full."
+        )
     if cov["unpriced_calls"]:
         caveats.append(f"{cov['unpriced_calls']:,} calls carry no cost and contribute $0 to every total below.")
     if cov["untimed_calls"]:
@@ -558,7 +576,7 @@ def _coverage_section(cov: dict[str, Any], outcome: dict[str, Any] | None) -> st
             f"truncates prompts, and the authoritative label lives in the wf_*.json workflow record. "
             f"They are shown as '{UNLABELLED}' rather than guessed at."
         )
-    if not cov["thinking"]:
+    if not cov["thinking"] and cov["calls"]:
         caveats.append(
             "No thinking tokens were recorded for this run, so the thinking columns are zero because "
             "there was nothing to record -- not because thinking was measured at zero."
@@ -574,16 +592,22 @@ def _coverage_section(cov: dict[str, Any], outcome: dict[str, Any] | None) -> st
             "different measured throughputs, so multiplying the per-phase gains does not give a "
             "measured figure. The observed first-to-last number is the measured one."
         )
-    caveats.append(
-        "Roles are derived from each agent's first prompt, not read from the workflow record. "
-        "They are a reading aid; the agent id is the identifier."
-    )
+    if cov["calls"]:
+        caveats.append(
+            "Roles are derived from each agent's first prompt, not read from the workflow record. "
+            "They are a reading aid; the agent id is the identifier."
+        )
     items = "".join(f"<li>{_esc(c)}</li>" for c in caveats)
     return (
         '<div class="note"><b>Coverage - read this before quoting a number</b>'
-        f"<div>{cov['calls']:,} API calls across {cov['agents']} agents and {cov['phases']} phases, "
-        f"model{'s' if len(cov['models']) != 1 else ''} {_esc(', '.join(cov['models']) or 'not recorded')}."
-        f"</div><ul>{items}</ul></div>"
+        + (
+            "<div>Outcome only: what this run measured, without its LLM ledger.</div>"
+            if not cov["calls"]
+            else f"<div>{cov['calls']:,} API calls across {cov['agents']} agents and {cov['phases']} phases, "
+            f"model{'s' if len(cov['models']) != 1 else ''} "
+            f"{_esc(', '.join(cov['models']) or 'not recorded')}.</div>"
+        )
+        + f"<ul>{items}</ul></div>"
     )
 
 
@@ -606,6 +630,16 @@ def _headline_cards(cov: dict[str, Any], outcome: dict[str, Any] | None) -> str:
                 "tok/s, baseline to last measured stage",
             )
         )
+    if not cov["calls"]:
+        # No ledger: a $0.00 card next to a real throughput number reads as
+        # "this run was free", which is the one thing it definitely was not.
+        cards.append(("Spend", "no ledger", "the LLM ledger for this run was not preserved"))
+        body = "".join(
+            f'<div class="card"><div class="k">{_esc(k)}</div><div class="v">{v}</div>'
+            f'<div class="n">{_esc(n)}</div></div>'
+            for k, v, n in cards
+        )
+        return f'<div class="cards">{body}</div>'
     cards += [
         ("Total spend", _usd(cov["usd"]), f"{cov['calls']:,} API calls"),
         ("Input tokens", _int(cov["isl"]), f"{cov['isl'] / max(1, cov['isl'] + cov['osl']) * 100:.1f}% of all tokens"),
@@ -622,7 +656,9 @@ def _headline_cards(cov: dict[str, Any], outcome: dict[str, Any] | None) -> str:
     return f'<div class="cards">{body}</div>'
 
 
-def _outcome_section(joined: list[dict[str, Any]], total_usd: float, outcome: dict[str, Any] | None) -> str:
+def _outcome_section(
+    joined: list[dict[str, Any]], total_usd: float, outcome: dict[str, Any] | None, no_ledger: bool = False
+) -> str:
     """The join the whole report exists for: spend beside measured result."""
     if outcome is None:
         return (
@@ -631,7 +667,7 @@ def _outcome_section(joined: list[dict[str, Any]], total_usd: float, outcome: di
             "Spend is still reported below; the result each phase measured is not, because nothing "
             "in the ledger records it and inferring it would be a guess.</p>"
         )
-    rows = []
+    rows: list[tuple[str, float, float, str, str]] = []
     for phase in joined:
         out = phase["outcome"]
         share = phase["usd"] / total_usd if total_usd else 0.0
@@ -678,13 +714,7 @@ def _outcome_section(joined: list[dict[str, Any]], total_usd: float, outcome: di
                     + f"; ceiling was {_num(best.get('amdahl_ceiling_pct')):.2f}%)</span>"
                 )
                 efficiency = _usd(phase["usd"] / delta) if delta > 0 else '<span class="none">n/a</span>'
-                rows.append(
-                    f"<tr><td><b>{_esc(phase['phase'])}</b></td>"
-                    f"<td>{_usd(phase['usd'])}{_bar(share)}</td>"
-                    f"<td>{share * 100:.1f}%</td>"
-                    f'<td style="text-align:left">{bought}</td>'
-                    f"<td>{efficiency}</td></tr>"
-                )
+                rows.append((phase["phase"], phase["usd"], share, bought, efficiency))
                 continue
             ceiling = max((_num(t["amdahl_ceiling_e2e_pct"]) for t in measured), default=0.0)
             detail = ", ".join(
@@ -701,13 +731,7 @@ def _outcome_section(joined: list[dict[str, Any]], total_usd: float, outcome: di
                 f'<span class="{tone}">{ceiling:+.2f}%</span> <span class="mut">end-to-end ceiling - {detail}</span>'
             )
             efficiency = '<span class="none">n/a</span>' if ceiling <= 0 else _usd(phase["usd"] / ceiling)
-        rows.append(
-            f"<tr><td><b>{_esc(phase['phase'])}</b></td>"
-            f"<td>{_usd(phase['usd'])}{_bar(share)}</td>"
-            f"<td>{share * 100:.1f}%</td>"
-            f'<td style="text-align:left">{bought}</td>'
-            f"<td>{efficiency}</td></tr>"
-        )
+        rows.append((phase["phase"], phase["usd"], share, bought, efficiency))
     summary = outcome.get("summary") or {}
     estimate_note = ""
     if summary.get("compounded_is_estimate"):
@@ -726,6 +750,29 @@ def _outcome_section(joined: list[dict[str, Any]], total_usd: float, outcome: di
             f"({_num(summary.get('observed_speedup_first_to_last')):.4f}x); compounding the phase gains "
             f"would give {_num(summary.get('compounded_speedup')):.4f}x, which is an estimate.</p>"
         )
+    if no_ledger:
+        # Every cost cell would read $0.00 and every share 0.0%, which is a claim
+        # about spend this report cannot make. Drop the columns instead.
+        body = "".join(
+            f'<tr><td><b>{_esc(name)}</b></td><td style="text-align:left">{bought}</td></tr>'
+            for name, _usd_, _share_, bought, _eff_ in rows
+        )
+        return (
+            '<h2 id="bought">What each phase bought</h2>'
+            '<p class="lede">The result each phase measured, from the artifacts the run wrote at each '
+            "phase boundary. What it cost to buy is not shown: this run's LLM ledger was not preserved, "
+            "so there is no spend to report and a zero would be a false one.</p>"
+            '<div class="scroll"><table><thead><tr><th>Phase</th>'
+            f"<th>Measured result</th></tr></thead><tbody>{body}</tbody></table></div>{estimate_note}"
+        )
+    body = "".join(
+        f"<tr><td><b>{_esc(name)}</b></td>"
+        f"<td>{_usd(usd)}{_bar(share)}</td>"
+        f"<td>{share * 100:.1f}%</td>"
+        f'<td style="text-align:left">{bought}</td>'
+        f"<td>{efficiency}</td></tr>"
+        for name, usd, share, bought, efficiency in rows
+    )
     return (
         '<h2 id="bought">What each phase bought, and what it cost to buy it</h2>'
         '<p class="lede">Spend comes from the call ledger; the result comes from the artifacts the run '
@@ -733,7 +780,7 @@ def _outcome_section(joined: list[dict[str, Any]], total_usd: float, outcome: di
         "shown as zero.</p>"
         '<div class="scroll"><table><thead><tr><th>Phase</th><th>Cost</th><th>Share</th>'
         "<th>Measured result</th><th>Cost per +1%</th></tr></thead>"
-        f"<tbody>{''.join(rows)}</tbody></table></div>{estimate_note}"
+        f"<tbody>{body}</tbody></table></div>{estimate_note}"
     )
 
 
@@ -793,7 +840,7 @@ def performance_ladder(joined: list[dict[str, Any]], outcome: dict[str, Any] | N
     }
 
 
-def _performance_section(ladder: dict[str, Any]) -> str:
+def _performance_section(ladder: dict[str, Any], no_ledger: bool = False) -> str:
     """Which phase made the run faster, and by how much."""
     if not ladder:
         return (
@@ -805,7 +852,10 @@ def _performance_section(ladder: dict[str, Any]) -> str:
     summary = ladder["summary"]
     rows = []
     for step in ladder["steps"]:
-        cost = _usd(step["usd"]) if step["usd"] is not None else '<span class="none">not billed</span>'
+        if step["usd"] is not None:
+            cost = _usd(step["usd"])
+        else:
+            cost = '<span class="none">' + ("no ledger" if no_ledger else "not billed") + "</span>"
         if step["kind"] == "reference":
             rows.append(
                 f'<tr class="ref"><td><b>{_esc(step["phase"])}</b></td>'
@@ -1149,8 +1199,30 @@ def render(calls_path: Path, outcome_path: Path, title: str | None = None) -> st
     ladder = performance_ladder(joined, outcome)
 
     run_id = (outcome or {}).get("run_id") or calls_path.parent.parent.name
-    heading = title or "GEAK run - where the time and the money went"
+    heading = title or ("GEAK run - what it measured" if not rows else "GEAK run - where the time and the money went")
     generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    # Name only the files actually read. Crediting a ledger that was not there is
+    # the kind of small untruth that makes a reader distrust the real numbers.
+    read = [calls_path.name] if rows else []
+    read += [outcome_path.name] if outcome else []
+    sources = " and ".join(f"<code>{_esc(name)}</code>" for name in read) or "no readable input"
+
+    # Without a ledger the three spend sections have no rows to show. An empty
+    # table under a confident heading reads as "nothing happened here"; leaving
+    # them out, and the nav entries with them, says the opposite and is true.
+    no_ledger = not cov["calls"]
+    nav_items = [("#perf", "Throughput"), ("#bought", "Cost vs result" if not no_ledger else "What it bought")]
+    if not no_ledger:
+        nav_items += [("#phases", "Spend by phase"), ("#deep", "Inside each phase")]
+        nav_items += [("#delegate", "Delegation signals")]
+    nav = "".join(f'<a href="{href}">{_esc(label)}</a>' for href, label in nav_items)
+    ledger_sections = (
+        ""
+        if no_ledger
+        else _phase_table(joined, cov["usd"], cov["isl"])
+        + _deepdive_section(joined, cov["usd"])
+        + _delegation_section(signals)
+    )
 
     return f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
@@ -1159,20 +1231,16 @@ def render(calls_path: Path, outcome_path: Path, title: str | None = None) -> st
 <body><div class="wrap">
 <h1>{_esc(heading)}</h1>
 <p class="sub">Run <code>{_esc(run_id)}</code> | generated {generated} from
-<code>{_esc(calls_path.name)}</code>
-{"and <code>" + _esc(outcome_path.name) + "</code>" if outcome else ""}</p>
-<nav><a href="#perf">Throughput</a><a href="#bought">Cost vs result</a><a href="#phases">Spend by phase</a>
-<a href="#deep">Inside each phase</a><a href="#delegate">Delegation signals</a></nav>
+{sources}</p>
+<nav>{nav}</nav>
 {_headline_cards(cov, outcome)}
 {_coverage_section(cov, outcome)}
-{_performance_section(ladder)}
-{_outcome_section(joined, cov["usd"], outcome)}
-{_phase_table(joined, cov["usd"], cov["isl"])}
-{_deepdive_section(joined, cov["usd"])}
-{_delegation_section(signals)}
+{_performance_section(ladder, no_ledger)}
+{_outcome_section(joined, cov["usd"], outcome, no_ledger)}
+{ledger_sections}
 <h2>How to reproduce this</h2>
-<p class="lede">Everything above is computed from two files this run wrote. Nothing is modelled or
-carried over from another run. Regenerate with:</p>
+<p class="lede">Everything above is computed from {"the file" if len(read) == 1 else "two files"}
+this run wrote. Nothing is modelled or carried over from another run. Regenerate with:</p>
 <pre class="mono">python3 -m hyperloom.inference_optimizer.tools.render_geak_html_report \\
     --reports-dir {_esc(calls_path.parent)} -o {_esc(calls_path.parent / DEFAULT_OUTPUT)}</pre>
 </div>
@@ -1189,12 +1257,15 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     calls_path = args.reports_dir / CALLS_FILENAME
-    if not calls_path.is_file():
-        print(f"error: no {CALLS_FILENAME} in {args.reports_dir}", file=sys.stderr)
+    outcome_path = args.reports_dir / OUTCOME_FILENAME
+    if not calls_path.is_file() and not outcome_path.is_file():
+        print(f"error: neither {CALLS_FILENAME} nor {OUTCOME_FILENAME} in {args.reports_dir}", file=sys.stderr)
         return 2
+    if not calls_path.is_file():
+        print(f"warning: no {CALLS_FILENAME}; rendering the outcome half only", file=sys.stderr)
     output = args.output or args.reports_dir / DEFAULT_OUTPUT
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(render(calls_path, args.reports_dir / OUTCOME_FILENAME, args.title), encoding="utf-8")
+    output.write_text(render(calls_path, outcome_path, args.title), encoding="utf-8")
     print(f"wrote {output} ({output.stat().st_size:,} bytes)")
     return 0
 

--- a/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
+++ b/src/hyperloom/inference_optimizer/tools/render_geak_html_report.py
@@ -1,0 +1,964 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Render a GEAK run's per-LLM-call ledger as a structured, self-contained HTML report.
+
+The tree report (``dump_geak_call_report``) is exhaustive but flat: 5,000 call rows
+in one document answer "what happened" and not "where did the money go". This
+renderer takes the same ``geak_calls.jsonl`` and arranges it as a small number of
+questions, each with its own section:
+
+* what did the run *buy*, and what did each phase *cost* to buy it (joined against
+  ``geak_outcome.json`` when the run wrote one);
+* inside an expensive phase, which agents carry the spend;
+* inside an agent, where in the conversation the cost is incurred;
+* which tasks look cheap enough to delegate to a smaller model.
+
+Two rules hold throughout, the same two the outcome report follows:
+
+* nothing is modelled or extrapolated -- every number is computed from the rows in
+  the ledger, and the coverage banner says what the ledger does not contain;
+* a quantity that was not recorded is rendered as "not recorded", never as zero,
+  because "we did not measure it" and "it was nothing" are different claims.
+
+Role labels are the one derived field. Claude Code records ``{phase, label}`` per
+agent in the workflow record, but ``geak_calls.jsonl`` carries only the phase, so a
+role is inferred from the agent's first prompt and is marked as derived wherever it
+is shown. An agent whose prompt does not identify a role is shown as unlabelled, not
+guessed at.
+
+Usage::
+
+    python3 -m hyperloom.inference_optimizer.tools.render_geak_html_report \\
+        --reports-dir <RUN>/reports -o <RUN>/reports/geak_report.html
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import statistics
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+CALLS_FILENAME = "geak_calls.jsonl"
+OUTCOME_FILENAME = "geak_outcome.json"
+DEFAULT_OUTPUT = "geak_report.html"
+
+# Matches the role sentence GEAK's role prompts open with ("You are the tech_lead",
+# "You are Engineer r1_d2 (specialty=memory)"). geak_calls.jsonl truncates prompts,
+# so this finds a role often but not always -- hence UNLABELLED rather than a guess.
+ROLE_RE = re.compile(r"You are (?:the )?([A-Za-z][\w \-/]{0,48}?)(?:[.,\n(]|\s+for\s|\s+committing\s)")
+SPECIALTY_RE = re.compile(r"specialty=(\w+)")
+ROUND_RE = re.compile(r"\br(\d+)_d(\d+)\b")
+UNLABELLED = "unlabelled"
+
+# A conversation is split into this many equal position buckets to show how cost
+# moves as context accumulates. Ten is enough to see the trend and few enough to read.
+DECILES = 10
+# Agents shorter than this have too few calls for a position curve to mean anything.
+MIN_CALLS_FOR_CURVE = 10
+# Per-agent call rows embedded for the drill-down. The ledger stays the full record;
+# this only bounds the size of the HTML.
+MAX_CALLS_EMBEDDED = 400
+
+
+def load_calls(path: Path) -> list[dict[str, Any]]:
+    """Read the ledger, skipping lines that are not JSON objects."""
+    rows: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(row, dict):
+                rows.append(row)
+    return rows
+
+
+def load_outcome(path: Path) -> dict[str, Any] | None:
+    """Read ``geak_outcome.json`` if the run wrote one; ``None`` is 'not measured'."""
+    try:
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _num(value: Any) -> float:
+    """Coerce to float, treating anything non-numeric as 0.0 for summation."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0.0
+    if value != value or value in (float("inf"), float("-inf")):  # NaN / inf
+        return 0.0
+    return float(value)
+
+
+def derive_role(prompt: str) -> dict[str, Any]:
+    """Infer a readable role from an agent's first prompt. Never guesses."""
+    text = prompt or ""
+    match = ROLE_RE.search(text)
+    role = match.group(1).strip() if match else UNLABELLED
+    specialty = SPECIALTY_RE.search(text)
+    rounds = ROUND_RE.search(role) or ROUND_RE.search(text[:400])
+    return {
+        "role": role,
+        "specialty": specialty.group(1) if specialty else None,
+        "round": int(rounds.group(1)) if rounds else None,
+        "derived": True,
+    }
+
+
+def agent_records(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Fold the call rows into one record per (phase, agent), ordered by spend."""
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[(str(row.get("phase", "")), str(row.get("agent", "")))].append(row)
+
+    agents: list[dict[str, Any]] = []
+    for (phase, agent), calls in grouped.items():
+        calls.sort(key=lambda r: (_num(r.get("call_index")), str(r.get("ts", ""))))
+        isls = [_num(c.get("isl")) for c in calls]
+        tools: dict[str, int] = defaultdict(int)
+        for call in calls:
+            for tool in call.get("tools") or []:
+                tools[tool if isinstance(tool, str) else json.dumps(tool)[:40]] += 1
+        usd = sum(_num(c.get("usd")) for c in calls)
+        seconds = sum(_num(c.get("dt_s")) for c in calls)
+        agents.append(
+            {
+                "phase": phase,
+                "agent": agent,
+                "calls": len(calls),
+                "usd": usd,
+                "seconds": seconds,
+                "isl": sum(isls),
+                "osl": sum(_num(c.get("osl")) for c in calls),
+                "thinking": sum(_num(c.get("thinking")) for c in calls),
+                "tool_calls": sum(tools.values()),
+                "tools": dict(sorted(tools.items(), key=lambda kv: -kv[1])),
+                "first_isl": isls[0] if isls else 0.0,
+                "last_isl": isls[-1] if isls else 0.0,
+                "median_isl": statistics.median(isls) if isls else 0.0,
+                "usd_per_call": usd / len(calls) if calls else 0.0,
+                "started": str(calls[0].get("ts", "")) if calls else "",
+                "models": sorted({str(c.get("model")) for c in calls if c.get("model")}),
+                **derive_role(str(calls[0].get("prompt", "")) if calls else ""),
+                "rows": calls[:MAX_CALLS_EMBEDDED],
+                "rows_truncated": max(0, len(calls) - MAX_CALLS_EMBEDDED),
+            }
+        )
+    agents.sort(key=lambda a: -a["usd"])
+    return agents
+
+
+def phase_records(rows: list[dict[str, Any]], agents: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """One record per phase, with the agent roster that produced its spend."""
+    by_phase: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for agent in agents:
+        by_phase[agent["phase"]].append(agent)
+
+    calls_by_phase: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        calls_by_phase[str(row.get("phase", ""))].append(row)
+
+    phases: list[dict[str, Any]] = []
+    for phase, roster in by_phase.items():
+        calls = calls_by_phase[phase]
+        stamps = sorted(str(c.get("ts", "")) for c in calls if c.get("ts"))
+        tools: dict[str, int] = defaultdict(int)
+        for agent in roster:
+            for tool, count in agent["tools"].items():
+                tools[tool] += count
+        phases.append(
+            {
+                "phase": phase,
+                "agents": len(roster),
+                "calls": len(calls),
+                "usd": sum(a["usd"] for a in roster),
+                "seconds": sum(a["seconds"] for a in roster),
+                "isl": sum(a["isl"] for a in roster),
+                "osl": sum(a["osl"] for a in roster),
+                "tool_calls": sum(a["tool_calls"] for a in roster),
+                "tools": dict(sorted(tools.items(), key=lambda kv: -kv[1])),
+                "first_ts": stamps[0] if stamps else "",
+                "last_ts": stamps[-1] if stamps else "",
+                "roster": roster,
+                "cost_curve": cost_curve(roster),
+                "concentration": concentration(roster),
+            }
+        )
+    phases.sort(key=lambda p: -p["usd"])
+    return phases
+
+
+def cost_curve(roster: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Spend and median ISL by position within a conversation.
+
+    Every agent is stretched onto the same 0-9 scale, so this answers "does a call
+    get more expensive the longer its conversation runs?" without being dominated by
+    whichever agent happened to run longest. Agents too short to bucket are excluded,
+    and the count of those is reported so the exclusion is visible.
+    """
+    spend: dict[int, float] = defaultdict(float)
+    islers: dict[int, list[float]] = defaultdict(list)
+    counts: dict[int, int] = defaultdict(int)
+    used = 0
+    for agent in roster:
+        calls = agent["rows"]
+        total = len(calls)
+        if total < MIN_CALLS_FOR_CURVE:
+            continue
+        used += 1
+        for index, call in enumerate(calls):
+            bucket = min(DECILES - 1, int(DECILES * index / total))
+            spend[bucket] += _num(call.get("usd"))
+            islers[bucket].append(_num(call.get("isl")))
+            counts[bucket] += 1
+    if not used:
+        return []
+    return [
+        {
+            "decile": bucket,
+            "usd": spend[bucket],
+            "calls": counts[bucket],
+            "median_isl": statistics.median(islers[bucket]) if islers[bucket] else 0.0,
+        }
+        for bucket in range(DECILES)
+    ]
+
+
+def concentration(roster: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Cumulative share of phase spend as agents are added most-expensive first."""
+    total = sum(a["usd"] for a in roster)
+    if total <= 0:
+        return []
+    running = 0.0
+    points: list[dict[str, Any]] = []
+    for rank, agent in enumerate(sorted(roster, key=lambda a: -a["usd"]), start=1):
+        running += agent["usd"]
+        points.append({"rank": rank, "cum_pct": running / total * 100.0})
+    return points
+
+
+def coverage(rows: list[dict[str, Any]], agents: list[dict[str, Any]]) -> dict[str, Any]:
+    """What the ledger does and does not contain. Read this before quoting a number."""
+    unpriced = sum(1 for r in rows if not _num(r.get("usd")))
+    untimed = sum(1 for r in rows if not _num(r.get("dt_s")))
+    unlabelled = sum(1 for a in agents if a["role"] == UNLABELLED)
+    models = sorted({str(r.get("model")) for r in rows if r.get("model")})
+    return {
+        "calls": len(rows),
+        "agents": len(agents),
+        "phases": len({str(r.get("phase", "")) for r in rows}),
+        "models": models,
+        "unpriced_calls": unpriced,
+        "untimed_calls": untimed,
+        "unlabelled_agents": unlabelled,
+        "usd": sum(_num(r.get("usd")) for r in rows),
+        "isl": sum(_num(r.get("isl")) for r in rows),
+        "osl": sum(_num(r.get("osl")) for r in rows),
+        "thinking": sum(_num(r.get("thinking")) for r in rows),
+        "tool_calls": sum(len(r.get("tools") or []) for r in rows),
+        "wall_seconds": sum(_num(r.get("dt_s")) for r in rows),
+    }
+
+
+def delegation_signals(agents: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Per-agent signals bearing on 'could a smaller model have done this?'.
+
+    These are observations, not a recommendation. A low output-per-call agent spent
+    its budget reading rather than writing; a single-tool agent ran a mechanical loop.
+    Both are reasons to *look* at an agent, and neither is evidence on its own that a
+    cheaper model would have reached the same result.
+    """
+    signals: list[dict[str, Any]] = []
+    for agent in agents:
+        calls = max(1, agent["calls"])
+        signals.append(
+            {
+                "phase": agent["phase"],
+                "agent": agent["agent"],
+                "role": agent["role"],
+                "usd": agent["usd"],
+                "calls": agent["calls"],
+                "osl_per_call": agent["osl"] / calls,
+                "isl_per_call": agent["isl"] / calls,
+                "output_share": (agent["osl"] / agent["isl"]) if agent["isl"] else None,
+                "tool_variety": len(agent["tools"]),
+                "top_tool": next(iter(agent["tools"]), None),
+                "thinking": agent["thinking"],
+            }
+        )
+    signals.sort(key=lambda s: -s["usd"])
+    return signals
+
+
+def join_outcome(phases: list[dict[str, Any]], outcome: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Put each phase's measured throughput change beside what that phase cost.
+
+    A phase that measured nothing gets ``outcome: None`` -- rendered as "not
+    measured", never as 0%, because the two mean opposite things.
+
+    Delta stages carry the phase name the ledger uses. Kernel stages are all
+    recorded under the phase "HeadKernel" and distinguished by ``task``
+    ("h0_gemm_..."), while the ledger names those phases "P8 HeadKernel h0", so the
+    head token is what joins them.
+    """
+    deltas: dict[str, dict[str, Any]] = {}
+    references: dict[str, dict[str, Any]] = {}
+    kernels: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for stage in (outcome or {}).get("stages") or []:
+        if not isinstance(stage, dict):
+            continue
+        if stage.get("kind") == "reference":
+            references[str(stage.get("phase", ""))] = stage
+        elif stage.get("kind") == "delta":
+            deltas[str(stage.get("phase", ""))] = stage
+        elif stage.get("kind") == "kernel":
+            task = str(stage.get("task", ""))
+            head = task.split("_", 1)[0] if "_" in task else task
+            if head:
+                kernels[head].append(stage)
+
+    joined: list[dict[str, Any]] = []
+    for phase in phases:
+        name = phase["phase"]
+        found: dict[str, Any] | None = None
+        if name in deltas:
+            stage = deltas[name]
+            found = {
+                "kind": "delta",
+                "gain_pct": stage.get("delta_pct"),
+                "before_tok_s": stage.get("before_tok_s"),
+                "after_tok_s": stage.get("after_tok_s"),
+                "gate": stage.get("gate") or stage.get("correctness_gate"),
+                "source": stage.get("source"),
+            }
+        elif name in references:
+            stage = references[name]
+            found = {
+                "kind": "reference",
+                "gain_pct": None,
+                "after_tok_s": stage.get("after_tok_s"),
+                "measurement_mode": stage.get("measurement_mode"),
+                "source": stage.get("source"),
+            }
+        else:
+            head = name.rsplit(" ", 1)[-1] if " " in name else ""
+            if head in kernels:
+                stages = kernels[head]
+                measured = [s for s in stages if s.get("present")]
+                found = {
+                    "kind": "kernel",
+                    "gain_pct": max((_num(s.get("amdahl_ceiling_e2e_pct")) for s in measured), default=None)
+                    if measured
+                    else None,
+                    "tasks": [
+                        {
+                            "task": s.get("task"),
+                            "present": bool(s.get("present")),
+                            "isolated_speedup": s.get("isolated_speedup"),
+                            "amdahl_ceiling_e2e_pct": s.get("amdahl_ceiling_e2e_pct"),
+                            "pct_gpu_time": s.get("pct_gpu_time"),
+                            "winner_backend": s.get("winner_backend"),
+                        }
+                        for s in stages
+                    ],
+                }
+        joined.append({**phase, "outcome": found})
+    return joined
+
+
+def _esc(value: Any) -> str:
+    return html.escape("" if value is None else str(value), quote=True)
+
+
+def _usd(value: Any) -> str:
+    number = _num(value)
+    return f"${number:,.2f}" if number >= 0.01 or number == 0 else f"${number:,.4f}"
+
+
+def _int(value: Any) -> str:
+    return f"{int(_num(value)):,}"
+
+
+def _hms(seconds: Any) -> str:
+    total = int(_num(seconds))
+    return f"{total // 3600}:{total % 3600 // 60:02d}:{total % 60:02d}"
+
+
+def _pct(value: Any, digits: int = 2) -> str:
+    """Format a percentage, or say plainly that it was never measured."""
+    if value is None:
+        return '<span class="none">not measured</span>'
+    return f"{_num(value):+.{digits}f}%"
+
+
+def _bar(fraction: float, tone: str = "spend") -> str:
+    width = max(0.0, min(100.0, fraction * 100.0))
+    return f'<span class="bar {tone}"><i style="width:{width:.2f}%"></i></span>'
+
+
+def _sparkline(values: list[float], width: int = 220, height: int = 44) -> str:
+    """A dependency-free inline SVG line. Empty input renders nothing, not a flat line."""
+    if not values:
+        return '<span class="none">no data</span>'
+    top = max(values)
+    bottom = min(values)
+    span = (top - bottom) or 1.0
+    step = width / max(1, len(values) - 1)
+    points = " ".join(
+        f"{index * step:.1f},{height - (value - bottom) / span * (height - 6) - 3:.1f}"
+        for index, value in enumerate(values)
+    )
+    return (
+        f'<svg class="spark" viewBox="0 0 {width} {height}" width="{width}" height="{height}" '
+        f'preserveAspectRatio="none" role="img"><polyline points="{points}"/></svg>'
+    )
+
+
+CSS = """
+:root{--bg:#fbfbfa;--fg:#1c1b19;--mut:#6b6862;--line:#e3e0da;--card:#fff;
+--accent:#2d6cdf;--good:#1a7f4b;--bad:#b3261e;--warn:#8a6d00;--spend:#2d6cdf;--time:#8a5cd0;}
+@media (prefers-color-scheme:dark){:root{--bg:#16161a;--fg:#eceae6;--mut:#9d9a94;--line:#2e2e34;
+--card:#1d1d22;--accent:#7aa5f5;--good:#5cc98d;--bad:#f0857c;--warn:#e0be4e;--spend:#7aa5f5;--time:#b394ea;}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--fg);
+font:14px/1.55 ui-sans-serif,-apple-system,"Segoe UI",Roboto,sans-serif}
+.wrap{max-width:1180px;margin:0 auto;padding:28px 20px 80px}
+h1{font-size:23px;margin:0 0 4px}h2{font-size:18px;margin:38px 0 6px;padding-top:14px;border-top:1px solid var(--line)}
+h3{font-size:15px;margin:20px 0 6px}
+.sub{color:var(--mut);margin:0 0 18px}
+.lede{color:var(--mut);margin:0 0 14px;max-width:80ch}
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:10px;margin:16px 0}
+.card{background:var(--card);border:1px solid var(--line);border-radius:9px;padding:11px 13px}
+.card .k{color:var(--mut);font-size:11px;text-transform:uppercase;letter-spacing:.05em}
+.card .v{font-size:20px;font-weight:600;margin-top:3px}
+.card .n{color:var(--mut);font-size:11.5px;margin-top:2px}
+.note{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--warn);
+border-radius:7px;padding:11px 14px;margin:14px 0}
+.note b{display:block;margin-bottom:3px}
+.note ul{margin:6px 0 0;padding-left:20px}.note li{margin:2px 0}
+table{border-collapse:collapse;width:100%;margin:10px 0;font-size:13px}
+th,td{text-align:right;padding:6px 9px;border-bottom:1px solid var(--line);white-space:nowrap}
+th:first-child,td:first-child{text-align:left;white-space:normal}
+th{color:var(--mut);font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.04em}
+tbody tr:hover{background:color-mix(in srgb,var(--accent) 7%,transparent)}
+.scroll{overflow-x:auto}
+.bar{display:inline-block;width:74px;height:7px;background:var(--line);border-radius:4px;
+overflow:hidden;vertical-align:middle;margin-left:7px}
+.bar i{display:block;height:100%;background:var(--spend)}
+.bar.time i{background:var(--time)}
+.good{color:var(--good)}.bad{color:var(--bad)}.none{color:var(--mut);font-style:italic}
+.mut{color:var(--mut)}
+.spark{display:block;margin-top:4px}
+.spark polyline{fill:none;stroke:var(--accent);stroke-width:1.8;vector-effect:non-scaling-stroke}
+code,.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px}
+details{background:var(--card);border:1px solid var(--line);border-radius:9px;margin:10px 0;padding:0}
+summary{cursor:pointer;padding:11px 14px;font-weight:600;list-style:none;display:flex;
+justify-content:space-between;gap:14px;align-items:baseline}
+summary::-webkit-details-marker{display:none}
+summary::before{content:"\\25b8";color:var(--mut);margin-right:8px;transition:transform .15s}
+details[open]>summary::before{transform:rotate(90deg);display:inline-block}
+summary .r{color:var(--mut);font-weight:500;font-size:12.5px}
+.body{padding:0 14px 14px}
+.grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:18px}
+.tag{display:inline-block;background:color-mix(in srgb,var(--accent) 13%,transparent);
+color:var(--accent);border-radius:4px;padding:0 6px;font-size:11px;margin-left:5px}
+.tag.q{background:color-mix(in srgb,var(--mut) 16%,transparent);color:var(--mut)}
+nav{position:sticky;top:0;background:var(--bg);border-bottom:1px solid var(--line);
+padding:9px 0;margin-bottom:10px;z-index:5;font-size:13px}
+nav a{color:var(--accent);text-decoration:none;margin-right:16px}
+nav a:hover{text-decoration:underline}
+.calls{max-height:420px;overflow:auto;border:1px solid var(--line);border-radius:7px;margin-top:8px}
+.calls table{margin:0}.calls th{position:sticky;top:0;background:var(--card)}
+button.drill{background:none;border:1px solid var(--line);border-radius:5px;color:var(--accent);
+cursor:pointer;font-size:11.5px;padding:2px 8px}
+button.drill:hover{border-color:var(--accent)}
+.pw{max-width:56ch;overflow:hidden;text-overflow:ellipsis;color:var(--mut);font-size:11.5px}
+"""
+
+JS = """
+function fmtUsd(v){return v==null?'-':'$'+Number(v).toFixed(4);}
+function fmtInt(v){return v==null?'-':Number(v).toLocaleString();}
+function drill(key,btn){
+  var host=document.getElementById('calls-'+key);
+  if(host.dataset.built){host.hidden=!host.hidden;btn.textContent=host.hidden?'calls':'hide';return;}
+  var a=AGENTS[key];
+  var h='<table><thead><tr><th>#</th><th>time</th><th>ISL</th><th>OSL</th><th>think</th>'
+       +'<th>secs</th><th>USD</th><th>tools</th><th style="text-align:left">first line of prompt</th>'
+       +'</tr></thead><tbody>';
+  a.rows.forEach(function(r){
+    var p=(r.prompt||'').split('\\n').find(function(x){return x.trim();})||'';
+    h+='<tr><td>'+r.i+'</td><td class="mono">'+(r.ts||'').slice(11,19)+'</td><td>'+fmtInt(r.isl)
+      +'</td><td>'+fmtInt(r.osl)+'</td><td>'+fmtInt(r.think)+'</td><td>'+(r.dt==null?'-':r.dt.toFixed(1))
+      +'</td><td>'+fmtUsd(r.usd)+'</td><td>'+(r.tools||[]).join(', ')
+      +'</td><td class="pw" title="'+p.replace(/"/g,'&quot;').slice(0,400)+'">'+p.slice(0,110)+'</td></tr>';
+  });
+  h+='</tbody></table>';
+  if(a.more){h+='<p class="mut" style="padding:8px 10px;margin:0">'+a.more
+    +' further calls are in geak_calls.jsonl; this table is capped so the page stays loadable.</p>';}
+  host.innerHTML=h;host.dataset.built='1';host.hidden=false;btn.textContent='hide';
+}
+"""
+
+
+def _coverage_section(cov: dict[str, Any], outcome: dict[str, Any] | None) -> str:
+    """The banner that says what these numbers are and are not. Always rendered."""
+    caveats: list[str] = []
+    if cov["unpriced_calls"]:
+        caveats.append(f"{cov['unpriced_calls']:,} calls carry no cost and contribute $0 to every total below.")
+    if cov["untimed_calls"]:
+        share = cov["untimed_calls"] / max(1, cov["calls"]) * 100
+        caveats.append(
+            f"{cov['untimed_calls']:,} calls ({share:.1f}%) have no recorded duration, so wall-clock "
+            f"sums are lower bounds, not the elapsed time of the run."
+        )
+    if cov["unlabelled_agents"]:
+        caveats.append(
+            f"{cov['unlabelled_agents']} of {cov['agents']} agents could not be given a role: the ledger "
+            f"truncates prompts, and the authoritative label lives in the wf_*.json workflow record. "
+            f"They are shown as '{UNLABELLED}' rather than guessed at."
+        )
+    if not cov["thinking"]:
+        caveats.append(
+            "No thinking tokens were recorded for this run, so the thinking columns are zero because "
+            "there was nothing to record -- not because thinking was measured at zero."
+        )
+    if outcome is None:
+        caveats.append(
+            f"No {OUTCOME_FILENAME} was found beside the ledger, so this report can say what each phase "
+            f"cost but not what it bought. Sections that need it are omitted rather than estimated."
+        )
+    elif (outcome.get("summary") or {}).get("compounded_is_estimate"):
+        caveats.append(
+            "The run's compounded end-to-end speedup is flagged as an estimate: phases handed off at "
+            "different measured throughputs, so multiplying the per-phase gains does not give a "
+            "measured figure. The observed first-to-last number is the measured one."
+        )
+    caveats.append(
+        "Roles are derived from each agent's first prompt, not read from the workflow record. "
+        "They are a reading aid; the agent id is the identifier."
+    )
+    items = "".join(f"<li>{_esc(c)}</li>" for c in caveats)
+    return (
+        '<div class="note"><b>Coverage &mdash; read this before quoting a number</b>'
+        f"<div>{cov['calls']:,} API calls across {cov['agents']} agents and {cov['phases']} phases, "
+        f"model{'s' if len(cov['models']) != 1 else ''} {_esc(', '.join(cov['models']) or 'not recorded')}."
+        f"</div><ul>{items}</ul></div>"
+    )
+
+
+def _headline_cards(cov: dict[str, Any], outcome: dict[str, Any] | None) -> str:
+    summary = (outcome or {}).get("summary") or {}
+    observed = summary.get("observed_delta_pct_first_to_last")
+    per_pct = None
+    if observed and _num(observed) > 0:
+        per_pct = cov["usd"] / _num(observed)
+    cards = [
+        ("Total spend", _usd(cov["usd"]), f"{cov['calls']:,} API calls"),
+        ("Input tokens", _int(cov["isl"]), f"{cov['isl'] / max(1, cov['isl'] + cov['osl']) * 100:.1f}% of all tokens"),
+        ("Output tokens", _int(cov["osl"]), "what the model actually wrote"),
+        ("Recorded wall time", _hms(cov["wall_seconds"]), "sum of per-call durations"),
+        ("Tool calls", _int(cov["tool_calls"]), "shell, file and monitor actions"),
+    ]
+    if observed is not None:
+        cards.append(("Throughput gained", _pct(observed), "measured, first to last stage"))
+    if per_pct is not None:
+        cards.append(("Cost per +1%", _usd(per_pct), "whole-run average"))
+    body = "".join(
+        f'<div class="card"><div class="k">{_esc(k)}</div><div class="v">{v}</div><div class="n">{_esc(n)}</div></div>'
+        for k, v, n in cards
+    )
+    return f'<div class="cards">{body}</div>'
+
+
+def _outcome_section(joined: list[dict[str, Any]], total_usd: float, outcome: dict[str, Any] | None) -> str:
+    """The join the whole report exists for: spend beside measured result."""
+    if outcome is None:
+        return (
+            '<h2 id="bought">What each phase bought</h2>'
+            f'<p class="lede">Not available: no <code>{OUTCOME_FILENAME}</code> beside the ledger. '
+            "Spend is still reported below; the result each phase measured is not, because nothing "
+            "in the ledger records it and inferring it would be a guess.</p>"
+        )
+    rows = []
+    for phase in joined:
+        out = phase["outcome"]
+        share = phase["usd"] / total_usd if total_usd else 0.0
+        if out is None:
+            bought = '<span class="none">no throughput measurement for this phase</span>'
+            efficiency = '<span class="none">n/a</span>'
+        elif out["kind"] == "reference":
+            bought = (
+                f'<span class="mut">established the baseline every later gain is measured against: '
+                f"{_int(out['after_tok_s'])} tok/s"
+                + (f" ({_esc(out['measurement_mode'])})" if out.get("measurement_mode") else "")
+                + "</span>"
+            )
+            efficiency = '<span class="none">n/a</span>'
+        elif out["kind"] == "delta":
+            gain = _num(out["gain_pct"])
+            tone = "good" if gain > 0 else "bad" if gain < 0 else "mut"
+            gate = out.get("gate")
+            bought = (
+                f'<span class="{tone}">{_pct(out["gain_pct"])}</span> '
+                f'<span class="mut">({_int(out["before_tok_s"])} &rarr; {_int(out["after_tok_s"])} tok/s'
+                + (f", gate {_esc(gate)}" if gate else "")
+                + ")</span>"
+            )
+            efficiency = _usd(phase["usd"] / gain) if gain > 0 else '<span class="none">n/a</span>'
+        else:
+            tasks = out.get("tasks") or []
+            measured = [t for t in tasks if t["present"]]
+            ceiling = max((_num(t["amdahl_ceiling_e2e_pct"]) for t in measured), default=0.0)
+            detail = ", ".join(
+                f"{_esc(t['task'])}: "
+                + (
+                    f"{_num(t['isolated_speedup']):.4f}x isolated, {_num(t['pct_gpu_time']):.2f}% GPU time"
+                    if t["present"]
+                    else "never benchmarked"
+                )
+                for t in tasks
+            )
+            tone = "good" if ceiling > 0 else "bad"
+            bought = (
+                f'<span class="{tone}">{ceiling:+.2f}%</span> '
+                f'<span class="mut">end-to-end ceiling &mdash; {detail}</span>'
+            )
+            efficiency = '<span class="none">n/a</span>' if ceiling <= 0 else _usd(phase["usd"] / ceiling)
+        rows.append(
+            f"<tr><td><b>{_esc(phase['phase'])}</b></td>"
+            f"<td>{_usd(phase['usd'])}{_bar(share)}</td>"
+            f"<td>{share * 100:.1f}%</td>"
+            f'<td style="text-align:left">{bought}</td>'
+            f"<td>{efficiency}</td></tr>"
+        )
+    summary = outcome.get("summary") or {}
+    estimate_note = ""
+    if summary.get("compounded_is_estimate"):
+        seams = summary.get("handoff_seams") or []
+        seam_text = "; ".join(
+            f"{_esc(s.get('from_phase'))} handed off at {_int(s.get('handoff_from_tok_s'))} tok/s but "
+            f"{_esc(s.get('to_phase'))} measured its own baseline at {_int(s.get('handoff_to_tok_s'))} "
+            f"({_num(s.get('gap_pct')):+.2f}%)"
+            for s in seams
+            if isinstance(s, dict)
+        )
+        estimate_note = (
+            f'<p class="lede"><b>Why the per-phase gains do not multiply out to the headline.</b> '
+            f"{seam_text}. The measured end-to-end figure is "
+            f"{_pct(summary.get('observed_delta_pct_first_to_last'))} "
+            f"({_num(summary.get('observed_speedup_first_to_last')):.4f}x); compounding the phase gains "
+            f"would give {_num(summary.get('compounded_speedup')):.4f}x, which is an estimate.</p>"
+        )
+    return (
+        '<h2 id="bought">What each phase bought, and what it cost to buy it</h2>'
+        '<p class="lede">Spend comes from the call ledger; the result comes from the artifacts the run '
+        "wrote at each phase boundary. A phase with no measurement is marked as such and is never "
+        "shown as zero.</p>"
+        '<div class="scroll"><table><thead><tr><th>Phase</th><th>Cost</th><th>Share</th>'
+        "<th>Measured result</th><th>Cost per +1%</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table></div>{estimate_note}"
+    )
+
+
+def _anatomy(phase: dict[str, Any]) -> str:
+    """Where inside a phase the cost is actually incurred."""
+    curve = phase["cost_curve"]
+    conc = phase["concentration"]
+    blocks: list[str] = []
+
+    if curve:
+        spend = [c["usd"] for c in curve]
+        isls = [c["median_isl"] for c in curve]
+        total = sum(spend) or 1.0
+        rows = "".join(
+            f"<tr><td>{c['decile'] * 10}&ndash;{c['decile'] * 10 + 10}%</td>"
+            f"<td>{c['calls']:,}</td><td>{_int(c['median_isl'])}</td>"
+            f"<td>{_usd(c['usd'])}{_bar(c['usd'] / max(spend))}</td>"
+            f"<td>{c['usd'] / total * 100:.1f}%</td></tr>"
+            for c in curve
+        )
+        growth = (isls[-1] / isls[0]) if isls and isls[0] else None
+        lede = (
+            f"Each call re-sends the conversation so far, so the input grows as an agent works. "
+            f"Median input goes from {_int(isls[0])} tokens in the first tenth of a conversation to "
+            f"{_int(isls[-1])} in the last"
+            + (f", a {growth:.2f}x growth" if growth else "")
+            + f"; the last tenth costs {spend[-1] / total * 100:.1f}% of the phase against "
+            f"{spend[0] / total * 100:.1f}% for the first."
+        )
+        blocks.append(
+            "<div><h3>Cost by position in the conversation</h3>"
+            f'<p class="lede">{_esc(lede)}</p>'
+            "<table><thead><tr><th>Position</th><th>Calls</th><th>Median ISL</th><th>Spend</th>"
+            f"<th>Share</th></tr></thead><tbody>{rows}</tbody></table>"
+            f'<p class="mut">Median input tokens across the conversation:</p>{_sparkline(isls)}</div>'
+        )
+    else:
+        blocks.append(
+            "<div><h3>Cost by position in the conversation</h3>"
+            f'<p class="none">Not shown: no agent in this phase ran {MIN_CALLS_FOR_CURVE} or more calls, '
+            "which is too few for a position curve to mean anything.</p></div>"
+        )
+
+    if conc:
+
+        def agents_to(pct: float) -> int:
+            for point in conc:
+                if point["cum_pct"] >= pct:
+                    return point["rank"]
+            return len(conc)
+
+        half, most = agents_to(50.0), agents_to(80.0)
+        rows = "".join(
+            f"<tr><td>top {p['rank']}</td><td>{p['cum_pct']:.1f}%{_bar(p['cum_pct'] / 100)}</td></tr>"
+            for p in conc
+            if p["rank"] in {1, 3, 5, 10, 20, max(1, len(conc) // 2), len(conc)}
+        )
+        blocks.append(
+            "<div><h3>How concentrated the spend is</h3>"
+            f'<p class="lede">{half} of this phase\'s {len(conc)} agents account for half its cost, and '
+            f"{most} account for 80%. Ranked most expensive first.</p>"
+            f"<table><thead><tr><th>Agents</th><th>Cumulative share</th></tr></thead>"
+            f"<tbody>{rows}</tbody></table></div>"
+        )
+
+    if phase["tools"]:
+        total_tools = sum(phase["tools"].values()) or 1
+        rows = "".join(
+            f"<tr><td><code>{_esc(name)}</code></td><td>{count:,}</td>"
+            f"<td>{count / total_tools * 100:.1f}%{_bar(count / max(phase['tools'].values()))}</td></tr>"
+            for name, count in list(phase["tools"].items())[:10]
+        )
+        blocks.append(
+            "<div><h3>What the agents actually did</h3>"
+            f'<p class="lede">{total_tools:,} tool calls across {phase["calls"]:,} API calls '
+            f"({total_tools / max(1, phase['calls']):.2f} per call). A phase dominated by one tool is "
+            "running a mechanical loop; a varied mix is exploratory work.</p>"
+            f"<table><thead><tr><th>Tool</th><th>Calls</th><th>Share</th></tr></thead>"
+            f"<tbody>{rows}</tbody></table></div>"
+        )
+    return f'<div class="grid2">{"".join(blocks)}</div>'
+
+
+def _roster(phase: dict[str, Any]) -> str:
+    """Every agent in the phase, ranked by spend, each drillable down to its calls."""
+    total = phase["usd"] or 1.0
+    peak = max((a["usd"] for a in phase["roster"]), default=1.0) or 1.0
+    rows: list[str] = []
+    for agent in phase["roster"]:
+        key = agent_key(agent)
+        tag = (
+            f'<span class="tag">{_esc(agent["role"])}</span>'
+            if agent["role"] != UNLABELLED
+            else f'<span class="tag q">{UNLABELLED}</span>'
+        )
+        if agent["specialty"]:
+            tag += f'<span class="tag q">{_esc(agent["specialty"])}</span>'
+        growth = f"{agent['last_isl'] / agent['first_isl']:.2f}x" if agent["first_isl"] else "-"
+        rows.append(
+            f"<tr><td><code>{_esc(agent['agent'][:12])}</code>{tag}</td>"
+            f"<td>{agent['calls']:,}</td>"
+            f"<td>{_usd(agent['usd'])}{_bar(agent['usd'] / peak)}</td>"
+            f"<td>{agent['usd'] / total * 100:.1f}%</td>"
+            f"<td>{_usd(agent['usd_per_call'])}</td>"
+            f"<td>{_hms(agent['seconds'])}</td>"
+            f"<td>{_int(agent['median_isl'])}</td>"
+            f"<td>{growth}</td>"
+            f"<td>{_int(agent['osl'])}</td>"
+            f"<td>{agent['tool_calls']:,}</td>"
+            f'<td><button class="drill" onclick="drill(\'{key}\',this)">calls</button></td></tr>'
+            f'<tr><td colspan="11" style="padding:0">'
+            f'<div class="calls" id="calls-{key}" hidden></div></td></tr>'
+        )
+    return (
+        '<div class="scroll"><table><thead><tr><th>Agent</th><th>Calls</th><th>Cost</th><th>Share</th>'
+        "<th>$/call</th><th>Recorded time</th><th>Median ISL</th><th>ISL growth</th><th>Output</th>"
+        f"<th>Tools</th><th></th></tr></thead><tbody>{''.join(rows)}</tbody></table></div>"
+    )
+
+
+def agent_key(agent: dict[str, Any]) -> str:
+    """A DOM-safe id for an agent's drill-down panel."""
+    raw = f"{agent['phase']}-{agent['agent']}"
+    return re.sub(r"[^A-Za-z0-9_-]", "_", raw)
+
+
+def _deepdive_section(joined: list[dict[str, Any]], total_usd: float) -> str:
+    """One collapsible block per phase, expensive first, the top two open by default."""
+    blocks: list[str] = []
+    for rank, phase in enumerate(joined):
+        share = phase["usd"] / total_usd * 100 if total_usd else 0.0
+        window = ""
+        if phase["first_ts"] and phase["last_ts"]:
+            window = f"{phase['first_ts'][11:19]}&ndash;{phase['last_ts'][11:19]} UTC"
+        blocks.append(
+            f"<details{' open' if rank < 2 else ''}>"
+            f"<summary><span>{_esc(phase['phase'])}</span>"
+            f'<span class="r">{_usd(phase["usd"])} &middot; {share:.1f}% of spend &middot; '
+            f"{phase['agents']} agents &middot; {phase['calls']:,} calls &middot; "
+            f"{_int(phase['isl'])} in / {_int(phase['osl'])} out"
+            + (f" &middot; {window}" if window else "")
+            + "</span></summary>"
+            f'<div class="body">{_anatomy(phase)}<h3>Agents, most expensive first</h3>{_roster(phase)}</div>'
+            "</details>"
+        )
+    return (
+        '<h2 id="deep">Inside each phase</h2>'
+        '<p class="lede">Expand a phase to see where its money went: how cost moves as a conversation '
+        "grows, how few agents carry the total, what tools the work actually consisted of, and the "
+        "full agent roster. Any agent row opens into its own API calls.</p>" + "".join(blocks)
+    )
+
+
+def _delegation_section(signals: list[dict[str, Any]], limit: int = 20) -> str:
+    """Signals bearing on 'could a cheaper model have done this?' -- signals, not a verdict."""
+    rows = "".join(
+        f"<tr><td><code>{_esc(s['agent'][:12])}</code>"
+        + (f'<span class="tag">{_esc(s["role"])}</span>' if s["role"] != UNLABELLED else "")
+        + f"</td><td>{_esc(s['phase'])}</td><td>{_usd(s['usd'])}</td><td>{s['calls']:,}</td>"
+        f"<td>{_int(s['isl_per_call'])}</td><td>{_int(s['osl_per_call'])}</td>"
+        + (
+            f"<td>{s['output_share'] * 100:.3f}%</td>"
+            if s["output_share"] is not None
+            else '<td><span class="none">n/a</span></td>'
+        )
+        + f"<td>{s['tool_variety']}</td><td><code>{_esc(s['top_tool'] or '-')}</code></td></tr>"
+        for s in signals[:limit]
+    )
+    return (
+        '<h2 id="delegate">Signals for delegating work to a cheaper model</h2>'
+        '<p class="lede">These are observations, not a recommendation. An agent that reads far more '
+        "than it writes spent its budget on context rather than reasoning, and one that uses a single "
+        "tool repeatedly is running a mechanical loop. Both are reasons to <em>look</em> at an agent; "
+        "neither is evidence that a smaller model would have reached the same result. The only way to "
+        "know that is to run the arm and compare the measured throughput.</p>"
+        '<div class="scroll"><table><thead><tr><th>Agent</th><th>Phase</th><th>Cost</th><th>Calls</th>'
+        "<th>Input/call</th><th>Output/call</th><th>Output share</th><th>Tool variety</th>"
+        f"<th>Main tool</th></tr></thead><tbody>{rows}</tbody></table></div>"
+        f'<p class="mut">Showing the {min(limit, len(signals))} most expensive agents of {len(signals)}.</p>'
+    )
+
+
+def _agent_payload(agents: list[dict[str, Any]]) -> str:
+    """The per-call rows the drill-down renders, keyed by DOM id."""
+    payload = {
+        agent_key(a): {
+            "more": a["rows_truncated"],
+            "rows": [
+                {
+                    "i": int(_num(r.get("call_index"))),
+                    "ts": r.get("ts"),
+                    "isl": _num(r.get("isl")),
+                    "osl": _num(r.get("osl")),
+                    "think": _num(r.get("thinking")),
+                    "dt": _num(r.get("dt_s")),
+                    "usd": _num(r.get("usd")),
+                    "tools": [t for t in (r.get("tools") or []) if isinstance(t, str)],
+                    "prompt": (r.get("prompt") or "")[:400],
+                }
+                for r in a["rows"]
+            ],
+        }
+        for a in agents
+    }
+    return json.dumps(payload, separators=(",", ":")).replace("</", "<\\/")
+
+
+def _phase_table(joined: list[dict[str, Any]], total_usd: float, total_isl: float) -> str:
+    peak = max((p["usd"] for p in joined), default=1.0) or 1.0
+    rows = "".join(
+        f"<tr><td><b>{_esc(p['phase'])}</b></td><td>{p['agents']}</td><td>{p['calls']:,}</td>"
+        f"<td>{_usd(p['usd'])}{_bar(p['usd'] / peak)}</td>"
+        f"<td>{p['usd'] / total_usd * 100 if total_usd else 0:.1f}%</td>"
+        f"<td>{_int(p['isl'])}</td><td>{p['isl'] / total_isl * 100 if total_isl else 0:.1f}%</td>"
+        f"<td>{_int(p['osl'])}</td><td>{_hms(p['seconds'])}</td>"
+        f"<td>{p['tool_calls']:,}</td><td>{_usd(p['usd'] / max(1, p['calls']))}</td></tr>"
+        for p in joined
+    )
+    return (
+        '<h2 id="phases">Spend by phase</h2>'
+        '<p class="lede">Ranked by cost. Input tokens carry almost all of it: every call re-sends the '
+        "conversation, so a phase’s bill tracks how long its agents talked, not how much they wrote.</p>"
+        '<div class="scroll"><table><thead><tr><th>Phase</th><th>Agents</th><th>Calls</th><th>Cost</th>'
+        "<th>Share</th><th>Input</th><th>Input share</th><th>Output</th><th>Recorded time</th>"
+        f"<th>Tools</th><th>$/call</th></tr></thead><tbody>{rows}</tbody></table></div>"
+    )
+
+
+def render(calls_path: Path, outcome_path: Path, title: str | None = None) -> str:
+    """Build the whole self-contained document."""
+    rows = load_calls(calls_path)
+    outcome = load_outcome(outcome_path)
+    agents = agent_records(rows)
+    phases = phase_records(rows, agents)
+    joined = join_outcome(phases, outcome)
+    cov = coverage(rows, agents)
+    signals = delegation_signals(agents)
+
+    run_id = (outcome or {}).get("run_id") or calls_path.parent.parent.name
+    heading = title or "GEAK run — where the time and the money went"
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{_esc(heading)}</title><style>{CSS}</style></head>
+<body><div class="wrap">
+<h1>{_esc(heading)}</h1>
+<p class="sub">Run <code>{_esc(run_id)}</code> &middot; generated {generated} from
+<code>{_esc(calls_path.name)}</code>
+{"and <code>" + _esc(outcome_path.name) + "</code>" if outcome else ""}</p>
+<nav><a href="#bought">What it bought</a><a href="#phases">Spend by phase</a>
+<a href="#deep">Inside each phase</a><a href="#delegate">Delegation signals</a></nav>
+{_headline_cards(cov, outcome)}
+{_coverage_section(cov, outcome)}
+{_outcome_section(joined, cov["usd"], outcome)}
+{_phase_table(joined, cov["usd"], cov["isl"])}
+{_deepdive_section(joined, cov["usd"])}
+{_delegation_section(signals)}
+<h2>How to reproduce this</h2>
+<p class="lede">Everything above is computed from two files this run wrote. Nothing is modelled or
+carried over from another run. Regenerate with:</p>
+<pre class="mono">python3 -m hyperloom.inference_optimizer.tools.render_geak_html_report \\
+    --reports-dir {_esc(calls_path.parent)} -o {_esc(calls_path.parent / DEFAULT_OUTPUT)}</pre>
+</div>
+<script>const AGENTS={_agent_payload(agents)};{JS}</script>
+</body></html>
+"""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--reports-dir", type=Path, required=True, help="Run's reports/ directory")
+    parser.add_argument("--output", "-o", type=Path, default=None, help="HTML file to write")
+    parser.add_argument("--title", default=None, help="Override the document heading")
+    args = parser.parse_args(argv)
+
+    calls_path = args.reports_dir / CALLS_FILENAME
+    if not calls_path.is_file():
+        print(f"error: no {CALLS_FILENAME} in {args.reports_dir}", file=sys.stderr)
+        return 2
+    output = args.output or args.reports_dir / DEFAULT_OUTPUT
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(render(calls_path, args.reports_dir / OUTCOME_FILENAME, args.title), encoding="utf-8")
+    print(f"wrote {output} ({output.stat().st_size:,} bytes)")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/hyperloom/inference_optimizer/tools/render_hyperloom_html_report.py
+++ b/src/hyperloom/inference_optimizer/tools/render_hyperloom_html_report.py
@@ -60,7 +60,7 @@ from hyperloom.inference_optimizer.tools._report_html import (
     num,
     sparkline,
 )
-from hyperloom.inference_optimizer.tools.dump_llm_call_report import Node, build_tree, load_ledgers
+from hyperloom.inference_optimizer.tools.dump_llm_call_report import Node, build_tree, call_identity, load_ledgers
 
 BREAKDOWN_FILENAME = "session_breakdown.json"
 DEFAULT_OUTPUT = "hyperloom_report.html"
@@ -125,9 +125,9 @@ def call_rows(turns: list[dict[str, Any]], details: list[dict[str, Any]]) -> lis
     Returns:
         The rows that carry spend.
     """
-    detailed = {str(r.get("call_id")) for r in details if r.get("call_id")}
+    detailed = {call_identity(r) for r in details}
     rows = list(details)
-    rows += [r for r in turns if str(r.get("call_id") or "") not in detailed]
+    rows += [r for r in turns if call_identity(r) not in detailed]
     return rows
 
 
@@ -354,8 +354,8 @@ def _coverage_section(cov: dict[str, Any], breakdown_seen: bool) -> str:
     if cov.get("turns_without_detail"):
         caveats.append(
             f"{fmt_int(cov['turns_without_detail'])} of {fmt_int(cov['turns_total'])} turns wrote no per-call "
-            "detail rows and are counted once from the turn row, so their internal API calls are not "
-            "separable here."
+            f"detail rows and {'is' if cov['turns_without_detail'] == 1 else 'are'} counted once from the turn "
+            "row, so their internal API calls are not separable here."
         )
     if cov.get("calls_unpriced"):
         caveats.append(
@@ -371,8 +371,9 @@ def _coverage_section(cov: dict[str, Any], breakdown_seen: bool) -> str:
         )
     if cov.get("detail_rows_orphaned"):
         caveats.append(
-            f"{fmt_int(cov['detail_rows_orphaned'])} detail rows have no matching turn row (typically "
-            "out-of-process children writing through the ext shards); they are counted, once."
+            f"{fmt_int(cov['detail_rows_orphaned'])} detail rows match no turn row -- an out-of-process "
+            "child writing through an <code>ext</code> shard, or a producer that recorded neither a "
+            "call id nor a task path. They are counted once, and their turn-level context is unknown."
         )
     if not breakdown_seen:
         caveats.append(

--- a/src/hyperloom/inference_optimizer/tools/render_hyperloom_html_report.py
+++ b/src/hyperloom/inference_optimizer/tools/render_hyperloom_html_report.py
@@ -1,0 +1,666 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Render a Hyperloom session's per-LLM-call ledger as a structured HTML report.
+
+``dump_llm_call_report`` already walks the same ledgers and prints the full
+phase -> task tree. That report is exhaustive, and exhaustive is the problem: it
+answers "what happened" in a few thousand rows and leaves "where did the money
+go, and what did it buy" to the reader. This renderer takes the identical input
+and arranges it as a small number of questions, each with its own section:
+
+* what the session *bought* -- baseline to final, and which source the validated
+  gain is attributed to (``session_breakdown.json``);
+* what each phase *cost* to buy it, and so the cost per +1% throughput;
+* inside an expensive phase, which task path carries the spend;
+* where in a conversation the cost is incurred, and which models did the work.
+
+This is the Hyperloom-wide counterpart of :mod:`render_geak_html_report`, which
+covers a standalone GEAK run. Where that report sees one kernel agent, this one
+sees every phase of a session -- PRELUDE, SWEEP, FRAMEWORK_AGENT, KERNEL_AGENT
+and whatever else the ledger carries -- because a session's bill is not spent in
+the kernel phase alone. Both pages share their formatting (:mod:`_report_html`)
+so a number means the same thing on either.
+
+Three rules hold throughout, the same three the other reports follow:
+
+* nothing is modelled or extrapolated -- every number is computed from rows in
+  the ledgers, and the coverage banner says what the ledgers do not contain;
+* a quantity that was not recorded renders as "not recorded", never as zero;
+* spend is attributed to a phase only where the ledger says so. Gain is
+  attributed only where ``session_breakdown.json`` says so, through the declared
+  map in :data:`ATTRIBUTION_PHASES` -- and any phase outside it is shown as
+  unattributed rather than credited with someone else's win.
+
+Usage::
+
+    python3 -m hyperloom.inference_optimizer.tools.render_hyperloom_html_report \\
+        --session-dir <SESSION> -o <SESSION>/reports/hyperloom_report.html
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hyperloom.inference_optimizer.tools._report_html import (
+    CSS,
+    bar,
+    esc,
+    fmt_hms,
+    fmt_int,
+    fmt_pct,
+    fmt_usd,
+    num,
+    sparkline,
+)
+from hyperloom.inference_optimizer.tools.dump_llm_call_report import Node, build_tree, load_ledgers
+
+BREAKDOWN_FILENAME = "session_breakdown.json"
+DEFAULT_OUTPUT = "hyperloom_report.html"
+
+#: How ``outcome.validation.attribution.by_source`` names map onto ledger phases.
+#: The breakdown attributes gain to a *source*; the ledger attributes spend to a
+#: *phase*. Joining the two needs this map, and the map is declared here rather
+#: than guessed per run so that a phase it does not cover is reported as
+#: unattributed instead of being quietly credited with another phase's gain.
+ATTRIBUTION_PHASES: dict[str, tuple[str, ...]] = {
+    "framework_agent": ("FRAMEWORK_AGENT",),
+    "kernel": ("KERNEL_AGENT", "GEAK", "FORGE"),
+    "warm_replay": ("WARM_REPLAY",),
+}
+
+#: Decisions in ``phase_timeline`` that mean the change was kept.
+KEEP_DECISIONS = {"KEEP", "PROMOTE", "promoted"}
+
+
+def load_breakdown(path: Path) -> dict[str, Any] | None:
+    """Read ``session_breakdown.json``, or return ``None`` when it is unusable.
+
+    Args:
+        path: Path to the breakdown file.
+
+    Returns:
+        The parsed object, or ``None`` if it is missing or not a JSON object.
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def phase_records(root: Node) -> list[dict[str, Any]]:
+    """One record per phase, heaviest spend first.
+
+    Args:
+        root: The tree root from :func:`build_tree`.
+
+    Returns:
+        A list of ``{phase, totals, node}`` dicts.
+    """
+    records = [{"phase": kid.name, "totals": kid.total, "node": kid} for kid in root.children.values()]
+    records.sort(key=lambda r: (-r["totals"].usd_total, -r["totals"].calls, r["phase"]))
+    return records
+
+
+def call_rows(turns: list[dict[str, Any]], details: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """The flat list of billable rows, counted the way :func:`build_tree` counts them.
+
+    A turn that expanded into detail rows is represented by those rows only; a
+    turn with none is represented by itself. That is the tree's own rule, so a
+    figure derived here always agrees with the tree's totals rather than
+    double-counting the turns that have a per-call breakdown.
+
+    Args:
+        turns: Turn-level rows.
+        details: Per-API-call rows.
+
+    Returns:
+        The rows that carry spend.
+    """
+    detailed = {str(r.get("call_id")) for r in details if r.get("call_id")}
+    rows = list(details)
+    rows += [r for r in turns if str(r.get("call_id") or "") not in detailed]
+    return rows
+
+
+def growth_curve(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Median ISL and mean cost by position within a conversation.
+
+    A long conversation re-sends its history on every turn, so the call index is
+    the axis along which context -- and therefore cost -- grows. Buckets with
+    fewer than three calls are dropped: a median of one call is not a median,
+    and a curve that tails off into single samples invites over-reading.
+
+    Args:
+        rows: Billable rows.
+
+    Returns:
+        ``[{index, calls, isl_median, usd_mean}]`` ordered by index.
+    """
+    by_index: dict[int, list[tuple[float, float]]] = defaultdict(list)
+    for row in rows:
+        index = int(num(row.get("api_call_index")) or num(row.get("turn")))
+        if index <= 0:
+            continue
+        by_index[index].append((num(row.get("isl")), num(row.get("cost_usd"))))
+
+    out: list[dict[str, Any]] = []
+    for index in sorted(by_index):
+        bucket = by_index[index]
+        if len(bucket) < 3:
+            continue
+        isls = sorted(item[0] for item in bucket)
+        mid = len(isls) // 2
+        median = isls[mid] if len(isls) % 2 else (isls[mid - 1] + isls[mid]) / 2
+        out.append(
+            {
+                "index": index,
+                "calls": len(bucket),
+                "isl_median": median,
+                "usd_mean": sum(item[1] for item in bucket) / len(bucket),
+            }
+        )
+    return out
+
+
+def model_mix(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Spend and volume per model, dearest first.
+
+    Args:
+        rows: Billable rows.
+
+    Returns:
+        ``[{model, calls, usd, isl, osl}]``.
+    """
+    acc: dict[str, dict[str, float]] = defaultdict(lambda: {"calls": 0.0, "usd": 0.0, "isl": 0.0, "osl": 0.0})
+    for row in rows:
+        entry = acc[str(row.get("model") or "unrecorded")]
+        entry["calls"] += 1
+        entry["usd"] += num(row.get("cost_usd"))
+        entry["isl"] += num(row.get("isl"))
+        entry["osl"] += num(row.get("osl"))
+    out = [{"model": name, **vals} for name, vals in acc.items()]
+    out.sort(key=lambda r: (-r["usd"], -r["calls"], r["model"]))
+    return out
+
+
+def outcome_ladder(breakdown: dict[str, Any] | None) -> dict[str, Any]:
+    """The measured throughput ladder and the gain attribution, as recorded.
+
+    Nothing is recomputed here. The breakdown is the harness's own record of
+    what it measured; this only reshapes it for display, and a field the harness
+    did not write stays absent so the page can say it was not measured.
+
+    Args:
+        breakdown: Parsed ``session_breakdown.json``, or ``None``.
+
+    Returns:
+        A dict with ``present`` and, when present, the ladder and attribution.
+    """
+    if not breakdown:
+        return {"present": False, "steps": [], "by_source": {}, "notes": []}
+
+    outcome = breakdown.get("outcome") or {}
+    final = outcome.get("final") or {}
+    validation = outcome.get("validation") or {}
+    attribution = validation.get("attribution") or {}
+
+    steps = [
+        {
+            "phase": str(row.get("phase") or ""),
+            "action": str(row.get("action") or ""),
+            "decision": str(row.get("decision") or ""),
+            "metric": row.get("key_metric"),
+            "metric_kind": str(row.get("key_metric_kind") or ""),
+            "ts": str(row.get("ts") or ""),
+        }
+        for row in breakdown.get("phase_timeline") or []
+        if isinstance(row, dict)
+    ]
+
+    return {
+        "present": True,
+        "baseline": outcome.get("baseline") or {},
+        "final": final,
+        "gain_pct": final.get("gain_pct"),
+        "status": str(outcome.get("status") or ""),
+        "stop_reason": str(outcome.get("stop_reason") or ""),
+        "stage_reached": str(outcome.get("stage_reached") or ""),
+        "action_path": [str(a) for a in (final.get("action_path") or [])],
+        "steps": steps,
+        "by_source": attribution.get("by_source") or {},
+        "attribution_available": bool(attribution.get("available")),
+        "unattributed_pct": validation.get("unattributed_gain_pct"),
+        "gap_pct": validation.get("reconciliation_gap_pct"),
+        "notes": [str(n) for n in (validation.get("notes") or [])],
+    }
+
+
+def join_gain(phases: list[dict[str, Any]], ladder: dict[str, Any]) -> list[dict[str, Any]]:
+    """Attach each phase's attributed gain, or mark it unattributed.
+
+    Args:
+        phases: Records from :func:`phase_records`.
+        ladder: The result of :func:`outcome_ladder`.
+
+    Returns:
+        The same records with ``source``, ``gain_pct`` and ``timeline_keeps``.
+    """
+    by_phase: dict[str, dict[str, Any]] = {}
+    for source, payload in (ladder.get("by_source") or {}).items():
+        if not isinstance(payload, dict):
+            continue
+        for phase_name in ATTRIBUTION_PHASES.get(source, ()):
+            by_phase[phase_name] = {
+                "source": source,
+                "gain_pct": payload.get("total_gain_pct"),
+                "keeps": payload.get("keep_count"),
+            }
+
+    keeps: dict[str, int] = defaultdict(int)
+    for step in ladder.get("steps") or []:
+        if step["decision"] in KEEP_DECISIONS and step["phase"]:
+            keeps[step["phase"]] += 1
+
+    joined = []
+    for record in phases:
+        hit = by_phase.get(record["phase"])
+        joined.append(
+            {
+                **record,
+                "source": (hit or {}).get("source"),
+                "gain_pct": (hit or {}).get("gain_pct"),
+                "keeps": (hit or {}).get("keeps"),
+                "timeline_keeps": keeps.get(record["phase"], 0),
+            }
+        )
+    return joined
+
+
+def session_identity(session_dir: Path, breakdown: dict[str, Any] | None) -> dict[str, str]:
+    """Name the session and its model, preferring what the run recorded.
+
+    ``metadata.session.session_dir`` records the *writer's* mount, which is not
+    necessarily the path the report is generated from, so the directory on disk
+    is a fallback rather than the authority.
+
+    Args:
+        session_dir: The session root as read.
+        breakdown: Parsed breakdown, or ``None``.
+
+    Returns:
+        ``{session_id, model, revision, elapsed_min}``, "" for anything absent.
+    """
+    meta = ((breakdown or {}).get("metadata") or {}).get("session") or {}
+    model = ""
+    for source in ((breakdown or {}).get("session_meta") or {}, (breakdown or {}).get("model_info") or {}):
+        if not isinstance(source, dict):
+            continue
+        for key in ("model_name", "model", "model_type"):
+            if source.get(key):
+                model = str(source[key])
+                break
+        if model:
+            break
+    return {
+        "session_id": str(meta.get("session_id") or session_dir.name),
+        "model": model or session_dir.parent.name,
+        "revision": str(meta.get("code_revision") or ""),
+        "elapsed_min": str(meta.get("elapsed_minutes") or ""),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+
+
+def _share(part: float, whole: float) -> str:
+    """A share of a total, rendered as a bar plus its percentage."""
+    fraction = (part / whole) if whole else 0.0
+    return f'{bar(fraction)} <span class="mut">{fraction * 100:.1f}%</span>'
+
+
+def _headline_cards(ident: dict[str, str], totals: Any, ladder: dict[str, Any]) -> str:
+    """The four numbers a reader wants before they scroll."""
+    gain = ladder.get("gain_pct") if ladder.get("present") else None
+    gain_html = fmt_pct(gain) if gain is not None else '<span class="none">not recorded</span>'
+    tone = "good" if num(gain) > 0 else ("bad" if num(gain) < 0 else "")
+    return (
+        '<div class="cards">'
+        f'<div class="card"><h3>Validated gain</h3><p class="big {tone}">{gain_html}</p>'
+        f'<p class="mut">{esc(ladder.get("stop_reason") or "outcome not recorded")}</p></div>'
+        f'<div class="card"><h3>LLM spend</h3><p class="big">{fmt_usd(totals.usd_total)}</p>'
+        f'<p class="mut">{fmt_int(totals.calls)} API calls over {fmt_int(totals.turns)} turns</p></div>'
+        f'<div class="card"><h3>Tokens in / out</h3><p class="big">{fmt_int(totals.isl)}</p>'
+        f'<p class="mut">{fmt_int(totals.osl)} out -- a {num(totals.isl) / (num(totals.osl) or 1):,.0f}:1 ratio</p></div>'
+        f'<div class="card"><h3>Agent time</h3><p class="big">{fmt_hms(totals.ms_total / 1000.0)}</p>'
+        f'<p class="mut">summed over calls, not wall clock</p></div>'
+        "</div>"
+    )
+
+
+def _coverage_section(cov: dict[str, Any], breakdown_seen: bool) -> str:
+    """The banner that says what these numbers are and are not. Always rendered."""
+    caveats: list[str] = []
+    if cov.get("turns_without_detail"):
+        caveats.append(
+            f"{fmt_int(cov['turns_without_detail'])} of {fmt_int(cov['turns_total'])} turns wrote no per-call "
+            "detail rows and are counted once from the turn row, so their internal API calls are not "
+            "separable here."
+        )
+    if cov.get("calls_unpriced"):
+        caveats.append(
+            f"{fmt_int(cov['calls_unpriced'])} calls could not be priced and are <b>left out of the USD "
+            "total</b> rather than counted as free -- the totals below are therefore a floor."
+        )
+    if cov.get("calls_untimed"):
+        caveats.append(f"{fmt_int(cov['calls_untimed'])} calls carry no timing, so agent time is a floor too.")
+    if cov.get("calls_timing_apportioned"):
+        caveats.append(
+            f"{fmt_int(cov['calls_timing_apportioned'])} calls had their thinking/output time split "
+            "apportioned from the token ratio rather than measured off stream events."
+        )
+    if cov.get("detail_rows_orphaned"):
+        caveats.append(
+            f"{fmt_int(cov['detail_rows_orphaned'])} detail rows have no matching turn row (typically "
+            "out-of-process children writing through the ext shards); they are counted, once."
+        )
+    if not breakdown_seen:
+        caveats.append(
+            f"No <code>{BREAKDOWN_FILENAME}</code> was readable, so this page can say what the session "
+            "<b>cost</b> but not what it <b>bought</b>."
+        )
+    sources = ", ".join(f"{esc(k)} ({fmt_int(v)})" for k, v in (cov.get("cost_sources") or {}).items())
+    body = "".join(f"<li>{c}</li>" for c in caveats) or "<li>No gaps recorded: every call is priced and timed.</li>"
+    return (
+        '<h2 id="coverage">What these numbers cover</h2>'
+        '<p class="lede">Every figure on this page is computed from the rows in this session\'s ledgers. '
+        "Nothing is modelled, and nothing is carried over from another session.</p>"
+        f'<ul class="caveats">{body}</ul>' + (f'<p class="mut">Cost sources: {sources}.</p>' if sources else "")
+    )
+
+
+def _outcome_section(ladder: dict[str, Any]) -> str:
+    """What the session bought: the measured ladder, then who is credited with it."""
+    if not ladder.get("present"):
+        return (
+            '<h2 id="bought">What the session bought</h2>'
+            f'<p class="lede">No readable <code>{BREAKDOWN_FILENAME}</code>, so the outcome is '
+            "<b>not recorded here</b>. That is not the same as no gain, and it is not reported as zero.</p>"
+        )
+
+    base = num((ladder.get("baseline") or {}).get("throughput_tok_s_per_gpu"))
+    final = num((ladder.get("final") or {}).get("throughput_tok_s_per_gpu"))
+    step_rows = []
+    for step in ladder["steps"]:
+        tone = "good" if step["decision"] in KEEP_DECISIONS else "mut"
+        metric = f"{num(step['metric']):,.2f}" if step["metric"] is not None else "--"
+        stamp = step["ts"][11:19] if len(step["ts"]) > 18 else step["ts"]
+        step_rows.append(
+            "<tr><td>"
+            + esc(step["phase"] or "--")
+            + "</td><td>"
+            + esc(step["action"])
+            + "</td>"
+            + f'<td class="{tone}">'
+            + esc(step["decision"])
+            + "</td>"
+            + f'<td class="mono">{metric}</td>'
+            + '<td class="mut">'
+            + esc(step["metric_kind"] or "")
+            + "</td>"
+            + '<td class="mono mut">'
+            + esc(stamp)
+            + "</td></tr>"
+        )
+    rows = "".join(step_rows)
+
+    no_phase = '<span class="none">no phase mapped</span>'
+    credit = "".join(
+        f"<tr><td>{esc(source)}</td>"
+        f"<td>{', '.join(ATTRIBUTION_PHASES.get(source, ())) or no_phase}</td>"
+        f"<td>{fmt_pct(payload.get('total_gain_pct'))}</td>"
+        f"<td>{fmt_int(payload.get('keep_count'))}</td></tr>"
+        for source, payload in sorted(
+            ((k, v) for k, v in ladder["by_source"].items() if isinstance(v, dict)),
+            key=lambda kv: -num(kv[1].get("total_gain_pct")),
+        )
+    )
+
+    notes = "".join(f"<li>{esc(n)}</li>" for n in ladder.get("notes") or [])
+    return (
+        '<h2 id="bought">What the session bought</h2>'
+        f'<p class="lede">Baseline <b>{base:,.2f}</b> to final <b>{final:,.2f}</b> tok/s/GPU '
+        f"({fmt_pct(ladder.get('gain_pct'))}), status <code>{esc(ladder.get('status'))}</code>, stopped because "
+        f"<code>{esc(ladder.get('stop_reason'))}</code> at stage <code>{esc(ladder.get('stage_reached'))}</code>."
+        + (
+            f" The kept path was <code>{esc(' -> '.join(ladder['action_path']))}</code>."
+            if ladder.get("action_path")
+            else ""
+        )
+        + "</p>"
+        "<h3>Who is credited with the gain</h3>"
+        '<p class="mut">The harness attributes gain to a <i>source</i>; the ledger attributes spend to a '
+        "<i>phase</i>. The middle column is the declared map between them -- a source with no phase mapped "
+        "cannot be joined to spend, and is shown rather than dropped.</p>"
+        '<table class="grid"><thead><tr><th>Source</th><th>Ledger phase</th><th>Attributed gain</th>'
+        f"<th>Keeps</th></tr></thead><tbody>{credit or '<tr><td colspan=4>none recorded</td></tr>'}</tbody></table>"
+        f'<p class="mut">Unattributed {fmt_pct(ladder.get("unattributed_pct"))}, reconciliation gap '
+        f"{fmt_pct(ladder.get('gap_pct'))}.</p>"
+        + (f'<ul class="caveats">{notes}</ul>' if notes else "")
+        + "<h3>Every decision the session recorded</h3>"
+        '<table class="grid"><thead><tr><th>Phase</th><th>Action</th><th>Decision</th><th>Key metric</th>'
+        f"<th>Kind</th><th>UTC</th></tr></thead><tbody>{rows or '<tr><td colspan=6>none</td></tr>'}"
+        "</tbody></table>"
+    )
+
+
+def _phase_table(joined: list[dict[str, Any]], total_usd: float) -> str:
+    """The money question: what each phase cost, and what it bought."""
+    rows = []
+    for record in joined:
+        totals = record["totals"]
+        gain = record.get("gain_pct")
+        if gain is None:
+            bought = '<span class="none">not attributed</span>'
+            per_pct = "--"
+        else:
+            bought = f'<span class="{"good" if num(gain) > 0 else "mut"}">{fmt_pct(gain)}</span>'
+            per_pct = fmt_usd(totals.usd_total / num(gain)) if num(gain) > 0 else '<span class="none">n/a</span>'
+        rows.append(
+            f"<tr><td><b>{esc(record['phase'])}</b>"
+            f'<div class="mut">{fmt_int(record["timeline_keeps"])} kept decisions</div></td>'
+            f"<td>{fmt_usd(totals.usd_total)}</td><td>{_share(totals.usd_total, total_usd)}</td>"
+            f"<td>{fmt_int(totals.calls)}</td><td>{fmt_int(totals.turns)}</td>"
+            f"<td>{fmt_int(totals.isl)}</td><td>{fmt_int(totals.osl)}</td>"
+            f"<td>{fmt_hms(totals.ms_total / 1000.0)}</td>"
+            f"<td>{bought}</td><td>{per_pct}</td></tr>"
+        )
+    return (
+        '<h2 id="phases">What each phase cost, and what it bought</h2>'
+        "<p class=\"lede\">Spend is the ledger's own attribution. Gain is the breakdown's, joined through the "
+        "declared source map -- so a phase can legitimately show real spend against no attributed gain, and "
+        "that is the single most useful row on the page.</p>"
+        '<table class="grid"><thead><tr><th>Phase</th><th>USD</th><th>Share</th><th>Calls</th><th>Turns</th>'
+        "<th>ISL</th><th>OSL</th><th>Agent time</th><th>Bought</th><th>Per +1%</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table>"
+    )
+
+
+def _tree_rows(node: Node, depth: int, parent_usd: float, out: list[str], limit: int) -> None:
+    """Render one subtree as indented table rows, heaviest child first."""
+    if depth > limit:
+        return
+    kids = sorted(node.children.values(), key=lambda n: (-n.total.usd_total, n.name))
+    for kid in kids:
+        totals = kid.total
+        out.append(
+            f'<tr><td style="padding-left:{depth * 18}px">{esc(kid.name)}</td>'
+            f"<td>{fmt_usd(totals.usd_total)}</td><td>{_share(totals.usd_total, parent_usd)}</td>"
+            f"<td>{fmt_int(totals.calls)}</td><td>{fmt_int(totals.isl)}</td>"
+            f"<td>{fmt_int(totals.osl)}</td><td>{fmt_hms(totals.ms_total / 1000.0)}</td></tr>"
+        )
+        _tree_rows(kid, depth + 1, totals.usd_total or parent_usd, out, limit)
+
+
+def _deepdive_section(joined: list[dict[str, Any]], depth_limit: int) -> str:
+    """Inside each phase: the task path that carries the spend."""
+    blocks = []
+    for record in joined:
+        totals = record["totals"]
+        rows: list[str] = []
+        _tree_rows(record["node"], 0, totals.usd_total, rows, depth_limit)
+        if not rows:
+            rows = ['<tr><td colspan="7" class="mut">no task path recorded beneath this phase</td></tr>']
+        blocks.append(
+            f'<details class="phase"><summary><span>{esc(record["phase"])}</span>'
+            f"<span>{fmt_usd(totals.usd_total)} | {fmt_int(totals.calls)} calls</span></summary>"
+            '<table class="grid"><thead><tr><th>Task path</th><th>USD</th><th>Share of parent</th>'
+            "<th>Calls</th><th>ISL</th><th>OSL</th><th>Agent time</th></tr></thead>"
+            f"<tbody>{''.join(rows)}</tbody></table></details>"
+        )
+    return (
+        '<h2 id="deep">Inside each phase</h2>'
+        '<p class="lede">The same tree <code>dump_llm_call_report</code> prints, folded so the expensive '
+        "branch is the one you open. Share is against the parent, not the session.</p>" + "".join(blocks)
+    )
+
+
+def _growth_section(curve: list[dict[str, Any]]) -> str:
+    """Where in a conversation the cost is incurred."""
+    if not curve:
+        return (
+            '<h2 id="growth">Where in a conversation the cost lands</h2>'
+            '<p class="lede">No call index recorded on these rows, so the position of a call within its '
+            "conversation is <b>not recorded</b> for this session.</p>"
+        )
+    spark = sparkline([point["isl_median"] for point in curve])
+    rows = "".join(
+        f"<tr><td>{point['index']}</td><td>{fmt_int(point['calls'])}</td>"
+        f"<td>{fmt_int(point['isl_median'])}</td><td>{fmt_usd(point['usd_mean'])}</td></tr>"
+        for point in curve
+        if point["index"] in {1, 5, 10, 20, 40, 60, 80, 100, 150, 200} or point is curve[-1]
+    )
+    first, last = curve[0]["isl_median"], curve[-1]["isl_median"]
+    ratio = (last / first) if first else 0.0
+    return (
+        '<h2 id="growth">Where in a conversation the cost lands</h2>'
+        f'<p class="lede">Median input length grows {ratio:,.2f}x between call {curve[0]["index"]} and call '
+        f"{curve[-1]['index']} of a conversation. Every turn re-sends what came before, so turn count and "
+        "context size multiply -- which is why a long agent is dearer than its token count suggests.</p>"
+        f"<p>{spark}</p>"
+        '<table class="grid"><thead><tr><th>Call index</th><th>Calls at this index</th><th>Median ISL</th>'
+        f"<th>Mean USD</th></tr></thead><tbody>{rows}</tbody></table>"
+    )
+
+
+def _models_section(mix: list[dict[str, Any]], total_usd: float) -> str:
+    """Which models did the work, and what each cost."""
+    rows = "".join(
+        f"<tr><td><code>{esc(entry['model'])}</code></td><td>{fmt_usd(entry['usd'])}</td>"
+        f"<td>{_share(entry['usd'], total_usd)}</td><td>{fmt_int(entry['calls'])}</td>"
+        f"<td>{fmt_int(entry['isl'])}</td><td>{fmt_int(entry['osl'])}</td></tr>"
+        for entry in mix
+    )
+    return (
+        '<h2 id="models">Which models did the work</h2>'
+        '<p class="lede">A phase served by an expensive model for cheap work is the easiest saving on this '
+        "page, and the only one visible without changing what the session does.</p>"
+        '<table class="grid"><thead><tr><th>Model</th><th>USD</th><th>Share</th><th>Calls</th><th>ISL</th>'
+        f"<th>OSL</th></tr></thead><tbody>{rows or '<tr><td colspan=6>none recorded</td></tr>'}</tbody></table>"
+    )
+
+
+def render(session_dir: Path, title: str | None = None, depth_limit: int = 3) -> str:
+    """Build the whole self-contained document.
+
+    Args:
+        session_dir: Session root directory.
+        title: Override for the document heading.
+        depth_limit: How deep to walk each phase's task tree.
+
+    Returns:
+        The HTML document.
+    """
+    turns, details = load_ledgers(session_dir)
+    root, cov = build_tree(turns, details)
+    breakdown = load_breakdown(session_dir / BREAKDOWN_FILENAME)
+    ladder = outcome_ladder(breakdown)
+    joined = join_gain(phase_records(root), ladder)
+    rows = call_rows(turns, details)
+    ident = session_identity(session_dir, breakdown)
+
+    heading = title or f"Hyperloom session - where the time and the money went ({ident['model']})"
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    read = ["llm_calls.jsonl", "llm_calls_detail.jsonl"] + ([BREAKDOWN_FILENAME] if breakdown else [])
+    sources = ", ".join(f"<code>{esc(name)}</code>" for name in read)
+
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{esc(heading)}</title><style>{CSS}</style></head>
+<body><div class="wrap">
+<h1>{esc(heading)}</h1>
+<p class="sub">Session <code>{esc(ident["session_id"])}</code>
+{f"| revision <code>{esc(ident['revision'])}</code>" if ident["revision"] else ""}
+{f"| {esc(ident['elapsed_min'])} min elapsed" if ident["elapsed_min"] else ""}
+| generated {generated} from {sources}</p>
+<nav><a href="#bought">What it bought</a><a href="#phases">Spend by phase</a>
+<a href="#deep">Inside each phase</a><a href="#growth">Conversation growth</a>
+<a href="#models">Models</a><a href="#coverage">Coverage</a></nav>
+{_headline_cards(ident, root.total, ladder)}
+{_coverage_section(cov, breakdown is not None)}
+{_outcome_section(ladder)}
+{_phase_table(joined, root.total.usd_total)}
+{_deepdive_section(joined, depth_limit)}
+{_growth_section(growth_curve(rows))}
+{_models_section(model_mix(rows), root.total.usd_total)}
+<h2>How to reproduce this</h2>
+<p class="lede">Everything above is computed from the files this session wrote. Regenerate with:</p>
+<pre class="mono">python3 -m hyperloom.inference_optimizer.tools.render_hyperloom_html_report \\
+    --session-dir {esc(session_dir)} -o {esc(session_dir / "reports" / DEFAULT_OUTPUT)}</pre>
+</div></body></html>
+"""
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Args:
+        argv: Argument vector, or ``None`` for ``sys.argv``.
+
+    Returns:
+        ``0`` on success, ``2`` when the session has no readable ledger.
+    """
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--session-dir", "-s", type=Path, required=True, help="Session root directory")
+    parser.add_argument("--output", "-o", type=Path, default=None, help="HTML file to write")
+    parser.add_argument("--title", default=None, help="Override the document heading")
+    parser.add_argument("--max-depth", type=int, default=3, help="How deep to walk each phase's task tree")
+    args = parser.parse_args(argv)
+
+    session_dir = args.session_dir
+    turns, details = load_ledgers(session_dir)
+    if not turns and not details:
+        print(f"error: no llm_calls.jsonl or detail rows under {session_dir}", file=sys.stderr)
+        return 2
+
+    output = args.output or (session_dir / "reports" / DEFAULT_OUTPUT)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    html_text = render(session_dir, title=args.title, depth_limit=args.max_depth)
+    output.write_text(html_text, encoding="utf-8")
+    print(f"wrote {output} ({len(html_text.encode('utf-8')):,} bytes)")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    raise SystemExit(main())

--- a/src/hyperloom/inference_optimizer/tools/render_hyperloom_html_report.py
+++ b/src/hyperloom/inference_optimizer/tools/render_hyperloom_html_report.py
@@ -61,6 +61,11 @@ from hyperloom.inference_optimizer.tools._report_html import (
     sparkline,
 )
 from hyperloom.inference_optimizer.tools.dump_llm_call_report import Node, build_tree, call_identity, load_ledgers
+from hyperloom.inference_optimizer.tools import _report_agents as agents_mod
+from hyperloom.inference_optimizer.tools._report_agents import UNLABELLED
+from hyperloom.inference_optimizer.tools.render_geak_html_report import CALLS_FILENAME as GEAK_LEDGER
+from hyperloom.inference_optimizer.tools.render_geak_html_report import derive_role as derive_geak_role
+from hyperloom.inference_optimizer.tools.render_geak_html_report import load_calls as load_geak_ledger
 
 BREAKDOWN_FILENAME = "session_breakdown.json"
 DEFAULT_OUTPUT = "hyperloom_report.html"
@@ -78,6 +83,14 @@ ATTRIBUTION_PHASES: dict[str, tuple[str, ...]] = {
 
 #: Decisions in ``phase_timeline`` that mean the change was kept.
 KEEP_DECISIONS = {"KEEP", "PROMOTE", "promoted"}
+
+#: The ledger component whose rows the GEAK harvester writes into ``ext/``. When
+#: GEAK's own ledger is grafted in, these are dropped so the spend is not counted
+#: twice -- the harvested rows and the grafted ones describe the same API calls.
+GEAK_COMPONENT = "geak"
+
+#: The phase a grafted GEAK run is nested under. GEAK is invoked as this phase.
+GEAK_PHASE = "KERNEL_AGENT"
 
 
 def load_breakdown(path: Path) -> dict[str, Any] | None:
@@ -323,6 +336,213 @@ def session_identity(session_dir: Path, breakdown: dict[str, Any] | None) -> dic
 # --------------------------------------------------------------------------- #
 
 
+
+def agent_identity(row: dict[str, Any]) -> tuple[str, str]:
+    """The conversation a row belongs to, and the readable name for it.
+
+    Hyperloom's ledger has no agent column. What it has is ``task_path``, which
+    for a specialist reads ``specialist/<instance id>/turn-N`` -- so the instance
+    is the conversation and ``turn-N`` is a position inside it -- and for
+    everything else is either a bare name (``critic``) or absent. ``role`` is the
+    readable name, but it is written by some producers and not others: on the
+    runs seen so far it is present on orchestration and critic rows and empty on
+    every specialist row. So identity comes from the task path, which is
+    populated, and the name from ``role`` when the producer recorded one.
+
+    Args:
+        row: A ledger row.
+
+    Returns:
+        ``(agent id, role)``. The role is :data:`UNLABELLED` when nothing
+        recorded one -- never inferred from the id.
+    """
+    path = str(row.get("task_path") or "").strip("/")
+    component = str(row.get("component") or "").strip()
+    segments = [seg for seg in path.split("/") if seg]
+    if len(segments) >= 2:
+        agent = "/".join(segments[:2])
+    elif segments:
+        agent = segments[0]
+    else:
+        agent = component or "unattributed"
+    role = str(row.get("role") or "").strip()
+    if not role:
+        role = component if component and component != agent else UNLABELLED
+    return agent, role
+
+
+def normalise(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Reshape ledger rows into the record the shared deep dive works on.
+
+    Ordering within a conversation is ``(turn, api_call_index, ts)`` and the
+    position is then renumbered from zero, so the position curve measures where
+    a call sat in its own conversation rather than in the session.
+
+    Args:
+        rows: Billable rows from :func:`call_rows`.
+
+    Returns:
+        Normalised rows, ordered by agent then position.
+    """
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[agent_identity(row)[0]].append(row)
+
+    out: list[dict[str, Any]] = []
+    for agent, calls in grouped.items():
+        calls.sort(key=lambda r: (num(r.get("turn")), num(r.get("api_call_index")), str(r.get("ts") or "")))
+        for index, row in enumerate(calls):
+            isl = num(row.get("isl")) or (
+                num(row.get("input_tokens"))
+                + num(row.get("cache_read_input_tokens"))
+                + num(row.get("cache_creation_input_tokens"))
+            )
+            thinking = num(row.get("reasoning_output_tokens"))
+            # Hyperloom's ledger puts thinking beside output, not inside it.
+            osl = num(row.get("osl")) or (num(row.get("output_tokens")) + thinking)
+            tools = [
+                str(t.get("tool"))
+                for t in (row.get("tool_calls") or [])
+                if isinstance(t, dict) and t.get("tool")
+            ]
+            out.append(
+                {
+                    "phase": str(row.get("phase") or "unattributed"),
+                    "agent": agent,
+                    "role": agent_identity(row)[1],
+                    "call_index": index,
+                    "ts": row.get("ts"),
+                    "isl": isl,
+                    "osl": osl,
+                    "thinking": thinking,
+                    "usd": num(row.get("cost_usd")),
+                    "dt_s": num(row.get("latency_ms")) / 1000.0,
+                    "tools": tools,
+                    "model": row.get("model"),
+                    "component": row.get("component"),
+                    # Hyperloom records no prompt text; the drill-down column stays blank
+                    # rather than being filled with something the ledger did not say.
+                    "prompt": "",
+                }
+            )
+    return out
+
+
+def hyperloom_role_of(calls: list[dict[str, Any]]) -> dict[str, Any]:
+    """Name an agent from what its rows recorded, in that order of preference.
+
+    A recorded ``role`` wins wherever the producer wrote one. Grafted GEAK rows
+    carry prompt text instead, so they fall back to the role sentence every GEAK
+    prompt opens with -- the same derivation GEAK's own report uses, so an agent
+    is named identically on both pages. Nothing else is inferred.
+
+    Args:
+        calls: One agent's calls, in order.
+
+    Returns:
+        The identity mapping :func:`agents_mod.agent_records` merges in.
+    """
+    for call in calls:
+        role = str(call.get("role") or "").strip()
+        if role and role != UNLABELLED:
+            return {"role": role, "specialty": None, "round": None, "derived": False}
+    prompt = str(calls[0].get("prompt") or "") if calls else ""
+    if prompt:
+        return derive_geak_role(prompt)
+    return {"role": UNLABELLED, "specialty": None, "round": None, "derived": False}
+
+
+def geak_eval_dir(session_dir: Path) -> Path | None:
+    """Where the session's GEAK cycle wrote its own artifacts, as the run recorded it.
+
+    Read from the handoff records rather than guessed from the directory layout,
+    because a resumed session can carry more than one cycle and only the record
+    says which one ran.
+
+    Args:
+        session_dir: Session root.
+
+    Returns:
+        The eval directory, or ``None`` when no record names one.
+    """
+    for name in ("geak/result.json", "geak/handoff.json", "state.json"):
+        try:
+            data = json.loads((session_dir / name).read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        candidate = data.get("eval_dir") or (data.get("geak") or {}).get("eval_dir")
+        if isinstance(candidate, str) and candidate:
+            path = Path(candidate)
+            if path.is_dir():
+                return path
+    return None
+
+
+def graft_geak(session_dir: Path, rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Replace the harvested GEAK summary rows with GEAK's own per-call ledger.
+
+    GEAK is invoked as the ``KERNEL_AGENT`` phase and has historically been the
+    majority of a session's bill, but the session ledger sees it from outside:
+    the harvester writes a handful of turn rows into an ``ext`` shard, so the
+    phase that cost the most is the phase with the least to show. GEAK writes a
+    full per-call ledger of its own, and when the run left one behind this
+    grafts it in so ``KERNEL_AGENT`` drills down to GEAK's own agents.
+
+    The harvested rows are dropped in the same step. They describe the same API
+    calls as the grafted ones, so keeping both would count GEAK's spend twice.
+
+    Args:
+        session_dir: Session root.
+        rows: Normalised session rows.
+
+    Returns:
+        ``(rows, status)`` -- the status says what was grafted, or why not, and
+        is rendered in the coverage banner rather than left implicit.
+    """
+    eval_dir = geak_eval_dir(session_dir)
+    status: dict[str, Any] = {
+        "eval_dir": str(eval_dir) if eval_dir else "",
+        "grafted": False,
+        "calls": 0,
+        "usd": 0.0,
+        "dropped_harvested": 0,
+        "reason": "",
+    }
+    harvested = [r for r in rows if str(r.get("component") or "") == GEAK_COMPONENT]
+    if eval_dir is None:
+        status["reason"] = "no GEAK eval directory is named in this session's records"
+        return rows, status
+
+    ledger = eval_dir / "reports" / GEAK_LEDGER
+    geak_rows = load_geak_ledger(ledger)
+    if not geak_rows:
+        status["reason"] = (
+            f"GEAK left no <code>{esc(GEAK_LEDGER)}</code> under <code>{esc(eval_dir / 'reports')}</code>. "
+            "A GEAK build without the trace mirror writes its call ledger only into the Claude config "
+            "home, which does not survive the container; run <code>dump_geak_call_report</code> against "
+            "a surviving home to rebuild it."
+        )
+        return rows, status
+
+    kept = [r for r in rows if str(r.get("component") or "") != GEAK_COMPONENT]
+    grafted = [
+        {**row, "phase": f"{GEAK_PHASE} / {row.get('phase') or 'unattributed'}", "component": GEAK_COMPONENT}
+        for row in geak_rows
+    ]
+    status.update(
+        {
+            "grafted": True,
+            "calls": len(grafted),
+            "usd": sum(num(r.get("usd")) for r in grafted),
+            "dropped_harvested": len(harvested),
+            "dropped_usd": sum(num(r.get("usd")) for r in harvested),
+        }
+    )
+    return kept + grafted, status
+
+
 def _share(part: float, whole: float) -> str:
     """A share of a total, rendered as a bar plus its percentage."""
     fraction = (part / whole) if whole else 0.0
@@ -348,9 +568,32 @@ def _headline_cards(ident: dict[str, str], totals: Any, ladder: dict[str, Any]) 
     )
 
 
-def _coverage_section(cov: dict[str, Any], breakdown_seen: bool) -> str:
+def _coverage_section(
+    cov: dict[str, Any],
+    breakdown_seen: bool,
+    agents: list[dict[str, Any]],
+    geak: dict[str, Any],
+) -> str:
     """The banner that says what these numbers are and are not. Always rendered."""
     caveats: list[str] = []
+    unlabelled = agents_mod.unlabelled_count(agents)
+    if unlabelled:
+        caveats.append(
+            f"{fmt_int(unlabelled)} of {fmt_int(len(agents))} agents carry no <code>role</code>: that "
+            "field is written by some producers and not others, so those agents are identified by their "
+            "task path and shown as <i>unlabelled</i> rather than given an inferred name."
+        )
+    if geak.get("grafted"):
+        caveats.append(
+            f"GEAK's own per-call ledger is grafted in beneath <code>{esc(GEAK_PHASE)}</code>: "
+            f"{fmt_int(geak['calls'])} calls worth {fmt_usd(geak['usd'])}, replacing the "
+            f"{fmt_int(geak['dropped_harvested'])} harvested summary rows "
+            f"({fmt_usd(geak.get('dropped_usd', 0.0))}) that describe the same calls. The headline "
+            "cards above are the session ledger's own totals and still carry the harvested figure, so "
+            "the two differ by whatever the harvest missed."
+        )
+    elif geak.get("reason"):
+        caveats.append(f"No GEAK detail beneath <code>{esc(GEAK_PHASE)}</code>: {geak['reason']}")
     if cov.get("turns_without_detail"):
         caveats.append(
             f"{fmt_int(cov['turns_without_detail'])} of {fmt_int(cov['turns_total'])} turns wrote no per-call "
@@ -513,26 +756,52 @@ def _tree_rows(node: Node, depth: int, parent_usd: float, out: list[str], limit:
         _tree_rows(kid, depth + 1, totals.usd_total or parent_usd, out, limit)
 
 
-def _deepdive_section(joined: list[dict[str, Any]], depth_limit: int) -> str:
-    """Inside each phase: the task path that carries the spend."""
-    blocks = []
-    for record in joined:
-        totals = record["totals"]
-        rows: list[str] = []
-        _tree_rows(record["node"], 0, totals.usd_total, rows, depth_limit)
-        if not rows:
-            rows = ['<tr><td colspan="7" class="mut">no task path recorded beneath this phase</td></tr>']
-        blocks.append(
-            f'<details class="phase"><summary><span>{esc(record["phase"])}</span>'
-            f"<span>{fmt_usd(totals.usd_total)} | {fmt_int(totals.calls)} calls</span></summary>"
-            '<table class="grid"><thead><tr><th>Task path</th><th>USD</th><th>Share of parent</th>'
-            "<th>Calls</th><th>ISL</th><th>OSL</th><th>Agent time</th></tr></thead>"
-            f"<tbody>{''.join(rows)}</tbody></table></details>"
-        )
+def _task_tree(record: dict[str, Any], depth_limit: int) -> str:
+    """The task-path tree beneath one phase, heaviest branch first."""
+    totals = record["totals"]
+    rows: list[str] = []
+    _tree_rows(record["node"], 0, totals.usd_total, rows, depth_limit)
+    if not rows:
+        return ""
     return (
-        '<h2 id="deep">Inside each phase</h2>'
-        '<p class="lede">The same tree <code>dump_llm_call_report</code> prints, folded so the expensive '
-        "branch is the one you open. Share is against the parent, not the session.</p>" + "".join(blocks)
+        "<h3>The task path beneath this phase</h3>"
+        '<p class="lede">The same tree <code>dump_llm_call_report</code> prints. Share is against the '
+        "parent, not the session.</p>"
+        '<div class="scroll"><table><thead><tr><th>Task path</th><th>USD</th><th>Share of parent</th>'
+        "<th>Calls</th><th>ISL</th><th>OSL</th><th>Agent time</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table></div>"
+    )
+
+
+def _deepdive_section(
+    phases: list[dict[str, Any]],
+    total_usd: float,
+    trees: dict[str, str],
+) -> str:
+    """Inside each phase: the shared anatomy and roster, plus this page's task tree.
+
+    The anatomy and roster are rendered by the module both reports share, so a
+    column means the same thing here as on a GEAK run's own page. The task tree
+    is Hyperloom's alone and is appended beneath them.
+
+    Args:
+        phases: Phase records from the shared module, most expensive first.
+        total_usd: The bill shares are taken against.
+        trees: Rendered task-path tree per phase name, "" where there is none.
+
+    Returns:
+        The section HTML.
+    """
+    return agents_mod.deepdive_html(
+        phases,
+        total_usd,
+        lede=(
+            "Expand a phase to see where its money went: how cost moves as a conversation grows, how "
+            "few agents carry the total, what tools the work actually consisted of, and the full agent "
+            "roster. Any agent row opens into its own API calls. A phase named "
+            "<code>KERNEL_AGENT / ...</code> is a GEAK phase grafted in from GEAK's own ledger."
+        ),
+        extra_of=lambda phase: trees.get(phase["phase"], ""),
     )
 
 
@@ -600,6 +869,14 @@ def render(session_dir: Path, title: str | None = None, depth_limit: int = 3) ->
     rows = call_rows(turns, details)
     ident = session_identity(session_dir, breakdown)
 
+    # The deep dive runs on the normalised rows, with GEAK's own ledger grafted in
+    # place of the handful of summary rows the harvester wrote for it.
+    normalised, geak_status = graft_geak(session_dir, normalise(rows))
+    agents = agents_mod.agent_records(normalised, hyperloom_role_of)
+    deep_phases = agents_mod.phase_records(normalised, agents)
+    deep_usd = sum(p["usd"] for p in deep_phases)
+    trees = {record["phase"]: _task_tree(record, depth_limit) for record in joined}
+
     heading = title or f"Hyperloom session - where the time and the money went ({ident['model']})"
     generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     read = ["llm_calls.jsonl", "llm_calls_detail.jsonl"] + ([BREAKDOWN_FILENAME] if breakdown else [])
@@ -616,20 +893,24 @@ def render(session_dir: Path, title: str | None = None, depth_limit: int = 3) ->
 {f"| {esc(ident['elapsed_min'])} min elapsed" if ident["elapsed_min"] else ""}
 | generated {generated} from {sources}</p>
 <nav><a href="#bought">What it bought</a><a href="#phases">Spend by phase</a>
-<a href="#deep">Inside each phase</a><a href="#growth">Conversation growth</a>
+<a href="#deep">Inside each phase</a><a href="#delegate">Delegation signals</a>
+<a href="#growth">Conversation growth</a>
 <a href="#models">Models</a><a href="#coverage">Coverage</a></nav>
 {_headline_cards(ident, root.total, ladder)}
-{_coverage_section(cov, breakdown is not None)}
+{_coverage_section(cov, breakdown is not None, agents, geak_status)}
 {_outcome_section(ladder)}
 {_phase_table(joined, root.total.usd_total)}
-{_deepdive_section(joined, depth_limit)}
+{_deepdive_section(deep_phases, deep_usd, trees)}
+{agents_mod.delegation_html(agents_mod.delegation_signals(agents))}
 {_growth_section(growth_curve(rows))}
 {_models_section(model_mix(rows), root.total.usd_total)}
 <h2>How to reproduce this</h2>
 <p class="lede">Everything above is computed from the files this session wrote. Regenerate with:</p>
 <pre class="mono">python3 -m hyperloom.inference_optimizer.tools.render_hyperloom_html_report \\
     --session-dir {esc(session_dir)} -o {esc(session_dir / "reports" / DEFAULT_OUTPUT)}</pre>
-</div></body></html>
+</div>
+<script>const AGENTS={agents_mod.agent_payload(agents)};{agents_mod.drill_js("llm_calls_detail.jsonl")}</script>
+</body></html>
 """
 
 

--- a/src/hyperloom/orchestrator/kernel/controller_submit.py
+++ b/src/hyperloom/orchestrator/kernel/controller_submit.py
@@ -139,6 +139,7 @@ def record_controller_llm_usage(*, result: dict[str, Any], session_dir: Path) ->
         if not isinstance(row, dict):
             continue
         try:
+            from hyperloom.orchestrator.trace.call_detail import append_turn_call_details
             from hyperloom.orchestrator.trace.llm_trace import (
                 LLMCallRecord,
                 append_llm_call,
@@ -156,6 +157,15 @@ def record_controller_llm_usage(*, result: dict[str, Any], session_dir: Path) ->
                     cache_creation_input_tokens=row.get("cache_creation_input_tokens"),
                     cache_read_input_tokens=row.get("cache_read_input_tokens"),
                 ),
+            )
+            # The child reports one total per forge-loop, not per request, so
+            # the sidecar row covers the loop and carries no call index.
+            append_turn_call_details(
+                session_dir=Path(session_dir),
+                session_id=Path(session_dir).name,
+                component="forge",
+                metadata=row,
+                task_id=str(row.get("operator_id") or "") or None,
             )
         except Exception:  # noqa: BLE001 - accounting must not fail the phase
             continue

--- a/src/hyperloom/orchestrator/loop/coordinator.py
+++ b/src/hyperloom/orchestrator/loop/coordinator.py
@@ -81,6 +81,7 @@ from ..state.shared_state import SharedState, effective_closing_grace_sec, timed
 from .intent_router import IntentRouter
 from .sub_agent_runner import SubAgentRunner
 from ..state.task_registry import TaskRegistry
+from ..trace.call_detail import append_turn_call_details
 from ..trace.llm_trace import LLMCallRecord, append_llm_call
 from hyperloom.common.prompt_safety import defang_prompt_structure as _defang_prompt_structure
 from hyperloom.common.prompt_safety import flatten_for_prompt as _flatten_for_inbox
@@ -2075,6 +2076,7 @@ class Coordinator(metaclass=_CoordinatorMeta):
             agent_name: The reactor role; doubles as trace component and role.
             result: The backend turn result whose metadata carries token
                 counters.
+            latency_ms: Measured wall-clock of the turn, when available.
         """
         try:
             metadata = result.metadata or {}
@@ -2099,6 +2101,15 @@ class Coordinator(metaclass=_CoordinatorMeta):
                 latency_ms=latency_ms,
             )
             append_llm_call(session_dir=self.session_dir, record=record)
+            append_turn_call_details(
+                session_dir=self.session_dir,
+                session_id=self.session_dir.name,
+                component=agent_name,
+                metadata=metadata,
+                role=agent_name,
+                tick=int(self.shared_state.tick or 0),
+                phase=(self.shared_state.phase or "") or None,
+            )
         except Exception:  # noqa: BLE001 — trace must never break the loop
             log.debug(
                 "full-trace: reactor llm_call append failed for %s",

--- a/src/hyperloom/orchestrator/loop/dispatcher.py
+++ b/src/hyperloom/orchestrator/loop/dispatcher.py
@@ -12,7 +12,7 @@ from collections.abc import Callable, Collection
 from concurrent.futures import CancelledError as FuturesCancelledError
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, NamedTuple
-from hyperloom.common.llm_attribution import current_action_scope
+from hyperloom.common.llm_attribution import current_action_scope, task_scope
 from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
 from hyperloom.inference_optimizer.protocol.action_surfaces import (
     KERNEL_AGENT_OWNED_ACTIONS,
@@ -910,8 +910,9 @@ class DispatcherCollaborator:
                 self._inflight_actions[task.task_id] = _InflightAction(task.kind, handle, cancel_scope)
         try:
             # Every LLM call this action makes, in-process or in a child, is
-            # labelled with its kind from here.
-            with use_cancel_scope(cancel_scope), current_action_scope(task.kind):
+            # labelled with its kind from here, and roots its task path there
+            # so the report can nest what the action did beneath it.
+            with use_cancel_scope(cancel_scope), current_action_scope(task.kind), task_scope(task.kind):
                 return await self.sub.run_task(
                     task,
                     prebound_lease=lease,

--- a/src/hyperloom/orchestrator/loop/sub_agent_runner.py
+++ b/src/hyperloom/orchestrator/loop/sub_agent_runner.py
@@ -22,6 +22,7 @@ from hyperloom.inference_optimizer.session.session_paths import _RUNS_ACTIONS, r
 from ..bus.resource_lock import Lease, ResourceLockManager
 from ..policy.gate import PolicyDenied
 from ..state.task_registry import IllegalTransition, Task, TaskRegistry
+from hyperloom.common.llm_attribution import task_scope
 from ..trace.task_progress import ProgressReporter, progress_scope
 
 if TYPE_CHECKING:
@@ -308,7 +309,7 @@ class SubAgentRunner:
                 if extra_context:
                     extra.update(dict(extra_context))
                 ctx = RunnerContext(task=task, lease=lease, extra=extra)
-                with progress_scope(self._progress_reporter(task.task_id)):
+                with progress_scope(self._progress_reporter(task.task_id)), task_scope(task.task_id):
                     result_payload = await runner(ctx)
             except asyncio.CancelledError:
                 # Stopped from outside -- shutdown, or a wall-clock budget that

--- a/src/hyperloom/orchestrator/phases/kernel.py
+++ b/src/hyperloom/orchestrator/phases/kernel.py
@@ -1435,6 +1435,7 @@ class KernelPhase(PhaseHandler):
                 )
             return subprocess.CompletedProcess(cmd, p.returncode, out, err)
 
+        geak_started_at = time.time()
         try:
             proc = await asyncio.to_thread(_run)
             stderr_tail = (proc.stderr or "")[-2000:]
@@ -1475,6 +1476,11 @@ class KernelPhase(PhaseHandler):
             log.exception("GEAK runner crashed")
             _finish_skip({"status": "error", "error_class": "runner_crashed", "error": repr(exc)})
             return
+        finally:
+            # Every exit above returns, so the harvest is attached here to cover
+            # the timed-out and crashed runs too: those are the ones whose spend
+            # would otherwise vanish, and they are the expensive ones.
+            self._harvest_geak_spend(str(out_dir), since=geak_started_at)
 
         result: dict[str, Any] = _read_geak_result(result_path)
         if not result:
@@ -1580,6 +1586,39 @@ class KernelPhase(PhaseHandler):
         # KERNEL is a one-shot under GEAK: wind down to SWEEP (persist the hint).
         state.set_pending_escalate_hint(_phase_state.ESCALATE_HINT_SKIP_TO_SWEEP)
         state.save(self.session_dir)
+
+    def _harvest_geak_spend(self, exp_root: str, *, since: float) -> None:
+        """Fold the GEAK subprocess's model spend into this session's ledger.
+
+        GEAK drives its own Claude SDK client and never touches the in-process
+        ledger, so its calls are read back off the Claude Code transcripts it
+        left behind and written to the session's ``ext`` trace shard. It is the
+        majority of a session's bill; without this the ledger's total is a
+        minority of the truth while looking complete.
+
+        Args:
+            exp_root: This run's GEAK experiment root, which is the marker that
+                separates its transcripts from a neighbouring run sharing the
+                same GEAK checkout.
+            since: Epoch seconds the subprocess started, used to skip
+                transcripts that cannot belong to it.
+        """
+        try:
+            from ..trace.geak_harvest import harvest_geak_calls
+
+            runner = os.environ.get("GEAK_E2E_RUNNER", "").strip()
+            workflow_dir = str(Path(runner).parent.parent / "e2e_workflow") if runner else None
+            harvest_geak_calls(
+                session_dir=self.session_dir,
+                session_id=self.session_dir.name,
+                exp_root=exp_root,
+                workflow_dir=workflow_dir,
+                phase="KERNEL_AGENT",
+                tick=int(getattr(self.shared_state, "tick", 0) or 0),
+                not_before=since,
+            )
+        except Exception:  # noqa: BLE001 — accounting cannot change kernel behavior
+            log.debug("geak: transcript harvest failed", exc_info=True)
 
     def _geak_win_already_recorded(self) -> bool:
         """Whether a GEAK e2e win is already in this session's state.

--- a/src/hyperloom/orchestrator/roles/claude.py
+++ b/src/hyperloom/orchestrator/roles/claude.py
@@ -18,6 +18,7 @@ import importlib
 import json
 import logging
 import os
+import time
 from dataclasses import dataclass, field
 from typing import Any, Callable
 from urllib.parse import urlsplit
@@ -31,6 +32,8 @@ from hyperloom.inference_optimizer.protocol.intent import (
 )
 from ..prompts.transport import TRANSPORT_TOOLS
 from ..trace.llm_trace import new_call_id
+from ..trace.parse_usage import reasoning_output_tokens
+from hyperloom.common.timeutil import now_iso
 from .base import (
     BackendError,
     BackendTurnResult,
@@ -138,6 +141,70 @@ _RAW_COMPLETION_MIN_MAX_TURNS: int = 8
 # Retried timeouts get a progressively larger idle budget so a genuinely slow
 # gateway is not re-killed at the same wall.
 _RETRY_IDLE_TIMEOUT_MULTIPLIER: float = 2.0
+
+
+def _is_terminal_result(message: Any) -> bool:
+    """Whether a streamed message is the run's terminal summary.
+
+    Its ``usage`` is cumulative over the whole turn, so it must never be
+    counted as one more API call. The class name identifies it under the real
+    SDK; the run-summary fields identify it under any stand-in.
+
+    Args:
+        message (Any): A streamed SDK message.
+
+    Returns:
+        bool: ``True`` when the message is the terminal ``ResultMessage``.
+    """
+    if type(message).__name__ == "ResultMessage":
+        return True
+    return getattr(message, "num_turns", None) is not None or getattr(message, "total_cost_usd", None) is not None
+
+
+def _tool_use_entry(block: Any) -> dict[str, Any] | None:
+    """Project any tool-use block onto a ledger tool-call entry.
+
+    Unlike :meth:`ClaudeBackend._is_tool_use_for_emit_intent` this counts every
+    tool the model called, not just the intent transport, because the report
+    asks what work a call did and a file read is work.
+
+    Args:
+        block (Any): A single SDK content block.
+
+    Returns:
+        dict | None: The ``{tool, tool_use_id}`` entry, or ``None`` when the
+        block is not a tool use.
+    """
+    if type(block).__name__ not in ("ToolUseBlock", "ServerToolUseBlock"):
+        return None
+    name = getattr(block, "name", None)
+    if not isinstance(name, str) or not name:
+        return None
+    entry: dict[str, Any] = {"tool": name}
+    tool_use_id = getattr(block, "id", None)
+    if isinstance(tool_use_id, str) and tool_use_id:
+        entry["tool_use_id"] = tool_use_id
+    return entry
+
+
+@dataclass
+class _TurnCollection:
+    """What one streamed turn yielded, beyond its intents and text.
+
+    ``api_calls`` holds one entry per real API call the turn made, in order,
+    shaped for :class:`..trace.call_detail.CallDetailRecord`. The backend is
+    stateless about the session directory, so it collects the rows and the
+    caller -- which holds that context -- writes them.
+    """
+
+    intents: list[Intent] = field(default_factory=list)
+    raw_text: str = ""
+    tool_block_count: int = 0
+    usage: dict[str, Any] = field(default_factory=dict)
+    session_id: str | None = None
+    stop_reason: str | None = None
+    api_calls: list[dict[str, Any]] = field(default_factory=list)
+    total_cost_usd: float | None = None
 
 
 def _intent_fingerprint(intent: Intent) -> str:
@@ -399,11 +466,11 @@ class ClaudeBackend:
         # budget), not the total turn; each retry amplifies the idle budget.
         attempt_state = {"n": 0}
 
-        async def _one_attempt() -> tuple[Any, ...]:
+        async def _one_attempt() -> _TurnCollection:
             """Run one SDK invocation under an amplified per-attempt idle timeout.
 
             Returns:
-                The collected ``_invoke_and_collect`` result tuple.
+                The turn's collected :class:`_TurnCollection`.
 
             Raises:
                 asyncio.TimeoutError: If the stream stays idle (no new message)
@@ -428,14 +495,7 @@ class ClaudeBackend:
             )
 
         try:
-            (
-                intents,
-                raw_text,
-                tool_block_count,
-                usage,
-                session_id,
-                stop_reason,
-            ) = await retry_with_backoff(
+            collected = await retry_with_backoff(
                 _one_attempt,
                 policy=self.retry_policy,
                 retry_on=(
@@ -446,6 +506,12 @@ class ClaudeBackend:
                 ),
                 on_retry=_note_retry,
             )
+            intents = collected.intents
+            raw_text = collected.raw_text
+            tool_block_count = collected.tool_block_count
+            usage = collected.usage
+            session_id = collected.session_id
+            stop_reason = collected.stop_reason
         except asyncio.TimeoutError as exc:
             self.calls.append(
                 {
@@ -543,6 +609,15 @@ class ClaudeBackend:
                 # Per-request context size; the counters above sum the call's
                 # internal turns and are spend, not size.
                 "context_tokens_peak": safe_int(usage.get("context_tokens_peak") if usage else None),
+                # How many real API calls this one turn made, and what each of
+                # them cost in tokens and wall-clock. The caller holds the
+                # session context, so it writes them to the sidecar ledger.
+                "api_calls": len(collected.api_calls) or None,
+                "api_call_details": collected.api_calls,
+                # The CLI prices the whole turn and its figure wins over the
+                # rate card. Read only off the terminal result: an assistant
+                # message's own cost field would double-bill.
+                "total_cost_usd": collected.total_cost_usd,
                 # Full conversation text so the caller (which holds the
                 # session_dir / component / tick context the stateless
                 # backend lacks) can persist it to conversations.jsonl.
@@ -876,10 +951,8 @@ class ClaudeBackend:
 
     async def _invoke_and_collect(
         self, prompt: str, options: Any, *, idle_timeout_s: float | None = None
-    ) -> tuple[list[Intent], str, int, dict[str, Any], str | None, str | None]:
-        """Stream SDK messages, collecting intents, raw text, tool counts,
-        the latest `ResultMessage.usage` dict, the SDK ``session_id`` and the
-        model's ``stop_reason``.
+    ) -> _TurnCollection:
+        """Stream SDK messages, collecting everything one turn yielded.
 
         Args:
             prompt: The composed prompt to stream to the SDK.
@@ -890,11 +963,11 @@ class ClaudeBackend:
                 slow-but-live reasoning model is never killed (issue #679).
 
         Returns:
-            A tuple ``(intents, raw_text, tool_block_count, usage, session_id,
-            stop_reason)`` where ``usage`` is the latest cumulative usage dict
-            plus a per-request ``context_tokens_peak``, ``session_id`` is the
-            SDK session token (or ``None``), and ``stop_reason`` is the last
-            reason the model reported (or ``None``).
+            The :class:`_TurnCollection` for the turn: its intents, raw text,
+            tool-block count, the latest cumulative usage dict plus a
+            per-request ``context_tokens_peak``, the SDK session token, the last
+            ``stop_reason`` the model reported, one entry per API call, and the
+            CLI's own charge for the turn when it reported one.
         """
         intents: list[Intent] = []
         text_chunks: list[str] = []
@@ -909,6 +982,14 @@ class ClaudeBackend:
         num_turns = 0
         session_id: str | None = None
         stop_reason: str | None = None
+        # One entry per real API call, for the per-call sidecar ledger. The SDK
+        # hands over whole messages, so a call's span is the gap between message
+        # arrivals and there is no first-token instant to read: ``ttft_ms`` is
+        # left unset here rather than filled with the full latency.
+        api_calls: list[dict[str, Any]] = []
+        total_cost_usd: float | None = None
+        call_started = time.perf_counter()
+        call_started_ts = now_iso()
         stream = self.sdk_query_factory(prompt=prompt, options=options)
         try:
             stream_iter = stream.__aiter__()
@@ -927,8 +1008,12 @@ class ClaudeBackend:
                 if isinstance(msg_session, str) and msg_session:
                     session_id = msg_session
                 self._record_message_diagnostic(message)
+                msg_tool_calls: list[dict[str, Any]] = []
                 for block in self._iter_blocks(message):
                     self._record_tool_block_diagnostic(block)
+                    tool_entry = _tool_use_entry(block)
+                    if tool_entry is not None:
+                        msg_tool_calls.append(tool_entry)
                     if self._is_tool_use_for_emit_intent(block):
                         tool_block_count += 1
                         intent = self._parse_tool_use_block(block)
@@ -962,9 +1047,35 @@ class ClaudeBackend:
                 msg_stop = getattr(message, "stop_reason", None)
                 if isinstance(msg_stop, str) and msg_stop:
                     stop_reason = msg_stop
+                is_result = _is_terminal_result(message)
+                if is_result:
+                    msg_cost = getattr(message, "total_cost_usd", None)
+                    if isinstance(msg_cost, (int, float)):
+                        total_cost_usd = float(msg_cost)
                 msg_usage = getattr(message, "usage", None)
                 if isinstance(msg_usage, dict) and msg_usage:
                     usages.append(dict(msg_usage))
+                    # The terminal summary restates the turn; only the messages
+                    # before it describe single requests.
+                    if not is_result:
+                        now = time.perf_counter()
+                        api_calls.append(
+                            {
+                                "api_call_index": len(api_calls),
+                                "started_ts": call_started_ts,
+                                "latency_ms": int((now - call_started) * 1000),
+                                "model": getattr(message, "model", None) or self.model,
+                                "stop_reason": msg_stop if isinstance(msg_stop, str) else None,
+                                "input_tokens": safe_int(msg_usage.get("input_tokens")),
+                                "output_tokens": safe_int(msg_usage.get("output_tokens")),
+                                "cache_creation_input_tokens": safe_int(msg_usage.get("cache_creation_input_tokens")),
+                                "cache_read_input_tokens": safe_int(msg_usage.get("cache_read_input_tokens")),
+                                "reasoning_output_tokens": reasoning_output_tokens(msg_usage),
+                                "tool_calls": msg_tool_calls or None,
+                            }
+                        )
+                        call_started = now
+                        call_started_ts = now_iso()
         except Exception as exc:
             # The SDK raises on a terminal ResultMessage with is_error=True. Two
             # such subtypes are NON-fatal turn boundaries, not real failures, and
@@ -1013,7 +1124,16 @@ class ClaudeBackend:
                 last_usage,
                 num_turns=num_turns,
             )
-        return intents, raw_text, tool_block_count, last_usage, session_id, stop_reason
+        return _TurnCollection(
+            intents=intents,
+            raw_text=raw_text,
+            tool_block_count=tool_block_count,
+            usage=last_usage,
+            session_id=session_id,
+            stop_reason=stop_reason,
+            api_calls=api_calls,
+            total_cost_usd=total_cost_usd,
+        )
 
     @staticmethod
     def _iter_blocks(message: Any):

--- a/src/hyperloom/orchestrator/roles/critic_agent.py
+++ b/src/hyperloom/orchestrator/roles/critic_agent.py
@@ -48,6 +48,8 @@ from hyperloom.inference_optimizer.protocol.intent import (
 )
 from hyperloom.inference_optimizer.session.session_paths import allocate_turn_workdir, manifest_path
 from ..trace.conversation_trace import ConversationRecord, append_conversation
+from hyperloom.common.llm_attribution import task_scope
+from ..trace.call_detail import append_turn_call_details
 from ..trace.llm_trace import LLMCallRecord, append_llm_call, new_call_id
 from ..trace.parse_usage import reasoning_output_tokens
 from .base import BackendError, BackendTurnResult, LLMCallFailed, build_chat_messages, parse_call_timeout_env
@@ -1454,23 +1456,38 @@ class CriticAgentBackend:
             call_id: Per-call id shared with this call's conversation row.
         """
         try:
-            record = LLMCallRecord(
-                session_id=self.session_dir.name,
-                component="critic",
-                role="critic",
-                call_id=call_id,
-                model=self._review_model,
-                tick=self._trace_tick,
-                phase=self._trace_phase,
-                input_tokens=usage_acc.get("input_tokens"),
-                output_tokens=usage_acc.get("output_tokens"),
-                cache_read_input_tokens=usage_acc.get("cache_read_input_tokens"),
-                cache_creation_input_tokens=usage_acc.get("cache_creation_input_tokens"),
-                reasoning_output_tokens=usage_acc.get("reasoning_output_tokens"),
-                latency_ms=latency_ms,
-                reviewed_msg_ids=self._trace_reviewed_msg_ids,
-            )
-            append_llm_call(session_dir=self.session_dir, record=record)
+            # Review is a child of whatever action asked for it; naming it here
+            # puts its spend on its own branch of that action's tree.
+            with task_scope("critic"):
+                record = LLMCallRecord(
+                    session_id=self.session_dir.name,
+                    component="critic",
+                    role="critic",
+                    call_id=call_id,
+                    model=self._review_model,
+                    tick=self._trace_tick,
+                    phase=self._trace_phase,
+                    input_tokens=usage_acc.get("input_tokens"),
+                    output_tokens=usage_acc.get("output_tokens"),
+                    cache_read_input_tokens=usage_acc.get("cache_read_input_tokens"),
+                    cache_creation_input_tokens=usage_acc.get("cache_creation_input_tokens"),
+                    reasoning_output_tokens=usage_acc.get("reasoning_output_tokens"),
+                    latency_ms=latency_ms,
+                    reviewed_msg_ids=self._trace_reviewed_msg_ids,
+                )
+                append_llm_call(session_dir=self.session_dir, record=record)
+                # The review transports report one usage total for the whole
+                # reasoning loop, so the sidecar gets the matching whole-turn row.
+                append_turn_call_details(
+                    session_dir=self.session_dir,
+                    session_id=self.session_dir.name,
+                    component="critic",
+                    metadata={**usage_acc, "model": self._review_model, "call_id": call_id},
+                    role="critic",
+                    tick=self._trace_tick,
+                    phase=self._trace_phase,
+                    turn_latency_ms=latency_ms,
+                )
         except Exception:  # noqa: BLE001 — trace must never break review
             log.debug(
                 "full-trace: critic llm_call append failed",

--- a/src/hyperloom/orchestrator/scoring/proposal_scorer.py
+++ b/src/hyperloom/orchestrator/scoring/proposal_scorer.py
@@ -37,6 +37,8 @@ from hyperloom.common.llm_config import (
 from ..roles.base import parse_call_timeout_env
 from ..loop.coordinator_helpers import format_exc_brief
 from ..trace.conversation_trace import ConversationRecord, append_conversation
+from hyperloom.common.llm_attribution import task_scope
+from ..trace.call_detail import append_turn_call_details
 from ..trace.llm_trace import LLMCallRecord, append_llm_call, new_call_id
 from ..trace.parse_usage import reasoning_output_tokens
 
@@ -444,24 +446,51 @@ class ProposalScorer:
                 ct = getattr(usage, "completion_tokens", None)
                 input_tokens = int(pt) if pt is not None else None
                 output_tokens = int(ct) if ct is not None else None
-            record = LLMCallRecord(
-                session_id=self.session_dir.name,
-                component="proposal_scorer",
-                role="proposal_scorer",  # must match the conversation row's role
-                call_id=call_id,
-                model=str(model),
-                task_id=task_id,
-                tick=tick,
-                phase=phase,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                # A scoring model with a reasoning split bills it separately;
-                # reading it here keeps the ledger consistent with the backends
-                # that report it on their turn metadata.
-                reasoning_output_tokens=reasoning_output_tokens(usage),
-                latency_ms=latency_ms,
-            )
-            append_llm_call(session_dir=self.session_dir, record=record)
+            # Scoring hangs off the action that requested it; the segment
+            # gives it its own branch of that action's tree.
+            with task_scope("proposal_scorer"):
+                record = LLMCallRecord(
+                    session_id=self.session_dir.name,
+                    component="proposal_scorer",
+                    role="proposal_scorer",  # must match the conversation row's role
+                    call_id=call_id,
+                    model=str(model),
+                    task_id=task_id,
+                    tick=tick,
+                    phase=phase,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    # A scoring model with a reasoning split bills it separately;
+                    # reading it here keeps the ledger consistent with the backends
+                    # that report it on their turn metadata.
+                    reasoning_output_tokens=reasoning_output_tokens(usage),
+                    latency_ms=latency_ms,
+                )
+                append_llm_call(session_dir=self.session_dir, record=record)
+                # Scoring is one request, so this turn's row and its single
+                # per-call row describe the same call; the index says so.
+                append_turn_call_details(
+                    session_dir=self.session_dir,
+                    session_id=self.session_dir.name,
+                    component="proposal_scorer",
+                    metadata={
+                        "call_id": call_id,
+                        "api_call_details": [
+                            {
+                                "api_call_index": 0,
+                                "model": str(model),
+                                "input_tokens": input_tokens,
+                                "output_tokens": output_tokens,
+                                "reasoning_output_tokens": reasoning_output_tokens(usage),
+                                "latency_ms": latency_ms,
+                            }
+                        ],
+                    },
+                    role="proposal_scorer",
+                    task_id=task_id,
+                    tick=tick,
+                    phase=phase,
+                )
         except Exception:  # noqa: BLE001 — trace must never break scoring
             log.debug(
                 "full-trace: proposal_scorer llm_call append failed for model=%s",

--- a/src/hyperloom/orchestrator/specialists/runner.py
+++ b/src/hyperloom/orchestrator/specialists/runner.py
@@ -30,6 +30,8 @@ from hyperloom.common.timeutil import now_iso
 from hyperloom.inference_optimizer.session.session_paths import runs_dir, specialist_intel_path
 from ..roles.base import BackendError, LLMCallFailed
 from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
+from hyperloom.common.llm_attribution import task_scope
+from ..trace.call_detail import append_turn_call_details
 from ..trace.conversation_trace import ConversationRecord, append_conversation
 from ..trace.llm_trace import LLMCallRecord, append_llm_call
 from .domains import (
@@ -709,7 +711,9 @@ class SpecialistRunner:
         if self.session_dir is None:
             return
         try:
-            md = metadata or {}
+            # Copied, not aliased: the single-turn caller passes the backend's
+            # own usage dict and must not see the join key added below.
+            md = dict(metadata or {})
             has_tokens = any(
                 md.get(k) is not None
                 for k in (
@@ -721,17 +725,41 @@ class SpecialistRunner:
             )
             if not has_tokens:
                 return
-            record = LLMCallRecord.from_metadata(
-                session_id=self.session_dir.name,
-                component="specialist",
-                task_id=task_id,
-                turn=turn,
-                metadata=md,
-                latency_ms=latency_ms,
-                tick=tick,
-                phase=phase,
-            )
-            append_llm_call(session_dir=self.session_dir, record=record)
+            # The turn row and its per-API-call detail rows are joined on
+            # ``call_id``. A backend that stamps one (Claude, via the response's
+            # ``message.id``) supplies the real identity; one that does not
+            # (Codex, or a log naming no message ids) would otherwise emit
+            # detail rows that join to nothing and drop out of every rollup, so
+            # a synthetic key is derived from the pair that is already unique
+            # within the session.
+            if not md.get("call_id"):
+                md["call_id"] = f"{task_id}:turn-{turn}"
+            # The turn is a level of the task tree, and the ledger rows are
+            # written after it has ended, so the segment is opened here rather
+            # than around the turn itself.
+            with task_scope(f"turn-{turn}"):
+                record = LLMCallRecord.from_metadata(
+                    session_id=self.session_dir.name,
+                    component="specialist",
+                    task_id=task_id,
+                    turn=turn,
+                    metadata=md,
+                    latency_ms=latency_ms,
+                    tick=tick,
+                    phase=phase,
+                )
+                append_llm_call(session_dir=self.session_dir, record=record)
+                append_turn_call_details(
+                    session_dir=self.session_dir,
+                    session_id=self.session_dir.name,
+                    component="specialist",
+                    metadata=md,
+                    task_id=task_id,
+                    turn=turn,
+                    tick=tick,
+                    phase=phase,
+                    turn_latency_ms=latency_ms,
+                )
         except Exception:  # noqa: BLE001 — trace must never break the run
             log.debug(
                 "full-trace: specialist llm_call append failed for task_id=%s turn=%s",

--- a/src/hyperloom/orchestrator/trace/__init__.py
+++ b/src/hyperloom/orchestrator/trace/__init__.py
@@ -12,7 +12,14 @@ live Langfuse push (gated on ``HYPERLOOM_LANGFUSE_ENABLE`` + the
 Modules:
 
 * :mod:`llm_trace` — :class:`LLMCallRecord` closed-schema dataclass and
-  :func:`append_llm_call`, the best-effort single-line appender.
+  :func:`append_llm_call`, the best-effort single-line appender. One row is
+  one agentic turn.
+* :mod:`call_detail` — the per-API-call sidecar a turn expands into, joined
+  on ``call_id``.
+* :mod:`geak_harvest` — recovers GEAK's out-of-process spend from the Claude
+  Code transcripts it leaves behind, into the session's ``ext`` shard.
+* :mod:`pricing` — USD for one call, from the provider's own figure when it
+  reports one and the shipped rate card otherwise.
 * :mod:`parse_usage` — parsers that recover ``usage`` token counts from
   out-of-process child output (Claude CLI ``stream-json``, Codex CLI
   ``codex exec --json``), plus sanitized Codex failure messages.
@@ -32,6 +39,12 @@ The collector that joins this ledger with the decision streams lives in
 ``src/hyperloom/inference_optimizer/breakdown/collectors/decision.py`` (``collect_decision_trace``).
 """
 
+from .call_detail import (
+    CallDetailRecord,
+    CallDetailRowError,
+    append_call_detail,
+)
+from .geak_harvest import HarvestResult, harvest_geak_calls
 from .conversation_trace import (
     ConversationRecord,
     ConversationRowError,
@@ -48,6 +61,7 @@ from .orchestration_trace import (
     write_mcp_setup_once,
 )
 from .langfuse_emitter import flush_session, get_emitter
+from .pricing import CostBreakdown, resolve_cost
 from .parse_usage import (
     normalize_usage,
     parse_claude_stream_json_usage,
@@ -58,14 +72,20 @@ from .task_progress import progress_scope, report_progress
 from .trace_env import langfuse_live_enabled
 
 __all__ = [
+    "CallDetailRecord",
+    "CallDetailRowError",
     "ConversationRecord",
     "ConversationRowError",
     "LLMCallRecord",
+    "CostBreakdown",
+    "HarvestResult",
     "LLMTraceRowError",
+    "append_call_detail",
     "append_conversation",
     "append_llm_call",
     "flush_session",
     "get_emitter",
+    "harvest_geak_calls",
     "langfuse_live_enabled",
     "new_call_id",
     "normalize_usage",
@@ -74,6 +94,7 @@ __all__ = [
     "parse_codex_jsonl_usage",
     "progress_scope",
     "redact_secrets",
+    "resolve_cost",
     "report_progress",
     "write_mcp_setup_once",
 ]

--- a/src/hyperloom/orchestrator/trace/_row_utils.py
+++ b/src/hyperloom/orchestrator/trace/_row_utils.py
@@ -11,6 +11,7 @@ of that logic; ``parse_usage`` shares the int coercion.
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 
@@ -48,6 +49,29 @@ def coerce_optional_int(value: Any) -> int | None:
         return None
 
 
+def coerce_optional_float(value: Any) -> float | None:
+    """Coerce a value to a finite ``float``, or ``None`` on a miss / bad type.
+
+    Keeps ``None`` distinct from ``0.0`` -- the difference between "this call
+    was not priced" and "this call was free" is the whole point of the cost
+    columns. Non-finite values are rejected rather than written, since JSON has
+    no spelling for them.
+
+    Args:
+        value: Arbitrary value to convert.
+
+    Returns:
+        The float value, or ``None`` on failure.
+    """
+    if value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
 def validate_closed_row(
     row: dict[str, Any],
     *,
@@ -82,4 +106,9 @@ def validate_closed_row(
         raise error_cls(f"{label} row 'component'={component!r} is not one of {sorted(valid_components)!r}")
 
 
-__all__ = ["coerce_optional_str", "coerce_optional_int", "validate_closed_row"]
+__all__ = [
+    "coerce_optional_float",
+    "coerce_optional_int",
+    "coerce_optional_str",
+    "validate_closed_row",
+]

--- a/src/hyperloom/orchestrator/trace/call_detail.py
+++ b/src/hyperloom/orchestrator/trace/call_detail.py
@@ -1,0 +1,542 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Closed-schema writer for ``reports/trace/llm_calls_detail.jsonl``.
+
+The sidecar to :mod:`llm_trace`. That ledger stays one row per agentic *turn*,
+because the breakdown rollup, the CI session report and the Langfuse mirror all
+count its rows; changing what a row means would silently restate every published
+total. A turn, however, is often several real API calls -- an agentic backend
+loops tool-use round trips inside one ``run`` -- and the questions this
+instrumentation exists to answer (what did each call cost, how long was its
+first token, how much of it was thinking) are per call, not per turn.
+
+So the per-call rows live here, joined to their turn on ``call_id`` and ordered
+within it by ``api_call_index``. Nothing reads this file to compute a total that
+already has a published value.
+
+``isl`` and ``osl`` are derived once, here, so every consumer means the same
+thing by them: ISL counts everything the model read (fresh input plus both cache
+halves), OSL everything it wrote (visible reply plus hidden reasoning).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, fields
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from hyperloom.common.io import append_jsonl
+from hyperloom.common.llm_attribution import TASK_PATH_SEPARATOR
+from hyperloom.common.timeutil import now_iso
+from hyperloom.inference_optimizer.session.session_paths import llm_call_detail_path
+from .llm_trace import (
+    LLM_STATUS_OK,
+    VALID_COMPONENTS,
+    VALID_STATUSES,
+    resolve_task_path,
+)
+from .pricing import resolve_cost
+from ._row_utils import (
+    coerce_optional_float as _coerce_optional_float,
+    coerce_optional_int as _coerce_optional_int,
+    coerce_optional_str as _coerce_optional_str,
+    validate_closed_row,
+)
+
+log = logging.getLogger(__name__)
+
+# A transcript can carry a pathological number of tool blocks in one reply; cap
+# what reaches the ledger so a single row cannot dominate the file.
+_TOOL_CALLS_MAX = 200
+_TOOL_ARG_MAX = 200
+
+#: Values for a row's ``timing_source``; see :class:`CallDetailRecord`.
+TIMING_MEASURED = "measured"
+TIMING_APPORTIONED = "apportioned"
+
+
+_ROW_FIELDS: frozenset[str] = frozenset(
+    {
+        "session_id",
+        "ts",
+        "started_ts",
+        "component",
+        "call_id",
+        "api_call_index",
+        "parent_call_id",
+        "role",
+        "task_id",
+        "dyn_id",
+        "tick",
+        "phase",
+        "turn",
+        "task_path",
+        "task_depth",
+        "model",
+        "isl",
+        "osl",
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "reasoning_output_tokens",
+        "latency_ms",
+        "ttft_ms",
+        "thinking_ms",
+        "output_ms",
+        "timing_source",
+        "cost_usd",
+        "cost_input_usd",
+        "cost_output_usd",
+        "cost_thinking_usd",
+        "cost_cache_usd",
+        "cost_source",
+        "tool_calls",
+        "tool_call_count",
+        "stop_reason",
+        "status",
+        "error_type",
+        "error_message",
+    }
+)
+
+
+class CallDetailRowError(ValueError):
+    """Raised when a per-API-call row violates the closed schema."""
+
+
+def _tool_call_entry(entry: Any) -> dict[str, Any] | None:
+    """Project one tool-call record onto the fields the ledger keeps.
+
+    Args:
+        entry: A tool-call mapping from a backend or a transcript parser.
+
+    Returns:
+        The projected entry, or ``None`` when it names no tool.
+    """
+    if not isinstance(entry, Mapping):
+        name = _coerce_optional_str(entry)
+        return {"tool": name} if name else None
+    tool = _coerce_optional_str(entry.get("tool") or entry.get("name"))
+    if not tool:
+        return None
+    out: dict[str, Any] = {"tool": tool}
+    query = _coerce_optional_str(entry.get("query"))
+    if query:
+        out["query"] = query[:_TOOL_ARG_MAX]
+    for key in ("tool_use_id", "ts"):
+        value = _coerce_optional_str(entry.get(key))
+        if value:
+            out[key] = value
+    for key in ("turn_index", "duration_ms"):
+        value = _coerce_optional_int(entry.get(key))
+        if value is not None:
+            out[key] = value
+    return out
+
+
+def _coerce_tool_calls(value: Any) -> list[dict[str, Any]] | None:
+    """Normalize a backend's tool-call list for the ledger, or ``None``."""
+    if value is None:
+        return None
+    if isinstance(value, (str, bytes, Mapping)):
+        items: Sequence[Any] = [value]
+    else:
+        try:
+            items = list(value)
+        except TypeError:
+            return None
+    out = [e for e in (_tool_call_entry(i) for i in items[:_TOOL_CALLS_MAX]) if e]
+    return out or None
+
+
+def _sum_or_none(*values: int | None) -> int | None:
+    """Sum the counters that were measured, or ``None`` when none were.
+
+    ``None`` means "not measured" throughout the trace layer, so a sum of
+    nothing must stay ``None`` rather than becoming a confident zero.
+    """
+    present = [v for v in values if v is not None]
+    return sum(present) if present else None
+
+
+def split_turn_timing(
+    *,
+    latency_ms: int | None,
+    output_tokens: int | None,
+    reasoning_output_tokens: int | None,
+    thinking_ms: int | None = None,
+    output_ms: int | None = None,
+) -> tuple[int | None, int | None, str | None]:
+    """Resolve a call's thinking/output time split and say where it came from.
+
+    A backend that saw partial stream events can time the two halves directly;
+    pass them and they are returned as ``TIMING_MEASURED``. Without them the
+    span is divided in proportion to the reasoning and visible output token
+    counts -- the model writes both at roughly one rate, so the proportion is a
+    fair estimate, but it is an estimate and is labelled ``TIMING_APPORTIONED``
+    so a report never presents it as a stopwatch reading.
+
+    Args:
+        latency_ms: The measured span of the call.
+        output_tokens: Visible output tokens the call produced.
+        reasoning_output_tokens: Hidden reasoning tokens the call produced.
+        thinking_ms: Directly measured reasoning time, when available.
+        output_ms: Directly measured visible-output time, when available.
+
+    Returns:
+        ``(thinking_ms, output_ms, timing_source)``; the source is ``None``
+        when neither half could be established.
+    """
+    measured_think = _coerce_optional_int(thinking_ms)
+    measured_out = _coerce_optional_int(output_ms)
+    if measured_think is not None or measured_out is not None:
+        return measured_think, measured_out, TIMING_MEASURED
+    span = _coerce_optional_int(latency_ms)
+    think_tok = _coerce_optional_int(reasoning_output_tokens)
+    out_tok = _coerce_optional_int(output_tokens)
+    if span is None or span < 0 or think_tok is None or out_tok is None:
+        return None, None, None
+    total_tok = think_tok + out_tok
+    if total_tok <= 0:
+        return None, None, None
+    think_span = int(round(span * think_tok / total_tok))
+    return think_span, span - think_span, TIMING_APPORTIONED
+
+
+@dataclass
+class CallDetailRecord:
+    """One real LLM API call.
+
+    Carries the same join keys as its turn's :class:`llm_trace.LLMCallRecord`
+    plus ``api_call_index``, its position within that turn.
+    """
+
+    session_id: str
+    component: str
+    call_id: str | None = None
+    api_call_index: int | None = None
+    # The turn-level ``call_id`` when this row was produced by a nested agent
+    # whose own calls carry a different id -- a GEAK sub-agent, say. ``None``
+    # when the call is a direct child of its turn.
+    parent_call_id: str | None = None
+    role: str | None = None
+    task_id: str | None = None
+    dyn_id: str | None = None
+    tick: int | None = None
+    phase: str | None = None
+    turn: int | None = None
+    task_path: str | None = None
+    model: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cache_creation_input_tokens: int | None = None
+    cache_read_input_tokens: int | None = None
+    reasoning_output_tokens: int | None = None
+    latency_ms: int | None = None
+    ttft_ms: int | None = None
+    thinking_ms: int | None = None
+    output_ms: int | None = None
+    # How the thinking/output split above was arrived at. ``latency_ms`` is
+    # always a measurement; the split is only one when the backend saw partial
+    # stream events. ``TIMING_APPORTIONED`` means the measured span was divided
+    # in proportion to the reasoning and visible output token counts, which is
+    # an estimate and must not be reported as a stopwatch reading.
+    timing_source: str | None = None
+    # The provider's own charge for this call when it reported one; it wins
+    # over the rate card and is never mixed with a derived figure.
+    total_cost_usd: float | None = None
+    tool_calls: list[dict[str, Any]] | None = None
+    stop_reason: str | None = None
+    # When the call started. Detail rows are usually written in a batch once
+    # the turn ends, so the write-time ``ts`` cannot order them.
+    started_ts: str | None = None
+    status: str = LLM_STATUS_OK
+    error_type: str | None = None
+    error_message: str | None = None
+
+    def to_row(self) -> dict[str, Any]:
+        """Serialize to the on-disk row dict, deriving ISL/OSL and cost.
+
+        Returns:
+            The on-disk per-API-call row dict.
+        """
+        in_tok = _coerce_optional_int(self.input_tokens)
+        out_tok = _coerce_optional_int(self.output_tokens)
+        write_tok = _coerce_optional_int(self.cache_creation_input_tokens)
+        read_tok = _coerce_optional_int(self.cache_read_input_tokens)
+        think_tok = _coerce_optional_int(self.reasoning_output_tokens)
+        tokens = {
+            "input_tokens": in_tok,
+            "output_tokens": out_tok,
+            "cache_creation_input_tokens": write_tok,
+            "cache_read_input_tokens": read_tok,
+            "reasoning_output_tokens": think_tok,
+        }
+        cost = resolve_cost(
+            model=self.model,
+            tokens=tokens,
+            provider_usd=_coerce_optional_float(self.total_cost_usd),
+        )
+        path = resolve_task_path(self.task_path)
+        tool_calls = _coerce_tool_calls(self.tool_calls)
+        return {
+            "session_id": str(self.session_id),
+            "ts": now_iso(),
+            "started_ts": _coerce_optional_str(self.started_ts),
+            "component": str(self.component),
+            "call_id": _coerce_optional_str(self.call_id),
+            "api_call_index": _coerce_optional_int(self.api_call_index),
+            "parent_call_id": _coerce_optional_str(self.parent_call_id),
+            "role": _coerce_optional_str(self.role),
+            "task_id": _coerce_optional_str(self.task_id),
+            "dyn_id": _coerce_optional_str(self.dyn_id),
+            "tick": _coerce_optional_int(self.tick),
+            "phase": _coerce_optional_str(self.phase),
+            "turn": _coerce_optional_int(self.turn),
+            "task_path": path or None,
+            "task_depth": path.count(TASK_PATH_SEPARATOR) + 1 if path else None,
+            "model": _coerce_optional_str(self.model),
+            "isl": _sum_or_none(in_tok, read_tok, write_tok),
+            "osl": _sum_or_none(out_tok, think_tok),
+            "input_tokens": in_tok,
+            "output_tokens": out_tok,
+            "cache_creation_input_tokens": write_tok,
+            "cache_read_input_tokens": read_tok,
+            "reasoning_output_tokens": think_tok,
+            "latency_ms": _coerce_optional_int(self.latency_ms),
+            "ttft_ms": _coerce_optional_int(self.ttft_ms),
+            "thinking_ms": _coerce_optional_int(self.thinking_ms),
+            "output_ms": _coerce_optional_int(self.output_ms),
+            "timing_source": _coerce_optional_str(self.timing_source),
+            "cost_usd": cost.total_usd,
+            "cost_input_usd": cost.input_usd,
+            "cost_output_usd": cost.output_usd,
+            "cost_thinking_usd": cost.thinking_usd,
+            "cost_cache_usd": cost.cache_usd,
+            "cost_source": cost.source,
+            "tool_calls": tool_calls,
+            "tool_call_count": len(tool_calls) if tool_calls is not None else None,
+            "stop_reason": _coerce_optional_str(self.stop_reason),
+            "status": str(self.status),
+            "error_type": _coerce_optional_str(self.error_type),
+            "error_message": _coerce_optional_str(self.error_message),
+        }
+
+
+def append_call_detail(
+    *,
+    session_dir: Path,
+    record: CallDetailRecord,
+    dest: Path | None = None,
+) -> None:
+    """Append one validated per-API-call row to the sidecar ledger.
+
+    Mirrors :func:`llm_trace.append_llm_call`: the row is validated against the
+    closed schema (a violation raises, because it is a call-site bug), and
+    ``OSError`` while writing is logged and swallowed, because instrumentation
+    must never break the optimization loop.
+
+    Args:
+        session_dir: Session directory used to resolve the ledger path.
+        record: The per-API-call record to serialize and append.
+        dest: Write here instead of the session's sidecar -- used by
+            out-of-process producers, which own their own ``ext/`` shard
+            because appending into the shared file is not atomic across
+            processes.
+
+    Raises:
+        CallDetailRowError: If the serialized row violates the closed schema.
+    """
+    row = record.to_row()
+    validate_closed_row(
+        row,
+        fields=_ROW_FIELDS,
+        valid_components=VALID_COMPONENTS,
+        error_cls=CallDetailRowError,
+        label="llm_calls_detail",
+    )
+    status = row.get("status")
+    if status not in VALID_STATUSES:
+        raise CallDetailRowError(f"llm_calls_detail row 'status'={status!r} is not one of {sorted(VALID_STATUSES)!r}")
+    target = dest if dest is not None else llm_call_detail_path(session_dir)
+    try:
+        append_jsonl(target, row, make_parents=True, sort_keys=True)
+    except OSError as exc:
+        log.warning(
+            "call_detail: append failed for component=%s session_id=%s: %r",
+            record.component,
+            record.session_id,
+            exc,
+        )
+
+
+#: Backend metadata key holding the per-API-call entries of one turn.
+METADATA_DETAIL_KEY = "api_call_details"
+
+_TOKEN_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+    "reasoning_output_tokens",
+)
+
+
+def _has_token_counts(metadata: Mapping[str, Any]) -> bool:
+    """Whether turn metadata carries any token counter worth a stand-in row."""
+    return any(metadata.get(key) is not None for key in _TOKEN_KEYS)
+
+
+def _resolve_call_index(entry: Mapping[str, Any], position: int) -> int | None:
+    """Position of a call within its turn, or ``None`` for a whole-turn row.
+
+    An entry that names no index but sets the key to ``None`` is the stand-in
+    for a backend that reports per-turn totals only; one that omits the key
+    entirely is a real call that simply did not number itself.
+    """
+    if "api_call_index" in entry and entry.get("api_call_index") is None:
+        return None
+    stated = _coerce_optional_int(entry.get("api_call_index"))
+    return position if stated is None else stated
+
+
+def append_turn_call_details(
+    *,
+    session_dir: Path,
+    session_id: str,
+    component: str,
+    metadata: Mapping[str, Any] | None,
+    role: str | None = None,
+    task_id: str | None = None,
+    dyn_id: str | None = None,
+    tick: int | None = None,
+    phase: str | None = None,
+    turn: int | None = None,
+    task_path: str | None = None,
+    turn_latency_ms: int | None = None,
+    dest: Path | None = None,
+) -> int:
+    """Write the sidecar rows for one turn from its backend metadata.
+
+    The backend collects the per-call entries but knows nothing about the
+    session; the caller that writes the turn row holds that context and so
+    writes these too, with the same join keys.
+
+    A backend whose SDK reports only per-turn totals gets one stand-in row
+    carrying those totals, with ``api_call_index`` left unset to say the row
+    covers a whole turn rather than a positioned call inside one. That keeps
+    the sidecar a complete account of spend; the turn row's ``api_calls``
+    column stays ``None``, which is how a report tells "one call" from "call
+    count not reported".
+
+    Args:
+        session_dir: Session directory used to resolve the sidecar path.
+        session_id: Session id stamped on every row.
+        component: Trace component the turn belongs to.
+        metadata: The turn's ``BackendTurnResult.metadata``.
+        role: Role that ran the turn.
+        task_id: Task id in scope, when the caller has one.
+        dyn_id: Dynamic-agent id in scope, when the caller has one.
+        tick: Loop tick in scope.
+        phase: Phase in scope.
+        turn: Turn index within the task.
+        task_path: Explicit task path; defaults to the ambient scope.
+        turn_latency_ms: The turn's measured wall-clock, used for any entry
+            that reports none of its own.
+        dest: Write here instead of the session's sidecar (shard writers).
+
+    Returns:
+        The number of rows written.
+    """
+    md = metadata or {}
+    entries = md.get(METADATA_DETAIL_KEY)
+    if not isinstance(entries, Sequence) or isinstance(entries, (str, bytes)):
+        entries = [dict(md, api_call_index=None)] if _has_token_counts(md) else []
+    call_id = _coerce_optional_str(md.get("call_id"))
+    written = 0
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, Mapping):
+            continue
+        latency_ms = _coerce_optional_int(entry.get("latency_ms"))
+        if latency_ms is None:
+            latency_ms = _coerce_optional_int(turn_latency_ms)
+        out_tok = _coerce_optional_int(entry.get("output_tokens"))
+        think_tok = _coerce_optional_int(entry.get("reasoning_output_tokens"))
+        think_ms, out_ms, timing_source = split_turn_timing(
+            latency_ms=latency_ms,
+            output_tokens=out_tok,
+            reasoning_output_tokens=think_tok,
+            thinking_ms=entry.get("thinking_ms"),
+            output_ms=entry.get("output_ms"),
+        )
+        record = CallDetailRecord(
+            session_id=session_id,
+            component=component,
+            call_id=call_id,
+            api_call_index=_resolve_call_index(entry, index),
+            role=role,
+            task_id=task_id,
+            dyn_id=dyn_id,
+            tick=tick,
+            phase=phase,
+            turn=turn,
+            task_path=task_path,
+            model=entry.get("model"),
+            input_tokens=entry.get("input_tokens"),
+            output_tokens=out_tok,
+            cache_creation_input_tokens=entry.get("cache_creation_input_tokens"),
+            cache_read_input_tokens=entry.get("cache_read_input_tokens"),
+            reasoning_output_tokens=think_tok,
+            latency_ms=latency_ms,
+            ttft_ms=entry.get("ttft_ms"),
+            thinking_ms=think_ms,
+            output_ms=out_ms,
+            timing_source=timing_source,
+            total_cost_usd=entry.get("total_cost_usd"),
+            tool_calls=entry.get("tool_calls"),
+            stop_reason=entry.get("stop_reason"),
+            started_ts=entry.get("started_ts"),
+        )
+        append_call_detail(session_dir=session_dir, record=record, dest=dest)
+        written += 1
+    return written
+
+
+# The dataclass carries the raw inputs; the row carries what is derived from
+# them. Guard the derived-only keys explicitly so a field added to one and not
+# the other is caught at import, the way llm_trace's drift assert does.
+_DERIVED_ONLY: frozenset[str] = frozenset(
+    {
+        "ts",
+        "task_depth",
+        "isl",
+        "osl",
+        "tool_call_count",
+        "cost_usd",
+        "cost_input_usd",
+        "cost_output_usd",
+        "cost_thinking_usd",
+        "cost_cache_usd",
+        "cost_source",
+    }
+)
+_INPUT_ONLY: frozenset[str] = frozenset({"total_cost_usd"})
+_DATACLASS_FIELDS: frozenset[str] = frozenset(f.name for f in fields(CallDetailRecord))
+assert (_DATACLASS_FIELDS - _INPUT_ONLY) | _DERIVED_ONLY == _ROW_FIELDS, (
+    f"CallDetailRecord fields drifted from _ROW_FIELDS: dataclass={sorted(_DATACLASS_FIELDS)} row={sorted(_ROW_FIELDS)}"
+)
+
+
+__all__ = [
+    "METADATA_DETAIL_KEY",
+    "TIMING_APPORTIONED",
+    "TIMING_MEASURED",
+    "CallDetailRecord",
+    "CallDetailRowError",
+    "append_call_detail",
+    "append_turn_call_details",
+    "split_turn_timing",
+]

--- a/src/hyperloom/orchestrator/trace/geak_harvest.py
+++ b/src/hyperloom/orchestrator/trace/geak_harvest.py
@@ -1,0 +1,526 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Recover GEAK's LLM spend from the Claude Code transcripts it leaves behind.
+
+GEAK runs out-of-process (``interface/run_e2e.py``), drives its own
+``ClaudeSDKClient`` with ``cwd`` set to its ``e2e_workflow`` directory, and fans
+that client out into a Workflow whose agents are separate conversations. None of
+it reaches Hyperloom's in-process ledger, yet it is the majority of a session's
+model bill -- so it has to be read back off disk afterwards.
+
+Two artifacts carry everything needed:
+
+* ``<claude_home>/projects/<slug>/<session>.jsonl`` -- the driving conversation,
+  and ``<session>/subagents/workflows/<run>/agent-<id>.jsonl`` one per Workflow
+  agent. These hold the per-API-call token counts.
+* ``<session>/workflows/<run>.json`` -- the Workflow's own record, whose
+  ``workflowProgress`` names each agent's GEAK phase (Setup, Profile,
+  HeadKernel, ...) and its label (``director:setup``,
+  ``extract_op ck_..._gemm``). That is GEAK's task tree, and it becomes the
+  ``task_path`` under which the report nests these calls.
+
+Selection is deliberately narrow: a transcript counts only when its ``cwd`` is
+GEAK's workflow directory *and* it mentions this session's ``exp_root``. Several
+Hyperloom runs share one GEAK checkout, so the second predicate is what keeps a
+neighbour's spend off this session's ledger.
+
+Rows go to the session's ``reports/trace/ext/`` shard, never to
+``llm_calls.jsonl`` directly: that append is not atomic across processes and the
+session tree lives on a network filesystem. The collector already merges the
+shard back in at read time.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from hyperloom.inference_optimizer.session.session_paths import (
+    trace_ext_dir,
+    trace_ext_shard_path,
+)
+from .call_detail import CallDetailRecord, append_call_detail, split_turn_timing
+from .llm_trace import LLMCallRecord, append_llm_call, new_call_id
+from .parse_usage import parse_claude_transcript_calls
+
+log = logging.getLogger(__name__)
+
+#: Trace component label for everything GEAK spends.
+GEAK_COMPONENT = "geak"
+
+#: First segment of every harvested ``task_path``, so a report can lift GEAK's
+#: whole subtree out of the phase that delegated to it in one filter.
+ROOT_SEGMENT = "geak"
+
+#: Task-path segment for the driving conversation itself -- the client that
+#: invokes the Workflow tool, as opposed to the agents it fans out into.
+RUNNER_SEGMENT = "runner"
+
+#: Splits a Workflow agent label into path segments. Labels are written either
+#: colon-separated (``director:setup``) or as a verb and its target
+#: (``extract_op ck_bpreshuffle_fp8_a8w8_blockscale_gemm``); both become the
+#: role / lane / kernel levels of the tree.
+_LABEL_SPLIT = re.compile(r"[:\s]+")
+
+#: Name of the harvest bookkeeping file inside ``reports/trace/ext/``. It is
+#: what makes a second harvest (one per macro cycle) additive instead of
+#: duplicating every call the first one already wrote.
+_STATE_FILENAME = "geak_harvest_state.json"
+
+
+@dataclass(frozen=True)
+class HarvestResult:
+    """What one harvest pass recovered.
+
+    Attributes:
+        transcripts: Conversations that matched this session and had new calls.
+        turns: Turn-level rows written to the ``ext`` shard.
+        api_calls: Per-API-call rows written to the ``ext`` detail shard.
+    """
+
+    transcripts: int = 0
+    turns: int = 0
+    api_calls: int = 0
+
+
+def claude_projects_dir(claude_home: Path | None = None) -> Path:
+    """Locate the directory Claude Code keeps its session transcripts in.
+
+    Args:
+        claude_home: Explicit Claude home, for tests. Defaults to
+            ``$CLAUDE_CONFIG_DIR`` and then ``~/.claude``.
+
+    Returns:
+        The ``projects`` directory, which may not exist.
+    """
+    if claude_home is None:
+        configured = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
+        claude_home = Path(configured) if configured else Path.home() / ".claude"
+    return Path(claude_home) / "projects"
+
+
+def _label_segments(label: str | None) -> tuple[str, ...]:
+    """Split a Workflow agent label into ``task_path`` segments.
+
+    An unrecognized label is kept whole rather than dropped: a call attributed
+    to a strange-looking node is still attributed, whereas a dropped one
+    silently shrinks the total.
+
+    Args:
+        label: The Workflow's own label for the agent.
+
+    Returns:
+        The path segments, or ``()`` when there is no label.
+    """
+    text = (label or "").strip()
+    if not text:
+        return ()
+    return tuple(seg for seg in _LABEL_SPLIT.split(text) if seg)
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    """Parse a transcript ISO-8601 timestamp.
+
+    Args:
+        value: The record's ``timestamp`` field.
+
+    Returns:
+        The parsed datetime, or ``None`` when it is absent or malformed.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _matches_session(path: Path, *, workflow_dir: str | None, marker: str) -> bool:
+    """Decide whether a transcript belongs to this session's GEAK subprocess.
+
+    Args:
+        path: The transcript to test.
+        workflow_dir: GEAK's ``e2e_workflow`` directory, or ``None`` to accept
+            any ``cwd``.
+        marker: A string only this session's run mentions -- its ``exp_root``.
+
+    Returns:
+        True when both predicates hold.
+    """
+    saw_cwd = workflow_dir is None
+    saw_marker = False
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                if not saw_marker and marker in line:
+                    saw_marker = True
+                if not saw_cwd and '"cwd"' in line:
+                    try:
+                        record = json.loads(line)
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+                    if isinstance(record, dict) and str(record.get("cwd") or "") == workflow_dir:
+                        saw_cwd = True
+                if saw_cwd and saw_marker:
+                    return True
+    except OSError as exc:
+        log.debug("geak_harvest: unreadable transcript %s: %r", path, exc)
+    return False
+
+
+def _agent_index(session_root: Path) -> dict[str, dict[str, Any]]:
+    """Map every Workflow agent id to its phase, label and measured span.
+
+    Args:
+        session_root: ``<projects>/<slug>/<session_id>/``, the sidecar tree
+            Claude Code writes next to a transcript.
+
+    Returns:
+        ``agentId`` -> the agent's ``workflowProgress`` entry. Empty when the
+        session ran no Workflow.
+    """
+    index: dict[str, dict[str, Any]] = {}
+    for record_path in sorted((session_root / "workflows").glob("*.json")):
+        try:
+            payload = json.loads(record_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            log.debug("geak_harvest: unreadable workflow record %s: %r", record_path, exc)
+            continue
+        if not isinstance(payload, dict):
+            continue
+        for entry in payload.get("workflowProgress") or []:
+            if not isinstance(entry, dict) or entry.get("type") != "workflow_agent":
+                continue
+            agent_id = str(entry.get("agentId") or "").strip()
+            if agent_id:
+                index[agent_id] = entry
+    return index
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    """Read the harvest bookkeeping file.
+
+    Args:
+        path: The state file.
+
+    Returns:
+        Transcript path -> ``{"size", "calls"}``. Empty on a first harvest or
+        an unreadable file, which costs at worst a repeat of work already done.
+    """
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _save_state(path: Path, state: dict[str, Any]) -> None:
+    """Write the harvest bookkeeping file, best-effort.
+
+    Args:
+        path: The state file.
+        state: The mapping to persist.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+    except OSError as exc:
+        log.debug("geak_harvest: could not persist state to %s: %r", path, exc)
+
+
+def _emit_conversation(
+    *,
+    transcript: Path,
+    calls: list[dict[str, Any]],
+    session_dir: Path,
+    session_id: str,
+    shard: Path,
+    detail_shard: Path,
+    task_path: tuple[str, ...],
+    phase: str | None,
+    task_id: str | None,
+    dyn_id: str | None,
+    tick: int | None,
+    turn: int | None,
+    started_ms: int | None,
+    duration_ms: int | None,
+) -> int:
+    """Write one conversation's calls out as a turn row plus its detail rows.
+
+    A GEAK agent is one conversation of many requests, so it maps onto a single
+    turn row carrying the summed counters and an ``api_calls`` count, with one
+    detail row per request joined on the shared ``call_id``.
+
+    Per-request latency is the gap between message arrivals, anchored for the
+    first request on the Workflow's recorded ``startedAt`` when there is one.
+    That measures queueing plus generation together, which is the only span a
+    transcript of whole messages actually witnesses.
+
+    Args:
+        transcript: The conversation being harvested, for logging.
+        calls: Rows from :func:`parse_claude_transcript_calls`, in order.
+        session_dir: Hyperloom session directory.
+        session_id: Hyperloom session id, the cross-process join key.
+        shard: Destination for the turn row.
+        detail_shard: Destination for the per-API-call rows.
+        task_path: Where this conversation sits in GEAK's task tree.
+        phase: The Hyperloom phase that delegated to GEAK.
+        task_id: Hyperloom task id of the delegation, when known.
+        dyn_id: The Workflow agent id, which separates two agents that share a
+            label.
+        tick: Hyperloom timeline tick of the delegation.
+        turn: Index of this conversation among the run's agents.
+        started_ms: Workflow ``startedAt`` epoch-ms, when recorded.
+        duration_ms: Workflow ``durationMs``, the agent's measured span.
+
+    Returns:
+        The number of detail rows written.
+    """
+    if not calls:
+        return 0
+    call_id = new_call_id()
+    path_str = "/".join(task_path)
+    totals: dict[str, int] = {}
+    tool_total = 0
+    previous_ms = started_ms
+    written = 0
+    for index, call in enumerate(calls):
+        for key in (
+            "input_tokens",
+            "output_tokens",
+            "cache_creation_input_tokens",
+            "cache_read_input_tokens",
+            "reasoning_output_tokens",
+        ):
+            value = call.get(key)
+            if isinstance(value, int):
+                totals[key] = totals.get(key, 0) + value
+        tool_calls = call.get("tool_calls") or []
+        tool_total += len(tool_calls)
+        arrived = _parse_ts(call.get("ts"))
+        arrived_ms = int(arrived.timestamp() * 1000) if arrived is not None else None
+        latency_ms: int | None = None
+        if arrived_ms is not None and previous_ms is not None and arrived_ms >= previous_ms:
+            latency_ms = arrived_ms - previous_ms
+        if arrived_ms is not None:
+            previous_ms = arrived_ms
+        thinking_ms, output_ms, timing_source = split_turn_timing(
+            latency_ms=latency_ms,
+            output_tokens=call.get("output_tokens"),
+            reasoning_output_tokens=call.get("reasoning_output_tokens"),
+        )
+        append_call_detail(
+            session_dir=session_dir,
+            dest=detail_shard,
+            record=CallDetailRecord(
+                session_id=session_id,
+                component=GEAK_COMPONENT,
+                call_id=call_id,
+                api_call_index=index,
+                role=task_path[-1] if task_path else None,
+                task_id=task_id,
+                dyn_id=dyn_id,
+                tick=tick,
+                phase=phase,
+                turn=turn,
+                task_path=path_str,
+                model=call.get("model"),
+                input_tokens=call.get("input_tokens"),
+                output_tokens=call.get("output_tokens"),
+                cache_creation_input_tokens=call.get("cache_creation_input_tokens"),
+                cache_read_input_tokens=call.get("cache_read_input_tokens"),
+                reasoning_output_tokens=call.get("reasoning_output_tokens"),
+                latency_ms=latency_ms,
+                thinking_ms=thinking_ms,
+                output_ms=output_ms,
+                timing_source=timing_source,
+                total_cost_usd=call.get("cost_usd"),
+                started_ts=call.get("ts"),
+                tool_calls=tool_calls,
+                stop_reason=call.get("stop_reason"),
+            ),
+        )
+        written += 1
+
+    turn_thinking, turn_output, _ = split_turn_timing(
+        latency_ms=duration_ms,
+        output_tokens=totals.get("output_tokens"),
+        reasoning_output_tokens=totals.get("reasoning_output_tokens"),
+    )
+    append_llm_call(
+        session_dir=session_dir,
+        dest=shard,
+        record=LLMCallRecord(
+            session_id=session_id,
+            component=GEAK_COMPONENT,
+            call_id=call_id,
+            role=task_path[-1] if task_path else None,
+            task_id=task_id,
+            dyn_id=dyn_id,
+            tick=tick,
+            phase=phase,
+            turn=turn,
+            model=calls[-1].get("model"),
+            input_tokens=totals.get("input_tokens"),
+            output_tokens=totals.get("output_tokens"),
+            cache_creation_input_tokens=totals.get("cache_creation_input_tokens"),
+            cache_read_input_tokens=totals.get("cache_read_input_tokens"),
+            reasoning_output_tokens=totals.get("reasoning_output_tokens"),
+            latency_ms=duration_ms,
+            thinking_ms=turn_thinking,
+            output_ms=turn_output,
+            task_path=path_str,
+            api_calls=written,
+            tool_call_count=tool_total,
+            stop_reason=calls[-1].get("stop_reason"),
+        ),
+    )
+    log.debug("geak_harvest: %s -> %d calls under %s", transcript.name, written, path_str)
+    return written
+
+
+def harvest_geak_calls(
+    *,
+    session_dir: Path,
+    session_id: str,
+    exp_root: str | Path,
+    workflow_dir: str | Path | None = None,
+    phase: str | None = None,
+    task_id: str | None = None,
+    tick: int | None = None,
+    not_before: float | None = None,
+    claude_home: Path | None = None,
+    pid: int | None = None,
+) -> HarvestResult:
+    """Fold one GEAK subprocess's spend into this session's trace ledger.
+
+    Safe to call more than once: what each transcript has already contributed is
+    remembered in ``reports/trace/ext/geak_harvest_state.json``, so a second
+    macro cycle adds only its own calls.
+
+    Args:
+        session_dir: Hyperloom session directory.
+        session_id: Hyperloom session id, stamped on every row.
+        exp_root: The run's GEAK experiment root. Its path string is the marker
+            that distinguishes this run's transcripts from a neighbour's in a
+            shared checkout.
+        workflow_dir: GEAK's ``e2e_workflow`` directory, matched against each
+            transcript's ``cwd``. ``None`` accepts any, which is looser than the
+            caller normally wants.
+        phase: Hyperloom phase that delegated to GEAK.
+        task_id: Hyperloom task id of the delegation.
+        tick: Hyperloom timeline tick of the delegation.
+        not_before: Epoch seconds before the subprocess started. Transcripts
+            untouched since then are skipped without being read, which keeps
+            the scan cheap on a box with a long Claude Code history.
+        claude_home: Explicit Claude home, for tests.
+        pid: Owning process id for the shard filename; defaults to this one.
+
+    Returns:
+        A :class:`HarvestResult` counting what was written.
+    """
+    projects = claude_projects_dir(claude_home)
+    if not projects.is_dir():
+        log.debug("geak_harvest: no claude projects dir at %s", projects)
+        return HarvestResult()
+
+    marker = str(exp_root)
+    wf_dir = str(workflow_dir) if workflow_dir is not None else None
+    owner = int(pid if pid is not None else os.getpid())
+    shard = trace_ext_shard_path(session_dir, GEAK_COMPONENT, owner)
+    detail_shard = trace_ext_shard_path(session_dir, GEAK_COMPONENT, owner, detail=True)
+    state_path = trace_ext_dir(session_dir) / _STATE_FILENAME
+    state = _load_state(state_path)
+
+    transcripts = 0
+    turns = 0
+    api_calls = 0
+    for transcript in sorted(projects.glob("*/*.jsonl")):
+        if not_before is not None:
+            try:
+                if transcript.stat().st_mtime < not_before:
+                    continue
+            except OSError:
+                continue
+        if not _matches_session(transcript, workflow_dir=wf_dir, marker=marker):
+            continue
+        session_root = transcript.with_suffix("")
+        agents = _agent_index(session_root)
+        conversations: list[tuple[Path, tuple[str, ...], str | None, dict[str, Any]]] = [
+            (transcript, (ROOT_SEGMENT, RUNNER_SEGMENT), None, {})
+        ]
+        for agent_path in sorted((session_root / "subagents").rglob("agent-*.jsonl")):
+            agent_id = agent_path.stem[len("agent-") :]
+            entry = agents.get(agent_id, {})
+            segments = (
+                ROOT_SEGMENT,
+                str(entry.get("phaseTitle") or "").strip() or "unlabelled",
+                *_label_segments(entry.get("label")),
+            )
+            conversations.append((agent_path, segments, agent_id, entry))
+
+        matched = False
+        for turn, (path, segments, agent_id, entry) in enumerate(conversations):
+            key = str(path)
+            seen = state.get(key) if isinstance(state.get(key), dict) else {}
+            try:
+                size = path.stat().st_size
+            except OSError:
+                continue
+            if seen.get("size") == size:
+                continue
+            calls = parse_claude_transcript_calls(path)
+            already = int(seen.get("calls") or 0)
+            fresh = calls[already:]
+            state[key] = {"size": size, "calls": len(calls)}
+            if not fresh:
+                continue
+            written = _emit_conversation(
+                transcript=path,
+                calls=fresh,
+                session_dir=session_dir,
+                session_id=session_id,
+                shard=shard,
+                detail_shard=detail_shard,
+                task_path=segments,
+                phase=phase,
+                task_id=task_id,
+                dyn_id=agent_id,
+                tick=tick,
+                turn=turn,
+                started_ms=entry.get("startedAt") if isinstance(entry.get("startedAt"), int) else None,
+                duration_ms=entry.get("durationMs") if isinstance(entry.get("durationMs"), int) else None,
+            )
+            if written:
+                matched = True
+                turns += 1
+                api_calls += written
+        if matched:
+            transcripts += 1
+
+    _save_state(state_path, state)
+    log.info(
+        "geak_harvest: %d transcript(s), %d turn row(s), %d api-call row(s) -> %s",
+        transcripts,
+        turns,
+        api_calls,
+        shard.name,
+    )
+    return HarvestResult(transcripts=transcripts, turns=turns, api_calls=api_calls)
+
+
+__all__ = [
+    "GEAK_COMPONENT",
+    "ROOT_SEGMENT",
+    "RUNNER_SEGMENT",
+    "HarvestResult",
+    "claude_projects_dir",
+    "harvest_geak_calls",
+]

--- a/src/hyperloom/orchestrator/trace/langfuse_emitter.py
+++ b/src/hyperloom/orchestrator/trace/langfuse_emitter.py
@@ -757,6 +757,7 @@ class LangfuseEmitter:
                 output=(conv_row or {}).get("response"),
                 metadata=lfmap.generation_metadata(base, phase=phase, has_text=has_text),
                 usage_details=lfmap.usage_details(token_row or {}),
+                cost_details=lfmap.cost_details(token_row or {}),
                 level=level,
                 status_message=lfmap.generation_status_message(base),
             )
@@ -1099,7 +1100,9 @@ class LangfuseEmitter:
         if not ext_dir.is_dir():
             return
         unsent = 0
-        for shard in sorted(ext_dir.glob("*.jsonl")):
+        # ``*.detail.jsonl`` is the per-API-call expansion of turn rows already
+        # mirrored from the sibling shard; mirroring it too would double-bill.
+        for shard in sorted(p for p in ext_dir.glob("*.jsonl") if not p.name.endswith(".detail.jsonl")):
             sent = self._ext_rows_sent.get(shard.name, 0)
             rows = _load_jsonl(shard)
             if sent == 0 and rows:

--- a/src/hyperloom/orchestrator/trace/langfuse_mapping.py
+++ b/src/hyperloom/orchestrator/trace/langfuse_mapping.py
@@ -27,6 +27,8 @@ from typing import Any
 
 from hyperloom.common.env_safety import BENCHMARK_SECRET_ENV_NAMES, is_secret_shaped_env_name, redact_secret_values
 
+from .pricing import SOURCE_UNAVAILABLE
+
 UNPHASED = "(unphased)"
 UNKNOWN_AGENT = "(unknown)"
 
@@ -273,6 +275,32 @@ def usage_details(row: dict[str, Any]) -> dict[str, int]:
     return {k: int(v) for k, v in raw.items() if v is not None}
 
 
+def cost_details(row: dict[str, Any]) -> dict[str, float]:
+    """Project a token row's USD figures onto Langfuse ``cost_details``.
+
+    Only a row whose ``cost_source`` says the figure is real contributes: an
+    unpriced call carries no cost keys at all, so Langfuse shows a gap rather
+    than a confident zero. ``total`` is the whole; the other four are its parts.
+
+    Args:
+        row: A token trace row dict.
+
+    Returns:
+        Mapping of Langfuse cost key to USD (empty when the row is unpriced).
+    """
+    source = str(row.get("cost_source") or "").strip().lower()
+    if source in ("", SOURCE_UNAVAILABLE):
+        return {}
+    raw = {
+        "total": row.get("cost_usd"),
+        "input": row.get("cost_input_usd"),
+        "output": row.get("cost_output_usd"),
+        "thinking": row.get("cost_thinking_usd"),
+        "cache": row.get("cost_cache_usd"),
+    }
+    return {k: float(v) for k, v in raw.items() if isinstance(v, (int, float))}
+
+
 def generation_name(row: dict[str, Any]) -> str:
     """Human-friendly Generation name: component, falling back to role.
 
@@ -343,6 +371,15 @@ def generation_metadata(
         "component": row.get("component"),
         "has_text": has_text,
         "latency_ms": row.get("latency_ms"),
+        "ttft_ms": row.get("ttft_ms"),
+        "thinking_ms": row.get("thinking_ms"),
+        "output_ms": row.get("output_ms"),
+        "task_path": row.get("task_path"),
+        "task_depth": row.get("task_depth"),
+        "api_calls": row.get("api_calls"),
+        "tool_call_count": row.get("tool_call_count"),
+        "stop_reason": row.get("stop_reason"),
+        "cost_source": row.get("cost_source"),
         "reviewed_msg_ids": row.get("reviewed_msg_ids"),
         "status": row.get("status") or _STATUS_OK,
         "error_type": row.get("error_type"),
@@ -624,6 +661,7 @@ __all__ = [
     "correlation_seed",
     "decision_to_scores",
     "derive_trace_id",
+    "cost_details",
     "generation_metadata",
     "generation_name",
     "generation_start",

--- a/src/hyperloom/orchestrator/trace/llm_trace.py
+++ b/src/hyperloom/orchestrator/trace/llm_trace.py
@@ -19,6 +19,13 @@ Design contract:
   collector can tell "no cache concept" from "zero cache hits";
   ``reasoning_output_tokens`` is the same story for reasoning models, and is
   kept out of ``output_tokens`` because that counts the visible reply only.
+* **Granularity**: one row is one agentic *turn*, which is what the
+  breakdown rollup and the Langfuse mirror count. A turn can span several
+  real API calls; ``api_calls`` says how many, and the per-call rows live in
+  the ``llm_calls_detail`` sidecar (:mod:`call_detail`) joined on ``call_id``.
+* **Cost**: ``cost_source`` records where the USD came from -- a provider
+  figure, a rate-card derivation, or nothing at all. A report must not sum
+  across sources silently; see :mod:`pricing`.
 * **Pairing**: ``call_id`` is the join key against the conversation ledger's
   row for the same call. Both halves carry it when the producing backend
   stamped one; otherwise the emitter falls back to its identity+second key.
@@ -44,9 +51,12 @@ from pathlib import Path
 from typing import Any
 
 from hyperloom.common.io import append_jsonl
+from hyperloom.common.llm_attribution import TASK_PATH_SEPARATOR, current_task_path_str
 from hyperloom.common.timeutil import now_iso
 from hyperloom.inference_optimizer.session.session_paths import llm_calls_path
+from .pricing import CostBreakdown, resolve_cost
 from ._row_utils import (
+    coerce_optional_float as _coerce_optional_float,
     coerce_optional_int as _coerce_optional_int,
     coerce_optional_str as _coerce_optional_str,
     validate_closed_row,
@@ -112,6 +122,20 @@ _ROW_FIELDS: frozenset[str] = frozenset(
         "cache_read_input_tokens",
         "reasoning_output_tokens",
         "latency_ms",
+        "ttft_ms",
+        "thinking_ms",
+        "output_ms",
+        "task_path",
+        "task_depth",
+        "api_calls",
+        "tool_call_count",
+        "stop_reason",
+        "cost_usd",
+        "cost_input_usd",
+        "cost_output_usd",
+        "cost_thinking_usd",
+        "cost_cache_usd",
+        "cost_source",
         "reviewed_msg_ids",
         "status",
         "error_type",
@@ -135,6 +159,21 @@ def new_call_id() -> str:
         A fresh hex id.
     """
     return uuid.uuid4().hex
+
+
+def resolve_task_path(task_path: str | None) -> str:
+    """Return the task path for a row, defaulting to the ambient scope.
+
+    Args:
+        task_path: An explicit path from the call site, or ``None``.
+
+    Returns:
+        The path, or ``""`` when neither the caller nor the ambient scope has
+        one.
+    """
+    if task_path is not None:
+        return str(task_path).strip(TASK_PATH_SEPARATOR)
+    return current_task_path_str()
 
 
 # Canonical timestamp helper; kept importable for callers.
@@ -203,6 +242,33 @@ class LLMCallRecord:
     # (None = not measured); the Langfuse generation is placed at
     # ``[ts - latency_ms, ts]``.
     latency_ms: int | None = None
+    # Time to the turn's first content block, and how the rest of the latency
+    # split between hidden reasoning and visible output. ``None`` for a backend
+    # that does not stream, which cannot observe either boundary.
+    ttft_ms: int | None = None
+    thinking_ms: int | None = None
+    output_ms: int | None = None
+    # Where this call sits in the phase -> task -> subtask tree, as the
+    # separator-joined path published by ``llm_attribution.task_scope``.
+    # ``task_depth`` is its segment count, carried so a rollup can group by
+    # level without re-splitting every row.
+    task_path: str | None = None
+    task_depth: int | None = None
+    # One ledger row covers one agentic turn, which may span several real API
+    # calls; ``api_calls`` says how many, and the per-call rows live in the
+    # ``llm_calls_detail`` sidecar keyed on the same ``call_id``.
+    api_calls: int | None = None
+    tool_call_count: int | None = None
+    stop_reason: str | None = None
+    # USD for the turn. ``cost_source`` says where the figure came from
+    # (:mod:`pricing`): a provider figure and a derived one are never summed
+    # into the same total, so a rollup can report each separately.
+    cost_usd: float | None = None
+    cost_input_usd: float | None = None
+    cost_output_usd: float | None = None
+    cost_thinking_usd: float | None = None
+    cost_cache_usd: float | None = None
+    cost_source: str | None = None
     # Proposal ``msg_id``s this call reviewed (critic only), so the call can be
     # attributed to the decision it served. ``None`` for non-critic producers.
     reviewed_msg_ids: list[str] | None = None
@@ -211,6 +277,32 @@ class LLMCallRecord:
     status: str = LLM_STATUS_OK
     error_type: str | None = None
     error_message: str | None = None
+
+    def _cost_breakdown(self) -> CostBreakdown:
+        """This row's USD figures, keeping any the call site already resolved.
+
+        Returns:
+            The resolved :class:`~.pricing.CostBreakdown`.
+        """
+        if self.cost_source is not None:
+            return CostBreakdown(
+                total_usd=_coerce_optional_float(self.cost_usd),
+                input_usd=_coerce_optional_float(self.cost_input_usd),
+                output_usd=_coerce_optional_float(self.cost_output_usd),
+                thinking_usd=_coerce_optional_float(self.cost_thinking_usd),
+                cache_usd=_coerce_optional_float(self.cost_cache_usd),
+                source=self.cost_source,
+            )
+        return resolve_cost(
+            model=self.model,
+            tokens={
+                "input_tokens": self.input_tokens,
+                "output_tokens": self.output_tokens,
+                "cache_creation_input_tokens": self.cache_creation_input_tokens,
+                "cache_read_input_tokens": self.cache_read_input_tokens,
+                "reasoning_output_tokens": self.reasoning_output_tokens,
+            },
+        )
 
     def to_row(self) -> dict[str, Any]:
         """Serialize to the on-disk row dict, stamping ``ts`` (UTC µs).
@@ -222,6 +314,14 @@ class LLMCallRecord:
         Returns:
             The on-disk LLM-call row dict.
         """
+        # A record built field-by-field (the critic, the scorer, the forge
+        # backfill) carries no path of its own; it inherits the scope it is
+        # written from, the same way ``from_metadata`` does.
+        path = resolve_task_path(self.task_path)
+        # Same for cost: ``from_metadata`` resolves it (and can prefer the
+        # provider's own figure), but a hand-built record would otherwise carry
+        # tokens with no price. Deriving it here keeps every row comparable.
+        cost = self._cost_breakdown()
         return {
             "session_id": str(self.session_id),
             "ts": _now_iso(),
@@ -240,6 +340,20 @@ class LLMCallRecord:
             "cache_read_input_tokens": _coerce_optional_int(self.cache_read_input_tokens),
             "reasoning_output_tokens": _coerce_optional_int(self.reasoning_output_tokens),
             "latency_ms": _coerce_optional_int(self.latency_ms),
+            "ttft_ms": _coerce_optional_int(self.ttft_ms),
+            "thinking_ms": _coerce_optional_int(self.thinking_ms),
+            "output_ms": _coerce_optional_int(self.output_ms),
+            "task_path": path or None,
+            "task_depth": path.count(TASK_PATH_SEPARATOR) + 1 if path else None,
+            "api_calls": _coerce_optional_int(self.api_calls),
+            "tool_call_count": _coerce_optional_int(self.tool_call_count),
+            "stop_reason": _coerce_optional_str(self.stop_reason),
+            "cost_usd": cost.total_usd,
+            "cost_input_usd": cost.input_usd,
+            "cost_output_usd": cost.output_usd,
+            "cost_thinking_usd": cost.thinking_usd,
+            "cost_cache_usd": cost.cache_usd,
+            "cost_source": cost.source,
             "reviewed_msg_ids": _coerce_optional_str_list(self.reviewed_msg_ids),
             "status": str(self.status),
             "error_type": _coerce_optional_str(self.error_type),
@@ -260,6 +374,7 @@ class LLMCallRecord:
         phase: str | None = None,
         turn: int | None = None,
         latency_ms: int | None = None,
+        task_path: str | None = None,
     ) -> "LLMCallRecord":
         """Build a record from a ``BackendTurnResult.metadata`` dict.
 
@@ -280,11 +395,26 @@ class LLMCallRecord:
             turn: Multi-turn sub-agent sequence index, when known.
             latency_ms: Measured call latency in ms; overrides
                 ``metadata["latency_ms"]`` when not ``None``.
+            task_path: Task-tree path for the call; ``None`` takes the path
+                published by :func:`llm_attribution.task_scope`.
 
         Returns:
             A populated :class:`LLMCallRecord`.
         """
         md = metadata or {}
+        tokens = {
+            "input_tokens": md.get("input_tokens"),
+            "output_tokens": md.get("output_tokens"),
+            "cache_creation_input_tokens": md.get("cache_creation_input_tokens"),
+            "cache_read_input_tokens": md.get("cache_read_input_tokens"),
+            "reasoning_output_tokens": md.get("reasoning_output_tokens"),
+        }
+        cost = resolve_cost(
+            model=md.get("model"),
+            tokens=tokens,
+            provider_usd=md.get("total_cost_usd"),
+        )
+        path = resolve_task_path(task_path)
         return cls(
             session_id=session_id,
             component=component,
@@ -304,6 +434,20 @@ class LLMCallRecord:
             cache_read_input_tokens=md.get("cache_read_input_tokens"),
             reasoning_output_tokens=md.get("reasoning_output_tokens"),
             latency_ms=latency_ms if latency_ms is not None else md.get("latency_ms"),
+            ttft_ms=md.get("ttft_ms"),
+            thinking_ms=md.get("thinking_ms"),
+            output_ms=md.get("output_ms"),
+            task_path=path or None,
+            task_depth=path.count(TASK_PATH_SEPARATOR) + 1 if path else None,
+            api_calls=md.get("api_calls"),
+            tool_call_count=md.get("tool_call_count", md.get("tool_blocks")),
+            stop_reason=md.get("stop_reason"),
+            cost_usd=cost.total_usd,
+            cost_input_usd=cost.input_usd,
+            cost_output_usd=cost.output_usd,
+            cost_thinking_usd=cost.thinking_usd,
+            cost_cache_usd=cost.cache_usd,
+            cost_source=cost.source,
         )
 
     @classmethod
@@ -322,6 +466,7 @@ class LLMCallRecord:
         phase: str | None = None,
         turn: int | None = None,
         latency_ms: int | None = None,
+        task_path: str | None = None,
     ) -> "LLMCallRecord":
         """Build an ``error`` record for a call that produced no usable response.
 
@@ -343,10 +488,13 @@ class LLMCallRecord:
             phase: Phase name, when known.
             turn: Multi-turn sub-agent sequence index, when known.
             latency_ms: Time spent before failing, when measured.
+            task_path: Task-tree path for the call; ``None`` takes the path
+                published by :func:`llm_attribution.task_scope`.
 
         Returns:
             A populated :class:`LLMCallRecord` with ``status="error"``.
         """
+        path = resolve_task_path(task_path)
         return cls(
             session_id=session_id,
             component=component,
@@ -359,6 +507,8 @@ class LLMCallRecord:
             turn=turn,
             model=model,
             latency_ms=latency_ms,
+            task_path=path or None,
+            task_depth=path.count(TASK_PATH_SEPARATOR) + 1 if path else None,
             status=LLM_STATUS_ERROR,
             error_type=type(error).__name__ if isinstance(error, BaseException) else None,
             error_message=str(error)[:_ERROR_MESSAGE_MAX],
@@ -389,6 +539,7 @@ def append_llm_call(
     *,
     session_dir: Path,
     record: LLMCallRecord,
+    dest: Path | None = None,
 ) -> None:
     """Append one validated LLM-call row to the trace ledger.
 
@@ -408,6 +559,9 @@ def append_llm_call(
     Args:
         session_dir: Session directory used to resolve the ledger path.
         record: The LLM-call record to serialize and append.
+        dest: Write here instead of the session ledger -- used by producers
+            that own an ``ext/`` shard, since appending into the shared file is
+            not atomic across processes.
 
     Raises:
         LLMTraceRowError: If the serialized row violates the closed schema.
@@ -423,7 +577,7 @@ def append_llm_call(
     status = row.get("status")
     if status not in VALID_STATUSES:
         raise LLMTraceRowError(f"llm_calls row 'status'={status!r} is not one of {sorted(VALID_STATUSES)!r}")
-    dest = llm_calls_path(session_dir)
+    dest = dest or llm_calls_path(session_dir)
     try:
         append_jsonl(dest, row, make_parents=True, sort_keys=True)
     except OSError as exc:
@@ -460,4 +614,5 @@ __all__ = [
     "VALID_STATUSES",
     "append_llm_call",
     "new_call_id",
+    "resolve_task_path",
 ]

--- a/src/hyperloom/orchestrator/trace/parse_usage.py
+++ b/src/hyperloom/orchestrator/trace/parse_usage.py
@@ -38,12 +38,13 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 from hyperloom.common.env_safety import redact_secret_values
 
-from ._row_utils import coerce_optional_int
+from ._row_utils import coerce_optional_int, coerce_optional_str
 
 log = logging.getLogger(__name__)
 
@@ -249,6 +250,181 @@ def parse_claude_stream_json_response(
     return None
 
 
+def parse_claude_stream_json_cost(log_path: str | Path) -> dict[str, Any] | None:
+    """Recover what the Claude CLI says a run cost, from its stream-json log.
+
+    The terminal ``result`` row is the only place a dollar figure exists, and
+    it is the *provider's own* charge -- authoritative in a way no rate card
+    is, because it already accounts for the plan, the discounts and the model
+    mix. ``modelUsage`` is the per-model breakdown that figure was computed
+    from, so it also says which model spent what when a run mixed several.
+
+    Only the ``result`` row is read. An ``assistant`` row's cumulative usage
+    would double-bill, which is the same trap
+    ``kernelforge/agent_backends/claude.py`` documents.
+
+    Args:
+        log_path: Path to the Claude CLI ``stream-json`` log.
+
+    Returns:
+        ``{"total_cost_usd": float, "by_model": {model: {...}}}`` -- either key
+        absent when the log did not carry it -- or ``None`` when the file is
+        missing or held no ``result`` row with cost.
+    """
+    path = Path(log_path)
+    found: dict[str, Any] | None = None
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if not isinstance(obj, dict) or obj.get("type") != "result":
+                    continue
+                row: dict[str, Any] = {}
+                total = obj.get("total_cost_usd", obj.get("costUSD"))
+                if isinstance(total, (int, float)):
+                    row["total_cost_usd"] = float(total)
+                per_model = obj.get("modelUsage")
+                if isinstance(per_model, dict) and per_model:
+                    row["by_model"] = {str(name): entry for name, entry in per_model.items() if isinstance(entry, dict)}
+                if row:
+                    found = row
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        log.warning("parse_usage: failed reading stream-json log %s: %r", path, exc)
+        return None
+    return found
+
+
+def _anthropic_thinking_tokens(usage: Any) -> int | None:
+    """Read Anthropic's hidden-reasoning token count off a ``usage`` block.
+
+    Anthropic bills thinking inside ``output_tokens`` and reports it as a
+    breakdown; the ledger means the visible reply by ``output_tokens``, so a
+    caller that reads this must subtract it rather than add it, or the same
+    tokens are counted twice.
+
+    Args:
+        usage: A usage mapping, provider usage object, or ``None``.
+
+    Returns:
+        The thinking-token count, or ``None`` when the block carries none.
+    """
+    details = _field(usage, "output_tokens_details")
+    if details is None:
+        return None
+    return coerce_optional_int(_field(details, "thinking_tokens"))
+
+
+def parse_claude_transcript_calls(log_path: str | Path) -> list[dict[str, Any]]:
+    """Recover one row per API call from a Claude Code session transcript.
+
+    A Claude Code session writes ``<claude_home>/projects/<slug>/<id>.jsonl``,
+    one line per streamed message. This is the only record of what an agent
+    that drives the SDK itself spent -- GEAK, for instance, runs as a
+    subprocess and never touches Hyperloom's own ledger.
+
+    Rows are keyed on ``message.id`` and each id is kept once. That is not an
+    optimization: one API response arrives as several lines that repeat the
+    same id and the same cumulative ``usage``, so counting lines instead of
+    ids overstates a run's spend by roughly 60%.
+
+    Args:
+        log_path: Path to a Claude Code session transcript.
+
+    Returns:
+        One row per API call in stream order, each carrying ``message_id``,
+        ``ts``, ``model``, ``stop_reason``, the canonical token counters,
+        ``tool_calls`` and, when the transcript records it, ``cost_usd``.
+        Hidden reasoning is moved out of ``output_tokens`` into
+        ``reasoning_output_tokens``; see :func:`_anthropic_thinking_tokens`.
+        ``[]`` when the file is missing or carries no usable message.
+    """
+    path = Path(log_path)
+    calls: list[dict[str, Any]] = []
+    by_id: dict[str, dict[str, Any]] = {}
+    by_use_id: dict[str, dict[str, Any]] = {}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                if obj.get("type") == "user":
+                    _attach_tool_results(obj, by_use_id)
+                    continue
+                if obj.get("type") != "assistant":
+                    continue
+                message = obj.get("message")
+                if not isinstance(message, dict):
+                    continue
+                message_id = coerce_optional_str(message.get("id"))
+                if not message_id:
+                    continue
+                ts = coerce_optional_str(obj.get("timestamp"))
+                row = by_id.get(message_id)
+                if row is None:
+                    row = {
+                        "message_id": message_id,
+                        "ts": ts,
+                        "model": coerce_optional_str(message.get("model")),
+                        "stop_reason": coerce_optional_str(message.get("stop_reason")),
+                        "tool_calls": [],
+                    }
+                    usage = message.get("usage")
+                    normalized = normalize_usage(usage if isinstance(usage, dict) else None)
+                    if normalized:
+                        row.update(normalized)
+                    thinking = _anthropic_thinking_tokens(usage)
+                    if thinking is not None:
+                        row["reasoning_output_tokens"] = thinking
+                        visible = row.get("output_tokens")
+                        if isinstance(visible, int):
+                            row["output_tokens"] = max(0, visible - thinking)
+                    cost = obj.get("costUSD", message.get("costUSD"))
+                    if isinstance(cost, (int, float)):
+                        row["cost_usd"] = float(cost)
+                    by_id[message_id] = row
+                    calls.append(row)
+                elif row.get("stop_reason") is None:
+                    row["stop_reason"] = coerce_optional_str(message.get("stop_reason"))
+                for block in message.get("content") or []:
+                    if not isinstance(block, dict) or block.get("type") != "tool_use":
+                        continue
+                    name = str(block.get("name") or "").strip()
+                    if not name:
+                        continue
+                    entry: dict[str, Any] = {
+                        "tool": name,
+                        "query": _summarize_tool_input(block.get("input")),
+                    }
+                    use_id = coerce_optional_str(block.get("id"))
+                    if use_id:
+                        entry["tool_use_id"] = use_id
+                        by_use_id[use_id] = entry
+                    if ts:
+                        entry["ts"] = ts
+                    row["tool_calls"].append(entry)
+    except FileNotFoundError:
+        return []
+    except OSError as exc:
+        log.warning("parse_usage: failed reading claude transcript %s: %r", path, exc)
+        return []
+    return calls
+
+
 def _claude_result_output_tokens(result: dict[str, Any]) -> int | None:
     """Read the authoritative output-token count off a ``result`` row.
 
@@ -283,9 +459,9 @@ def _claude_result_output_tokens(result: dict[str, Any]) -> int | None:
 
 
 def _reattach_turn_output(
-    usages: list[dict[str, int | None]],
+    usages: list[dict[str, Any]],
     session_output: int | None,
-) -> list[dict[str, int | None]]:
+) -> list[dict[str, Any]]:
     """Swap placeholder per-turn ``output_tokens`` for the session's real count.
 
     See :func:`parse_claude_stream_json_turn_usages` for why the per-response
@@ -295,6 +471,8 @@ def _reattach_turn_output(
 
     Args:
         usages: De-duplicated per-response usages, in stream order (mutated).
+            Rows may carry identity keys beside the counters; only
+            ``output_tokens`` is touched.
         session_output: The session's true output-token count, or ``None``
             when the log carried no ``result`` row to read it from.
 
@@ -314,7 +492,7 @@ def _reattach_turn_output(
 
 def parse_claude_stream_json_turn_usages(
     log_path: str | Path,
-) -> list[dict[str, int | None]]:
+) -> list[dict[str, Any]]:
     """Recover *per-API-response* usage from a Claude CLI stream-json log.
 
     Unlike :func:`parse_claude_stream_json_usage` (which returns one cumulative
@@ -339,6 +517,14 @@ def parse_claude_stream_json_turn_usages(
 
     Input and cache counters need no such repair and are kept as the responses
     reported them; de-duplicated, they reconcile with the ``result`` row.
+
+    Each row also carries the response's **identity** beside its counters, in
+    the spelling :class:`~hyperloom.orchestrator.trace.llm_trace.LLMCallRecord`
+    reads: ``call_id`` (the ``message.id`` this parse already de-duplicates on)
+    and ``model``. Without them a specialist's ledger row is unpriceable (no
+    model to look a rate up by) and its per-API-call detail rows cannot be
+    joined back to it, which is what left sub-agent spend uncosted. Both keys
+    are omitted when the log does not name them, never emitted empty.
 
     Assistant lines carrying no ``message.id`` cannot be de-duplicated safely,
     so such a log yields ``[]`` and the caller falls back to the cumulative
@@ -382,6 +568,10 @@ def parse_claude_stream_json_turn_usages(
                     if message_id in seen_ids:
                         continue
                     seen_ids.add(message_id)
+                    normalized["call_id"] = message_id
+                model = message.get("model") if isinstance(message, dict) else None
+                if isinstance(model, str) and model:
+                    normalized["model"] = model
                 usages.append(normalized)
     except FileNotFoundError:
         return []
@@ -398,6 +588,57 @@ def parse_claude_stream_json_turn_usages(
     return _reattach_turn_output(usages, session_output)
 
 
+def _iso_delta_ms(start: str | None, end: str | None) -> int | None:
+    """Milliseconds between two ISO-8601 stamps, or ``None`` if unusable.
+
+    Args:
+        start: The earlier timestamp.
+        end: The later timestamp.
+
+    Returns:
+        The non-negative delta in ms, or ``None`` when either stamp is missing
+        or unparseable, or the pair runs backwards.
+    """
+    if not start or not end:
+        return None
+    try:
+        began = datetime.fromisoformat(str(start).replace("Z", "+00:00"))
+        ended = datetime.fromisoformat(str(end).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    delta = (ended - began).total_seconds() * 1000.0
+    return int(delta) if delta >= 0 else None
+
+
+def _attach_tool_results(obj: dict[str, Any], by_use_id: dict[str, dict[str, Any]]) -> None:
+    """Close out the tool calls this ``user`` row carries results for.
+
+    A ``tool_result`` block names the ``tool_use_id`` it answers, which is the
+    only reliable pairing: results come back out of order when the agent runs
+    calls in parallel.
+
+    Args:
+        obj: A decoded ``{"type": "user", ...}`` row.
+        by_use_id: Open tool-call entries keyed by their ``tool_use_id``,
+            mutated in place.
+    """
+    if not by_use_id:
+        return
+    message = obj.get("message")
+    if not isinstance(message, dict):
+        return
+    ended = coerce_optional_str(obj.get("timestamp"))
+    for block in message.get("content") or []:
+        if not isinstance(block, dict) or block.get("type") != "tool_result":
+            continue
+        entry = by_use_id.pop(coerce_optional_str(block.get("tool_use_id")) or "", None)
+        if entry is None:
+            continue
+        duration = _iso_delta_ms(entry.get("ts"), ended)
+        if duration is not None:
+            entry["duration_ms"] = duration
+
+
 def parse_claude_stream_json_tool_calls(
     log_path: str | Path,
 ) -> list[dict[str, Any]]:
@@ -407,16 +648,25 @@ def parse_claude_stream_json_tool_calls(
     surface what the specialist actually read (WebSearch / WebFetch / Grep /
     Read / ...). This is the data behind the per-call ``intel:<tool>`` spans.
 
-    Each returned entry is ``{"tool": <name>, "query": <short input summary>}``,
-    in call order. The input summary prefers common query-ish keys
-    (``query`` / ``url`` / ``pattern`` / ``path`` / ``prompt``) and otherwise
-    falls back to a compact clipped JSON of the input.
+    Each returned entry carries ``{"tool": <name>, "query": <short input
+    summary>}`` in call order, plus whatever the log supports: ``tool_use_id``,
+    the emitting response's ``turn_index``, the block's ``ts``, and
+    ``duration_ms`` measured against the matching ``tool_result``. The input
+    summary prefers common query-ish keys (``query`` / ``url`` / ``pattern`` /
+    ``path`` / ``prompt``) and otherwise falls back to a compact clipped JSON
+    of the input.
+
+    ``duration_ms`` is the round trip the agent waited on -- issue to result --
+    which is why a turn's wall-clock can dwarf the model time inside it. It is
+    absent when the log carries no timestamps or the call never returned.
 
     Tolerant by contract: a missing file, malformed lines, or no tool calls
     returns ``[]``.
     """
     path = Path(log_path)
     calls: list[dict[str, Any]] = []
+    by_use_id: dict[str, dict[str, Any]] = {}
+    turn_ids: list[str] = []
     try:
         with path.open("r", encoding="utf-8") as f:
             for line in f:
@@ -427,23 +677,41 @@ def parse_claude_stream_json_tool_calls(
                     obj = json.loads(line)
                 except (json.JSONDecodeError, ValueError):
                     continue
-                if not isinstance(obj, dict) or obj.get("type") != "assistant":
+                if not isinstance(obj, dict):
+                    continue
+                kind = obj.get("type")
+                if kind == "user":
+                    _attach_tool_results(obj, by_use_id)
+                    continue
+                if kind != "assistant":
                     continue
                 message = obj.get("message")
                 if not isinstance(message, dict):
                     continue
+                ts = coerce_optional_str(obj.get("timestamp"))
+                message_id = coerce_optional_str(message.get("id"))
+                if message_id and message_id not in turn_ids:
+                    turn_ids.append(message_id)
+                turn_index = turn_ids.index(message_id) if message_id else None
                 for block in message.get("content") or []:
                     if not isinstance(block, dict) or block.get("type") != "tool_use":
                         continue
                     name = str(block.get("name") or "").strip()
                     if not name:
                         continue
-                    calls.append(
-                        {
-                            "tool": name,
-                            "query": _summarize_tool_input(block.get("input")),
-                        }
-                    )
+                    entry: dict[str, Any] = {
+                        "tool": name,
+                        "query": _summarize_tool_input(block.get("input")),
+                    }
+                    use_id = coerce_optional_str(block.get("id"))
+                    if use_id:
+                        entry["tool_use_id"] = use_id
+                        by_use_id[use_id] = entry
+                    if ts:
+                        entry["ts"] = ts
+                    if turn_index is not None:
+                        entry["turn_index"] = turn_index
+                    calls.append(entry)
     except FileNotFoundError:
         return []
     except OSError as exc:
@@ -821,13 +1089,19 @@ def parse_codex_jsonl_tool_calls(
     a warning — an unmodelled tool must not vanish from the trace, and must not
     crash the parse either.
 
+    ``item.started`` and ``item.completed`` bracket one call, so the pair also
+    yields its ``duration_ms`` when the log timestamps its events.
+
     Args:
         log_path: Path to the Codex CLI JSONL log.
 
     Returns:
-        One ``{"tool", "query"}`` entry per call, or ``[]`` when there were none.
+        One entry per call carrying ``{"tool", "query"}`` plus whatever the log
+        supports (``tool_use_id``, ``ts``, ``duration_ms``), or ``[]`` when
+        there were none.
     """
     calls: list[dict[str, Any]] = []
+    open_calls: dict[str, dict[str, Any]] = {}
     seen_ids: set[str] = set()
     unknown_types: set[str] = set()
     for event in _iter_codex_events(log_path):
@@ -839,17 +1113,28 @@ def parse_codex_jsonl_tool_calls(
         kind = str(item.get("type") or "").strip()
         if not kind or kind in _CODEX_NON_TOOL_ITEM_TYPES:
             continue
-        # ``item.started`` and ``item.completed`` describe one call; count it once.
+        ts = coerce_optional_str(event.get("timestamp") or item.get("timestamp"))
         item_id = str(item.get("id") or "")
+        if item_id and item_id in seen_ids:
+            entry = open_calls.pop(item_id, None)
+            if entry is not None:
+                duration = _iso_delta_ms(entry.get("ts"), ts)
+                if duration is not None:
+                    entry["duration_ms"] = duration
+            continue
         if item_id:
-            if item_id in seen_ids:
-                continue
             seen_ids.add(item_id)
         tool = _CODEX_TOOL_NAMES.get(kind)
         if tool is None:
             unknown_types.add(kind)
             tool = kind
-        calls.append({"tool": tool, "query": _summarize_codex_item(kind, item)})
+        entry = {"tool": tool, "query": _summarize_codex_item(kind, item)}
+        if item_id:
+            entry["tool_use_id"] = item_id
+            open_calls[item_id] = entry
+        if ts:
+            entry["ts"] = ts
+        calls.append(entry)
     if unknown_types:
         log.warning(
             "parse_usage: codex log %s carried unmodelled item types %s; recorded under their raw names",
@@ -931,10 +1216,12 @@ def parse_forge_steps(stdout: str) -> dict[str, Any] | None:
 
 __all__ = [
     "normalize_usage",
+    "parse_claude_stream_json_cost",
     "parse_claude_stream_json_response",
     "parse_claude_stream_json_tool_calls",
     "parse_claude_stream_json_turn_usages",
     "parse_claude_stream_json_usage",
+    "parse_claude_transcript_calls",
     "parse_codex_jsonl_error",
     "parse_codex_jsonl_response",
     "parse_codex_jsonl_tool_calls",

--- a/src/hyperloom/orchestrator/trace/pricing.py
+++ b/src/hyperloom/orchestrator/trace/pricing.py
@@ -1,0 +1,332 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""USD pricing for a single LLM call.
+
+Two sources exist and they are never mixed inside one total. When the provider
+reports what it charged -- the Claude CLI's ``total_cost_usd`` is the only one
+that does -- that figure wins outright and the per-bucket split is prorated
+from the token counts. Otherwise the cost is derived from the shipped rate card
+in ``assets/llm_pricing.yaml``. A model the card does not know yields an
+``unavailable`` breakdown with every figure ``None``, so a report can say
+"unpriced" instead of quietly totalling zero.
+
+The ``source`` vocabulary matches ``kernelforge/tracker/usage.py``, which
+already reports provider/partial/unavailable for the same reason.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+log = logging.getLogger(__name__)
+
+ENV_PRICING_FILE = "HYPERLOOM_LLM_PRICING_FILE"
+
+SOURCE_PROVIDER = "provider"
+SOURCE_DERIVED = "derived"
+SOURCE_PARTIAL = "partial"
+SOURCE_UNAVAILABLE = "unavailable"
+
+_PER_MILLION = 1_000_000.0
+
+# Rate-card keys are normalized model ids; these prefixes and suffixes are the
+# routing decoration a gateway adds and never part of the identity we price.
+_PROVIDER_PREFIXES: tuple[str, ...] = (
+    "anthropic/",
+    "openai/",
+    "openrouter/",
+    "litellm/",
+    "bedrock/",
+    "vertex_ai/",
+    "hosted_vllm/",
+)
+
+
+@dataclass(frozen=True)
+class ModelRates:
+    """USD per million tokens for one model."""
+
+    input: float
+    output: float
+    cache_read: float | None = None
+    cache_write: float | None = None
+
+    def read_rate(self) -> float:
+        """Rate charged for a cache-read token (input rate when unpriced)."""
+        return self.input if self.cache_read is None else self.cache_read
+
+    def write_rate(self) -> float:
+        """Rate charged for a cache-write token (input rate when unpriced)."""
+        return self.input if self.cache_write is None else self.cache_write
+
+
+@dataclass(frozen=True)
+class CostBreakdown:
+    """What one call cost, split by the bucket that incurred it.
+
+    ``thinking_usd`` is an addend of ``total_usd``, not a share of
+    ``output_usd``: the ledger carries ``reasoning_output_tokens`` alongside
+    ``output_tokens`` rather than folded into it (see
+    :func:`parse_usage.reasoning_output_tokens`), so the two are priced
+    separately at the same rate.
+    """
+
+    total_usd: float | None = None
+    input_usd: float | None = None
+    output_usd: float | None = None
+    thinking_usd: float | None = None
+    cache_usd: float | None = None
+    source: str = SOURCE_UNAVAILABLE
+
+    @property
+    def available(self) -> bool:
+        """True when a figure was produced at all."""
+        return self.total_usd is not None
+
+
+_UNPRICED = CostBreakdown()
+
+_rates_cache: dict[str, ModelRates] | None = None
+_rates_cache_key: str | None = None
+
+
+def normalize_model(model: str | None) -> str:
+    """Reduce a provider model id to the identity the rate card is keyed on.
+
+    Strips the routing provider prefix and any ``:tag`` / ``@version`` suffix,
+    then lowercases. Returns ``""`` for a missing model.
+
+    Args:
+        model: The model id as the provider reported it.
+
+    Returns:
+        The normalized id, or ``""`` when there is nothing to normalize.
+    """
+    name = str(model or "").strip().lower()
+    if not name:
+        return ""
+    for prefix in _PROVIDER_PREFIXES:
+        if name.startswith(prefix):
+            name = name[len(prefix) :]
+            break
+    name = name.split(":", 1)[0]
+    name = name.split("@", 1)[0]
+    return name.strip("/ ")
+
+
+def pricing_file() -> Path:
+    """Return the rate-card path, honouring ``$HYPERLOOM_LLM_PRICING_FILE``."""
+    override = os.environ.get(ENV_PRICING_FILE)
+    if override and override.strip():
+        return Path(override).expanduser()
+    from hyperloom.inference_optimizer.session.paths import asset_root
+
+    return asset_root() / "assets" / "llm_pricing.yaml"
+
+
+def _parse_rates(payload: Any) -> dict[str, ModelRates]:
+    """Project a loaded rate-card document onto ``{model: ModelRates}``.
+
+    Entries without a usable input and output rate are dropped with a warning
+    rather than priced at zero.
+
+    Args:
+        payload: The parsed YAML document.
+
+    Returns:
+        The rate map, empty when the document carries no usable entry.
+    """
+    if not isinstance(payload, Mapping):
+        return {}
+    defaults = payload.get("defaults") if isinstance(payload.get("defaults"), Mapping) else {}
+    models = payload.get("models")
+    if not isinstance(models, Mapping):
+        return {}
+
+    def _rate(entry: Mapping[str, Any], key: str) -> float | None:
+        raw = entry.get(key, defaults.get(key))
+        if raw is None:
+            return None
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return None
+        return value if value >= 0 else None
+
+    rates: dict[str, ModelRates] = {}
+    for name, entry in models.items():
+        if not isinstance(entry, Mapping):
+            continue
+        in_rate = _rate(entry, "input")
+        out_rate = _rate(entry, "output")
+        if in_rate is None or out_rate is None:
+            log.warning("llm_pricing: %s has no usable input/output rate; skipping", name)
+            continue
+        rates[normalize_model(str(name))] = ModelRates(
+            input=in_rate,
+            output=out_rate,
+            cache_read=_rate(entry, "cache_read"),
+            cache_write=_rate(entry, "cache_write"),
+        )
+    return rates
+
+
+def load_rates(*, refresh: bool = False) -> dict[str, ModelRates]:
+    """Load and memoize the rate card for the current pricing file.
+
+    A missing or malformed card is not fatal: it yields an empty map, and every
+    call then prices as ``unavailable``.
+
+    Args:
+        refresh: Re-read the file even when it is already cached.
+
+    Returns:
+        The model-id to :class:`ModelRates` map.
+    """
+    global _rates_cache, _rates_cache_key
+    path = pricing_file()
+    key = str(path)
+    if not refresh and _rates_cache is not None and _rates_cache_key == key:
+        return _rates_cache
+    rates: dict[str, ModelRates] = {}
+    try:
+        import yaml
+
+        with open(path, "r", encoding="utf-8") as handle:
+            rates = _parse_rates(yaml.safe_load(handle))
+    except FileNotFoundError:
+        log.warning("llm_pricing: no rate card at %s; costs will be unavailable", path)
+    except (OSError, ImportError) as exc:
+        log.warning("llm_pricing: cannot read %s (%s); costs will be unavailable", path, exc)
+    except Exception as exc:  # noqa: BLE001 -- yaml raises its own error tree
+        log.warning("llm_pricing: %s is not valid YAML (%s)", path, exc)
+    _rates_cache = rates
+    _rates_cache_key = key
+    return rates
+
+
+def rates_for(model: str | None) -> ModelRates | None:
+    """Return the rate entry for ``model`` by longest-prefix match.
+
+    ``claude-opus-4-8-20260101`` matches the card's ``claude-opus-4`` entry;
+    the longest matching key wins so a more specific entry always beats a
+    family default.
+
+    Args:
+        model: The provider model id.
+
+    Returns:
+        The matching :class:`ModelRates`, or ``None`` when the card knows no
+        prefix of this model.
+    """
+    name = normalize_model(model)
+    if not name:
+        return None
+    rates = load_rates()
+    exact = rates.get(name)
+    if exact is not None:
+        return exact
+    best_key = ""
+    for key in rates:
+        if name.startswith(key) and len(key) > len(best_key):
+            best_key = key
+    return rates.get(best_key) if best_key else None
+
+
+def _count(tokens: Mapping[str, Any] | None, key: str) -> int:
+    """Read a non-negative token counter off a usage mapping."""
+    if not isinstance(tokens, Mapping):
+        return 0
+    try:
+        value = int(tokens.get(key) or 0)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, value)
+
+
+def resolve_cost(
+    *,
+    model: str | None,
+    tokens: Mapping[str, Any] | None,
+    provider_usd: float | None = None,
+) -> CostBreakdown:
+    """Price one call, preferring the provider's own figure over the card.
+
+    When ``provider_usd`` is given it becomes ``total_usd`` verbatim and the
+    buckets are prorated by what the card says each bucket is worth -- so the
+    total is always the provider's, and the split is only an attribution of it.
+    When the card knows nothing about ``model`` and the provider reported
+    nothing, every figure is ``None`` and ``source`` is ``unavailable``.
+
+    Args:
+        model: The provider model id the call ran on.
+        tokens: Usage mapping carrying ``input_tokens``, ``output_tokens``,
+            ``cache_creation_input_tokens``, ``cache_read_input_tokens`` and
+            ``reasoning_output_tokens``.
+        provider_usd: The provider's own charge for this call, when it
+            reported one.
+
+    Returns:
+        The :class:`CostBreakdown` for the call.
+    """
+    rates = rates_for(model)
+    has_provider = provider_usd is not None and provider_usd >= 0
+
+    if rates is None:
+        if not has_provider:
+            return _UNPRICED
+        return CostBreakdown(total_usd=float(provider_usd), source=SOURCE_PROVIDER)
+
+    in_tok = _count(tokens, "input_tokens")
+    out_tok = _count(tokens, "output_tokens")
+    think_tok = _count(tokens, "reasoning_output_tokens")
+    read_tok = _count(tokens, "cache_read_input_tokens")
+    write_tok = _count(tokens, "cache_creation_input_tokens")
+
+    input_usd = in_tok * rates.input / _PER_MILLION
+    output_usd = out_tok * rates.output / _PER_MILLION
+    thinking_usd = think_tok * rates.output / _PER_MILLION
+    cache_usd = (read_tok * rates.read_rate() + write_tok * rates.write_rate()) / _PER_MILLION
+    derived_total = input_usd + output_usd + thinking_usd + cache_usd
+
+    if not has_provider:
+        return CostBreakdown(
+            total_usd=derived_total,
+            input_usd=input_usd,
+            output_usd=output_usd,
+            thinking_usd=thinking_usd,
+            cache_usd=cache_usd,
+            source=SOURCE_DERIVED,
+        )
+
+    total = float(provider_usd)
+    scale = (total / derived_total) if derived_total > 0 else 0.0
+    return CostBreakdown(
+        total_usd=total,
+        input_usd=input_usd * scale,
+        output_usd=output_usd * scale,
+        thinking_usd=thinking_usd * scale,
+        cache_usd=cache_usd * scale,
+        source=SOURCE_PROVIDER,
+    )
+
+
+__all__ = [
+    "ENV_PRICING_FILE",
+    "SOURCE_DERIVED",
+    "SOURCE_PARTIAL",
+    "SOURCE_PROVIDER",
+    "SOURCE_UNAVAILABLE",
+    "CostBreakdown",
+    "ModelRates",
+    "load_rates",
+    "normalize_model",
+    "pricing_file",
+    "rates_for",
+    "resolve_cost",
+]

--- a/src/hyperloom/skills/geak-llm-report/SKILL.md
+++ b/src/hyperloom/skills/geak-llm-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: geak-llm-report
-description: Render the phase → agent → API call → tool call report for a GEAK run, standalone or inside a Hyperloom session — every call's ISL/OSL, tokens (input/thinking/output/cache), wall-clock, derived USD and tool calls. Use when asked where GEAK's time or money went, which GEAK phase or agent dominates a run, whether a task is cheap enough to delegate to a smaller model, or to compare two models' GEAK runs.
+description: Render the phase → agent → API call → tool call report for a GEAK run, standalone or inside a Hyperloom session — every call's ISL/OSL, tokens (input/thinking/output/cache), wall-clock, derived USD and tool calls. Use when asked where GEAK's time or money went, which GEAK phase or agent dominates a run, whether a task is cheap enough to delegate to a smaller model, or to compare two models' GEAK runs. Also renders a single self-contained HTML page that joins what each phase cost to what it bought.
 ---
 
 # GEAK per-LLM-call report
@@ -58,13 +58,50 @@ ledger and none needs to.
    usually wants; the full depth bottoms out at tool names and runs to
    thousands of rows.
 
-3. **For the cross-hierarchy view**, add `--join-hyperloom <SESSION_DIR>`. The
+3. **Render the structured HTML page.** The Markdown tree above is a tree; the
+   HTML is the page to hand someone who has to *decide* something. It joins the
+   two halves of a run — what each phase cost, from `geak_calls.jsonl`, and what
+   each phase bought, from `geak_outcome.json` — into one file with no external
+   fetches, so it survives being copied to shared storage.
+
+   ```bash
+   PYTHONPATH=src python3 -m hyperloom.inference_optimizer.tools.render_geak_html_report \
+       --reports-dir <EVAL_DIR>/reports
+   ```
+
+   It needs `geak_calls.jsonl`, so render step 2 with `--include-text` first.
+   `geak_outcome.json` is written by GEAK's own outcome report and is optional —
+   without it the page says so, and every gain column reads *not measured*
+   rather than 0.00%.
+
+   | Section | Answers |
+   | --- | --- |
+   | Headline cards | total spend, calls, agents, wall-clock, USD per +1% throughput |
+   | Coverage | what the ledger does **not** contain — read this before quoting anything |
+   | What each phase bought | gain beside cost, and USD per +1%, per phase |
+   | Spend by phase | share of the bill, with the concentration curve |
+   | Inside each phase | the deep dive: cost by position in the conversation, ISL growth, per-call cost percentiles, tool mix, and the agent roster |
+   | Delegation signals | which phases look mechanical enough to hand to a cheaper model |
+
+   **Reading the deep dive.** Every agent's conversation is stretched onto the
+   same 0-9 scale, so the position curve answers *"does a call get more expensive
+   the longer its conversation runs?"* without being dominated by whichever agent
+   ran longest. It does: each call re-sends the conversation so far, so ISL
+   climbs through a conversation and the later deciles cost more. Agents with
+   fewer than 10 calls cannot be bucketed and are excluded; the count of those
+   is printed so the exclusion is visible.
+
+   **The delegation table is signals, not a verdict.** A high tool-call rate and
+   a flat per-call cost say a phase is a mechanical loop; they do not say a
+   smaller model would get the same answer. Nothing in the ledger can say that.
+
+4. **For the cross-hierarchy view**, add `--join-hyperloom <SESSION_DIR>`. The
    GEAK tree is nested under the session's `KERNEL_AGENT` phase, so one document
    carries Hyperloom phases on top and GEAK phases inside. Rows the GEAK
    harvester already wrote into that session's `ext/` shard are dropped first,
    so the run is not billed twice.
 
-4. **Read the Coverage section before quoting a number.** It is printed first
+5. **Read the Coverage section before quoting a number.** It is printed first
    for that reason.
 
 ## Options that widen the report
@@ -99,6 +136,9 @@ context is what `isl` counts.
 - **Summed agent durations exceed the run's wall-clock** wherever the script
   fanned out. The record's `durationMs` is the wall-clock; quote that for
   elapsed time and the sum for compute-time attribution.
+- **Agent roles in the HTML are derived from the prompt text**, not recorded.
+  A prompt that does not open with a role sentence renders as `unlabelled`
+  and is counted as such in Coverage — never guessed at.
 - **A repeated label gets `#2`, `#3`** suffixes — those are separate agents
   (a retry, or an unnumbered fan-out), not duplicates to merge.
 

--- a/src/hyperloom/skills/geak-llm-report/SKILL.md
+++ b/src/hyperloom/skills/geak-llm-report/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: geak-llm-report
+description: Render the phase → agent → API call → tool call report for a GEAK run, standalone or inside a Hyperloom session — every call's ISL/OSL, tokens (input/thinking/output/cache), wall-clock, derived USD and tool calls. Use when asked where GEAK's time or money went, which GEAK phase or agent dominates a run, whether a task is cheap enough to delegate to a smaller model, or to compare two models' GEAK runs.
+---
+
+# GEAK per-LLM-call report
+
+Answers: *for every LLM API call a GEAK run made, what did it cost in tokens,
+seconds and dollars, and which phase and agent did it belong to?*
+
+## Where the data comes from
+
+GEAK issues almost no LLM calls itself. `interface/run_e2e.py` opens one
+`ClaudeSDKClient` and hands a single prompt to Claude Code, which runs
+`e2e_workflow/e2e_workflow.js` — a Workflow script that declares its phases and
+tags every `agent()` call with `{phase, label}`. **Claude Code already records
+that structure**, so this report reads existing files; no GEAK code writes a
+ledger and none needs to.
+
+| File | Holds |
+| --- | --- |
+| `<claude_home>/projects/<slug>/<session>/workflows/wf_*.json` | phases, `args.eval_dir`, `workflowProgress` — one entry per agent with label, phase, model, tool calls, `durationMs` |
+| `<session>/subagents/workflows/<runId>/agent-<agentId>.jsonl` | one row per API call: `usage`, `model`, `apiBlockIndex`, `timestamp`, `tool_use` blocks |
+
+## Steps
+
+1. **Find the run.** Selection is an identity match on `args.eval_dir`, never a
+   guess by mtime:
+
+   ```bash
+   PYTHONPATH=src python3 -m hyperloom.inference_optimizer.tools.dump_geak_call_report \
+       --session-dir <HYPERLOOM_SESSION_DIR> --list
+   ```
+
+   A run made by a GEAK build that mirrors its own ledger also carries a copy at
+   `<eval_dir>/llm_trace/` — pass that as `--claude-home` and everything below
+   works unchanged. Prefer it: it is the copy that survives the container the
+   run's Claude home lived in.
+
+   `--eval-dir <path>` and `--run-id wf_...` also select; `--eval-dir` matches
+   `args.eval_dir` first and falls back to `args.exp_root`, so it finds a
+   standalone GEAK run as well as a Hyperloom-driven one. `--list` with no
+   selector at all lists every record in every home, which is how to find a run
+   whose paths you do not know. Archived runs sit in another user's home — add
+   `--claude-home /shared_nfs/<user>/.claude` (repeatable). Confirm the
+   candidate you meant before rendering.
+
+2. **Render.** From the Hyperloom checkout:
+
+   ```bash
+   PYTHONPATH=src python3 -m hyperloom.inference_optimizer.tools.dump_geak_call_report \
+       --run-id wf_ec8b57b0-1a7 --claude-home /shared_nfs/chaox/.claude
+   ```
+
+   Writes `geak_call_report.md` and `geak_call_report.json` to
+   `$USER_DATA_PATH/reports/<runId>/`. `--max-depth 2` gives the
+   phase → agent table alone, which is what a "where did the time go" question
+   usually wants; the full depth bottoms out at tool names and runs to
+   thousands of rows.
+
+3. **For the cross-hierarchy view**, add `--join-hyperloom <SESSION_DIR>`. The
+   GEAK tree is nested under the session's `KERNEL_AGENT` phase, so one document
+   carries Hyperloom phases on top and GEAK phases inside. Rows the GEAK
+   harvester already wrote into that session's `ext/` shard are dropped first,
+   so the run is not billed twice.
+
+4. **Read the Coverage section before quoting a number.** It is printed first
+   for that reason.
+
+## Options that widen the report
+
+| Flag | Effect |
+| --- | --- |
+| `--include-orchestrator` | Folds in the launching SDK conversation from `<session>.jsonl` as an `(orchestrator)` phase. It is a couple of calls against the workflow's thousands — include it for a complete bill, omit it to keep the tree about the workflow. |
+| `--include-text` | Also writes `geak_calls.jsonl`: one row per API call with `prompt_text`, `thinking_text` and `output_text` beside every metric, tagged with its phase, agent and call index. This is the artifact to read when deciding *which* tasks are cheap enough to delegate — the tree says where the money went, the sidecar says what was being asked. |
+| `--text-chars N` | Caps each captured field (default 4000; `0` uncaps). Truncation is marked inline as `[+N chars]`, never silent. Uncapped on a large run produces a multi-gigabyte file. |
+| `--no-nested` | Suppresses grafting of nested workflow records. |
+
+`prompt_text` is the *increment* the model was handed since it last spoke — the
+agent prompt on call 0, tool results after that — not the full context. The full
+context is what `isl` counts.
+
+## Reading the numbers
+
+- **ISL** = `input_tokens + cache_read + cache_creation`. Cache read dominates
+  by two orders of magnitude in these runs; a token total that ignores it
+  understates the bill enormously, and one that includes it is not comparable
+  to a "tokens" figure quoted from anywhere else. Say which you mean.
+- **Thinking is a subset of output here** — the opposite of Hyperloom's own
+  ledger. `OSL = output_tokens` alone. Adding thinking on top double-counts it.
+- **Cost is always derived** from the shipped rate card; Claude Code records no
+  provider cost. An unpriced model is excluded from the USD total, never counted
+  as free, and Coverage says how many calls that was.
+- **Thinking seconds are always 0.** Only per-message timestamps exist. Thinking
+  *tokens* are exact.
+- **Per-call time is inferred** from consecutive timestamps, so an agent's first
+  call absorbs its queue wait. Agent-level time is the runtime's own
+  `durationMs` and is authoritative.
+- **Summed agent durations exceed the run's wall-clock** wherever the script
+  fanned out. The record's `durationMs` is the wall-clock; quote that for
+  elapsed time and the sum for compute-time attribution.
+- **A repeated label gets `#2`, `#3`** suffixes — those are separate agents
+  (a retry, or an unnumbered fan-out), not duplicates to merge.
+
+## Reconciliation
+
+The report prints the record's own figures beside the leaf-derived ones. Tool
+calls, agent count and per-agent duration reconcile exactly; **tokens do not,
+and are not expected to** — `workflowProgress[].tokens` is a streamed snapshot
+that lands on either side of the transcript sums agent by agent. The transcripts
+are authoritative for tokens. A tool-call or agent-count mismatch, by contrast,
+means a transcript is missing and should be investigated.
+
+## Do not
+
+- Do not modify anything under a GEAK checkout to produce this report; nothing
+  needs instrumenting.
+- Do not run a report against `/shared_nfs/chaox/GEAK` expecting it to match a
+  local checkout's phase list — the deployed build carries phases no local
+  checkout has, so a missing phase there is a build difference, not a bug.
+- Do not treat a nested workflow's numbers as certain. Records carry no parent
+  linkage, so nesting is joined by time containment within the session and
+  Coverage labels it as such. Every archived run inspected so far has
+  `spawnDepth: 1` and no nesting at all.
+- Do not present the `--join-hyperloom` total as the session bill when the
+  session's own ledger has no `KERNEL_AGENT` rows; in that case Hyperloom never
+  harvested GEAK, and the two hierarchies were measured independently.

--- a/src/hyperloom/skills/geak-llm-report/SKILL.md
+++ b/src/hyperloom/skills/geak-llm-report/SKILL.md
@@ -76,6 +76,12 @@ ledger and none needs to.
    numbers are not comparable.
 
    It needs `geak_calls.jsonl`, so render step 2 with `--include-text` first.
+   **A run whose ledger was lost still gets a page.** With only
+   `geak_outcome.json` present the renderer warns and produces the outcome half
+   alone: the throughput ladder and what each phase measured, with every cost,
+   token and wall-clock figure marked absent rather than shown as zero, and the
+   three spend sections omitted rather than rendered empty. Only when both files
+   are missing does it fail.
    `geak_outcome.json` is written by GEAK's own outcome report and is optional —
    without it the page says so, and every gain column reads *not measured*
    rather than 0.00%.

--- a/src/hyperloom/skills/geak-llm-report/SKILL.md
+++ b/src/hyperloom/skills/geak-llm-report/SKILL.md
@@ -76,9 +76,10 @@ ledger and none needs to.
 
    | Section | Answers |
    | --- | --- |
-   | Headline cards | total spend, calls, agents, wall-clock, USD per +1% throughput |
+   | Headline cards | throughput gained, baseline -> final tok/s, total spend, calls, wall-clock, USD per +1% |
+   | What each phase contributed to throughput | the ladder in run order: from/to tok/s, gain, and each phase's share of the summed measured gain |
    | Coverage | what the ledger does **not** contain — read this before quoting anything |
-   | What each phase bought | gain beside cost, and USD per +1%, per phase |
+   | What each phase bought | the same gains put beside what they cost, and USD per +1% |
    | Spend by phase | share of the bill, with the concentration curve |
    | Inside each phase | the deep dive: cost by position in the conversation, ISL growth, per-call cost percentiles, tool mix, and the agent roster |
    | Delegation signals | which phases look mechanical enough to hand to a cheaper model |
@@ -90,6 +91,12 @@ ledger and none needs to.
    climbs through a conversation and the later deciles cost more. Agents with
    fewer than 10 calls cannot be bucketed and are excluded; the count of those
    is printed so the exclusion is visible.
+
+   **Share of measured gain is arithmetic, not attribution.** It is a phase's own
+   tok/s gain over the summed tok/s gains of the phases that measured one. It
+   deliberately does not reconcile with the end-to-end figure -- a phase does not
+   always start from where the previous one finished, and the page names the
+   handoff seam that accounts for the gap.
 
    **The delegation table is signals, not a verdict.** A high tool-call rate and
    a flat per-call cost say a phase is a mechanical loop; they do not say a

--- a/src/hyperloom/skills/geak-llm-report/SKILL.md
+++ b/src/hyperloom/skills/geak-llm-report/SKILL.md
@@ -69,6 +69,12 @@ ledger and none needs to.
        --reports-dir <EVAL_DIR>/reports
    ```
 
+   Without `-o` it writes `geak_report.html`. GEAK's own end-of-run step passes a
+   name instead: `geak_run_report_<model>.html` for a standalone run,
+   `hl_run_report_<model>.html` when Hyperloom invoked GEAK as its KERNEL_AGENT
+   phase. One page per run, and the two modes never collide, because their
+   numbers are not comparable.
+
    It needs `geak_calls.jsonl`, so render step 2 with `--include-text` first.
    `geak_outcome.json` is written by GEAK's own outcome report and is optional —
    without it the page says so, and every gain column reads *not measured*

--- a/src/hyperloom/skills/geak-llm-report/SKILL.md
+++ b/src/hyperloom/skills/geak-llm-report/SKILL.md
@@ -114,6 +114,14 @@ ledger and none needs to.
    a flat per-call cost say a phase is a mechanical loop; they do not say a
    smaller model would get the same answer. Nothing in the ledger can say that.
 
+   **A Hyperloom-driven run's session page may already carry all of this.**
+   `render_hyperloom_html_report` grafts `geak_calls.jsonl` in beneath its
+   `KERNEL_AGENT` phase and renders it through the same deep-dive code, so one
+   page covers both hierarchies and a column means the same thing on either.
+   That graft reads the ledger off disk; a GEAK build without the trace mirror
+   wrote it only into the Claude config home, and then this report against a
+   surviving home is the way to get the detail back.
+
 4. **For the cross-hierarchy view**, add `--join-hyperloom <SESSION_DIR>`. The
    GEAK tree is nested under the session's `KERNEL_AGENT` phase, so one document
    carries Hyperloom phases on top and GEAK phases inside. Rows the GEAK

--- a/src/hyperloom/skills/hyperloom-llm-report/SKILL.md
+++ b/src/hyperloom/skills/hyperloom-llm-report/SKILL.md
@@ -83,7 +83,28 @@ Everything comes from `<session_dir>/reports/trace/`:
      bill — is missing, and the session total is badly understated. Check that
      `reports/trace/ext/geak-*.jsonl` exists and that the harvester ran.
 
-5. **Answer the question that was asked.** The markdown tree is the artifact;
+5. **Inside a phase, read the deep dive.** The page renders the same four panels
+   a GEAK run's own report does, from the same shared code, so a column means
+   the same thing on either: cost by position in the conversation, how few
+   agents carry the phase, what tools the work consisted of, and the agent
+   roster with every agent drillable to its own API calls. Two things about
+   identity there are worth knowing before quoting it:
+
+   - **An agent is a conversation, identified by its task path.** A specialist's
+     rows read `specialist/<instance>/turn-N`, so the instance is the agent and
+     `turn-N` is a position inside it. The readable name comes from the `role`
+     field where a producer wrote one -- on the runs seen so far that is
+     orchestration and critic rows, not specialists -- and an agent with none is
+     shown `unlabelled` rather than named from its id.
+   - **`KERNEL_AGENT / ...` phases are GEAK's own.** When the run left a
+     `geak_calls.jsonl` behind, GEAK's per-call ledger is grafted in beneath
+     `KERNEL_AGENT` and the harvested `ext/geak-*` rows are dropped in the same
+     step, because both describe the same API calls. The coverage banner says
+     which happened. A build without GEAK's trace mirror leaves no ledger to
+     graft, and then `KERNEL_AGENT` shows only what the harvester saw -- often a
+     single lumped agent for the phase that cost the most.
+
+6. **Answer the question that was asked.** The markdown tree is the artifact;
    the JSON (`tree` → `totals` per node) is what to compute from when comparing
    two runs. When comparing models, compare `usd_total` and `ms_total` per
    phase, not session totals alone — a cheaper session that spent it all in one

--- a/src/hyperloom/skills/hyperloom-llm-report/SKILL.md
+++ b/src/hyperloom/skills/hyperloom-llm-report/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: hyperloom-llm-report
+description: Render the per-LLM-call report for a finished Hyperloom session — every API call's ISL/OSL, tokens (input/thinking/output), wall-clock, USD cost and tool calls, arranged as a phase → task → subtask → sub-sub-task tree, including the GEAK subprocess spend. Use when asked where a run's time or money went, to compare two models' runs, or to audit the trace ledgers' coverage.
+---
+
+# Hyperloom per-LLM-call report
+
+Turns a session's trace ledgers into one report answering: *for every LLM API
+call this run made, what did it cost in tokens, seconds and dollars, and which
+task did it belong to?*
+
+## Inputs
+
+Everything comes from `<session_dir>/reports/trace/`:
+
+| File | Cardinality | Written by |
+| --- | --- | --- |
+| `llm_calls.jsonl` | one row per **agentic turn** | in-process backends |
+| `llm_calls_detail.jsonl` | one row per **API call**, joined on `call_id` | in-process backends |
+| `ext/<component>-<pid>.jsonl` | turn rows from an out-of-process child | that child |
+| `ext/<component>-<pid>.detail.jsonl` | its per-API-call rows | that child |
+| `ext/geak-*.jsonl` | GEAK's spend | the harvester, from GEAK's Claude Code transcripts |
+
+## Steps
+
+1. **Locate the session directory.** It is the directory containing
+   `reports/trace/`. If the user gave a model name rather than a path, look
+   under `$USER_DATA_PATH` and the Hyperloom session roots for the newest
+   session for that model. Confirm the path before rendering — a report for the
+   wrong run is worse than no report.
+
+2. **Render.** From the Hyperloom checkout:
+
+   ```bash
+   PYTHONPATH=src python3 -m hyperloom.inference_optimizer.tools.dump_llm_call_report \
+       --session-dir <SESSION_DIR>
+   ```
+
+   Writes `llm_call_report.md` and `llm_call_report.json` to
+   `$USER_DATA_PATH/reports/<session-id>/` (or `<session_dir>/reports/` when
+   `USER_DATA_PATH` is unset). `--output-dir` overrides; `--max-depth N` trims
+   the tree without changing any total.
+
+3. **Read the Coverage section before quoting any number**, and carry its
+   caveats into whatever you tell the user:
+
+   - **Unpriced calls.** Excluded from every USD figure. If any exist, the cost
+     total is a floor, not the bill — say so rather than presenting it as the
+     bill.
+   - **Cost sources.** `provider` is the vendor's own charge; `derived` is the
+     shipped rate card applied to token counts. A total spanning both is an
+     estimate.
+   - **Apportioned timing.** `latency_ms` is always measured. The
+     thinking/output split is measured only where the backend saw partial
+     stream events; otherwise it is the measured span divided in proportion to
+     the token counts. Report those two columns as estimates.
+   - **Turns without detail rows.** Counted once, from the turn row, so their
+     "per-call" line is really the turn's aggregate.
+   - **No `geak` subtree.** If the run invoked the kernel agent and no `geak`
+     node appears, GEAK's spend — historically the majority of a session's
+     bill — is missing, and the session total is badly understated. Check that
+     `reports/trace/ext/geak-*.jsonl` exists and that the harvester ran.
+
+4. **Answer the question that was asked.** The markdown tree is the artifact;
+   the JSON (`tree` → `totals` per node) is what to compute from when comparing
+   two runs. When comparing models, compare `usd_total` and `ms_total` per
+   phase, not session totals alone — a cheaper session that spent it all in one
+   phase is the finding.
+
+## Reading the numbers
+
+- **ISL** = `input_tokens + cache_read + cache_creation`; **OSL** =
+  `output_tokens + reasoning_output_tokens`.
+- **Thinking sits beside output, not inside it.** `output_tokens` excludes
+  thinking; OSL is output + thinking. Likewise `cost_usd` = input + output +
+  thinking + cache, so thinking is a part of the total but not a part of
+  `cost_output_usd`.
+- **Share-of-parent** is by cost where the parent has any, and by call count
+  otherwise.
+
+## Do not
+
+- Do not sum `llm_calls.jsonl` and `llm_calls_detail.jsonl` together — the
+  detail rows are the expansion of the turn rows, and the tool already avoids
+  counting a turn twice.
+- Do not append to `llm_calls.jsonl` from any tooling; that append is not
+  atomic across processes. Out-of-process producers write their own `ext/` shard.

--- a/src/hyperloom/skills/hyperloom-llm-report/SKILL.md
+++ b/src/hyperloom/skills/hyperloom-llm-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hyperloom-llm-report
-description: Render the per-LLM-call report for a finished Hyperloom session — every API call's ISL/OSL, tokens (input/thinking/output), wall-clock, USD cost and tool calls, arranged as a phase → task → subtask → sub-sub-task tree, including the GEAK subprocess spend. Use when asked where a run's time or money went, to compare two models' runs, or to audit the trace ledgers' coverage.
+description: Render the per-LLM-call report for a finished Hyperloom session — every API call's ISL/OSL, tokens (input/thinking/output), wall-clock, USD cost and tool calls, arranged as a phase → task → subtask → sub-sub-task tree, including the GEAK subprocess spend. Use when asked where a run's time or money went, to compare two models' runs, or to audit the trace ledgers' coverage. Also renders a self-contained HTML page joining that spend against the session's measured outcome.
 ---
 
 # Hyperloom per-LLM-call report
@@ -41,7 +41,24 @@ Everything comes from `<session_dir>/reports/trace/`:
    `USER_DATA_PATH` is unset). `--output-dir` overrides; `--max-depth N` trims
    the tree without changing any total.
 
-3. **Read the Coverage section before quoting any number**, and carry its
+3. **Render the HTML page too** when the answer is for a person rather than for
+   a computation:
+
+   ```bash
+   PYTHONPATH=src python3 -m hyperloom.inference_optimizer.tools.render_hyperloom_html_report \
+       --session-dir <SESSION_DIR> --output <SESSION_DIR>/reports/hyperloom_report.html
+   ```
+
+   It reads the same two ledgers plus `session_breakdown.json`, and adds what
+   the markdown tree cannot show: the outcome ladder (baseline to final, every
+   KEEP/REJECT decision), spend joined against measured gain as dollars per
+   +1 %, the ISL growth curve across a conversation, and the model mix. The
+   join is by a declared phase map, so **a phase outside that map renders "not
+   attributed" rather than being credited**, and a session with no
+   `session_breakdown.json` renders "not recorded" rather than "+0.00 %".
+   Self-contained, no network, no assets.
+
+4. **Read the Coverage section before quoting any number**, and carry its
    caveats into whatever you tell the user:
 
    - **Unpriced calls.** Excluded from every USD figure. If any exist, the cost
@@ -61,7 +78,7 @@ Everything comes from `<session_dir>/reports/trace/`:
      bill — is missing, and the session total is badly understated. Check that
      `reports/trace/ext/geak-*.jsonl` exists and that the harvester ran.
 
-4. **Answer the question that was asked.** The markdown tree is the artifact;
+5. **Answer the question that was asked.** The markdown tree is the artifact;
    the JSON (`tree` → `totals` per node) is what to compute from when comparing
    two runs. When comparing models, compare `usd_total` and `ms_total` per
    phase, not session totals alone — a cheaper session that spent it all in one

--- a/src/hyperloom/skills/hyperloom-llm-report/SKILL.md
+++ b/src/hyperloom/skills/hyperloom-llm-report/SKILL.md
@@ -41,8 +41,13 @@ Everything comes from `<session_dir>/reports/trace/`:
    `USER_DATA_PATH` is unset). `--output-dir` overrides; `--max-depth N` trims
    the tree without changing any total.
 
-3. **Render the HTML page too** when the answer is for a person rather than for
-   a computation:
+3. **Render the HTML page** when the answer is for a person rather than for a
+   computation. A run that finished normally has already written it to
+   `<SESSION_DIR>/reports/hyperloom_report.html` — the CLI renders it as the
+   last report step of every teardown, so reach for the command below only for
+   a session that predates that, one killed before teardown, or when you want a
+   different `--max-depth`. Re-rendering is safe; it overwrites in place.
+   (`HYPERLOOM_SKIP_HTML_REPORT=1` turns the automatic write off.)
 
    ```bash
    PYTHONPATH=src python3 -m hyperloom.inference_optimizer.tools.render_hyperloom_html_report \


### PR DESCRIPTION
## What this is

Right now, when a Hyperloom run finishes, we can tell you what the whole run cost —
but not what any individual piece of it cost. The ledger records one row per *turn*,
and a turn can be many API calls. So questions like "which task is eating our tokens?"
or "is this subtask cheap enough to hand to a smaller model?" have no answer in the data.

This PR adds that missing layer: **one row per LLM API call**, with the time, input
tokens (ISL), output tokens (OSL), thinking tokens, cache reads, tool calls and a
derived dollar cost — all hung off the task path that produced it. Plus two report
generators that turn those rows into a readable phase → task → subtask → tool tree.

## Why it matters

Two things came out of this the moment it started recording:

- **Sub-agent spend was invisible.** Specialist calls carried no `call_id` and no
  model name, so they got double-counted against their parent *and* priced at $0.
  Both bugs are fixed here. On a real session that correction moved the bill by ~5x.
- **We could finally see where the money goes.** On the Qwen3-14B-FP8 run, the GEAK
  phase alone is 74% of the session's LLM bill — which is not something anyone would
  have guessed from the turn-level numbers.

## What's in it

| Piece | What it does |
| --- | --- |
| `trace/call_detail.py` | Writes the per-call rows beside the existing turn rows |
| `trace/pricing.py` | Prices a call from a rate card shipped in-repo, so costs are reproducible and not hardcoded |
| `trace/geak_harvest.py` | Pulls GEAK's own spend out of its Claude Code transcripts |
| `tools/dump_llm_call_report.py` | Renders the Hyperloom-side report |
| `tools/dump_geak_call_report.py` | Renders the GEAK-side report |
| `tools/render_geak_html_report.py` | The GEAK run as a self-contained HTML page |
| `tools/render_hyperloom_html_report.py` | The **whole session** as an HTML page — every phase, not just GEAK |
| `tools/_report_html.py` | Formatting and stylesheet shared by both pages |
| `tools/_report_agents.py` | The per-phase deep dive shared by both pages |
| `skills/{hyperloom,geak}-llm-report/SKILL.md` | So you don't have to remember the flags |

Nothing existing changes shape: the turn rows are untouched, and the per-call rows are
additive. Totals still reconcile — that invariant is covered by the tests.

## The session-wide page

The GEAK HTML report answers where one phase's time and money went. A session also
spends in `FRAMEWORK_AGENT`, `PRELUDE`, `SWEEP` and `WARM_REPLAY`, and none of that
had a page. `render_hyperloom_html_report` covers all of them:

```bash
PYTHONPATH=src python3 -m hyperloom.inference_optimizer.tools.render_hyperloom_html_report \
    --session-dir <SESSION_DIR> --output <SESSION_DIR>/reports/hyperloom_report.html
```

It reads the same two ledgers as `dump_llm_call_report` — reusing its tree and its
counting rule, so every derived figure agrees with the tree totals — and joins them
against `session_breakdown.json` to show what the spend *bought*: the outcome ladder
from baseline to final with every KEEP/REJECT decision, dollars per +1% gain, the ISL
growth curve across a conversation, and the model mix.

The join is only as good as the map, so the page refuses to guess:

- Spend reaches a gain source only through a declared phase map. A phase outside it
  renders **not attributed** rather than being credited to whichever source is nearest.
- A session with no `session_breakdown.json` renders **not recorded**, never `+0.00%`.
  "Not measured" and "gained nothing" are different claims.
- Unpriced calls stay out of the USD total, which makes that total a floor — the
  coverage banner says so, with counts.
- Growth-curve buckets with fewer than three calls are dropped. A median of one call
  is not a median.

## Inside a phase, on both pages

The session page told you which phase cost the most and then stopped. The GEAK page,
on the same data one level down, told you where inside a phase the money went. Two
pages, one of them useful.

`tools/_report_agents.py` now holds that machinery and both pages render through it,
so a column means the same thing on either: cost by position in the conversation, how
few agents carry the phase, what tools the work consisted of, an agent roster where
every row drills into its own API calls, and the delegation-signals table.

Identity is the one thing the two ledgers genuinely disagree on, so it is injected
rather than assumed. GEAK's ledger carries prompt text and no label; Hyperloom's
carries a `role` field that some producers write and others do not — on a real
gpt-oss-120b session, 27 of 845 turn rows. So a Hyperloom agent is its task path
(`specialist/<instance>`, populated on 830 of those rows) and its *name* is the `role`
where one was recorded. An agent with neither is shown `unlabelled`, never named from
its id, and the coverage banner counts them.

`KERNEL_AGENT` is the phase this was worth doing for: 55.6% of that session's bill and,
seen from the session ledger alone, a single lumped agent. Where the run left a
`geak_calls.jsonl` behind, GEAK's own per-call ledger is grafted in beneath it — eval
dir read from `geak/result.json`, then `handoff.json`, then `state.json`, never guessed
from the directory layout — and the harvested `ext/geak-*` rows are dropped in the same
step, because both describe the same API calls and keeping both would bill GEAK twice.

A GEAK build without the trace mirror leaves no ledger to graft. The banner then says
so and names the tool that rebuilds it, rather than showing a thin phase and letting it
read as a cheap one.

## A note on reading the output

Every report leads with a **Coverage** line. If some calls couldn't be priced or matched
to a task, that line says so, and you should read it before quoting any number from the
report. A missing call is reported as missing, never as zero.

## Testing

- 63 new unit tests across call detail, pricing, GEAK harvest and both report tools —
  all passing.
- `ruff check` and `ruff format --check` clean on the new and touched modules.
- Verified end-to-end against a real finished run (Qwen3-14B-FP8): 5,140 calls,
  109 agents, ISL 579,743,865, OSL 2,818,841, $602.81, 0 unpriced.


- The shared-chrome refactor is provably a no-op: re-rendering the shipped
  Qwen3-14B-FP8 GEAK report from it is byte-identical apart from the generation
  timestamp. The deep-dive extraction was held to the same bar and passes it — the
  same 1.8 MB page, byte for byte, before and after.
- The session page rendered against the finished gpt-oss-120b run: 441 KB, and its
  per-phase spend sums to $184.36, which reconciles with that run's independently
  computed cost anatomy. The graft's absent-ledger branch is exercised by that same
  run, whose GEAK cycle predates the trace mirror.
- The session-wide page cross-checked against `dump_llm_call_report`'s JSON on a real
  gpt-oss-120b session — 248 calls, 203 turns, ISL 15,232,743, OSL 167,140, $3.669404,
  and the same per-phase shares — and independently recomputed straight from the JSONL
  by a script that imports neither tool, which agrees on every figure. A second session
  with no `session_breakdown.json` exercises the "not recorded" branch.

## One bug this shook out

Building the second reader against the first is what exposed it. The turn-to-detail
join used the raw `call_id`; where a producer wrote none — the specialist and critic
runners, on sessions recorded before they learned to emit one — the id collapsed to
`""` on both sides and matched nothing, so the detail row was booked as an orphan
*and* its turn was booked as undetailed and counted a second time.

On that gpt-oss-120b session, 195 of 247 detail rows had no call id and every one
matched a turn row on `(session_id, task_path, turn)` with byte-identical token
fields. Calls 443 → 248, ISL 27,131,576 → 15,232,743, OSL 332,731 → 167,140, agent
time 1:54:43 → 1:00:20, unpriced 390 → 195. **USD is unaffected** — the duplicated
rows were all unpriced, so the cost total and the per-phase shares were right all
along. `call_identity()` now makes the fallback key explicit and both readers go
through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
