### PR TITLE
ci: let the e2e job name its runner pool

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -177,7 +177,10 @@ jobs:
     if: needs.resolve.outputs.run == 'true'
     # Self-hosted runner registered with the label `Hyperloom-e2e-ci`
     # (config.sh --labels Hyperloom-e2e-ci). Must reach github.com + the run API.
-    runs-on: Hyperloom-e2e-ci
+    #
+    # Overridable so that a replacement runner can be proven on a real run before the
+    # pool moves to it. Unset, this is the pool it has always been.
+    runs-on: ${{ vars.CI_E2E_RUNNER_LABEL || 'Hyperloom-e2e-ci' }}
     # Covers a full MAX_HOURS run + setup/baseline overhead.
     timeout-minutes: 240
     steps:


### PR DESCRIPTION
One line, and the default is today's behaviour.

### Why

The two other self-hosted jobs in this repository already read their runner from a variable:

| file | line |
|---|---|
| `.github/workflows/forge-e2e.yml` | `runs-on: ${{ vars.FORGE_E2E_RUNNER_LABEL \|\| 'Hyperloom-e2e-ci' }}` |
| `.github/workflows/forge-kernel-bench.yml` | `runs-on: ${{ fromJSON(vars.KA_RUNNER_LABELS \|\| '[...]') }}` |

`ci-e2e.yml` is the last one with the label written into the file.

That matters when the runner pool has to be replaced. Today the only way to prove a new runner is to let it take a real pull request's check — the pool shares one label, so whichever machine is free picks up whatever job arrives. With a variable, a replacement can be given its own label, exercised by one deliberate run, and adopted only once it has passed.

### Behaviour

Unset, `vars.CI_E2E_RUNNER_LABEL` resolves to `Hyperloom-e2e-ci` — the same pool, the same scheduling. Nothing changes until somebody sets the variable, and unsetting it is the whole rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)