### PR TITLE
tier3 (2/2): fused MoE — the gate reaches the table the fleet actually loses time on

### DIFF
--- a/src/kernelforge/gemm_tune/cli.py
+++ b/src/kernelforge/gemm_tune/cli.py
@@ -10,11 +10,14 @@ import logging
 import sys
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import click
 
 from . import __version__
+
+if TYPE_CHECKING:
+    from .tuners.base import TuneResult
 
 log = logging.getLogger("kernelforge.gemm_tune")
 
@@ -104,20 +107,33 @@ def _load_demand_report(demand_json: str) -> dict | None:
         return None
 
 
-def _coverage_gaps(demand_report: dict | None, tuner_specs: list, output_dir: Path) -> list:
-    """Write the demanded tables no selected tuner will produce, and return them."""
+def _coverage_gaps(
+    demand_report: dict | None,
+    tuner_specs: list,
+    output_dir: Path,
+    results: list | None = None,
+) -> list:
+    """Write the demanded tables no selected tuner produced, and return them.
+
+    Called twice per run, and the difference is the point: before the tuners run
+    ``results`` is None and selection alone says what is uncovered; after, a
+    table whose owner came back empty-handed joins the list, which is the state
+    the runtime is in either way. Best-effort -- a report must not affect the
+    tuning it describes.
+    """
     if not demand_report:
         return []
     try:
         from .tier3 import coverage_gaps
 
-        gaps = coverage_gaps(demand_report, tuner_specs)
-        if not gaps:
-            return []
-        (output_dir / "coverage_gaps.json").write_text(
-            json.dumps([g.to_dict() for g in gaps], indent=2),
-            encoding="utf-8",
-        )
+        gaps = coverage_gaps(demand_report, tuner_specs, results)
+        # The second pass writes even when it finds nothing, or the pre-run
+        # file it supersedes would be read as this run's final answer.
+        if gaps or results is not None:
+            (output_dir / "coverage_gaps.json").write_text(
+                json.dumps([g.to_dict() for g in gaps], indent=2),
+                encoding="utf-8",
+            )
         return gaps
     except Exception:  # noqa: BLE001 - a report must never fail the run
         log.debug("could not record coverage gaps", exc_info=True)
@@ -132,13 +148,25 @@ def _attempt_tier3(
     profile: Any,
     gpu_type: str,
     framework: str,
-) -> dict | None:
-    """Try a generated tuner for the strongest gap nothing else can cover."""
+) -> "TuneResult | None":
+    """Try a generated tuner for the strongest gap nothing else covered.
+
+    Reached only for a table that went untuned anyway, so its time is not taken
+    from a tuner that would have covered it. Returns a ``TuneResult`` only when
+    the referee confirmed an improvement, so verified rows travel the same road
+    as every other tuner's -- candidate, report, e2e, deploy -- and everything
+    else stays off that road entirely.
+
+    Never raises. Note the caller must not compute arguments for this call
+    either: reading one wrong attribute off the profile at the call site took
+    down a completed run, because argument evaluation happens outside the guard.
+    Hence ``profile`` rather than fields pulled from it.
+    """
     if not gaps:
         return None
     try:
         model_name = str(getattr(profile, "model_path", "") or getattr(profile, "architecture", "") or "unknown")
-        from .evidence import load_demand
+        from .evidence import demand_shapes, load_demand
         from .tier3 import attempt_generated_tuner
         from .tier3.dispatch import adapters_for
         from .tier3.gate import should_generate
@@ -146,14 +174,20 @@ def _attempt_tier3(
         decision = should_generate(gaps)
         if not decision.allowed or decision.gap is None:
             log.info("tier3: not attempted -- %s", "; ".join(decision.reasons))
-            return {"attempted": False, "reasons": decision.reasons}
+            return None
 
         adapter = adapters_for(decision.gap.table)
         demand = load_demand(demand_json)
 
         def shapes_for(gap):
-            entry = demand.tables.get(gap.table) if demand else None
-            return list(getattr(entry, "shapes", None) or [])
+            # ``load_demand`` returns the parsed document, not an object: this
+            # read ``demand.tables`` and raised AttributeError inside the guard
+            # below, so every attempt died as "tier3 attempt failed" before it
+            # had a mandate to write.
+            for entry in (demand or {}).get("demands") or []:
+                if str(entry.get("table") or "") == gap.table:
+                    return demand_shapes(entry)
+            return []
 
         outcome = attempt_generated_tuner(
             gaps,
@@ -173,10 +207,46 @@ def _attempt_tier3(
             json.dumps(outcome.to_dict(), indent=2),
             encoding="utf-8",
         )
-        return outcome.to_dict()
+        return _tier3_result(outcome, decision.gap)
     except Exception:  # noqa: BLE001 - a bonus attempt must not fail the run
         log.warning("tier3 attempt failed; tuning continues", exc_info=True)
         return None
+
+
+def _tier3_result(outcome: Any, gap: Any) -> "TuneResult | None":
+    """A verified generated tuner as an ordinary tuner result, or nothing.
+
+    ``outcome.ok`` is the referee's verdict on our own clock, and nothing short
+    of it becomes a result: an attempt that stopped at the gate, failed the
+    contract, or was re-timed and found no faster kernel has produced no rows
+    worth deploying, and emitting it as a no-improvement result would only put
+    an unverified artifact in front of the integrate lane.
+
+    ``candidate=True`` rather than relying on ``has_improvement``, so this
+    lands on the same e2e-validated path as split-K: the referee's micro
+    speedup is measured on graph replays of individual kernels and is not by
+    itself a claim about end-to-end throughput.
+    """
+    from .tuners.base import TuneResult
+
+    if not outcome.ok or not outcome.output_csv:
+        return None
+    best = max(
+        (j.best_timing.speedup for j in outcome.judgements if j.best_timing and j.best_timing.usable),
+        default=1.0,
+    )
+    return TuneResult(
+        tuner_name=f"tier3_generated_{Path(outcome.table).stem}",
+        status="ok",
+        artifact_path=outcome.output_csv,
+        env_var=gap.env_var,
+        env_value=outcome.output_csv,
+        candidate=True,
+        total_shapes=len(outcome.judgements),
+        improved_shapes=outcome.improved_shapes,
+        best_micro_speedup=float(best or 1.0),
+        key_source="runtime_observed",
+    )
 
 
 def _normalize_inline_shapes_json(value: str, output_dir: Path) -> str:
@@ -616,9 +686,12 @@ def run(
             result.elapsed_s,
         )
 
-    # Last, and only on what the selected tuners left behind.
+    # Last, and only on what the selected tuners left behind: by now they have
+    # all run, so a generated tuner cannot take time from one that would have
+    # produced something, and the recomputed list says which of them did.
+    coverage_gap_list = _coverage_gaps(demand_report, tuner_specs, output_path, results)
     if coverage_gap_list and time.time() < global_deadline:
-        _attempt_tier3(
+        generated = _attempt_tier3(
             coverage_gap_list,
             demand_json,
             output_path,
@@ -626,6 +699,8 @@ def run(
             gpu_type=gpu_type,
             framework=framework,
         )
+        if generated is not None:
+            results.append(generated)
 
     # Build report
     total_elapsed = time.time() - start_time

--- a/src/kernelforge/gemm_tune/evidence.py
+++ b/src/kernelforge/gemm_tune/evidence.py
@@ -96,6 +96,49 @@ TABLE_TO_TUNER: dict[str, tuple[str, str]] = {
     "tuned_fmoe.csv": ("fmoe_ck", "AITER_CONFIG_FMOE"),
 }
 
+# The name a table has in an aiter miss line is not always the name it has in
+# ``TABLE_TO_TUNER``, for two reasons that compose:
+#
+# * A tuner's artifact is named after the tuner, not after the table the runtime
+#   looks it up in -- ``sglang_dense_bf16`` writes ``tuned_dense_bf16.csv`` for
+#   what aiter calls ``bf16_tuned_gemm.csv``.
+# * Deploy merges the candidate into the bundled default and lands the result as
+#   ``merged_<artifact>.csv``.
+#
+# So once we have deployed anything, the runtime misses against a name no map
+# here has ever heard of, and the demand entry it produces claims no owner. That
+# is not hypothetical: across the fleet's 0903-0906 serving logs,
+# ``merged_tuned_dense_bf16.csv`` accounts for 28,818 misses, all of them filed
+# as ownerless, while ``sglang_dense_bf16`` owns precisely that table. Anything
+# reading ``tuner is None`` as "nothing implements this" -- coverage gaps most of
+# all -- is then reading our own artifact as a hole in our coverage.
+ARTIFACT_TABLE_ALIASES: dict[str, str] = {
+    # Verified against each tuner's write path rather than inferred from its
+    # name: ``_aiter_dense_common.py`` writes ``tuned_{tuner_name}.csv`` and
+    # ``sglang_dense_bf16.py`` / ``fmoe_ck.py`` name theirs directly. ``fmoe_ck``
+    # needs no entry -- it writes ``tuned_fmoe.csv``, which is already the key.
+    "tuned_dense_bf16.csv": "bf16_tuned_gemm.csv",
+    "tuned_a8w8.csv": "a8w8_tuned_gemm.csv",
+    "tuned_a8w8_blockscale.csv": "a8w8_blockscale_tuned_gemm.csv",
+    "tuned_a8w8_bpreshuffle.csv": "a8w8_bpreshuffle_tuned_gemm.csv",
+    "tuned_a8w8_blockscale_bpreshuffle.csv": "a8w8_blockscale_bpreshuffle_tuned_gemm.csv",
+    "tuned_a4w4_blockscale.csv": "a4w4_blockscale_tuned_gemm.csv",
+}
+
+
+def canonical_table_name(name: str) -> str:
+    """The ``TABLE_TO_TUNER`` key for a table name as the runtime printed it.
+
+    Basename, minus the deploy-time ``merged_`` prefix, then through the artifact
+    aliases. Names that are already keys pass through untouched, and a genuinely
+    unknown name is returned as its own basename so it stays legible in a report.
+    """
+    base = str(name or "").strip().replace("\\", "/").rsplit("/", 1)[-1]
+    if base.startswith("merged_"):
+        base = base[len("merged_") :]
+    return ARTIFACT_TABLE_ALIASES.get(base, base)
+
+
 KEY_FIELDS = ("M", "N", "K", "dtype", "otype", "bias", "scaleAB", "bpreshuffle")
 
 SCHEMA_VERSION = "gemm_demand/v1"
@@ -254,7 +297,7 @@ def parse_log(text: str) -> dict[str, Any]:
                 table_path = (m.group("miss_table") or "").strip()
                 if table_path:
                     consulted.add(table_path)
-                base = table_path.rsplit("/", 1)[-1]
+                base = canonical_table_name(table_path)
                 tuner, env = TABLE_TO_TUNER.get(base, (None, None))
                 d = demands.get(base)
                 if d is None:

--- a/src/kernelforge/gemm_tune/evidence.py
+++ b/src/kernelforge/gemm_tune/evidence.py
@@ -66,6 +66,18 @@ MOE_KEY_FIELDS = MOE_TUPLE_FIELDS[2:]
 # identifies "the MoE shape to tune".
 MOE_SHAPE_FIELDS = tuple(f for f in MOE_KEY_FIELDS if f != "token")
 
+# The table fused-MoE misses are looked up in. Named here because the MoE side
+# records its misses under ``dispatch["moe"]`` rather than as a demand, and
+# turning those records into a demand needs the table's own name.
+MOE_TABLE = "tuned_fmoe.csv"
+
+# Kill switch for that conversion. It is on by default because the records it
+# reads are the only runtime evidence fmoe_ck has, but emitting the demand also
+# changes two behaviours outside this module -- the router starts selecting
+# fmoe_ck off the log, and ``demand_for_tuner(report, "fmoe_ck")`` stops
+# returning None -- so there has to be a way to put those back without a revert.
+MOE_DEMAND_DISABLE_ENV = "FORGE_MOE_DEMAND_DISABLE"
+
 # vLLM Triton MoE: found vs not-found are two different lines.
 VLLM_MOE_HIT = re.compile(r"Using configuration from (?P<path>\S+) for MoE layer")
 VLLM_MOE_MISS = re.compile(r"Config file not found at (?P<path>\S+)")
@@ -79,6 +91,10 @@ TABLE_KEY_SCHEMA: dict[str, tuple[str, ...]] = {
     "a8w8_bpreshuffle_tuned_gemm.csv": ("M", "N", "K", "q_dtype_w"),
     "a4w4_blockscale_tuned_gemm.csv": ("M", "N", "K"),
 }
+# ``tuned_fmoe.csv`` is deliberately absent. Its key schema is MOE_KEY_FIELDS,
+# but this map doubles as "is this a dense GEMM table?" -- vllm_dense_tunableop
+# borrows shapes from every table in it -- and a fused-MoE key has no (M, N, K)
+# for a dense tuner to borrow. The MoE demand carries its own key_schema.
 
 # Key columns the log actually exposes, so a demand entry can never claim one it did not observe.
 UNLOGGABLE_KEY_FIELDS = ("q_dtype_w",)
@@ -245,6 +261,12 @@ def _record_moe_key(moe: dict[str, Any], parts: list[str], *, miss: bool) -> int
             "cu_num": fields["cu_num"],
             "tokens": set(),
             "untuned_tokens": set(),
+            # Per-token miss counts, keyed by the token as a string so the
+            # record survives a JSON round trip unchanged. ``miss_count`` alone
+            # cannot say which token counts the runtime actually spent its
+            # misses on, and a demand that splits it evenly would be inventing
+            # the number it is asked for most.
+            "untuned_token_counts": {},
             "miss_count": 0,
         }
         moe["keys"][shape] = rec
@@ -252,9 +274,64 @@ def _record_moe_key(moe: dict[str, Any], parts: list[str], *, miss: bool) -> int
         rec["tokens"].add(token)
         if miss:
             rec["untuned_tokens"].add(token)
+            counts = rec.setdefault("untuned_token_counts", {})
+            counts[str(token)] = counts.get(str(token), 0) + 1
     if miss:
         rec["miss_count"] += 1
     return token
+
+
+def _moe_demand(report: dict[str, Any]) -> Demand | None:
+    """The fused-MoE misses, restated as a demand for ``tuned_fmoe.csv``.
+
+    MoE misses have always been recorded, but under ``dispatch["moe"]`` rather
+    than in ``demands`` -- so every consumer that reads the demand list saw a run
+    with millions of fmoe misses as a run with no MoE demand at all. The router
+    could not learn from the log that fmoe_ck was needed, ``demand_for_tuner``
+    answered None for it, and ``tuned_fmoe.csv`` could not become a coverage gap
+    however often the runtime missed it.
+
+    Nothing new is measured here. Each row is one (shape, token) pair the
+    runtime asked for and did not find, counted from the same lines, with the
+    stage attribution :func:`moe_ck_missed_keys` already applies -- a token only
+    ever seen on 1-stage dispatch is not something fmoe_ck's CK tuner can serve,
+    and handing it one would be demanding a row that cannot be produced.
+    """
+    if os.environ.get(MOE_DEMAND_DISABLE_ENV, "").strip().lower() in ("1", "true", "yes"):
+        return None
+    moe = ((report or {}).get("dispatch") or {}).get("moe") or {}
+    impl = str(moe.get("impl") or "")
+    if impl and impl != "aiter_ck":
+        # fmoe_ck tunes aiter's CK path. Under vLLM's Triton MoE -- or a log
+        # carrying both -- these keys do not describe what the runtime will
+        # dispatch, and a demand claiming otherwise would route a tuner at a
+        # backend it cannot reach.
+        return None
+
+    keys: list[dict[str, Any]] = []
+    for rec in moe_ck_missed_keys(report):
+        counts = rec.get("untuned_token_counts") or {}
+        for token in rec.get("untuned_tokens") or []:
+            row: dict[str, Any] = {f: str(rec.get(f, "")) for f in MOE_KEY_FIELDS}
+            row["token"] = str(token)
+            row["requests"] = _as_int(counts.get(str(token))) or 0
+            keys.append(row)
+    if not keys:
+        return None
+    keys.sort(key=lambda r: (-r["requests"], _as_int(r["token"]) or 0))
+
+    tuner, env_var = TABLE_TO_TUNER[MOE_TABLE]
+    return Demand(
+        table=MOE_TABLE,
+        tuner=tuner,
+        env_var=env_var,
+        key_schema=list(MOE_KEY_FIELDS),
+        # Every field of a MoE key comes off the dispatch tuple itself, so
+        # unlike the dense tables there is nothing here supplied from hardware.
+        logged_fields=list(MOE_KEY_FIELDS),
+        miss_count=sum(r["requests"] for r in keys),
+        keys=keys,
+    )
 
 
 def parse_log(text: str) -> dict[str, Any]:
@@ -392,7 +469,18 @@ def parse_log(text: str) -> dict[str, Any]:
     if moe and isinstance(moe.get("keys"), dict):
         # Most-missed key first, so a consumer that can only afford one row tunes the one the runtime asked for most.
         moe["keys"] = [
-            {**rec, "tokens": sorted(rec["tokens"]), "untuned_tokens": sorted(rec["untuned_tokens"])}
+            {
+                **rec,
+                "tokens": sorted(rec["tokens"]),
+                "untuned_tokens": sorted(rec["untuned_tokens"]),
+                "untuned_token_counts": {
+                    k: v
+                    for k, v in sorted(
+                        (rec.get("untuned_token_counts") or {}).items(),
+                        key=lambda kv: _as_int(kv[0]) or 0,
+                    )
+                },
+            }
             for rec in sorted(moe["keys"].values(), key=lambda r: (-r["miss_count"], -len(r["tokens"])))
         ]
         moe["miss_count"] = sum(r["miss_count"] for r in moe["keys"])
@@ -414,6 +502,10 @@ def parse_log(text: str) -> dict[str, Any]:
             dict(zip(KEY_FIELDS, k, strict=True)) | {"requests": n}
             for k, n in sorted(key_counts[base].items(), key=lambda kv: -kv[1])
         ]
+
+    moe_demand = _moe_demand({"dispatch": dispatch})
+    if moe_demand is not None:
+        demands[MOE_TABLE] = moe_demand
 
     ordered = sorted(demands.values(), key=lambda d: -d.miss_count)
     total = hits + misses
@@ -498,7 +590,14 @@ def demand_shapes(
     limit: int | None = None,
     bucket: bool = True,
 ) -> list[dict[str, Any]]:
-    """Requested keys for one table, most-requested first."""
+    """Requested keys for one table, most-requested first.
+
+    Fused-MoE keys are not M/N/K and are handled separately; everything else
+    goes through the padded-M bucketing below.
+    """
+    if canonical_table_name(entry.get("table") or "") == MOE_TABLE:
+        return _moe_demand_shapes(entry, limit=limit)
+
     shapes: list[dict[str, Any]] = []
     for key in entry.get("keys") or []:
         m, n, k = _as_int(key.get("M")), _as_int(key.get("N")), _as_int(key.get("K"))
@@ -529,6 +628,24 @@ def demand_shapes(
         for shape in shapes:
             shape["observed_M"] = sorted(set(shape["observed_M"]))
 
+    if limit is not None and limit > 0:
+        shapes = shapes[:limit]
+    return shapes
+
+
+def _moe_demand_shapes(entry: dict[str, Any], *, limit: int | None = None) -> list[dict[str, Any]]:
+    """Demanded shapes for the fused-MoE table.
+
+    Kept apart from the dense path rather than folded into it, because every
+    step of that path is dense-specific: a MoE key has no M/N/K to read, and the
+    padded-M bucketing that makes a dense budget worth spending has no analogue
+    here -- aiter looks a fmoe row up at the exact token count, so collapsing
+    two token counts into one row would drop one of them. The keys are already
+    one row per (shape, token) the runtime asked for, ranked by how often; the
+    budget just takes the front of that list.
+    """
+    shapes = [dict(key) for key in entry.get("keys") or []]
+    shapes.sort(key=lambda s: (-(_as_int(s.get("requests")) or 0), _as_int(s.get("token")) or 0))
     if limit is not None and limit > 0:
         shapes = shapes[:limit]
     return shapes

--- a/src/kernelforge/gemm_tune/tests/test_demand_from_serving_log.py
+++ b/src/kernelforge/gemm_tune/tests/test_demand_from_serving_log.py
@@ -81,7 +81,10 @@ class TestDerivingDemand:
 
         assert path == str(out / "demand.json")
         report = json.loads((out / "demand.json").read_text(encoding="utf-8"))
-        assert not report["demands"]  # no dense miss anywhere in this log
+        # No dense miss anywhere in this log, so the only demand is the MoE one
+        # the dispatch record now also states as a demand.
+        (dense,) = [d for d in report["demands"] if d["table"] != "tuned_fmoe.csv"] or [None]
+        assert dense is None
         (key,) = moe_dispatch_keys(report)
         assert key["tokens"] == [16]
         assert key["inter_dim"] == "384"

--- a/src/kernelforge/gemm_tune/tests/test_evidence.py
+++ b/src/kernelforge/gemm_tune/tests/test_evidence.py
@@ -204,3 +204,77 @@ class TestRobustness:
         d = ev.parse_log(line)["demands"][0]
         assert d["table"] == "brand_new.csv"
         assert d["tuner"] is None and d["key_schema"] == ["M", "N", "K"]
+
+
+class TestDeployedTableNamesResolveToTheirOwner:
+    """The deployed name of a table must not read as an ownerless one.
+
+    Deploy renames twice on the way to the runtime -- the artifact is named
+    after the tuner, and the merge prefixes it -- so a table we tuned ourselves
+    comes back as ``merged_tuned_dense_bf16.csv``. Before this resolution the
+    fleet's 0903-0906 logs filed all 28,818 of those misses under ``tuner:
+    None``, which is the same signal a genuinely unimplemented table gives.
+    Anything acting on that signal -- Tier-3's coverage gaps above all -- would
+    have been acting on our own artifact.
+    """
+
+    @staticmethod
+    def _miss(table: str) -> str:
+        return f"[aiter] shape is M:512, N:1536, K:7168, not found tuned config in {table}"
+
+    def test_deployed_dense_bf16_is_owned(self):
+        d = ev.parse_log(self._miss("/tmp/aiter_configs/merged_tuned_dense_bf16.csv"))["demands"][0]
+        assert d["table"] == "bf16_tuned_gemm.csv"
+        assert d["tuner"] == "sglang_dense_bf16"
+        assert d["env_var"] == "AITER_CONFIG_GEMM_BF16"
+
+    def test_undeployed_artifact_name_is_owned_too(self):
+        d = ev.parse_log(self._miss("/work/tuned_dense_bf16.csv"))["demands"][0]
+        assert d["table"] == "bf16_tuned_gemm.csv" and d["tuner"] == "sglang_dense_bf16"
+
+    def test_runtime_name_is_unchanged(self):
+        d = ev.parse_log(self._miss("/tmp/aiter_configs/bf16_tuned_gemm.csv"))["demands"][0]
+        assert d["table"] == "bf16_tuned_gemm.csv" and d["tuner"] == "sglang_dense_bf16"
+
+    def test_deployed_and_runtime_names_are_one_demand(self):
+        rep = ev.parse_log(
+            "\n".join(
+                [
+                    self._miss("/tmp/aiter_configs/bf16_tuned_gemm.csv"),
+                    self._miss("/tmp/aiter_configs/merged_tuned_dense_bf16.csv"),
+                ]
+            )
+        )
+        assert len(rep["demands"]) == 1
+        assert rep["demands"][0]["miss_count"] == 2
+
+    def test_key_schema_follows_the_resolved_table(self):
+        # Under the old basename lookup this fell back to bare M,N,K.
+        d = ev.parse_log(self._miss("merged_tuned_dense_bf16.csv"))["demands"][0]
+        assert d["key_schema"] == list(ev.TABLE_KEY_SCHEMA["bf16_tuned_gemm.csv"])
+
+    def test_fmoe_artifact_needs_no_alias(self):
+        d = ev.parse_log(self._miss("/tmp/merged_tuned_fmoe.csv"))["demands"][0]
+        assert d["table"] == "tuned_fmoe.csv" and d["tuner"] == "fmoe_ck"
+
+    def test_genuinely_unknown_table_stays_ownerless(self):
+        d = ev.parse_log(self._miss("/tmp/merged_brand_new.csv"))["demands"][0]
+        assert d["table"] == "brand_new.csv" and d["tuner"] is None
+
+
+class TestCanonicalTableName:
+    def test_every_alias_target_has_an_owner(self):
+        # An alias pointing at a table nobody owns would be worse than none:
+        # it renames the miss and still reports it as a coverage hole.
+        for artifact, table in ev.ARTIFACT_TABLE_ALIASES.items():
+            assert table in ev.TABLE_TO_TUNER, artifact
+
+    def test_every_owned_table_is_its_own_canonical_form(self):
+        for table in ev.TABLE_TO_TUNER:
+            assert ev.canonical_table_name(table) == table
+
+    def test_windows_separators_and_whitespace(self):
+        assert ev.canonical_table_name(r"  C:\aiter\merged_tuned_dense_bf16.csv ") == "bf16_tuned_gemm.csv"
+
+    def test_empty_is_empty_not_a_crash(self):
+        assert ev.canonical_table_name("") == ""

--- a/src/kernelforge/gemm_tune/tests/test_moe_demand.py
+++ b/src/kernelforge/gemm_tune/tests/test_moe_demand.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""The fused-MoE misses, stated as a demand instead of only as a dispatch fact.
+
+The records were always there. They were filed under ``dispatch["moe"]``, and
+every consumer that asks "what did this run demand?" reads ``demands`` -- so a
+run with millions of fmoe misses answered "nothing". Three things followed from
+that one placement: the router could not learn from the log that ``fmoe_ck`` was
+needed, ``demand_for_tuner(report, "fmoe_ck")`` was None however much the
+runtime had missed, and ``tuned_fmoe.csv`` could never become a coverage gap,
+which is the door tier3 comes through.
+
+Nothing new is measured here, and that is the point -- these tests pin the
+mapping down to the records, including the two places it must refuse: a token
+CK did not serve, and a runtime whose MoE is not CK at all.
+
+The tuple literals are verbatim from a production sglang log (MiniMax-M3-MXFP4,
+TP8, gfx950), the same source as ``test_moe_runtime_key``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kernelforge.gemm_tune import evidence as ev
+
+_TUPLE = (
+    "('gfx950', 256, {tok}, 6144, 384, 128, 4, <ActivationType.Swiglu: 2>, "
+    "'torch.bfloat16', 'torch.float4_e2m1fn_x2', 'torch.float4_e2m1fn_x2', "
+    "'QuantType.per_1x32', True, False)"
+)
+_MISS = (
+    "[aiter] [fused_moe] no tuned FlyDSL config for "
+    + _TUPLE
+    + ", using heuristic FlyDSL fallback (kn1='flydsl_moe1_afp4_wfp4_bf16', "
+    "kn2='flydsl_moe2_afp4_wfp4_bf16')"
+)
+_2STAGE = "[aiter] [fused_moe] using 2stage ck for " + _TUPLE
+_1STAGE = "[aiter] [fused_moe] using 1stage asm for " + _TUPLE
+_TRITON = "Using configuration from /x/E=8,N=14336.json for MoE layer"
+
+
+def _log(*lines: str) -> dict:
+    return ev.parse_log("\n".join(lines) + "\n")
+
+
+def _fmoe(report: dict):
+    entries = [d for d in report["demands"] if d["table"] == "tuned_fmoe.csv"]
+    return entries[0] if entries else None
+
+
+class TestTheMissesBecomeADemand:
+    def test_the_demand_exists_and_names_its_owner(self):
+        entry = _fmoe(_log(_MISS.format(tok=16)))
+        assert entry is not None, "a run that missed fmoe demanded fmoe"
+        assert entry["tuner"] == "fmoe_ck"
+        assert entry["env_var"] == "AITER_CONFIG_FMOE"
+
+    def test_the_key_schema_is_the_fmoe_csv_header(self):
+        # Not (M, N, K): a fused-MoE row is keyed on the dispatch tuple, and the
+        # header aiter reads untuned_fmoe.csv with is what a tuner must produce.
+        entry = _fmoe(_log(_MISS.format(tok=16)))
+        assert entry["key_schema"] == list(ev.MOE_KEY_FIELDS)
+        assert "token" in entry["key_schema"]
+
+    def test_one_row_per_token_the_runtime_asked_for(self):
+        # Keys collapse across token counts so the shape stays one row; a demand
+        # does not, because aiter looks a row up at the exact token count.
+        entry = _fmoe(_log(_MISS.format(tok=16), _MISS.format(tok=64)))
+        assert sorted(k["token"] for k in entry["keys"]) == ["16", "64"]
+        assert all(k["inter_dim"] == "384" for k in entry["keys"])
+
+    def test_requests_are_counted_per_token_not_split_evenly(self):
+        # The shape-level miss_count cannot say which token count the runtime
+        # spent its misses on, and dividing it would invent the answer.
+        entry = _fmoe(_log(_MISS.format(tok=16), _MISS.format(tok=16), _MISS.format(tok=64)))
+        by_token = {k["token"]: k["requests"] for k in entry["keys"]}
+        assert by_token == {"16": 2, "64": 1}
+
+    def test_the_most_requested_token_comes_first(self):
+        entry = _fmoe(_log(_MISS.format(tok=64), _MISS.format(tok=16), _MISS.format(tok=16)))
+        assert entry["keys"][0]["token"] == "16"
+
+    def test_miss_count_is_the_sum_of_what_was_counted(self):
+        entry = _fmoe(_log(_MISS.format(tok=16), _MISS.format(tok=16), _MISS.format(tok=64)))
+        assert entry["miss_count"] == 3
+        assert entry["distinct_keys"] == 2
+
+    def test_a_run_that_never_missed_demands_nothing(self):
+        # A dispatch line is not a demand: it says the runtime called fused_moe,
+        # not that it went looking for a tuned row and failed.
+        assert _fmoe(_log(_2STAGE.format(tok=16))) is None
+
+
+class TestItRefusesWhatCannotBeServed:
+    def test_a_token_only_1stage_ever_served_is_not_demanded(self):
+        # fmoe_ck tunes the CK 2-stage path. Demanding a row for a token the log
+        # only ever saw on the asm 1-stage path asks for a row nothing reads.
+        report = _log(
+            _2STAGE.format(tok=16),
+            _1STAGE.format(tok=4096),
+            _MISS.format(tok=16),
+            _MISS.format(tok=4096),
+        )
+        entry = _fmoe(report)
+        assert [k["token"] for k in entry["keys"]] == ["16"]
+
+    def test_a_triton_moe_run_demands_nothing_from_the_ck_tuner(self):
+        # Both kinds of line in one log means the runtime is not simply CK, and
+        # these keys no longer describe what it will dispatch.
+        assert _fmoe(_log(_MISS.format(tok=16), _TRITON)) is None
+
+    def test_the_dispatch_record_is_left_alone_either_way(self):
+        # The demand is a restatement, not a move: consumers of the dispatch
+        # facts must not lose them because a demand was added beside them.
+        report = _log(_MISS.format(tok=16), _TRITON)
+        (key,) = ev.moe_dispatch_keys(report)
+        assert key["untuned_tokens"] == [16]
+
+
+class TestWhatItUnblocks:
+    def test_the_tuner_can_now_find_its_own_demand(self):
+        report = _log(_MISS.format(tok=16))
+        assert ev.demand_for_tuner(report, "fmoe_ck") is not None
+
+    def test_the_demand_yields_shapes(self):
+        # demand_shapes reads M/N/K and buckets on padded M. A MoE key has
+        # neither, so the dense path returned [] for it -- a demand that
+        # produces no shapes is a mandate with nothing in it to cover.
+        entry = _fmoe(_log(_MISS.format(tok=16), _MISS.format(tok=64)))
+        shapes = ev.demand_shapes(entry)
+        assert len(shapes) == 2
+        assert {s["token"] for s in shapes} == {"16", "64"}
+        assert "observed_M" not in shapes[0], "padded-M bucketing does not apply to fmoe rows"
+
+    def test_the_budget_takes_the_most_requested_first(self):
+        entry = _fmoe(_log(_MISS.format(tok=64), _MISS.format(tok=16), _MISS.format(tok=16)))
+        (shape,) = ev.demand_shapes(entry, limit=1)
+        assert shape["token"] == "16"
+
+    def test_the_router_selects_the_ck_tuner_off_the_demand(self):
+        # The demand branch adds a tuner the framework branch left out. Before
+        # this, no demand ever named fmoe_ck, so that branch could not reach it
+        # however many times the runtime had missed its table.
+        from kernelforge.gemm_tune.model_analyzer import ModelProfile
+        from kernelforge.gemm_tune.router import select_tuners
+
+        specs = select_tuners(
+            ModelProfile(model_path="/fake", architecture="LlamaForCausalLM"),
+            framework="sglang",
+            precision="bf16",
+            quant_type="none",
+            gpu_type="mi355x",
+            demand_report=_log(_MISS.format(tok=16)),
+        )
+        assert "fmoe_ck" in [s.name for s in specs if not s.skip_reason]
+
+    def test_a_dense_tuner_does_not_borrow_moe_shapes(self):
+        # vllm_dense_tunableop borrows shapes from every table in
+        # TABLE_KEY_SCHEMA when it has no demand of its own. A fused-MoE key has
+        # no (M, N, K) to borrow, so tuned_fmoe.csv must stay out of that map.
+        assert "tuned_fmoe.csv" not in ev.TABLE_KEY_SCHEMA
+
+
+class TestTheKillSwitch:
+    def test_it_can_be_turned_off_without_a_revert(self, monkeypatch):
+        # Emitting this demand changes two behaviours outside evidence.py, so
+        # there has to be a way to put them back that is not a code change.
+        monkeypatch.setenv(ev.MOE_DEMAND_DISABLE_ENV, "1")
+        report = _log(_MISS.format(tok=16))
+        assert _fmoe(report) is None
+        # And the records it was built from are still reported.
+        assert ev.moe_dispatch_keys(report)
+
+    @pytest.mark.parametrize("value", ["", "0", "no"])
+    def test_it_is_on_unless_the_switch_says_otherwise(self, monkeypatch, value):
+        monkeypatch.setenv(ev.MOE_DEMAND_DISABLE_ENV, value)
+        assert _fmoe(_log(_MISS.format(tok=16))) is not None

--- a/src/kernelforge/gemm_tune/tests/test_moe_dispatch.py
+++ b/src/kernelforge/gemm_tune/tests/test_moe_dispatch.py
@@ -46,7 +46,10 @@ _KEY = {
 }
 _SHAPE = "|".join(f"{k}={v}" for k, v in _KEY.items())
 _KN1 = "flydsl_moe1_afp4_wfp4_bf16_t32x64x256_w3_kw2_fp4"
-_KN2 = "flydsl_moe2_afp4_wfp4_bf16_t32x128x256_atomic"
+# Tile K=128, not 256: stage 2 walks K over inter_dim, and 384 % 256 sends
+# aiter to a smaller tile than the name says. This fixture read 256 until the
+# check for it existed, which is the case for the check.
+_KN2 = "flydsl_moe2_afp4_wfp4_bf16_t32x128x128_atomic"
 _CAND = {"backend": "aiter_fmoe", "config": f"block_m=32;ksplit=0;kernelName1={_KN1};kernelName2={_KN2}"}
 
 
@@ -182,6 +185,91 @@ class TestThePairAiterWillActuallyRun:
         # resolve, which _build already catches -- and a list maintained on
         # this side would go stale against the generator that owns it.
         assert dp.aiter_honours_kernel_pair("flydsl_moe1_no_such_tile", "flydsl_moe2_no_such_tile")
+
+
+class TestAPairThatNamesOneKernelAndRunsAnother:
+    """Both silent substitutions, refused on paper rather than measured.
+
+    aiter downgrades a tile that does not divide the dimension it walks, and
+    indexes tokens at ``block_m`` regardless of what the names say. Neither
+    faults; both were measured on gfx950 returning a mean error near 1.4 while
+    running *faster* than the default path.
+    """
+
+    def test_a_tile_that_divides_is_fine(self):
+        assert (
+            dp.flydsl_pair_misconfigured(
+                "flydsl_moe1_afp4_wfp4_bf16_t32x128x256_w2",
+                "flydsl_moe2_afp4_wfp4_bf16_t32x128x128_atomic",
+                32,
+                384,
+            )
+            == ""
+        )
+
+    def test_stage_one_tile_n_that_does_not_divide_inter_dim(self):
+        # 384 % 256 -- aiter's resolve_flydsl_stage1_tile_n would run 128.
+        assert "stage-1 tile N=256" in dp.flydsl_pair_misconfigured(
+            "flydsl_moe1_afp4_wfp4_bf16_t32x256x256",
+            "flydsl_moe2_afp4_wfp4_bf16_t32x128x128_atomic",
+            32,
+            384,
+        )
+
+    def test_stage_two_tile_k_that_does_not_divide_inter_dim(self):
+        assert "stage-2 tile K=256" in dp.flydsl_pair_misconfigured(
+            "flydsl_moe1_afp4_wfp4_bf16_t32x128x256",
+            "flydsl_moe2_afp4_wfp4_bf16_t32x128x256_atomic",
+            32,
+            384,
+        )
+
+    def test_the_same_tile_is_legal_when_it_does_divide(self):
+        # The constraint is on the shape, not on the number: inter_dim=512
+        # makes both of the above legal.
+        assert (
+            dp.flydsl_pair_misconfigured(
+                "flydsl_moe1_afp4_wfp4_bf16_t32x256x256",
+                "flydsl_moe2_afp4_wfp4_bf16_t32x128x256_atomic",
+                32,
+                512,
+            )
+            == ""
+        )
+
+    def test_block_m_below_the_tile(self):
+        # The measured case: t128 stage 1 with the default block_m of 32 ran at
+        # 71.70us against a 111.67us baseline and was wrong by 1.404.
+        assert "block_m=32 is not the stage-1 tile M=128" in dp.flydsl_pair_misconfigured(
+            "flydsl_moe1_afp4_wfp4_bf16_t128x128x256",
+            "flydsl_moe2_afp4_wfp4_bf16_t128x128x128_atomic",
+            32,
+            384,
+        )
+
+    def test_block_m_matching_only_one_of_the_two(self):
+        assert "stage-2 tile M=32" in dp.flydsl_pair_misconfigured(
+            "flydsl_moe1_afp4_wfp4_bf16_t128x128x256",
+            "flydsl_moe2_afp4_wfp4_bf16_t32x128x128_atomic",
+            128,
+            384,
+        )
+
+    def test_a_foreign_partner_is_not_second_guessed(self):
+        # A CKTile name carries no t<M>x<N>x<K>, so there is nothing to check.
+        # Skipping it beats inventing a reading of a spelling we do not own.
+        assert (
+            dp.flydsl_pair_misconfigured(
+                "flydsl_moe1_afp4_wfp4_bf16_t32x128x256",
+                "cktile_moe2_something",
+                32,
+                384,
+            )
+            == ""
+        )
+
+    def test_a_flydsl_name_with_no_tile_at_all_is_left_alone(self):
+        assert dp.flydsl_tile("flydsl_moe1_no_such_tile") is None
 
 
 class TestReadingBackWhatAiterServed:

--- a/src/kernelforge/gemm_tune/tests/test_moe_dispatch.py
+++ b/src/kernelforge/gemm_tune/tests/test_moe_dispatch.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""The fused-MoE dispatch adapter, in the parts that do not need a GPU.
+
+What a GPU settled, and what these tests therefore take as given (measured on
+an MI355X, gfx950, aiter d9e5ef7ce, the production MiniMax-M3-MXFP4 key):
+
+* the FlyDSL-shuffled weights pair with the FlyDSL scales, and crossing the
+  pairings returns NaN rather than failing;
+* ``fused_moe`` derives ``q_dtype_a`` itself and will not serve the fp4-
+  activation key below 256 tokens, so a demanded key is not always reachable;
+* switching ``AITER_CONFIG_FMOE`` mid-process moves nothing unless three caches
+  are cleared with it;
+* a candidate aiter declines to take is served by the default path, and would
+  be timed as a tie.
+
+The last two are why :meth:`_build` reads the resolved kernel names back out of
+aiter's log instead of trusting that writing the row was enough, and that
+read-back is the part worth pinning here: it is the only thing standing between
+"the row was ignored" and "the candidate tied with the baseline".
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from kernelforge.gemm_tune.evidence import MOE_KEY_FIELDS, MOE_TABLE
+from kernelforge.gemm_tune.tier3 import dispatch as dp
+
+_KEY = {
+    "token": "512",
+    "model_dim": "6144",
+    "inter_dim": "384",
+    "expert": "128",
+    "topk": "4",
+    "act_type": "ActivationType.Swiglu",
+    "dtype": "torch.bfloat16",
+    "q_dtype_a": "torch.float4_e2m1fn_x2",
+    "q_dtype_w": "torch.float4_e2m1fn_x2",
+    "q_type": "QuantType.per_1x32",
+    "use_g1u1": "1",
+    "doweight_stage1": "0",
+}
+_SHAPE = "|".join(f"{k}={v}" for k, v in _KEY.items())
+_KN1 = "flydsl_moe1_afp4_wfp4_bf16_t32x64x256_w3_kw2_fp4"
+_KN2 = "flydsl_moe2_afp4_wfp4_bf16_t32x128x256_atomic"
+_CAND = {"backend": "aiter_fmoe", "config": f"block_m=32;ksplit=0;kernelName1={_KN1};kernelName2={_KN2}"}
+
+
+class TestTheShapeKey:
+    def test_it_round_trips_the_whole_dispatch_key(self):
+        assert dp.moe_shape_key(_SHAPE) == _KEY
+
+    def test_it_keeps_schema_order_whatever_order_it_was_written_in(self):
+        # Downstream writes these into a CSV column by column, so the order the
+        # author happened to use must not reach it.
+        shuffled = "|".join(f"{k}={_KEY[k]}" for k in reversed(list(_KEY)))
+        assert list(dp.moe_shape_key(shuffled)) == list(MOE_KEY_FIELDS)
+
+    @pytest.mark.parametrize("value", ["torch.float4_e2m1fn_x2", "QuantType.per_1x32"])
+    def test_values_containing_dots_and_x_survive(self, value):
+        # The reason this is not MxNxK: two of the twelve values contain an "x"
+        # and four contain a ".", so every obvious positional encoding is
+        # ambiguous against the data it has to carry.
+        assert value in dp.moe_shape_key(_SHAPE).values()
+
+    def test_a_missing_field_says_which_one(self):
+        partial = "|".join(f"{k}={v}" for k, v in _KEY.items() if k != "topk")
+        with pytest.raises(ValueError, match="topk"):
+            dp.moe_shape_key(partial)
+
+    def test_a_dense_shape_is_refused_rather_than_half_read(self):
+        with pytest.raises(ValueError):
+            dp.moe_shape_key("8192x3456x1152")
+
+
+class TestTheAdapterIsReachable:
+    def test_the_table_has_an_adapter_now(self):
+        assert MOE_TABLE in dp.SUPPORTED_TABLES
+        assert dp.adapters_for(MOE_TABLE) is not None
+
+    def test_a_table_we_still_cannot_serve_says_so(self):
+        assert dp.adapters_for("a4w4_blockscale_tuned_gemm.csv") is None
+
+    def test_the_mandate_describes_the_moe_protocol(self):
+        # An author working from the mandate alone has to learn the shape
+        # encoding and the config keys from it; nothing else tells them.
+        text = dp.describe_candidate_protocol(MOE_TABLE)
+        assert "kernelName1" in text and "kernelName2" in text
+        assert "aiter_fmoe" in text
+        for field in MOE_KEY_FIELDS:
+            assert field in text
+
+    def test_the_dense_protocol_is_untouched(self):
+        assert "MxNxK" in dp.describe_candidate_protocol("bf16_tuned_gemm.csv")
+
+
+class TestTheCandidateBecomesARow:
+    def _adapter(self, monkeypatch):
+        adapter = dp._FusedMoeAdapter()
+        monkeypatch.setattr(adapter, "_gfx", lambda: "gfx950")
+        monkeypatch.setattr(adapter, "_cu_num", lambda: 256)
+        return adapter
+
+    def test_the_row_is_the_key_plus_the_kernels(self, monkeypatch):
+        adapter = self._adapter(monkeypatch)
+        path, kn1, kn2 = adapter._candidate_csv(_SHAPE, _CAND)
+        header, row = path.read_text(encoding="utf-8").splitlines()
+        cells = dict(zip(header.split(","), row.split(","), strict=True))
+        assert (kn1, kn2) == (_KN1, _KN2)
+        assert cells["kernelName1"] == _KN1
+        assert cells["gfx"] == "gfx950" and cells["cu_num"] == "256"
+        for field, value in _KEY.items():
+            assert cells[field] == value
+
+    def test_the_header_is_the_one_aiter_reads(self, monkeypatch):
+        # Transcribed from a file aiter's own tuner wrote on gfx950. A column
+        # out of place here is a config aiter silently declines to match.
+        adapter = self._adapter(monkeypatch)
+        path, _, _ = adapter._candidate_csv(_SHAPE, _CAND)
+        assert path.read_text(encoding="utf-8").splitlines()[0] == (
+            "gfx,cu_num,token,model_dim,inter_dim,expert,topk,act_type,dtype,q_dtype_a,q_dtype_w,"
+            "q_type,use_g1u1,doweight_stage1,block_m,ksplit,us1,kernelName1,err1,us2,kernelName2,"
+            "err2,us,run_1stage,xbf16,flat,tflops,bw"
+        )
+
+    def test_the_baseline_table_is_empty_not_absent(self, monkeypatch):
+        # Unsetting AITER_CONFIG_FMOE would let aiter fall back to whatever
+        # tuned file is installed -- on a fleet box, one we deployed. Timing a
+        # candidate against our own previous answer is not a baseline.
+        adapter = self._adapter(monkeypatch)
+        assert adapter._baseline_csv.read_text(encoding="utf-8").strip().startswith("gfx,cu_num,token")
+        assert len(adapter._baseline_csv.read_text(encoding="utf-8").splitlines()) == 1
+
+    @pytest.mark.parametrize(
+        "cand",
+        [
+            {"backend": "aiter_flydsl", "config": f"kernelName1={_KN1};kernelName2={_KN2}"},
+            {"backend": "aiter_fmoe", "config": f"kernelName1={_KN1}"},
+            {"backend": "aiter_fmoe", "config": "tile_m=32;tile_n=64"},
+            {"backend": "aiter_fmoe", "config": "kernelName1=nope1;kernelName2=nope2"},
+        ],
+    )
+    def test_a_candidate_it_cannot_dispatch_is_refused_on_paper(self, monkeypatch, cand):
+        # Refused before any GPU work: an unknown backend or a missing kernel
+        # name cannot become a row, and guessing what was meant would time
+        # something nobody proposed.
+        assert self._adapter(monkeypatch)._candidate_csv(_SHAPE, cand) is None
+
+
+class TestThePairAiterWillActuallyRun:
+    """The guard the log read-back cannot be: aiter logs, then discards.
+
+    Measured on hardware before this existed: a candidate naming ``nope1`` and
+    ``nope2`` was logged by aiter verbatim as the pair it was using, ran the
+    heuristic kernels instead, and timed 1.1% faster than the baseline -- a
+    phantom win, over the referee's 1.01 floor.
+    """
+
+    def test_a_flydsl_stage_one_carries_a_foreign_partner(self):
+        # The partner is dispatched, but only from inside the branch the FlyDSL
+        # name opened, so one of the two is enough.
+        assert dp.aiter_honours_kernel_pair(_KN1, "cktile_moe2_something")
+
+    def test_a_flydsl_stage_two_is_enough_on_its_own(self):
+        assert dp.aiter_honours_kernel_pair("ck_moe_stage1_something", _KN2)
+
+    def test_neither_flydsl_means_the_row_is_read_and_dropped(self):
+        assert not dp.aiter_honours_kernel_pair("nope1", "nope2")
+
+    def test_a_plausible_looking_ck_pair_is_still_refused(self):
+        # Not a typo-catcher: these are names aiter uses elsewhere. They are
+        # refused because on this path nothing would consult them.
+        assert not dp.aiter_honours_kernel_pair("cktile_moe1_afp4", "cktile_moe2_afp4")
+
+    def test_a_fake_flydsl_name_is_left_to_aiter_to_reject(self):
+        # Deliberately not validated against a name list here. aiter raises
+        # ValueError("Invalid FlyDSL kernel name: ...") for one it cannot
+        # resolve, which _build already catches -- and a list maintained on
+        # this side would go stale against the generator that owns it.
+        assert dp.aiter_honours_kernel_pair("flydsl_moe1_no_such_tile", "flydsl_moe2_no_such_tile")
+
+
+class TestReadingBackWhatAiterServed:
+    """The check that separates "ignored" from "tied"."""
+
+    @staticmethod
+    def _emitting(*messages: str):
+        def run():
+            for message in messages:
+                logging.getLogger("aiter").info(message)
+
+        return run
+
+    def test_it_finds_the_kernel_pair_aiter_named(self, monkeypatch):
+        adapter = dp._FusedMoeAdapter()
+        monkeypatch.setattr(adapter, "_torch", staticmethod(lambda: _FakeTorch()))
+        served = adapter._resolved_kernels(
+            self._emitting(f"[fused_moe] using 2stage (kernelName1='{_KN1}', kernelName2='{_KN2}') for (...)")
+        )
+        assert served == (_KN1, _KN2)
+
+    def test_the_heuristic_fallback_names_no_pair(self, monkeypatch):
+        # This is the line the baseline produces. Reading it as a match would
+        # make every unreachable key look like a candidate that ran.
+        adapter = dp._FusedMoeAdapter()
+        monkeypatch.setattr(adapter, "_torch", staticmethod(lambda: _FakeTorch()))
+        assert (
+            adapter._resolved_kernels(
+                self._emitting("[fused_moe] no tuned FlyDSL config for (...), using heuristic FlyDSL fallback")
+            )
+            is None
+        )
+
+    def test_the_last_dispatch_wins_over_an_earlier_one(self, monkeypatch):
+        adapter = dp._FusedMoeAdapter()
+        monkeypatch.setattr(adapter, "_torch", staticmethod(lambda: _FakeTorch()))
+        served = adapter._resolved_kernels(
+            self._emitting(
+                "[fused_moe] using 2stage (kernelName1='stale1', kernelName2='stale2') for (...)",
+                f"[fused_moe] using 2stage (kernelName1='{_KN1}', kernelName2='{_KN2}') for (...)",
+            )
+        )
+        assert served == (_KN1, _KN2)
+
+    def test_it_leaves_the_aiter_logger_as_it_found_it(self, monkeypatch):
+        adapter = dp._FusedMoeAdapter()
+        monkeypatch.setattr(adapter, "_torch", staticmethod(lambda: _FakeTorch()))
+        aiter_log = logging.getLogger("aiter")
+        before = (aiter_log.level, list(aiter_log.handlers))
+        adapter._resolved_kernels(self._emitting("nothing to see"))
+        assert (aiter_log.level, list(aiter_log.handlers)) == before
+
+
+class TestTheErrorMeasure:
+    """Why fused MoE does not use the measure the dense adapter uses."""
+
+    def test_one_ulp_at_the_peak_swamps_the_peak_measure(self):
+        # Reproduces in miniature what the hardware showed: an output with a
+        # peak far above its mean, perturbed by a single element, scores badly
+        # on max|d|/mean and negligibly on mean|d|/mean. On the real kernel
+        # those numbers were 0.04701 and 0.00021, against limits of 0.05 and
+        # 0.01 -- one has 6% of margin, the other a factor of 48.
+        torch = pytest.importorskip("torch")
+        ref = torch.full((512, 6144), 1.0)
+        ref[0, 0] = 1248.0
+        got = ref.clone()
+        got[0, 0] += 8.0
+        assert dp.relative_error(got, ref) > dp.MAX_RELATIVE_ERROR * 0.8
+        assert dp.mean_error(got, ref) < dp.MAX_MOE_MEAN_ERROR / 100
+
+    def test_a_broadly_wrong_answer_still_fails_the_mean_measure(self):
+        # The measure has to stay able to reject. On hardware, deliberately
+        # holed scales scored 0.5697 and a genuinely divergent kernel 0.1445.
+        torch = pytest.importorskip("torch")
+        ref = torch.full((64, 64), 1.0)
+        assert dp.mean_error(ref * 1.2, ref) > dp.MAX_MOE_MEAN_ERROR
+
+
+class _FakeTorch:
+    """Just enough torch for the log read-back, which only needs a sync."""
+
+    class cuda:  # noqa: N801 - mirrors the attribute path being stood in for
+        @staticmethod
+        def synchronize():
+            return None

--- a/src/kernelforge/gemm_tune/tests/test_tier3.py
+++ b/src/kernelforge/gemm_tune/tests/test_tier3.py
@@ -425,3 +425,132 @@ def test_shape_key_parses_the_well_formed_case() -> None:
     from kernelforge.gemm_tune.tier3.dispatch import shape_key
 
     assert shape_key("16x1536x7168") == (16, 1536, 7168)
+
+
+class TestAWinHasToClearTheNoise:
+    """The baseline used to beat itself, so "faster" needed a floor.
+
+    Measured on an MI355X: ``time_paired`` run 25 times per shape with the same
+    callable on both sides, over four fleet-demanded shapes. 43 of the 100
+    trials were refused as unstable; of the 57 that produced a number, 28 read
+    above 1.0 and the largest was 1.00925x. None reached 1.01x.
+    """
+
+    def test_the_floor_sits_above_every_null_reading_we_measured(self):
+        from kernelforge.gemm_tune.tier3 import referee
+
+        assert referee.MIN_SPEEDUP > 1.00925
+
+    def test_a_speedup_inside_the_noise_is_not_an_improvement(self, clock):
+        # 1.0076x is verbatim what torch measured against itself on hardware.
+        j = judge_candidates(
+            "8192x3456x1152",
+            [{"backend": "torch", "config": ""}],
+            baseline=clock.call(1.0076e-6),
+            dispatch=lambda c: clock.call(1e-6),
+        )
+        assert j.best_timing.usable
+        assert j.best_timing.speedup == pytest.approx(1.0076)
+        assert not j.improved, "the unmodified path is not an improvement over itself"
+
+    def test_a_win_that_clears_the_floor_still_counts(self, clock):
+        from kernelforge.gemm_tune.tier3 import referee
+
+        clearly_over = (referee.MIN_SPEEDUP + 0.01) * 1e-6
+        j = judge_candidates(
+            "s",
+            [{"n": "a"}],
+            baseline=clock.call(clearly_over),
+            dispatch=lambda c: clock.call(1e-6),
+        )
+        assert j.improved
+
+    def test_the_timing_is_still_reported_when_it_falls_short(self, clock):
+        """Refusing to call it a win is not the same as hiding the number."""
+        j = judge_candidates(
+            "s",
+            [{"n": "a"}],
+            baseline=clock.call(1.002e-6),
+            dispatch=lambda c: clock.call(1e-6),
+        )
+        assert not j.improved
+        assert j.to_dict()["best_timing"]["speedup"] == pytest.approx(1.002)
+
+
+class TestHipblasltCannotTakeTheRunDownWithIt:
+    """Two ways to die on this backend, both confirmed on an MI355X.
+
+    Neither is catchable: the C++ error handler ends the process. Since the
+    referee runs in-process at the tail of a tuning session, after every other
+    tuner has finished, either one costs the whole run its report.
+
+    * ``hipb_mm`` with no extension created -> SIGSEGV (rc=-11).
+    * ``hipb_mm`` with an invented ``solidx`` -> ``INVALID_VALUE`` at
+      ``hipbsolgemm.cu:945``, rc=1. A generated tuner writes ``solidx`` as a
+      free integer, so this is the expected case for a first draft.
+    """
+
+    @pytest.fixture
+    def aiter(self, monkeypatch):
+        import sys
+        import types
+
+        mod = types.ModuleType("aiter")
+        mod.calls = []
+        mod.created = False
+        mod.sols = [17, 42, 99]
+
+        def create_extension():
+            mod.created = True
+
+        def findallsols(*a, **k):
+            # The real one dies here when the extension was never created.
+            assert mod.created, "hipb_findallsols before hipb_create_extension"
+            mod.calls.append("findallsols")
+            return list(mod.sols)
+
+        def hipb_mm(a, bt, sol, *rest, **k):
+            assert mod.created, "hipb_mm before hipb_create_extension"
+            assert sol in mod.sols, f"invented solidx {sol} would abort the process"
+            return "out"
+
+        mod.hipb_create_extension = create_extension
+        mod.hipb_findallsols = findallsols
+        mod.hipb_mm = hipb_mm
+        monkeypatch.setitem(sys.modules, "aiter", mod)
+        return mod
+
+    @pytest.fixture
+    def adapter(self, monkeypatch):
+        import types
+
+        from kernelforge.gemm_tune.tier3.dispatch import _Bf16DenseAdapter
+
+        a = _Bf16DenseAdapter()
+        operand = types.SimpleNamespace(t=lambda: "bt")
+        monkeypatch.setattr(a, "_ops", lambda key: (operand, operand))
+        monkeypatch.setattr(a, "_torch", lambda: types.SimpleNamespace(bfloat16="bf16"))
+        return a
+
+    def test_the_extension_is_created_before_anything_touches_the_handle(self, adapter, aiter):
+        call = adapter._build((512, 512, 512), {"backend": "hipblaslt", "config": "solidx=42"})
+        assert aiter.created, "the guard used to warm up with findallsols, which needs the same handle"
+        assert call is not None and call() == "out"
+
+    def test_a_solidx_hipblaslt_never_offered_is_refused_not_run(self, adapter, aiter):
+        call = adapter._build((512, 512, 512), {"backend": "hipblaslt", "config": "solidx=999999999"})
+        assert call is None, "dispatching this would end the process, not raise"
+
+    def test_a_solidx_that_is_not_even_a_number_is_refused(self, adapter, aiter):
+        assert adapter._build((512, 512, 512), {"backend": "hipblaslt", "config": "solidx=fastest"}) is None
+
+    def test_the_solution_set_is_fetched_once_per_shape(self, adapter, aiter):
+        for cfg in ("solidx=17", "solidx=42", "solidx=99"):
+            assert adapter._build((512, 512, 512), {"backend": "hipblaslt", "config": cfg}) is not None
+        assert aiter.calls == ["findallsols"]
+
+    def test_a_different_shape_asks_again(self, adapter, aiter):
+        """Solutions are per-operand; reusing one shape's set would invent indices."""
+        adapter._build((512, 512, 512), {"backend": "hipblaslt", "config": "solidx=17"})
+        adapter._build((1024, 512, 512), {"backend": "hipblaslt", "config": "solidx=17"})
+        assert aiter.calls == ["findallsols", "findallsols"]

--- a/src/kernelforge/gemm_tune/tests/test_tier3.py
+++ b/src/kernelforge/gemm_tune/tests/test_tier3.py
@@ -756,3 +756,88 @@ class TestTheAuthoringSessionHasSomewhereItIsAllowedToWrite:
             tmp_path / "w",
         )
         assert not out.ok and "sandbox worktree" in out.reason
+
+
+class TestTheAuthoringSessionIsAllowedToDoTheJob:
+    """It asked for permission and there was nobody there.
+
+    Measured on an MI355X with a working provider and a sandbox worktree: the
+    session could reach the model, and then stopped to request Write access and
+    permission to run python3, explaining that it could not enumerate hipBLASLt
+    solutions without them. `end_reason=agent_stopped`, no script, a GPU run
+    spent. `tool_policy` was None, so the backend set no allowed_tools at all
+    and nothing was pre-approved.
+    """
+
+    def _spec(self, monkeypatch, tmp_path):
+        from kernelforge.gemm_tune.tier3 import generate
+        from kernelforge.gemm_tune.tier3.mandate import TunerMandate
+
+        seen = {}
+
+        class Backend:
+            name = "fake"
+
+            def run(self, spec):
+                seen["spec"] = spec
+                Path(spec.cwd, "tuner.py").write_text("# authored", encoding="utf-8")
+                return type("R", (), {"text": "done", "end_reason": "agent_stopped", "session_id": "s"})()
+
+        monkeypatch.setattr(generate, "_isolate", lambda _w: None)
+        import kernelforge.agent_backends.registry as reg
+
+        monkeypatch.setattr(reg, "select_default_agent_provider", lambda _m: type("P", (), {"name": "fake"})())
+        monkeypatch.setattr(reg, "resolve_agent_runtime", lambda *a, **k: object())
+        monkeypatch.setattr(reg, "create_registered_backend", lambda _r: Backend())
+        out = generate.generate_tuner(
+            TunerMandate(table="t.csv", key_schema=["M"], demand_shapes=[], why_existing_tiers_failed=""),
+            tmp_path,
+        )
+        assert out.ok, out.reason
+        return seen["spec"]
+
+    def test_the_tools_it_needs_are_pre_approved(self, monkeypatch, tmp_path):
+        policy = self._spec(monkeypatch, tmp_path).tool_policy
+        assert policy is not None, "a None policy leaves allowed_tools unset and the session asks"
+        assert policy.write, "it cannot deliver tuner.py without Write"
+        # solidx, ASM kernel names and opus kernel ids only exist in the
+        # installed library; the mandate says inventing one kills the process.
+        assert policy.shell, "it cannot enumerate what is callable without running python"
+
+    def test_it_gets_more_than_one_turn(self, monkeypatch, tmp_path):
+        policy = self._spec(monkeypatch, tmp_path).tool_policy
+        assert policy.max_turns is None or policy.max_turns > 1, (
+            "the mandate tells it to explore before searching, which is several turns"
+        )
+
+    def test_what_the_agent_said_survives_into_the_reason(self, monkeypatch, tmp_path):
+        """Otherwise every failure reads the same and explains nothing."""
+        from kernelforge.gemm_tune.tier3 import generate
+        from kernelforge.gemm_tune.tier3.mandate import TunerMandate
+
+        class Silent:
+            name = "fake"
+
+            def run(self, _spec):
+                return type(
+                    "R",
+                    (),
+                    {
+                        "text": "Please grant Bash python3 execution and write access.",
+                        "end_reason": "agent_stopped",
+                        "session_id": "s",
+                    },
+                )()
+
+        monkeypatch.setattr(generate, "_isolate", lambda _w: None)
+        import kernelforge.agent_backends.registry as reg
+
+        monkeypatch.setattr(reg, "select_default_agent_provider", lambda _m: type("P", (), {"name": "fake"})())
+        monkeypatch.setattr(reg, "resolve_agent_runtime", lambda *a, **k: object())
+        monkeypatch.setattr(reg, "create_registered_backend", lambda _r: Silent())
+        out = generate.generate_tuner(
+            TunerMandate(table="t.csv", key_schema=["M"], demand_shapes=[], why_existing_tiers_failed=""),
+            tmp_path / "w",
+        )
+        assert not out.ok
+        assert "write access" in out.reason, "the agent named its own blocker and we dropped it"

--- a/src/kernelforge/gemm_tune/tests/test_tier3.py
+++ b/src/kernelforge/gemm_tune/tests/test_tier3.py
@@ -841,3 +841,49 @@ class TestTheAuthoringSessionIsAllowedToDoTheJob:
         )
         assert not out.ok
         assert "write access" in out.reason, "the agent named its own blocker and we dropped it"
+
+
+class TestTheAuthorIsWarnedThatABadLaunchKillsTheProcess:
+    """A GPU memory fault is not an exception, and the brief never said so.
+
+    Measured on an MI355X: a tuner written from this mandate swept one backend's
+    kernel ids, took a fault four minutes in on shape 2 of 42, and the process
+    ended -- no traceback, nothing for ``except`` to see, forty-one shapes of
+    work never started. A single-process script has no upper bound on what one
+    bad candidate costs it, and no amount of care in the search protects it.
+    The author cannot infer this from anywhere else, so the mandate has to say
+    it, and has to say what to do about it.
+    """
+
+    def _brief(self):
+        gap = CoverageGap(
+            table="bf16_tuned_gemm.csv",
+            tuner="sglang_dense_bf16",
+            env_var="AITER_CONFIG_GEMM_BF16",
+            key_schema=["M", "N", "K"],
+            miss_count=40,
+            reason="sglang_dense_bf16 produced nothing landable",
+        )
+        return build_mandate(gap, [{"M": 16, "N": 1536, "K": 7168}]).render()
+
+    def test_the_failure_mode_is_named_not_hinted_at(self):
+        brief = self._brief().lower()
+        assert "memory access fault" in brief
+        assert "does not raise" in brief, "an author who thinks it raises will wrap it in try/except"
+
+    def test_it_says_the_fault_can_surface_late(self):
+        # Blacklisting the candidate the process died on is only correct if the
+        # author knows it may be the wrong one; without this they trust it.
+        assert "asynchronous" in self._brief()
+
+    def test_it_says_how_to_survive_one(self):
+        brief = self._brief()
+        assert "subprocess" in brief, "in-process recovery is impossible; the brief must say so"
+        assert "on disk" in brief, "state that dies with the process is state that is lost"
+
+    def test_the_default_is_recorded_before_anything_risky(self):
+        # The control row is what lets a shape that was never tuned still meet
+        # the contract's "one row per demanded shape", so a fault costs a
+        # candidate rather than the whole submission.
+        brief = self._brief()
+        assert "the default first, before anything risky" in brief

--- a/src/kernelforge/gemm_tune/tests/test_tier3.py
+++ b/src/kernelforge/gemm_tune/tests/test_tier3.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -657,3 +658,101 @@ class TestTheVocabularyIsOneObject:
             # raises inside its own try, and neither is the fallthrough.
             adapter._build((16, 16, 16), {"backend": backend, "config": ""})
         assert reached == [], f"advertised but not implemented: {reached}"
+
+
+class TestTheAuthoringSessionHasSomewhereItIsAllowedToWrite:
+    """The generate stage never reached a model on a real box.
+
+    A writable session runs under the workspace guard, and the guard starts by
+    resolving ``git rev-parse --show-toplevel`` from the session's cwd. That cwd
+    is ``<tuning output>/tier3/<table>/`` -- an output directory, never a
+    repository -- so every attempt died at ``WorkspaceSafetyError('not a git
+    repository')``. Measured on an MI355X with a working provider: the gate
+    opened, the adapter resolved, and the run stopped at ``stage='generate'``
+    with that message, having asked nothing.
+    """
+
+    def _work_dir(self, tmp_path):
+        d = tmp_path / "tier3" / "bf16_tuned_gemm_csv"
+        d.mkdir(parents=True)
+        return d
+
+    def test_an_output_directory_becomes_a_worktree_of_its_own(self, tmp_path):
+        from kernelforge.gemm_tune.tier3.generate import _isolate
+
+        work = self._work_dir(tmp_path)
+        assert _isolate(work) is None
+        assert (work / ".git").exists()
+
+    def test_the_guard_can_resolve_a_baseline_afterwards(self, tmp_path):
+        """Exactly what the guard asks for, asked the same way it asks."""
+        import subprocess
+
+        from kernelforge.gemm_tune.tier3.generate import _isolate
+
+        work = self._work_dir(tmp_path)
+        _isolate(work)
+        top = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"], cwd=work, capture_output=True, text=True, check=True
+        )
+        assert top.stdout.strip(), "the guard refuses an empty toplevel"
+        head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=work, capture_output=True, text=True, check=False)
+        assert head.returncode == 0, "rollback needs a commit to roll back to"
+
+    def test_the_sandbox_is_its_own_root_even_inside_a_checkout(self, tmp_path):
+        """Otherwise the guard judges the operator's real tree, not the sandbox."""
+        import subprocess
+
+        from kernelforge.gemm_tune.tier3.generate import _isolate
+
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        work = self._work_dir(tmp_path)
+        _isolate(work)
+        top = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"], cwd=work, capture_output=True, text=True, check=True
+        ).stdout.strip()
+        assert Path(top).resolve() == work.resolve()
+
+    def test_an_existing_worktree_is_left_alone(self, tmp_path):
+        """The retry loop calls this twice; the second must not wipe the first."""
+        from kernelforge.gemm_tune.tier3.generate import _isolate
+
+        work = self._work_dir(tmp_path)
+        _isolate(work)
+        (work / "tuner.py").write_text("# attempt 1", encoding="utf-8")
+        assert _isolate(work) is None
+        assert (work / "tuner.py").read_text(encoding="utf-8") == "# attempt 1"
+
+    def test_git_missing_is_a_reason_not_a_traceback(self, tmp_path, monkeypatch):
+        import subprocess
+
+        from kernelforge.gemm_tune.tier3 import generate
+
+        def no_git(*_a, **_k):
+            raise OSError("No such file or directory: 'git'")
+
+        monkeypatch.setattr(subprocess, "run", no_git)
+        out = generate._isolate(self._work_dir(tmp_path))
+        assert out is not None and not out.ok
+        assert "sandbox worktree" in out.reason
+
+    def test_the_session_is_not_started_when_the_sandbox_cannot_be_made(self, tmp_path, monkeypatch):
+        """A failure here is reported, not walked past into a doomed session."""
+        from kernelforge.gemm_tune.tier3 import generate
+        from kernelforge.gemm_tune.tier3.mandate import TunerMandate
+
+        monkeypatch.setattr(
+            generate,
+            "_isolate",
+            lambda _w: generate.GeneratedTuner(False, None, "could not prepare a sandbox worktree"),
+        )
+
+        def must_not_run(*_a, **_k):
+            raise AssertionError("the authoring session was started without a sandbox")
+
+        monkeypatch.setattr(generate, "_run", must_not_run)
+        out = generate.generate_tuner(
+            TunerMandate(table="t.csv", key_schema=["M"], demand_shapes=[], why_existing_tiers_failed=""),
+            tmp_path / "w",
+        )
+        assert not out.ok and "sandbox worktree" in out.reason

--- a/src/kernelforge/gemm_tune/tests/test_tier3.py
+++ b/src/kernelforge/gemm_tune/tests/test_tier3.py
@@ -554,3 +554,106 @@ class TestHipblasltCannotTakeTheRunDownWithIt:
         adapter._build((512, 512, 512), {"backend": "hipblaslt", "config": "solidx=17"})
         adapter._build((1024, 512, 512), {"backend": "hipblaslt", "config": "solidx=17"})
         assert aiter.calls == ["findallsols", "findallsols"]
+
+
+class TestTheAuthorIsToldWhatACandidateHasToLookLike:
+    """The brief used to ask for re-dispatchable candidates without saying how.
+
+    ``dispatch._build`` reads five backend names and a ``k=v;k=v`` config, and
+    files candidates by an ``MxNxK`` key. None of that appeared anywhere the
+    author could see it, so a script written from the mandate alone -- the whole
+    premise of this tier -- proposes candidates in some other vocabulary and
+    every one of them is recorded as "not dispatchable". The gate opens, the
+    search runs, and nothing can be promoted.
+    """
+
+    def _gap(self, table="bf16_tuned_gemm.csv"):
+        return CoverageGap(
+            table=table,
+            tuner="sglang_dense_bf16",
+            env_var="AITER_CONFIG_GEMM_BF16",
+            key_schema=["M", "N", "K"],
+            miss_count=40,
+            reason="sglang_dense_bf16 produced nothing landable",
+        )
+
+    def _brief(self, table="bf16_tuned_gemm.csv"):
+        return build_mandate(self._gap(table), [{"M": 16, "N": 1536, "K": 7168}]).render()
+
+    def test_every_backend_the_referee_can_run_is_named_in_the_brief(self):
+        from kernelforge.gemm_tune.tier3.dispatch import DENSE_BF16_BACKENDS
+
+        text = self._brief()
+        for backend in DENSE_BF16_BACKENDS:
+            assert backend in text, f"{backend} is dispatchable but the author is never told"
+
+    def test_the_config_grammar_and_the_shape_key_are_spelled_out(self):
+        text = self._brief()
+        assert "MxNxK" in text, "the keys of candidates.json are parsed, not free text"
+        assert "8192x3456x1152" in text, "an example beats a description of one"
+        assert "key=value" in text and "`;`" in text
+
+    def test_the_required_key_of_each_backend_is_stated(self):
+        text = self._brief()
+        # A candidate missing these is refused, so leaving them implicit costs
+        # the whole shape.
+        assert "solidx" in text
+        assert "kernelName" in text
+        assert "kernelId" in text
+
+    def test_a_table_with_no_adapter_is_told_so_rather_than_told_nothing(self):
+        text = self._brief("odd_tuned_gemm.csv")
+        assert "re-dispatch" in text
+        assert "hipblaslt" not in text, "naming backends that cannot re-time this table misleads"
+
+    def test_the_protocol_reaches_the_machine_readable_form(self):
+        d = build_mandate(self._gap(), [{"M": 16, "N": 1536, "K": 7168}]).to_dict()
+        assert "hipblaslt" in d["candidate_protocol"]
+
+    def test_a_caller_can_still_supply_its_own(self):
+        m = build_mandate(self._gap(), [], candidate_protocol="say it however you like")
+        assert "say it however you like" in m.render()
+        assert "hipblaslt" not in m.render()
+
+
+class TestTheVocabularyIsOneObject:
+    """Advertised and dispatchable have to be the same set, or the gap is silent.
+
+    ``_build`` checks the candidate's backend against the very table the mandate
+    is rendered from, so a name can neither be runnable-but-unadvertised (the
+    author never proposes it) nor advertised-but-unrunnable (every proposal of
+    it is refused) without a test failing here.
+    """
+
+    def test_a_backend_nobody_advertised_is_refused_before_anything_is_touched(self, monkeypatch):
+        from kernelforge.gemm_tune.tier3.dispatch import _Bf16DenseAdapter
+
+        adapter = _Bf16DenseAdapter()
+
+        def explode(*_a, **_k):
+            raise AssertionError("an unknown backend must not reach the operands")
+
+        monkeypatch.setattr(adapter, "_ops", explode)
+        assert adapter._build((16, 16, 16), {"backend": "cutlass", "config": "tile=128"}) is None
+
+    def test_the_advertised_names_are_the_ones_build_implements(self, monkeypatch):
+        """Each advertised backend reaches its own branch, not the fallthrough."""
+        import sys
+        import types
+
+        import kernelforge.gemm_tune.tier3.dispatch as d
+
+        # Enough of aiter to be imported; the branches are reached and then
+        # bail on their own missing config, which is the point.
+        monkeypatch.setitem(sys.modules, "aiter", types.ModuleType("aiter"))
+        reached = []
+        monkeypatch.setattr(d.log, "warning", lambda msg, *a: reached.append(a[0] if a else msg))
+        adapter = d._Bf16DenseAdapter()
+        operand = types.SimpleNamespace(t=lambda: "bt")
+        monkeypatch.setattr(adapter, "_ops", lambda key: (operand, operand))
+        monkeypatch.setattr(adapter, "_torch", lambda: types.SimpleNamespace(bfloat16="bf16"))
+        for backend in d.DENSE_BF16_BACKENDS:
+            # Deliberately configless: every branch then returns None early or
+            # raises inside its own try, and neither is the fallthrough.
+            adapter._build((16, 16, 16), {"backend": backend, "config": ""})
+        assert reached == [], f"advertised but not implemented: {reached}"

--- a/src/kernelforge/gemm_tune/tests/test_tier3.py
+++ b/src/kernelforge/gemm_tune/tests/test_tier3.py
@@ -19,6 +19,7 @@ from kernelforge.gemm_tune.tier3 import (
     validate_output_csv,
 )
 from kernelforge.gemm_tune.tier3.coverage import CoverageGap
+from kernelforge.gemm_tune.tuners.base import TuneResult
 
 
 def _demand(table="odd_tuned_gemm.csv", tuner=None, misses=40, keys=7):
@@ -52,13 +53,42 @@ class TestCoverageGaps:
         assert gap.kind == "not_selected"
         assert not gap.warrants_generated_tuner
 
-    def test_a_tuner_that_declined_for_a_reason_of_its_own_is_not_tier3_work(self):
+    def test_a_tuner_that_declined_for_no_reason_of_substance_is_tier3_work(self):
+        # "The script is missing" is not a property of the table, the hardware
+        # or the checkpoint -- it is our own capability being absent on this
+        # run, which is the same position a table with no owner is in. The
+        # reasons that really are answers are excluded before a gap is built;
+        # see test_a_skip_that_is_an_answer_is_not_a_gap.
         specs = [TunerSpec("fmoe_ck", skip_reason="the tuner script is missing")]
         (gap,) = coverage_gaps(_demand(tuner="fmoe_ck"), specs)
         assert gap.kind == "skipped"
-        assert not gap.warrants_generated_tuner
+        assert gap.warrants_generated_tuner
 
-    def test_only_a_missing_capability_reaches_the_generated_tier(self):
+    def test_an_owner_that_ran_and_landed_nothing_is_tier3_work(self):
+        # The distinction that matters is not whether a tuner exists but
+        # whether the table got tuned. Selecting an owner that then hands back
+        # nothing leaves the runtime missing every key it asked about.
+        specs = [TunerSpec("sglang_dense_bf16")]
+        demand = _demand(tuner="sglang_dense_bf16")
+        assert coverage_gaps(demand, specs, results=None) == []
+        empty = TuneResult(tuner_name="sglang_dense_bf16", status="no_improvement")
+        (gap,) = coverage_gaps(demand, specs, results=[empty])
+        assert gap.kind == "empty"
+        assert gap.warrants_generated_tuner
+        assert "produced nothing landable" in gap.reason
+
+    def test_an_owner_that_landed_something_is_not_a_gap(self):
+        specs = [TunerSpec("sglang_dense_bf16")]
+        landed = TuneResult(
+            tuner_name="sglang_dense_bf16",
+            status="ok",
+            artifact_path="/tmp/tuned.csv",
+            improved_shapes=3,
+            best_micro_speedup=1.4,
+        )
+        assert coverage_gaps(_demand(tuner="sglang_dense_bf16"), specs, results=[landed]) == []
+
+    def test_routing_is_the_one_kind_that_stays_out(self):
         report = {
             "demands": [
                 {"table": "none.csv", "tuner": None, "miss_count": 5},
@@ -68,7 +98,8 @@ class TestCoverageGaps:
         }
         specs = [TunerSpec("fmoe_ck", skip_reason="script is missing")]
         gaps = coverage_gaps(report, specs)
-        assert [g.table for g in gaps if g.warrants_generated_tuner] == ["none.csv"]
+        assert [g.table for g in gaps if not g.warrants_generated_tuner] == ["unrouted.csv"]
+        assert {g.table for g in gaps if g.warrants_generated_tuner} == {"none.csv", "declined.csv"}
 
     def test_a_covered_table_is_not_a_gap(self):
         specs = [TunerSpec("sglang_dense_bf16")]

--- a/src/kernelforge/gemm_tune/tests/test_tier3_dispatch.py
+++ b/src/kernelforge/gemm_tune/tests/test_tier3_dispatch.py
@@ -158,14 +158,26 @@ class _FakeTorch:
         return self._matmul_result
 
 
-def _install_aiter(monkeypatch: pytest.MonkeyPatch, *, asm_result=None, raises: bool = False):
-    """Wire a fake ``aiter`` package, including the two submodules imported."""
-    calls: dict[str, int] = {"findallsols": 0, "workspace_init": 0}
+def _install_aiter(monkeypatch: pytest.MonkeyPatch, *, asm_result=None, raises: bool = False, sols=(7,)):
+    """Wire a fake ``aiter`` package, including the two submodules imported.
+
+    ``sols`` is what hipBLASLt says it can serve for these operands. It has to be
+    a real list rather than None, because ``_build`` now refuses a ``solidx``
+    that is not in it -- running an invented one aborts the process from C++.
+    """
+    calls: dict[str, int] = {"findallsols": 0, "workspace_init": 0, "create_extension": 0}
 
     aiter = types.ModuleType("aiter")
 
+    def _create_extension(*_a, **_k):
+        calls["create_extension"] += 1
+
     def _findallsols(*_a, **_k):
+        # findallsols on a handle nobody created aborts the same way hipb_mm
+        # does, so the order is part of what the fake has to enforce.
+        assert calls["create_extension"], "hipb_findallsols before hipb_create_extension"
         calls["findallsols"] += 1
+        return list(sols)
 
     def _hipb_mm(*_a, **_k):
         return _T([1.0, 2.0, 3.0])
@@ -175,6 +187,7 @@ def _install_aiter(monkeypatch: pytest.MonkeyPatch, *, asm_result=None, raises: 
             raise RuntimeError("asm kernel exploded")
         return asm_result if asm_result is not None else _T([1.0, 2.0, 3.0])
 
+    aiter.hipb_create_extension = _create_extension
     aiter.hipb_findallsols = _findallsols
     aiter.hipb_mm = _hipb_mm
     aiter.gemm_a16w16_asm = _gemm_asm
@@ -321,9 +334,16 @@ class TestWhatCanAndCannotBeDispatched:
         call = adapter._build((2, 3, 4), {"backend": "hipblaslt", "config": "solidx=7"})
 
         assert call is not None
+        assert calls["create_extension"] == 1
         assert calls["findallsols"] == 1
-        adapter._build((2, 3, 4), {"backend": "hipblaslt", "config": "solidx=9"})
+        adapter._build((2, 3, 4), {"backend": "hipblaslt", "config": "solidx=7"})
         assert calls["findallsols"] == 1, "the handle is created once, not per candidate"
+
+    def test_a_solidx_hipblaslt_never_offered_is_refused(self, adapter, monkeypatch):
+        # Not a typo-catcher: hipb_mm on an index outside the solution list
+        # aborts from C++ with INVALID_VALUE, which no `except` here can catch.
+        _install_aiter(monkeypatch, sols=(7,))
+        assert adapter._build((2, 3, 4), {"backend": "hipblaslt", "config": "solidx=9"}) is None
 
     def test_the_asm_backend_without_a_kernel_name_is_not_dispatchable(self, adapter, monkeypatch):
         _install_aiter(monkeypatch)

--- a/src/kernelforge/gemm_tune/tests/test_tier3_runner.py
+++ b/src/kernelforge/gemm_tune/tests/test_tier3_runner.py
@@ -58,13 +58,21 @@ class TestGate:
         monkeypatch.setenv(gate.ALLOW_ENV, "*")
         assert gate.should_generate([_gap()]).allowed
 
-    def test_a_tuner_that_exists_never_opens_the_gate(self, monkeypatch):
-        # Whatever the whitelist says.
+    def test_an_unrouted_tuner_never_opens_the_gate(self, monkeypatch):
+        # Whatever the whitelist says. The table has an owner that was simply
+        # not selected, and generating a second one papers over that.
         monkeypatch.setenv(gate.ALLOW_ENV, "*")
-        for kind in ("not_selected", "skipped"):
+        d = gate.should_generate([_gap(kind="not_selected", tuner="a8w8")])
+        assert not d.allowed
+        assert "not_selected" in d.reasons[0]
+
+    def test_an_owner_that_produced_nothing_does_open_it(self, monkeypatch):
+        # The table has an owner and is still untuned. That is the state the
+        # runtime is in, and it is indistinguishable from having no owner.
+        monkeypatch.setenv(gate.ALLOW_ENV, "*")
+        for kind in ("skipped", "empty"):
             d = gate.should_generate([_gap(kind=kind, tuner="a8w8")])
-            assert not d.allowed
-            assert kind in d.reasons[0]
+            assert d.allowed, kind
 
     def test_too_little_demand_stays_closed(self, monkeypatch):
         monkeypatch.setenv(gate.ALLOW_ENV, "*")
@@ -306,6 +314,139 @@ class TestTheCliActuallyReachesTier3:
 
         assert adapters_for("a4w4_blockscale_tuned_gemm.csv") is None
         assert adapters_for("bf16_tuned_gemm.csv") is not None
+
+    def test_the_call_site_keeps_what_it_returns(self):
+        # It did not. `_attempt_tier3(...)` was called for its side effects and
+        # its return value dropped on the floor, so a generated tuner that had
+        # survived generation, the sandbox, the contract and the referee still
+        # reached no report, no candidate and no deploy.
+        import inspect
+
+        from kernelforge.gemm_tune import cli
+
+        source = inspect.getsource(cli.run.callback)
+        assert "generated = _attempt_tier3(" in source
+        assert "results.append(generated)" in source
+
+    def test_the_gaps_it_acts_on_are_recomputed_after_the_tuners_ran(self):
+        # The list built before tuning cannot say which owners came back with
+        # nothing, and that is the only condition tier3 exists for in practice.
+        import inspect
+
+        from kernelforge.gemm_tune import cli
+
+        source = inspect.getsource(cli.run.callback)
+        recompute = source.index("_coverage_gaps(demand_report, tuner_specs, output_path, results)")
+        assert source.index("tuner_instance.execute()") < recompute < source.index("_attempt_tier3(")
+
+
+class TestAVerifiedGeneratedTunerBecomesAnOrdinaryResult:
+    """What the referee approved has to travel the same road as everything else.
+
+    Anything short of the referee's approval must not: the point of the tier is
+    that a generated tuner's own numbers are discarded, so an outcome that never
+    reached re-timing has established nothing to deploy.
+    """
+
+    @staticmethod
+    def _outcome(**kw):
+        from kernelforge.gemm_tune.tier3.runner import Tier3Outcome
+
+        base = {"attempted": True, "stage": "referee", "ok": True, "table": "bf16_tuned_gemm.csv"}
+        out = Tier3Outcome(**{**base, **kw})
+        out.output_csv = kw.get("output_csv", "/work/tier3/out.csv")
+        return out
+
+    @staticmethod
+    def _judgement(speedup: float):
+        """``improved`` is derived from the timing, so the timing is the input."""
+        from kernelforge.gemm_tune.tier3.referee import Judgement, PairedTiming
+
+        return Judgement(
+            shape="16x1536x7168",
+            best_timing=PairedTiming(baseline_us=10.0, candidate_us=10.0 / speedup, speedup=speedup),
+        )
+
+    def test_an_approved_outcome_maps_onto_a_tune_result(self):
+        from kernelforge.gemm_tune.cli import _tier3_result
+
+        out = self._outcome(judgements=[self._judgement(1.5), self._judgement(0.9)])
+        res = _tier3_result(out, _gap(table="bf16_tuned_gemm.csv"))
+        assert res is not None
+        assert res.tuner_name == "tier3_generated_bf16_tuned_gemm"
+        assert res.artifact_path == "/work/tier3/out.csv"
+        assert res.env_var == "AITER_CONFIG_ODD" and res.env_value == "/work/tier3/out.csv"
+        assert res.total_shapes == 2 and res.improved_shapes == 1
+        assert res.best_micro_speedup == pytest.approx(1.5)
+        assert res.key_source == "runtime_observed"
+
+    def test_it_is_a_candidate_so_e2e_still_has_to_agree(self):
+        from kernelforge.gemm_tune.candidates import is_candidate, per_tuner_candidates
+        from kernelforge.gemm_tune.cli import _tier3_result
+
+        res = _tier3_result(self._outcome(judgements=[self._judgement(1.5)]), _gap())
+        assert res.candidate is True
+        assert is_candidate(res)
+        assert [c.tuner for c in per_tuner_candidates([res])] == [res.tuner_name]
+
+    def test_an_outcome_the_referee_did_not_approve_is_not_a_result(self):
+        from kernelforge.gemm_tune.cli import _tier3_result
+
+        assert _tier3_result(self._outcome(ok=False), _gap()) is None
+
+    def test_an_attempt_that_never_reached_a_csv_is_not_a_result(self):
+        from kernelforge.gemm_tune.cli import _tier3_result
+
+        assert _tier3_result(self._outcome(output_csv=""), _gap()) is None
+
+    def test_the_outcome_carries_its_own_artifact_path(self):
+        # Rather than the caller rebuilding it from the work root by
+        # convention, which would deploy the wrong file the day that changes.
+        from kernelforge.gemm_tune.tier3.runner import Tier3Outcome
+
+        assert "output_csv" in Tier3Outcome().to_dict()
+
+
+class TestShapesComeFromTheDemandDocument:
+    def test_the_demand_lookup_matches_what_load_demand_returns(self, tmp_path):
+        # It did not: the call site read ``demand.tables`` off a plain dict, and
+        # the AttributeError was swallowed by the guard around the attempt, so
+        # every tier3 run died as "tier3 attempt failed" before writing a
+        # mandate. Nothing noticed, because nothing asserted it got that far.
+        from kernelforge.gemm_tune import cli, evidence
+
+        report = evidence.parse_log(
+            "[aiter] shape is M:512, N:1536, K:7168, "
+            "not found tuned config in /tmp/aiter_configs/a8w8_blockscale_tuned_gemm.csv"
+        )
+        path = evidence.write_demand(report, tmp_path / "demand.json")
+
+        seen = {}
+
+        def fake_attempt(gaps, shapes_for, *a, **kw):
+            seen["shapes"] = shapes_for(gaps[0])
+            raise RuntimeError("stop here; the mandate is not what this asserts")
+
+        # ``_attempt_tier3`` imports it inside the function, so the module
+        # attribute is the patch point.
+        import kernelforge.gemm_tune.tier3 as tier3
+
+        original = tier3.attempt_generated_tuner
+        tier3.attempt_generated_tuner = fake_attempt
+        try:
+            cli._attempt_tier3(
+                [_gap(table="a8w8_blockscale_tuned_gemm.csv")],
+                str(path),
+                tmp_path,
+                profile=None,
+                gpu_type="MI355X",
+                framework="sglang",
+            )
+        finally:
+            tier3.attempt_generated_tuner = original
+
+        assert seen["shapes"], "the demand document has one key and it did not arrive"
+        assert int(seen["shapes"][0]["N"]) == 1536
 
 
 class TestTheProviderCallMatchesTheProviderAPI:

--- a/src/kernelforge/gemm_tune/tests/test_tier3_runner.py
+++ b/src/kernelforge/gemm_tune/tests/test_tier3_runner.py
@@ -561,8 +561,18 @@ class TestTheWholeChain:
     def test_without_a_dispatch_nothing_is_emitted(self, tmp_path, monkeypatch, open_gate):
         # An unverified generated tuner is exactly what this tier must not emit.
         out = self._run(tmp_path, monkeypatch, rows=self._ROWS, cands=self._CANDS, with_dispatch=False)
-        assert out.stage == "referee" and not out.ok
-        assert "cannot be re-timed" in out.reason
+        assert not out.ok
+        assert "re-timed" in out.reason
+
+    def test_without_a_dispatch_it_stops_before_it_spends_anything(self, tmp_path, monkeypatch, open_gate):
+        # This used to be checked at the referee, so a table with no adapter
+        # first paid for an authoring session and a sandbox run and then had the
+        # result thrown away unread. Nothing between the gate and the referee
+        # changes the verdict, so it belongs before the spending.
+        out = self._run(tmp_path, monkeypatch, rows=self._ROWS, cands=self._CANDS, with_dispatch=False)
+        assert out.stage == "gate"
+        assert not out.attempted
+        assert not out.script, "no script should have been generated"
 
     def test_the_kill_switch_stops_it_before_anything_happens(self, tmp_path, monkeypatch):
         monkeypatch.setenv(gate.DISABLE_ENV, "1")

--- a/src/kernelforge/gemm_tune/tier3/coverage.py
+++ b/src/kernelforge/gemm_tune/tier3/coverage.py
@@ -16,6 +16,10 @@ _NOT_A_COVERAGE_GAP = (
     "already at peak performance",
     "not supported",
     "unavailable on",
+    # The fp4/gfx942 skip words it this way, and it is the strongest form of
+    # "not our problem" there is: aiter ships no fp4 kernel for this card, so
+    # there is nothing for any tuner, generated or not, to select between.
+    "unsupported on",
     "no gemm shapes available",
     "requires --tunableop-input",
     "is not moe",
@@ -25,10 +29,18 @@ _NOT_A_COVERAGE_GAP = (
 )
 
 
-# Why a demanded table went untuned.
-KIND_NO_TUNER = "no_tuner"  # nothing implements this: the Tier-3 case
+# Why a demanded table went untuned. Three of these argue for writing a tuner
+# and one does not: `not_selected` is a routing bug, and generating a second
+# tuner would paper over it.
+KIND_NO_TUNER = "no_tuner"  # nothing implements this at all
 KIND_SKIPPED = "skipped"  # a tuner exists and declined, for a reason
+KIND_EMPTY = "empty"  # a tuner exists, ran, and produced nothing landable
 KIND_NOT_SELECTED = "not_selected"  # a tuner exists and routing did not pick it
+
+# The kinds a generated tuner is a legitimate answer to. ``skipped`` is in here
+# only because the reasons that are *not* a gap have already been filtered out
+# by ``_is_coverage_gap`` before a gap of that kind is ever built.
+_WARRANTS = frozenset({KIND_NO_TUNER, KIND_SKIPPED, KIND_EMPTY})
 
 
 @dataclass
@@ -48,8 +60,14 @@ class CoverageGap:
 
     @property
     def warrants_generated_tuner(self) -> bool:
-        """Only an absent capability does. A routing miss is a routing bug."""
-        return self.kind == KIND_NO_TUNER
+        """An absent result does. A routing miss is a routing bug.
+
+        Absent, not unimplemented: a tuner that owns the table and hands back
+        nothing landable leaves the runtime no better off than one that was
+        never written. What a generated tuner cannot help with is a table whose
+        owner was simply never selected -- there the fix is to select it.
+        """
+        return self.kind in _WARRANTS
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -71,11 +89,50 @@ def _is_coverage_gap(skip_reason: str) -> bool:
     return not any(marker in low for marker in _NOT_A_COVERAGE_GAP)
 
 
+def _gap(entry: dict[str, Any], table: str, tuner: str | None, *, kind: str, reason: str) -> CoverageGap:
+    return CoverageGap(
+        table=table,
+        tuner=tuner,
+        env_var=entry.get("env_var"),
+        key_schema=list(entry.get("key_schema") or []),
+        logged_fields=list(entry.get("logged_fields") or []),
+        miss_count=int(entry.get("miss_count") or 0),
+        distinct_keys=int(entry.get("distinct_keys") or 0),
+        reason=reason,
+        kind=kind,
+    )
+
+
+def _landed(results: list[Any] | None) -> set[str] | None:
+    """Tuners that finished with something the integrate lane could apply.
+
+    ``None`` when no results were supplied, which is how the pre-run caller says
+    "nobody has run yet" rather than "nobody produced anything" -- the two must
+    not collapse, or every selected tuner would read as empty before it started.
+
+    Built from ``per_tuner_candidates`` rather than from ``status``, so this
+    agrees with the promotion rule the report itself uses. A tuner that reports
+    ``ok`` but wrote no artifact and named no env var is not landable, and the
+    runtime will keep missing exactly the keys it was asked about.
+    """
+    if results is None:
+        return None
+    from ..candidates import per_tuner_candidates
+
+    return {c.tuner for c in per_tuner_candidates(results)}
+
+
 def coverage_gaps(
     demand_report: dict[str, Any] | None,
     tuner_specs: list[Any],
+    results: list[Any] | None = None,
 ) -> list[CoverageGap]:
-    """Demanded tables that no selected tuner will write."""
+    """Demanded tables that no selected tuner will write.
+
+    Passing ``results`` is what turns "a tuner owns this" into "a tuner covered
+    this": an owner that came back empty-handed yields ``KIND_EMPTY`` instead of
+    silently counting as coverage. Omit it before the tuners run.
+    """
     demands = (demand_report or {}).get("demands") or []
     if not demands:
         return []
@@ -86,12 +143,24 @@ def coverage_gaps(
         for s in tuner_specs
         if not getattr(s, "should_run", True)
     }
+    landed = _landed(results)
 
     gaps: list[CoverageGap] = []
     for entry in demands:
         tuner = entry.get("tuner")
         table = str(entry.get("table") or "")
         if tuner and tuner in will_run:
+            if landed is None or tuner in landed:
+                continue
+            gaps.append(
+                _gap(
+                    entry,
+                    table,
+                    tuner,
+                    kind=KIND_EMPTY,
+                    reason=f"{tuner} ran and produced nothing landable for {table}",
+                )
+            )
             continue
         if tuner is None:
             kind = KIND_NO_TUNER
@@ -104,19 +173,7 @@ def coverage_gaps(
         else:
             kind = KIND_NOT_SELECTED
             reason = f"{tuner} owns {table} but was not selected for this run"
-        gaps.append(
-            CoverageGap(
-                table=table,
-                tuner=tuner,
-                env_var=entry.get("env_var"),
-                key_schema=list(entry.get("key_schema") or []),
-                logged_fields=list(entry.get("logged_fields") or []),
-                miss_count=int(entry.get("miss_count") or 0),
-                distinct_keys=int(entry.get("distinct_keys") or 0),
-                reason=reason,
-                kind=kind,
-            )
-        )
+        gaps.append(_gap(entry, table, tuner, kind=kind, reason=reason))
 
     gaps.sort(key=lambda g: -g.miss_count)
     for gap in gaps:

--- a/src/kernelforge/gemm_tune/tier3/dispatch.py
+++ b/src/kernelforge/gemm_tune/tier3/dispatch.py
@@ -97,10 +97,23 @@ FUSED_MOE_BACKENDS: dict[str, str] = {
     "aiter_fmoe": (
         "`kernelName1=<str>` and `kernelName2=<str>` (both required) -- the stage-1 and stage-2 "
         "kernels, spelled exactly as aiter spells them. Optional: `block_m=<int>` (default 32), "
-        "`ksplit=<int>` (default 0), `run_1stage`/`xbf16`/`flat` (default 0). A pair that aiter "
-        "does not resolve to is refused rather than timed: the adapter reads back which kernels "
-        "aiter actually chose, and a row it ignored would otherwise be timed as the default path "
-        "and scored as a tie."
+        "`ksplit=<int>` (default 0), `run_1stage`/`xbf16`/`flat` (default 0). Do not invent a "
+        "name: enumerate them from the installed library, which keeps the authoritative "
+        "registry in `aiter.ops.flydsl.moe_kernels` -- `get_flydsl_stage1_kernels(a, b, out)` "
+        "and `get_flydsl_stage2_kernels(a, b, out)` each return `{name: params}` for every "
+        "config it can compile. Filter that list against your own shape before proposing "
+        "anything: a name encodes its tile as `t<M>x<N>x<K>`, and aiter silently downgrades a "
+        "tile that does not divide the dimension it walks -- stage-1 `N` and stage-2 `K` are "
+        "both `inter_dim` -- so a name whose tile does not divide runs a different kernel than "
+        "the one you asked for. `block_m` is not a free knob either: it is the granularity the "
+        "tokens are sorted into before either kernel indexes them, and it has to equal the "
+        "`M` tile of *both* names. Measured on gfx950, every mismatch of the three ran without "
+        "faulting and returned garbage -- a mean error of 1.1 to 1.4 against the default path -- "
+        "and the mismatched pairs were the fastest thing in the search, so a tuner that pins "
+        "`block_m` and trusts its clock will rank nonsense first. A pair that aiter does not "
+        "resolve to is refused rather than "
+        "timed: the adapter reads back which kernels aiter actually chose, and a row it ignored "
+        "would otherwise be timed as the default path and scored as a tie."
     ),
 }
 

--- a/src/kernelforge/gemm_tune/tier3/dispatch.py
+++ b/src/kernelforge/gemm_tune/tier3/dispatch.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
@@ -110,7 +111,9 @@ FUSED_MOE_BACKENDS: dict[str, str] = {
         "`M` tile of *both* names. Measured on gfx950, every mismatch of the three ran without "
         "faulting and returned garbage -- a mean error of 1.1 to 1.4 against the default path -- "
         "and the mismatched pairs were the fastest thing in the search, so a tuner that pins "
-        "`block_m` and trusts its clock will rank nonsense first. A pair that aiter does not "
+        "`block_m` and trusts its clock will rank nonsense first. Both of those are refused here "
+        "before any GPU work, so a search that ignores this paragraph will spend its budget "
+        "collecting refusals rather than wrong answers. A pair that aiter does not "
         "resolve to is refused rather than "
         "timed: the adapter reads back which kernels aiter actually chose, and a row it ignored "
         "would otherwise be timed as the default path and scored as a tie."
@@ -498,11 +501,16 @@ class _FusedMoeAdapter:
             )
             return None
         key = moe_shape_key(shape)
+        block_m = int(cfg.get("block_m", 32))
+        wrong = flydsl_pair_misconfigured(kn1, kn2, block_m, int(key["inter_dim"]))
+        if wrong:
+            log.info("tier3: refusing (%s, %s) -- %s", kn1, kn2, wrong)
+            return None
         row = {
             "gfx": self._gfx(),
             "cu_num": self._cu_num(),
             **key,
-            "block_m": cfg.get("block_m", 32),
+            "block_m": block_m,
             "ksplit": cfg.get("ksplit", 0),
             "us1": 0,
             "kernelName1": kn1,
@@ -916,6 +924,56 @@ def aiter_honours_kernel_pair(kernel_name_1: str, kernel_name_2: str) -> bool:
     ``aiter/fused_moe.py``'s ``is_flydsl1 or is_flydsl2`` guard.
     """
     return kernel_name_1.startswith(FLYDSL_KERNEL_PREFIX) or kernel_name_2.startswith(FLYDSL_KERNEL_PREFIX)
+
+
+#: The tile a FlyDSL kernel name carries, as ``_t<M>x<N>x<K>``.
+FLYDSL_TILE = re.compile(r"_t(\d+)x(\d+)x(\d+)")
+
+
+def flydsl_tile(kernel_name: str) -> tuple[int, int, int] | None:
+    """The ``(M, N, K)`` tile in a FlyDSL name, or None if it carries none.
+
+    A CK, CKTile or Opus partner is spelled differently and returns None, which
+    is not an error -- the checks below skip whatever they cannot read rather
+    than refusing a name whose shape they do not know how to see.
+    """
+    if not kernel_name.startswith(FLYDSL_KERNEL_PREFIX):
+        return None
+    found = FLYDSL_TILE.search(kernel_name)
+    return (int(found.group(1)), int(found.group(2)), int(found.group(3))) if found else None
+
+
+def flydsl_pair_misconfigured(kernel_name_1: str, kernel_name_2: str, block_m: int, inter_dim: int) -> str:
+    """Why this pair would run something other than what it names -- or "".
+
+    Two ways to name one kernel and get another, both of which aiter accepts in
+    silence and neither of which faults:
+
+    * **A tile that does not divide the dimension it walks.** Stage 1 walks N
+      over ``inter_dim`` and stage 2 walks K over it. ``moe_kernels.py``'s
+      ``resolve_flydsl_stage1_tile_n`` and ``resolve_flydsl_stage2_tile_k``
+      quietly halve a tile that does not divide, so the kernel that runs is not
+      the one measured. Its own docstrings say tuners should not offer these.
+    * **A ``block_m`` that is not the pair's M tile.** ``block_m`` is the
+      granularity the tokens are sorted into before either kernel indexes them,
+      so a mismatch reads the wrong rows -- quickly. Measured on gfx950, nine
+      combinations with no exception: correct only when ``block_m`` equals the M
+      tile of *both* names, and the mismatched pairs were the fastest thing in
+      the search at 72us against a 112us default, wrong by a mean error of 1.4.
+
+    The correctness gate catches both, which is why this is a saving rather than
+    a safety net: a candidate refused here costs no GPU time, and a search that
+    keeps proposing them is told why instead of silently scoring zero.
+    """
+    tile_1, tile_2 = flydsl_tile(kernel_name_1), flydsl_tile(kernel_name_2)
+    if tile_1 and inter_dim % tile_1[1]:
+        return f"stage-1 tile N={tile_1[1]} does not divide inter_dim={inter_dim}; aiter would run a smaller tile"
+    if tile_2 and inter_dim % tile_2[2]:
+        return f"stage-2 tile K={tile_2[2]} does not divide inter_dim={inter_dim}; aiter would run a smaller tile"
+    for which, tile in (("stage-1", tile_1), ("stage-2", tile_2)):
+        if tile and tile[0] != block_m:
+            return f"block_m={block_m} is not the {which} tile M={tile[0]}; the token sort would not match the indexing"
+    return ""
 
 
 def mean_error(got: Any, ref: Any) -> float:

--- a/src/kernelforge/gemm_tune/tier3/dispatch.py
+++ b/src/kernelforge/gemm_tune/tier3/dispatch.py
@@ -23,6 +23,64 @@ MAX_RELATIVE_ERROR = 5e-2
 # Tables this module knows how to exercise.
 SUPPORTED_TABLES = ("bf16_tuned_gemm.csv",)
 
+#: What ``_Bf16DenseAdapter._build`` will accept, backend by backend.
+#:
+#: Load-bearing, not documentation: ``_build`` refuses a backend that is not a
+#: key here, and :func:`describe_candidate_protocol` renders it into the
+#: mandate. So the vocabulary the author is given and the vocabulary the referee
+#: understands are the same object, and cannot drift apart silently.
+#:
+#: They *had* drifted, in the only direction that matters. The mandate asked for
+#: candidates "carrying enough detail to be dispatched by code that did not
+#: write your script" and then never said what that code reads. Nothing named
+#: the five backends, the ``k=v;k=v`` grammar, or the fact that the keys of
+#: ``candidates.json`` are parsed as ``MxNxK``. An author working from the
+#: mandate alone -- which is the entire premise -- would have had to guess all
+#: three, and every wrong guess is recorded as "not dispatchable": the gate
+#: opens, the search runs, and nothing can possibly be re-timed.
+DENSE_BF16_BACKENDS: dict[str, str] = {
+    "torch": "the unmodified path, `torch.matmul(a, b.t())`. No config. Propose it only as a control.",
+    "hipblaslt": (
+        "`solidx=<int>` (required). Must be an index hipBLASLt itself offers for these exact "
+        "operands -- `aiter.hipb_findallsols` after `aiter.hipb_create_extension` is the "
+        "authoritative list. An invented index is refused, because running one kills the process."
+    ),
+    "aiter_asm": "`kernelName=<str>` (required), `splitK=<int>` (default 0).",
+    "aiter_opus": "`kernelId=<int>` (required), `splitK=<int>` (default 1).",
+    "aiter_flydsl": (
+        "`tile_m`, `tile_n`, `tile_k`, `split_k` (default 1), `block_m_warps`/`block_n_warps`/"
+        "`block_k_warps` (default 1), `stages` (default 4), `async_copy`/`b_to_lds` (default True)."
+    ),
+}
+
+
+def describe_candidate_protocol(table: str) -> str:
+    """How to write a candidate this module can actually dispatch, or "".
+
+    Empty for a table with no adapter, which is the same answer
+    :func:`adapters_for` gives: there is no protocol to describe because
+    nothing would re-time the result anyway.
+    """
+    if table != "bf16_tuned_gemm.csv":
+        return ""
+    backends = "\n".join(f"- `{name}` -- {detail}" for name, detail in DENSE_BF16_BACKENDS.items())
+    return (
+        "Each candidate is an object with a `backend` and a `config`, and the shape it belongs\n"
+        'to is the key it is filed under, written `MxNxK` -- `"8192x3456x1152"`, matching the\n'
+        "M, N and K columns of the same row in the CSV. `config` is `key=value` pairs joined by\n"
+        "`;` (never a comma); values that look like integers or `True`/`False` are read as such.\n"
+        "\n"
+        "These are the backends that can be re-dispatched, and the keys each one reads.\n"
+        "A candidate naming anything else, or omitting a required key, is recorded as not\n"
+        "dispatchable and cannot win -- so a well-measured candidate described in some other\n"
+        "vocabulary is worth exactly nothing here.\n"
+        "\n" + backends + "\n"
+        "\n"
+        "Anything the harness cannot re-dispatch is still worth reporting in the CSV; it just\n"
+        "cannot be promoted. If the only axis you find is unreachable through these backends,\n"
+        "say so plainly -- that is a real finding about this hardware, not a failure."
+    )
+
 
 def adapters_for(table: str) -> Any | None:
     """Return the dispatch adapter for a table, or None if we have none."""
@@ -181,11 +239,23 @@ class _Bf16DenseAdapter:
         return self._hipb_sols[key]
 
     def _build(self, key: tuple[int, int, int], cand: dict[str, Any]) -> Callable[[], Any] | None:
-        """One candidate as a callable, or None when we cannot dispatch it."""
+        """One candidate as a callable, or None when we cannot dispatch it.
+
+        None is recorded by the referee as "not dispatchable", which is a result
+        worth having; approximating what the candidate meant is not.
+        """
+        backend = str(cand.get("backend", ""))
+        if backend not in DENSE_BF16_BACKENDS:
+            # Checked against the same table the mandate is rendered from, so
+            # "the author was told about it" and "we can run it" are one fact.
+            # First, before aiter or the operands: a name we never offered is
+            # refused on paper, without allocating or importing anything.
+            log.info("tier3: unknown backend %r in a candidate", backend)
+            return None
+
         import aiter
 
         torch = self._torch()
-        backend = str(cand.get("backend", ""))
         cfg = parse_config(cand.get("config", ""))
         m, n, _k = key
         a, b = self._ops(key)
@@ -253,7 +323,9 @@ class _Bf16DenseAdapter:
             log.info("tier3: cannot dispatch %s: %r", backend, exc)
             return None
 
-        log.info("tier3: unknown backend %r in a candidate", backend)
+        # Declared above but not built here: a gap in this module, not in the
+        # candidate. Named as such so it is not mistaken for a bad proposal.
+        log.warning("tier3: backend %r is advertised in the mandate but not implemented", backend)
         return None
 
     def _is_correct(self, key: tuple[int, int, int], cand: dict[str, Any]) -> bool:

--- a/src/kernelforge/gemm_tune/tier3/dispatch.py
+++ b/src/kernelforge/gemm_tune/tier3/dispatch.py
@@ -6,8 +6,13 @@
 from __future__ import annotations
 
 import logging
+import os
+import tempfile
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
+
+from ..evidence import MOE_KEY_FIELDS, MOE_TABLE
 
 log = logging.getLogger(__name__)
 
@@ -20,8 +25,39 @@ CORRECTNESS_TRIALS = 8
 # Bound the aggregate referee error metric, not an element-wise relative ratio.
 MAX_RELATIVE_ERROR = 5e-2
 
-# Tables this module knows how to exercise.
-SUPPORTED_TABLES = ("bf16_tuned_gemm.csv",)
+#: The same limit for fused MoE, on the mean rather than the peak, because on
+#: MoE output the peak measure has no room left. Measured on an MI355X at
+#: gfx950, token=512 of the MiniMax-M3-MXFP4 key, as ``max|d|/mean`` and
+#: ``mean|d|/mean`` against one reference: the same kernel re-run gives 0.04701
+#: and 0.00021, a real tuning run's winner 1.2458 and 0.1445, deliberately
+#: holed scales 4.9008 and 0.5697. The 0.04701 is one bf16 ulp at the largest
+#: output element (``max|d|`` is 8.0 to the bit, twelve runs running) because
+#: stage 2 reduces with atomics and sums in a different order each time -- 6%
+#: of margin against :data:`MAX_RELATIVE_ERROR` on a kernel compared with
+#: itself. The mean measure leaves a factor of 48 below the limit and 14 above
+#: it to the nearest real failure.
+MAX_MOE_MEAN_ERROR = 1e-2
+
+#: The prefix that decides whether a tuned fused-MoE row is honoured at all.
+#: ``fused_moe`` reads the row, logs the pair it read, and only then asks
+#: whether either name starts with this; if neither does, control falls past
+#: the whole tuned branch into the heuristic chain. So the log line proves the
+#: row was read, not that the kernels ran. Measured: a candidate naming
+#: ``nope1``/``nope2`` was logged verbatim, ran the default path, and timed 1.1%
+#: faster than the baseline -- above the referee's 1.01 noise floor. A name that
+#: does start with it and is not real raises instead, and is refused on that.
+FLYDSL_KERNEL_PREFIX = "flydsl_"
+
+#: Fewer trials than :data:`CORRECTNESS_TRIALS`, and they vary less. A trial
+#: costs two ``fused_moe`` calls rather than a GEMM, and the weights cannot be
+#: re-rolled: ``generate_data_2stages`` is deterministic (verified -- two calls
+#: return bit-identical tensors), so only the activations differ between trials.
+#: Stated plainly because it is a weaker check than the dense one.
+MOE_CORRECTNESS_TRIALS = 4
+
+# Tables this module knows how to exercise. Everything else is honestly absent
+# rather than approximated.
+SUPPORTED_TABLES = ("bf16_tuned_gemm.csv", MOE_TABLE)
 
 #: What ``_Bf16DenseAdapter._build`` will accept, backend by backend.
 #:
@@ -54,6 +90,21 @@ DENSE_BF16_BACKENDS: dict[str, str] = {
 }
 
 
+#: What ``_FusedMoeAdapter._build`` will accept. One backend, because there is
+#: one way in: aiter resolves a fused-MoE kernel pair by looking the dispatch
+#: key up in a CSV, so a candidate *is* a row of that CSV and nothing else.
+FUSED_MOE_BACKENDS: dict[str, str] = {
+    "aiter_fmoe": (
+        "`kernelName1=<str>` and `kernelName2=<str>` (both required) -- the stage-1 and stage-2 "
+        "kernels, spelled exactly as aiter spells them. Optional: `block_m=<int>` (default 32), "
+        "`ksplit=<int>` (default 0), `run_1stage`/`xbf16`/`flat` (default 0). A pair that aiter "
+        "does not resolve to is refused rather than timed: the adapter reads back which kernels "
+        "aiter actually chose, and a row it ignored would otherwise be timed as the default path "
+        "and scored as a tie."
+    ),
+}
+
+
 def describe_candidate_protocol(table: str) -> str:
     """How to write a candidate this module can actually dispatch, or "".
 
@@ -61,6 +112,36 @@ def describe_candidate_protocol(table: str) -> str:
     :func:`adapters_for` gives: there is no protocol to describe because
     nothing would re-time the result anyway.
     """
+    if table == MOE_TABLE:
+        fields = ", ".join(f"`{f}`" for f in MOE_KEY_FIELDS)
+        backends = "\n".join(f"- `{name}` -- {detail}" for name, detail in FUSED_MOE_BACKENDS.items())
+        return (
+            "Each candidate is an object with a `backend` and a `config`, and the shape it belongs\n"
+            "to is the key it is filed under. A fused-MoE shape is not `MxNxK`: it is the whole\n"
+            "dispatch key, written as `field=value` pairs joined by `|`, in this order:\n"
+            f"{fields}.\n"
+            "Values are copied verbatim from the same row of the CSV -- including the spelling of\n"
+            "`act_type` (`ActivationType.Swiglu`), the dtypes (`torch.float4_e2m1fn_x2`) and\n"
+            "`q_type` (`QuantType.per_1x32`). For example:\n"
+            '`"token=512|model_dim=6144|inter_dim=384|expert=128|topk=4|'
+            "act_type=ActivationType.Swiglu|dtype=torch.bfloat16|"
+            "q_dtype_a=torch.float4_e2m1fn_x2|q_dtype_w=torch.float4_e2m1fn_x2|"
+            'q_type=QuantType.per_1x32|use_g1u1=1|doweight_stage1=0"`.\n'
+            "`config` is `key=value` pairs joined by `;` (never a comma).\n"
+            "\n" + backends + "\n"
+            "\n"
+            "At least one of `kernelName1` and `kernelName2` must be a FlyDSL kernel (its name\n"
+            f"starts with `{FLYDSL_KERNEL_PREFIX}`). aiter only consults a tuned row when one of\n"
+            "the two is; otherwise it reads the row, ignores it, and runs its heuristic choice --\n"
+            "so a pair without one is refused here rather than timed as a phantom win. The\n"
+            "partner name may be a CK, CKTile or Opus kernel.\n"
+            "\n"
+            "Only the mxfp4 SwiGLU path is re-timable here (`q_type=QuantType.per_1x32`,\n"
+            "`q_dtype_w=torch.float4_e2m1fn_x2`, `act_type=ActivationType.Swiglu`); a candidate\n"
+            "for any other combination is recorded as not dispatchable, because building the\n"
+            "operands for it in the layout its kernels expect is not something this harness knows\n"
+            "how to do yet. Report what you find for those anyway -- it just cannot be promoted."
+        )
     if table != "bf16_tuned_gemm.csv":
         return ""
     backends = "\n".join(f"- `{name}` -- {detail}" for name, detail in DENSE_BF16_BACKENDS.items())
@@ -86,6 +167,8 @@ def adapters_for(table: str) -> Any | None:
     """Return the dispatch adapter for a table, or None if we have none."""
     if table == "bf16_tuned_gemm.csv":
         return _Bf16DenseAdapter()
+    if table == MOE_TABLE:
+        return _FusedMoeAdapter()
     log.info(
         "tier3: no dispatch adapter for %s, so a generated tuner for it could not be re-timed; supported today: %s",
         table,
@@ -122,6 +205,435 @@ def shape_key(shape: str) -> tuple[int, int, int]:
     except ValueError as exc:
         raise ValueError(f"tier3 shape must be MxNxK of integers, got {shape!r}") from exc
     return (m, n, k)
+
+
+def moe_shape_key(shape: str) -> dict[str, str]:
+    """``"token=512|model_dim=6144|..."`` into the dispatch key, as strings.
+
+    Raises ``ValueError`` naming what is missing. Not ``MxNxK`` and not
+    positional: a fused-MoE key carries twelve fields, three of which contain
+    a ``.`` and one of which (``torch.float4_e2m1fn_x2``) contains an ``x``, so
+    any positional encoding built out of the obvious separators is ambiguous
+    against the values it has to carry.
+    """
+    parts = [p for p in str(shape).split("|") if p.strip()]
+    got: dict[str, str] = {}
+    for part in parts:
+        name, sep, value = part.partition("=")
+        if not sep:
+            raise ValueError(f"tier3 fused-MoE shape must be field=value pairs, got {part!r} in {shape!r}")
+        got[name.strip()] = value.strip()
+    missing = [f for f in MOE_KEY_FIELDS if f not in got]
+    if missing:
+        raise ValueError(f"tier3 fused-MoE shape {shape!r} is missing {', '.join(missing)}")
+    return {f: got[f] for f in MOE_KEY_FIELDS}
+
+
+class _FusedMoeAdapter:
+    """Dispatch, baseline and correctness for aiter's fused mxfp4 SwiGLU MoE.
+
+    Unlike the dense adapter this one cannot hand the kernel its arguments. A
+    fused-MoE kernel pair is chosen inside ``aiter.fused_moe`` by looking the
+    dispatch key up in a CSV named by ``AITER_CONFIG_FMOE``, so a candidate is
+    dispatched by writing that CSV and calling the ordinary entry point --
+    which is also aiter's own idiom for re-timing one
+    (``GroupedFmoeTuner._run_candidate``). Four things about that were measured
+    rather than assumed, each of which silently produces a wrong measurement:
+
+    * **The env var alone does not switch anything.** ``get_config_file`` is
+      ``lru_cache``d on a key that does not include the environment variable
+      whose value it reads, so within one process the first resolution wins
+      forever. Three caches have to be cleared together; see :meth:`_point_at`.
+    * **The caller does not choose the activation dtype.** ``fused_moe``
+      derives ``q_dtype_a`` itself from the quant type, the activation, the
+      gate mode and the token count -- for SwiGLU mxfp4 it is bf16 below 256
+      tokens and fp4 at or above. So a demanded key is not necessarily a key
+      this process can be steered to, and the adapter confirms which key was
+      actually served instead of predicting it.
+    * **Operands must match the kernel family's layout.** aiter's generator
+      hands back three pairings (CK-shuffled, unshuffled, FlyDSL-shuffled) and
+      crossing them does not fail -- it returns NaN, or, if the activations are
+      pre-quantized when the path wanted bf16, aborts the queue with
+      ``HSA_STATUS_ERROR_EXCEPTION``.
+    * **A row aiter ignores is timed as the default path.** Which reads as a
+      tie, or, with noise, as a small win for a candidate that did nothing. Two
+      different silences produce that, so there are two guards: a key this
+      process cannot be steered to is caught by reading the resolved kernel
+      names back out of aiter's own log, and a pair aiter discards *after*
+      logging it is caught by :func:`aiter_honours_kernel_pair` before any GPU
+      work happens.
+
+    Scope is the mxfp4 SwiGLU path (``per_1x32``, fp4 weights) because that is
+    where the demand is and where the candidates are: on gfx950 the production
+    MiniMax-M3-MXFP4 key has 834 tunable candidates, every one of them FlyDSL,
+    and zero from the other five generators.
+    """
+
+    #: aiter reads its tuned fused-MoE config from a CSV with exactly these
+    #: columns. The key half is :data:`MOE_KEY_FIELDS` plus the two aiter adds
+    #: itself; the rest is what the tuner records, of which only the kernel
+    #: names and the four flags are read back at dispatch time.
+    _CSV_COLUMNS = (
+        "gfx",
+        "cu_num",
+        *MOE_KEY_FIELDS,
+        "block_m",
+        "ksplit",
+        "us1",
+        "kernelName1",
+        "err1",
+        "us2",
+        "kernelName2",
+        "err2",
+        "us",
+        "run_1stage",
+        "xbf16",
+        "flat",
+        "tflops",
+        "bw",
+    )
+
+    def __init__(self) -> None:
+        self._operands: dict[str, Any] = {}
+        self._in_play: dict[str, dict[str, Any]] = {}
+        self._workdir = Path(tempfile.mkdtemp(prefix="forge_tier3_fmoe_"))
+        self._baseline_csv = self._workdir / "baseline.csv"
+        self._baseline_csv.write_text(",".join(self._CSV_COLUMNS) + "\n", encoding="utf-8")
+        self._restore = os.environ.get("AITER_CONFIG_FMOE")
+
+    # -- torch and aiter are imported lazily so this stays importable off-GPU --
+    @staticmethod
+    def _torch():
+        import torch
+
+        return torch
+
+    @staticmethod
+    def _fused_moe():
+        import aiter.fused_moe as fm
+
+        return fm
+
+    def _point_at(self, path: Path) -> None:
+        """Make the next ``fused_moe`` call read *path*, cache clears included.
+
+        All three clears are load-bearing and were found one at a time by
+        switching configs and watching the resolved kernel not change:
+        ``get_config_file`` caches the resolved path, ``cfg_2stages`` caches the
+        parsed table, and ``get_2stage_cfgs`` caches the row for a key.
+        """
+        from aiter.jit.core import AITER_CONFIGS
+
+        fm = self._fused_moe()
+        os.environ["AITER_CONFIG_FMOE"] = str(path)
+        AITER_CONFIGS.get_config_file.cache_clear()
+        fm.cfg_2stages = None
+        fm.get_2stage_cfgs.cache_clear()
+
+    # ------------------------------------------------------------- operands --
+    def _ops(self, shape: str) -> dict[str, Any] | None:
+        """Weights, scales and routing for one key, or None if we cannot build.
+
+        Built by aiter's own tuning script rather than reimplemented here.
+        Quantizing 128 experts to mxfp4 and pre-shuffling them into the layout
+        the FlyDSL kernels index is exactly the kind of thing a reimplementation
+        gets subtly wrong and then reports as a numerics failure in the
+        candidate. It lives in ``csrc/`` next to the installed package, so a
+        wheel without sources yields None -- an honest "no dispatch here", not
+        an approximation.
+        """
+        if shape in self._operands:
+            return self._operands[shape]
+        key = moe_shape_key(shape)
+        torch = self._torch()
+        try:
+            import aiter
+            from aiter import ActivationType, QuantType
+
+            if key["q_type"] != "QuantType.per_1x32" or key["act_type"] != "ActivationType.Swiglu":
+                log.info("tier3: %s is not the mxfp4 SwiGLU path; no fused-MoE operands for it", shape)
+                self._operands[shape] = None
+                return None
+            codegen = Path(aiter.__file__).resolve().parent.parent / "csrc" / "ck_gemm_moe_2stages_codegen"
+            if not (codegen / "gemm_moe_tune.py").is_file():
+                log.info("tier3: aiter sources are not installed at %s; cannot build fused-MoE operands", codegen)
+                self._operands[shape] = None
+                return None
+            import sys
+
+            if str(codegen) not in sys.path:
+                sys.path.insert(0, str(codegen))
+            import gemm_moe_tune as moe_tune
+
+            dtype = getattr(torch, key["dtype"].removeprefix("torch."))
+            q_dtype_w = getattr(torch, key["q_dtype_w"].removeprefix("torch."))
+            bundle = moe_tune.FmoeTuner.generate_data_2stages(
+                int(key["token"]),
+                int(key["model_dim"]),
+                int(key["inter_dim"]),
+                int(key["expert"]),
+                int(key["topk"]),
+                ActivationType.Swiglu,
+                dtype,
+                q_dtype_w,
+                q_dtype_w,
+                QuantType.per_1x32,
+                key["use_g1u1"] not in ("0", "False", "false", ""),
+                key["doweight_stage1"] not in ("0", "False", "false", ""),
+                # blockM only sizes the pre-sorted buffers the low-level stage
+                # entry points take. Nothing passed to fused_moe depends on it,
+                # so the candidate's own block_m does not force a rebuild.
+                32,
+                1,
+            )
+        except Exception as exc:  # noqa: BLE001 - "cannot build operands" is data
+            log.info("tier3: cannot build fused-MoE operands for %s: %r", shape, exc)
+            self._operands[shape] = None
+            return None
+        self._operands[shape] = bundle
+        return bundle
+
+    def _hidden(self, shape: str, seed: int):
+        torch = self._torch()
+        key = moe_shape_key(shape)
+        gen = torch.Generator(device="cuda").manual_seed(seed)
+        return torch.randn(int(key["token"]), int(key["model_dim"]), device="cuda", dtype=torch.bfloat16, generator=gen)
+
+    def _call(self, shape: str, hidden) -> Callable[[], Any] | None:
+        bundle = self._ops(shape)
+        if bundle is None:
+            return None
+        from aiter import ActivationType, QuantType
+
+        fm = self._fused_moe()
+        torch = self._torch()
+
+        def run():
+            return fm.fused_moe(
+                hidden,
+                bundle["w1_qt_shffle_flydsl"],
+                bundle["w2_qt_shffle_flydsl"],
+                bundle["topk_weights"],
+                bundle["topk_ids"],
+                activation=ActivationType.Swiglu,
+                quant_type=QuantType.per_1x32,
+                w1_scale=bundle["w1_scale_flydsl"],
+                w2_scale=bundle["w2_scale_flydsl"],
+                dtype=torch.bfloat16,
+            )
+
+        return run
+
+    # ------------------------------------------------------- the three hooks --
+    def as_graph(self, fn: Callable[[], Any]) -> Callable[[], Any]:
+        return _Bf16DenseAdapter.as_graph(self, fn)  # type: ignore[arg-type]
+
+    def make_baseline(self, shape: str) -> Callable[[], Any]:
+        """The unmodified path: no tuned row for this key, so aiter's heuristic.
+
+        An empty table rather than an unset variable, because unsetting it lets
+        aiter fall back to whatever tuned file happens to be installed -- which
+        on a fleet box is a file we deployed, and timing a candidate against our
+        own previous answer is not what "baseline" means here.
+        """
+        self._point_at(self._baseline_csv)
+        run = self._call(shape, self._hidden(shape, 0))
+        if run is None:
+            # The runner only reaches here for a table this adapter claimed, so
+            # a shape it cannot build is a real failure of the attempt rather
+            # than something to paper over with a no-op.
+            raise ValueError(f"tier3: no fused-MoE baseline could be built for {shape}")
+        return self.as_graph(run)
+
+    def make_dispatch(self, shape: str) -> Callable[[dict[str, Any]], Callable[[], Any] | None]:
+        def dispatch(cand: dict[str, Any]) -> Callable[[], Any] | None:
+            self._in_play[shape] = cand
+            run = self._build(shape, cand)
+            return self.as_graph(run) if run is not None else None
+
+        return dispatch
+
+    def make_correctness(self, shape: str) -> Callable[[Callable[[], Any]], bool]:
+        def check(_dispatched: Callable[[], Any]) -> bool:
+            cand = self._in_play.get(shape)
+            if cand is None:
+                return True
+            return self._is_correct(shape, cand)
+
+        return check
+
+    def sync(self) -> Callable[[], Any]:
+        return self._torch().cuda.synchronize
+
+    # ------------------------------------------------------------ internals --
+    def _candidate_csv(self, shape: str, cand: dict[str, Any]) -> tuple[Path, str, str] | None:
+        """Write the candidate as the one row of a tuned-config file."""
+        if str(cand.get("backend", "")) not in FUSED_MOE_BACKENDS:
+            log.info("tier3: unknown backend %r in a fused-MoE candidate", cand.get("backend"))
+            return None
+        cfg = parse_config(cand.get("config", ""))
+        kn1, kn2 = str(cfg.get("kernelName1", "")), str(cfg.get("kernelName2", ""))
+        if not kn1 or not kn2:
+            log.info("tier3: a fused-MoE candidate named no kernel pair: %r", cand.get("config"))
+            return None
+        if not aiter_honours_kernel_pair(kn1, kn2):
+            log.info(
+                "tier3: aiter would read the row for (%s, %s) and then ignore it -- one of the two "
+                "names has to be FlyDSL's for the tuned branch to be taken at all; refusing",
+                kn1,
+                kn2,
+            )
+            return None
+        key = moe_shape_key(shape)
+        row = {
+            "gfx": self._gfx(),
+            "cu_num": self._cu_num(),
+            **key,
+            "block_m": cfg.get("block_m", 32),
+            "ksplit": cfg.get("ksplit", 0),
+            "us1": 0,
+            "kernelName1": kn1,
+            "err1": "0.0%",
+            "us2": 0,
+            "kernelName2": kn2,
+            "err2": "0.0%",
+            "us": 0,
+            "run_1stage": int(bool(cfg.get("run_1stage", 0))),
+            "xbf16": int(bool(cfg.get("xbf16", 0))),
+            "flat": int(bool(cfg.get("flat", 0))),
+            "tflops": 0,
+            "bw": 0,
+        }
+        path = self._workdir / "candidate.csv"
+        path.write_text(
+            ",".join(self._CSV_COLUMNS) + "\n" + ",".join(str(row[c]) for c in self._CSV_COLUMNS) + "\n",
+            encoding="utf-8",
+        )
+        return path, kn1, kn2
+
+    def _gfx(self) -> str:
+        from aiter.jit.core import get_gfx
+
+        return get_gfx()
+
+    def _cu_num(self) -> int:
+        return int(self._torch().cuda.get_device_properties(0).multi_processor_count)
+
+    def _build(self, shape: str, cand: dict[str, Any]) -> Callable[[], Any] | None:
+        written = self._candidate_csv(shape, cand)
+        if written is None:
+            return None
+        path, kn1, kn2 = written
+        self._point_at(path)
+        run = self._call(shape, self._hidden(shape, 0))
+        if run is None:
+            return None
+        try:
+            resolved = self._resolved_kernels(run)
+        except Exception as exc:  # noqa: BLE001 - a candidate that raises is not dispatchable
+            log.info("tier3: fused-MoE candidate %s/%s raised: %r", kn1, kn2, exc)
+            self._point_at(self._baseline_csv)
+            return None
+        if resolved != (kn1, kn2):
+            # Not a bad candidate necessarily -- more often a key this process
+            # cannot be steered to at all, because fused_moe derives q_dtype_a
+            # from the token count. Either way it must not be timed: what would
+            # run is the default path, and that scores as a tie or, with noise,
+            # as a win for a row that changed nothing.
+            log.info(
+                "tier3: aiter did not take the candidate row for %s -- asked for (%s, %s), served %s; not timing it",
+                shape,
+                kn1,
+                kn2,
+                resolved,
+            )
+            self._point_at(self._baseline_csv)
+            return None
+        return run
+
+    def _resolved_kernels(self, run: Callable[[], Any]) -> tuple[str, str] | None:
+        """Which kernel pair aiter actually chose, read out of its own log.
+
+        Observation rather than prediction. The alternative is to re-derive
+        aiter's dispatch rules here, and those rules are a hundred lines of
+        branching on token count, gate mode and gfx that change release to
+        release -- a copy of them would be wrong quietly.
+        """
+        import re
+
+        records: list[str] = []
+
+        class _Catch(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record.getMessage())
+
+        aiter_log = logging.getLogger("aiter")
+        handler = _Catch()
+        previous = aiter_log.level
+        aiter_log.addHandler(handler)
+        aiter_log.setLevel(logging.INFO)
+        try:
+            run()
+            self._torch().cuda.synchronize()
+        finally:
+            aiter_log.removeHandler(handler)
+            aiter_log.setLevel(previous)
+        pattern = re.compile(r"kernelName1='([^']*)', kernelName2='([^']*)'")
+        for message in reversed(records):
+            found = pattern.search(message)
+            if found:
+                return (found.group(1), found.group(2))
+        return None
+
+    def _is_correct(self, shape: str, cand: dict[str, Any]) -> bool:
+        """Does the candidate agree with the path production runs today?
+
+        A weaker question than the dense adapter asks, and deliberately. There
+        the reference is an independent fp32 ``matmul``; here aiter's generator
+        hands over weights that are already quantized and pre-shuffled, and
+        there is no unquantized copy to build an independent reference from.
+        So the reference is the unmodified path -- which is the right question
+        for a promotion decision anyway ("would swapping this in change what we
+        serve?"), just not a proof that either side is arithmetically right.
+        """
+        torch = self._torch()
+        written = self._candidate_csv(shape, cand)
+        if written is None:
+            return False
+        hiddens = [self._hidden(shape, 1 + i) for i in range(MOE_CORRECTNESS_TRIALS)]
+        try:
+            self._point_at(self._baseline_csv)
+            refs = []
+            for hidden in hiddens:
+                run = self._call(shape, hidden)
+                if run is None:
+                    return False
+                refs.append(run().float())
+            torch.cuda.synchronize()
+
+            self._point_at(written[0])
+            worst = 0.0
+            for hidden, ref in zip(hiddens, refs, strict=True):
+                run = self._call(shape, hidden)
+                if run is None:
+                    return False
+                got = run()
+                torch.cuda.synchronize()
+                worst = max(worst, mean_error(got, ref))
+        except Exception as exc:  # noqa: BLE001 - a kernel that raises is wrong
+            log.warning("tier3: fused-MoE correctness check raised, rejecting: %r", exc)
+            return False
+
+        if worst > MAX_MOE_MEAN_ERROR:
+            log.error(
+                "tier3: rejecting %s -- worst mean error over %d activation sets was %.4g, above the %.3g limit",
+                str(cand.get("config"))[:80],
+                MOE_CORRECTNESS_TRIALS,
+                worst,
+                MAX_MOE_MEAN_ERROR,
+            )
+            return False
+        return True
 
 
 class _Bf16DenseAdapter:
@@ -374,3 +886,30 @@ class _Bf16DenseAdapter:
 def relative_error(got: Any, ref: Any) -> float:
     """Largest deviation, against the magnitude of the reference as a whole."""
     return float((got.float() - ref).abs().max() / ref.abs().mean())
+
+
+def aiter_honours_kernel_pair(kernel_name_1: str, kernel_name_2: str) -> bool:
+    """Will aiter actually run this pair, or read it and move on?
+
+    The one part of aiter's dispatch this adapter does have to mirror, because
+    it is the part no observation can recover: the tuned row is logged before
+    the decision that discards it, so a pair aiter throws away is
+    indistinguishable in the log from one it keeps. Everything else the adapter
+    confirms by watching; this it has to know.
+
+    A pair is honoured when at least one name is FlyDSL's. Its partner may then
+    be a CK, CKTile or Opus name and is dispatched too -- but only from inside
+    the branch that the FlyDSL name opened. See
+    ``aiter/fused_moe.py``'s ``is_flydsl1 or is_flydsl2`` guard.
+    """
+    return kernel_name_1.startswith(FLYDSL_KERNEL_PREFIX) or kernel_name_2.startswith(FLYDSL_KERNEL_PREFIX)
+
+
+def mean_error(got: Any, ref: Any) -> float:
+    """Average deviation, against the magnitude of the reference as a whole.
+
+    The peak measure above reports one bf16 ulp at the largest element, which
+    for a fused-MoE output is 0.047 for a kernel against itself. See
+    :data:`MAX_MOE_MEAN_ERROR` for the three cases that settled this.
+    """
+    return float((got.float() - ref).abs().mean() / ref.abs().mean())

--- a/src/kernelforge/gemm_tune/tier3/dispatch.py
+++ b/src/kernelforge/gemm_tune/tier3/dispatch.py
@@ -73,6 +73,7 @@ class _Bf16DenseAdapter:
         self._operands: dict[tuple[int, ...], tuple[Any, Any]] = {}
         self._in_play: dict[str, dict[str, Any]] = {}
         self._hipb_ready = False
+        self._hipb_sols: dict[tuple[int, ...], set[int]] = {}
 
     # -- torch is imported lazily so this module stays importable off-GPU --
     @staticmethod
@@ -145,15 +146,39 @@ class _Bf16DenseAdapter:
         return self._torch().cuda.synchronize
 
     # ------------------------------------------------------------ internals --
-    def _hipb_once(self, a, bt) -> None:
-        """hipb_mm on a handle nobody created aborts from C++, uncatchably."""
-        if self._hipb_ready:
-            return
+    def _hipb_solutions(self, key: tuple[int, int, int], a, bt) -> set[int]:
+        """The solution indices hipBLASLt will accept for this shape.
+
+        Everything here is about not being killed. Two ways to die, both
+        confirmed on an MI355X and neither of them catchable from Python,
+        because the C++ error handler ends the process rather than returning:
+
+        * ``hipb_mm`` on a handle nobody created is a SIGSEGV. The extension
+          has to be created explicitly; this used to warm up by calling
+          ``hipb_findallsols`` instead, which wants the very same handle and so
+          died at ``hipbsolgemm.cu:248`` with ``NOT_INITIALIZED`` before it
+          could protect anything.
+        * ``hipb_mm`` with a solution index that is not real exits at
+          ``hipbsolgemm.cu:945`` with ``INVALID_VALUE``. A generated tuner
+          proposes ``solidx`` as a free integer, so this is not a remote
+          possibility -- it is the expected case for a first draft.
+
+        The referee runs in-process at the tail of a tuning session, after
+        every other tuner has finished, so either death costs the whole run its
+        report. Hence the set: ``findallsols`` is the authoritative answer for
+        these exact operands, and a candidate naming anything outside it is
+        refused as undispatchable, which is an ordinary recorded result.
+        """
         import aiter
 
         torch = self._torch()
-        aiter.hipb_findallsols(a, bt, None, torch.bfloat16, None, None, None, False, False)
-        self._hipb_ready = True
+        if not self._hipb_ready:
+            aiter.hipb_create_extension()
+            self._hipb_ready = True
+        if key not in self._hipb_sols:
+            sols = aiter.hipb_findallsols(a, bt, None, torch.bfloat16, None, None, None, False, False)
+            self._hipb_sols[key] = {int(s) for s in (sols or [])}
+        return self._hipb_sols[key]
 
     def _build(self, key: tuple[int, int, int], cand: dict[str, Any]) -> Callable[[], Any] | None:
         """One candidate as a callable, or None when we cannot dispatch it."""
@@ -174,7 +199,10 @@ class _Bf16DenseAdapter:
                 if sol is None:
                     return None
                 bt = b.t()
-                self._hipb_once(a, bt)
+                sol = int(sol)
+                if sol not in self._hipb_solutions(key, a, bt):
+                    log.info("hipblaslt solidx %s is not a solution for %s; not dispatching", sol, key)
+                    return None
                 return lambda: aiter.hipb_mm(a, bt, sol, None, torch.bfloat16, None, None, None, False, False)
 
             if backend == "aiter_asm":

--- a/src/kernelforge/gemm_tune/tier3/gate.py
+++ b/src/kernelforge/gemm_tune/tier3/gate.py
@@ -1,7 +1,23 @@
 # SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Whether a generated tuner may be attempted at all."""
+"""Whether a generated tuner may be attempted at all.
+
+Four conditions, separate on purpose so that one misconfiguration cannot open
+the whole path: nobody turned it off, nothing else did the job, there is enough
+demand to be worth it, and the keys are describable.
+
+The second used to read ``no_tuner`` only, which sounds stricter and was in
+practice absolute -- across the fleet's 0903-0906 logs every demanded table had
+a registered owner, so no run ever produced a gap this would accept while the
+runtime went on missing millions of keys those owners never covered. "A tuner
+exists" was standing in for "the table got tuned", and only the second is what
+the runtime experiences.
+
+The decision carries its reasons rather than being a boolean, because when this
+says no the useful artefact is *why*: fix routing, widen the whitelist, or leave
+it alone.
+"""
 
 from __future__ import annotations
 
@@ -63,7 +79,8 @@ def should_generate(gaps: list[CoverageGap]) -> GateDecision:
     for gap in sorted(gaps, key=lambda g: -g.miss_count):
         if not gap.warrants_generated_tuner:
             reasons.append(
-                f"{gap.table}: {gap.kind} -- a tuner for this exists, so the fix is there and not a generated one"
+                f"{gap.table}: {gap.kind} -- a tuner for this exists and was not "
+                f"routed to, so the fix is there and not a generated one"
             )
             continue
         if allow and "*" not in allow and gap.table not in allow:

--- a/src/kernelforge/gemm_tune/tier3/generate.py
+++ b/src/kernelforge/gemm_tune/tier3/generate.py
@@ -1,11 +1,28 @@
 # SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Ask an agent to author a tuner from a mandate."""
+"""Ask an agent to author a tuner from a mandate.
+
+``kernelforge.llm`` is imported inside the call, never at module scope: the
+standalone wheel is meant to be the only thing a GPU box installs to tune, and a
+test asserts it imports with no ``kernelforge`` present. Absent, this returns
+"unavailable" and the caller carries on, the same outcome as a closed gate.
+
+The session is writable, which puts it under the workspace guard, which requires
+a git worktree it can snapshot and roll back. Nothing here ever was one, so on a
+real box this stage failed before the model was asked anything -- see
+:func:`_isolate`.
+
+The agent writes one file and is told what it will be judged on. It is not shown
+the existing tuners: this tier exists for a capability nothing else has, and a
+script derived from one that does is either the wrong shape or evidence the gate
+should not have opened.
+"""
 
 from __future__ import annotations
 
 import logging
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -105,6 +122,10 @@ def generate_tuner(
     except Exception as exc:  # noqa: BLE001 - provider setup must not fail tuning
         return GeneratedTuner(False, None, f"agent provider unusable: {exc!r}")
 
+    isolated = _isolate(work_dir)
+    if isolated is not None:
+        return isolated
+
     spec = AgentRunSpec(
         system_prompt=_SYSTEM_PROMPT,
         user_prompt=_user_prompt(mandate, script_path, retry_note),
@@ -132,6 +153,59 @@ def generate_tuner(
         )
     log.info("tier3: %s authored %s", provider or "agent", script_path)
     return GeneratedTuner(True, script_path, "", provider, session)
+
+
+def _isolate(work_dir: Path) -> GeneratedTuner | None:
+    """Make ``work_dir`` its own git worktree. ``None`` when it now is one.
+
+    A writable session runs under the workspace guard, and the guard refuses to
+    start anywhere ``git rev-parse --show-toplevel`` comes back empty -- it has
+    no baseline to snapshot and no way to roll back. Nothing ever gave it one
+    here: this work_dir is ``<tuning output>/tier3/<table>/``, an ordinary
+    output directory, so on a GPU box the authoring session died at
+    ``WorkspaceSafetyError('not a git repository')`` before the model was ever
+    asked anything. The gate opening changed nothing, because this is upstream
+    of everything the gate controls.
+
+    An empty repository of its own is the fix rather than an exemption. The
+    guard then does exactly its job -- baseline, rollback, and a verdict on what
+    the session touched -- against a directory that exists to be written to.
+
+    Initialising *the work_dir itself* also matters. Left alone, a tuning run
+    started from inside a checkout would resolve the toplevel to that checkout,
+    and the guard would be judging the operator's real tree against a session
+    that is supposed to be sandboxed.
+    """
+    if (work_dir / ".git").exists():
+        return None
+    steps = (
+        ("init", "-q"),
+        ("config", "user.email", "tier3@kernelforge.invalid"),
+        ("config", "user.name", "kernelforge tier3"),
+        # A baseline commit, so rollback has something to roll back to.
+        ("commit", "-q", "--allow-empty", "-m", "empty sandbox"),
+    )
+    for args in steps:
+        try:
+            done = subprocess.run(
+                ["git", *args],
+                cwd=str(work_dir),
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return GeneratedTuner(False, None, f"could not prepare a sandbox worktree: git {args[0]}: {exc}")
+        if done.returncode != 0:
+            detail = (done.stderr or done.stdout or "").strip()[:300]
+            return GeneratedTuner(
+                False,
+                None,
+                f"could not prepare a sandbox worktree: git {args[0]} failed: {detail}",
+            )
+    log.info("tier3: initialised a sandbox worktree at %s for the authoring session", work_dir)
+    return None
 
 
 def _run(backend: Any, spec: Any) -> Any:

--- a/src/kernelforge/gemm_tune/tier3/generate.py
+++ b/src/kernelforge/gemm_tune/tier3/generate.py
@@ -33,6 +33,13 @@ log = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT_S = 1800
 
+#: Turns the authoring session may take. The default of one is unusable: the
+#: mandate itself tells the author to explore what is callable before committing
+#: to a search, and enumerating a backend's identifiers, reading the answer and
+#: then writing the script is several turns at minimum. ``timeout_s`` remains
+#: the real limit.
+MAX_AUTHORING_TURNS = 120
+
 _SYSTEM_PROMPT = """\
 You author one GPU kernel tuning script, to a fixed contract, and nothing else.
 
@@ -99,7 +106,7 @@ def generate_tuner(
     script_path = work_dir / "tuner.py"
 
     try:
-        from kernelforge.agent_backends.base import AgentRunSpec
+        from kernelforge.agent_backends.base import AgentRunSpec, AgentToolPolicy
         from kernelforge.agent_backends.registry import (
             create_registered_backend,
             resolve_agent_runtime,
@@ -132,6 +139,21 @@ def generate_tuner(
         cwd=str(work_dir),
         writable=True,
         timeout_sec=timeout_s,
+        # Without a policy the backend sets no allowed_tools at all, so nothing
+        # is pre-approved and the session stops to ask. Measured on an MI355X:
+        # it asked for Write and for python3, explained at length why it could
+        # not enumerate hipBLASLt solutions without them, and ended its turn
+        # waiting for an answer nobody was there to give. `agent_stopped`,
+        # no script, a whole GPU run spent.
+        #
+        # Shell is not optional here, and not a widening of what this tier
+        # already does. Three of the five backends it may propose take
+        # identifiers only the installed library can supply -- a solidx, an ASM
+        # kernel name, an opus kernel id -- and the mandate tells the author
+        # that inventing one kills the process. Enumerating them means running
+        # python on this box. The script it writes is then executed anyway, by
+        # `sandbox.run_generated_tuner`, in the same container.
+        tool_policy=AgentToolPolicy(read=True, search=True, write=True, shell=True, max_turns=MAX_AUTHORING_TURNS),
         target_files=[str(script_path)],
         allow_untracked=True,
     )
@@ -144,10 +166,18 @@ def generate_tuner(
     provider = str(getattr(backend, "name", "") or "")
     session = str(getattr(result, "session_id", "") or "")
     if not script_path.is_file():
+        # Quote the agent. Without this the failure reads "the session ended
+        # (agent_stopped) without writing tuner.py" whatever went wrong, and
+        # the one thing that explains it -- the agent saying which permission
+        # it was missing -- is thrown away. That cost a full GPU run to
+        # rediscover by hand, and the same text is also what the retry note
+        # would need to be useful.
+        said = " ".join(str(getattr(result, "text", "") or "").split())[-600:]
         return GeneratedTuner(
             False,
             None,
-            f"the session ended ({getattr(result, 'end_reason', '?')}) without writing {script_path.name}",
+            f"the session ended ({getattr(result, 'end_reason', '?')}) without writing {script_path.name}"
+            + (f"; it said: {said}" if said else "; it said nothing"),
             provider,
             session,
         )

--- a/src/kernelforge/gemm_tune/tier3/mandate.py
+++ b/src/kernelforge/gemm_tune/tier3/mandate.py
@@ -1,7 +1,37 @@
 # SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""The brief handed to whoever writes a generated tuner."""
+"""The brief handed to whoever writes a generated tuner.
+
+Five things, because a tuner cannot be written without any of them: the output
+contract, the demand it must cover, why the existing tiers did not, the shape a
+candidate has to take to be re-dispatchable, and a skeleton that already runs on
+this hardware.
+
+The fourth was missing for as long as this tier existed, and it made the others
+moot. The brief asked for candidates "carrying enough detail to be dispatched by
+code that did not write your script" without saying what that code reads, so an
+author following it exactly proposed configurations in a vocabulary
+:mod:`.dispatch` does not parse -- every one recorded as "not dispatchable". It
+now comes from ``dispatch.describe_candidate_protocol``, so the words the author
+is given are generated from the code that reads them back.
+
+Three clauses are not style preferences. On the first real MI355X trial both an
+LLM-written tuner and aiter's own official tuner were confidently wrong the same
+two ways. Correctness must be re-checked on fresh inputs several times: four
+split-K winners were wrong on 1.25-3.98% of elements, and *which* elements
+changed between identical calls, so a single check passes them at random -- the
+generated tuner reported a worst-case relative error of 7.65e-3 for candidates a
+repeated audit measured at 17 to 50. A Python-loop timer cannot rank these
+kernels: one dispatch costs ~12us against kernels of 5-13us, so every candidate
+collapses to the same number and the honest conclusion from that data was "there
+is nothing to tune here"; capturing N calls into a graph removes the host cost.
+And its own timings decide nothing -- :mod:`.referee` re-times everything, which
+is what makes the rest survivable.
+
+The mandate is data. Rendering it as text is a convenience; the fields are what
+downstream code checks against.
+"""
 
 from __future__ import annotations
 
@@ -36,6 +66,7 @@ class TunerMandate:
     gpu: str = ""
     framework: str = ""
     dtype_note: str = ""
+    candidate_protocol: str = ""
     reference_skeleton: str = ""
     budget_seconds: int = 1500
     output_csv: str = "/tmp/generated_tuner/out.csv"
@@ -57,6 +88,7 @@ class TunerMandate:
             "gpu": self.gpu,
             "framework": self.framework,
             "dtype_note": self.dtype_note,
+            "candidate_protocol": self.candidate_protocol,
             "budget_seconds": self.budget_seconds,
             "output_csv": self.output_csv,
             "candidates_json": self.candidates_json,
@@ -81,6 +113,12 @@ class TunerMandate:
             candidates_json=self.candidates_json,
             top_k=self.max_candidates_per_shape,
             why=self.why_existing_tiers_failed,
+            protocol=self.candidate_protocol
+            or (
+                "Nothing on this box knows how to re-dispatch a candidate for this table, so\n"
+                "describe each one however is clearest and expect the result to be reported\n"
+                "rather than promoted."
+            ),
             trials=CORRECTNESS_TRIALS,
             max_rel=MAX_RELATIVE_ERROR,
             max_rel_def=MAX_RELATIVE_ERROR_DEFINITION,
@@ -117,9 +155,11 @@ Write `{output_csv}` with exactly this header:
   candidate; `improved` is True when tuned_us < default_us.
 - Emit one row per shape even when nothing beat the default.
 
-Also write `{candidates_json}`: for each shape, up to {top_k} candidates ranked
-best first, each carrying enough detail to be dispatched by code that did not
-write your script.
+Also write `{candidates_json}`: a JSON object mapping each shape to up to {top_k}
+candidates, ranked best first. This file is the only part of your work that can
+be promoted, because the harness re-times what is in it and nothing else.
+
+{protocol}
 
 ## Correctness
 Check every candidate against a reference implementation {trials} times, on
@@ -167,18 +207,31 @@ def build_mandate(
     gpu: str = "",
     framework: str = "",
     dtype_note: str = "",
+    candidate_protocol: str | None = None,
     reference_skeleton: str = "",
     budget_seconds: int = 1500,
 ) -> TunerMandate:
-    """Turn a coverage gap plus its demanded shapes into a mandate."""
+    """Turn a coverage gap plus its demanded shapes into a mandate.
+
+    ``candidate_protocol`` defaults to whatever the dispatch adapter for this
+    table says it can run, rather than to nothing: the author has no other way
+    to learn it, and a candidate the referee cannot re-dispatch is unpromotable
+    however well it was measured.
+    """
+    table = str(getattr(gap, "table", "") or "")
+    if candidate_protocol is None:
+        from .dispatch import describe_candidate_protocol
+
+        candidate_protocol = describe_candidate_protocol(table)
     return TunerMandate(
-        table=str(getattr(gap, "table", "") or ""),
+        table=table,
         key_schema=list(getattr(gap, "key_schema", []) or []),
         demand_shapes=list(demand_shapes),
         why_existing_tiers_failed=str(getattr(gap, "reason", "") or ""),
         gpu=gpu,
         framework=framework,
         dtype_note=dtype_note,
+        candidate_protocol=candidate_protocol,
         reference_skeleton=reference_skeleton,
         budget_seconds=budget_seconds,
     )

--- a/src/kernelforge/gemm_tune/tier3/mandate.py
+++ b/src/kernelforge/gemm_tune/tier3/mandate.py
@@ -16,18 +16,22 @@ author following it exactly proposed configurations in a vocabulary
 now comes from ``dispatch.describe_candidate_protocol``, so the words the author
 is given are generated from the code that reads them back.
 
-Three clauses are not style preferences. On the first real MI355X trial both an
-LLM-written tuner and aiter's own official tuner were confidently wrong the same
-two ways. Correctness must be re-checked on fresh inputs several times: four
-split-K winners were wrong on 1.25-3.98% of elements, and *which* elements
-changed between identical calls, so a single check passes them at random -- the
-generated tuner reported a worst-case relative error of 7.65e-3 for candidates a
-repeated audit measured at 17 to 50. A Python-loop timer cannot rank these
-kernels: one dispatch costs ~12us against kernels of 5-13us, so every candidate
-collapses to the same number and the honest conclusion from that data was "there
-is nothing to tune here"; capturing N calls into a graph removes the host cost.
-And its own timings decide nothing -- :mod:`.referee` re-times everything, which
-is what makes the rest survivable.
+Four clauses are not style preferences. On real MI355X trials both an LLM-written
+tuner and aiter's own official tuner were confidently wrong the same two ways,
+and a correct search was still destroyed by the hardware. Correctness must be
+re-checked on fresh inputs several times: four split-K winners were wrong on
+1.25-3.98% of elements, and *which* elements changed between identical calls, so
+a single check passes them at random -- the generated tuner reported a worst-case
+relative error of 7.65e-3 for candidates a repeated audit measured at 17 to 50.
+A Python-loop timer cannot rank these kernels: one dispatch costs ~12us against
+kernels of 5-13us, so every candidate collapses to the same number and the honest
+conclusion from that data was "there is nothing to tune here"; capturing N calls
+into a graph removes the host cost. The search must be crash-resumable, because
+sweeping one backend's kernel ids raised no exception and no error -- it ended
+the interpreter with a GPU memory fault, on shape 2 of 42, after four minutes of
+correct work, leaving one row, and nothing in Python can catch that. And its own
+timings decide nothing -- :mod:`.referee` re-times everything, which is what
+makes the rest survivable.
 
 The mandate is data. Rendering it as text is a convenience; the fields are what
 downstream code checks against.
@@ -188,6 +192,23 @@ Your timings are informational. The harness re-times your candidates with its
 own clock and only those numbers decide anything, so do not tune the benchmark
 -- propose genuinely fast configurations and describe them precisely enough to
 be re-dispatched.
+
+## Surviving the search
+A bad launch on this hardware does not raise. It ends the process:
+`Memory access fault by GPU node-N ... Write access to a read-only page`, no
+traceback, no `except` that can see it, and everything still in memory is gone.
+Measured:
+the first tuner written from this mandate died on shape 2 of 42 while sweeping
+one backend's kernel ids, four minutes in, and kept a single row. The fault is
+asynchronous too, so it can surface several launches after the one that caused
+it; the candidate the process died on is not reliably the guilty one.
+
+So keep the state on disk and do the GPU work in short-lived subprocesses.
+Record each candidate before you launch it, so a worker that dies names what it
+was running and the driver can skip that pair and carry on. Write each shape's
+result -- the default first, before anything risky -- as soon as it exists, and
+rebuild both output files from that state after every worker exits. A fault then
+costs one candidate instead of the whole run.
 
 ## Budget
 About {budget}s of wall time. Explore what is callable before committing to a

--- a/src/kernelforge/gemm_tune/tier3/referee.py
+++ b/src/kernelforge/gemm_tune/tier3/referee.py
@@ -1,7 +1,25 @@
 # SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Re-time a generated tuner's candidates with our own clock."""
+"""Re-time a generated tuner's candidates with our own clock.
+
+This is what makes a generated tuner safe to run at all: it may propose
+configurations, and nothing it reports about their speed is used.
+
+Each rule below replaced something that gave a wrong answer on this fleet first.
+Warm the clocks, because the GPU idles at 94MHz and whatever is measured first
+pays the ramp. Interleave baseline and candidate rather than timing them in
+blocks, which put one default at 1269us against 517us the day before -- a 2.5x
+swing owed to a neighbour. Take the minimum across repeats, not the median:
+interference only ever adds time, and median-based runs rejected 9 of 16
+measurements as unstable on spreads of 40-170%. Refuse a result whose best case
+and typical case disagree about which side is faster, since the two sides were
+then not measured under one machine state. And require a win to clear the noise
+rather than merely be positive.
+
+Dispatch is the caller's business: a candidate is only meaningful against the
+backend it names, so this takes callables and never interprets a config.
+"""
 
 from __future__ import annotations
 
@@ -17,6 +35,24 @@ log = logging.getLogger(__name__)
 WARMUP_CALLS = 20
 CALLS_PER_SAMPLE = 30
 REPEATS = 9
+
+#: How much faster a candidate has to read before we call it faster.
+#:
+#: Measured, not chosen. On an MI355X, ``time_paired`` was run 25 times per
+#: shape with *the same* callable on both sides, over four shapes demanded by
+#: the fleet (8192x3456x1152, 4096x4096x4096, 1024x1536x7168, 128x2048x2048).
+#: The pairing rules above did most of the work -- 43 of the 100 trials were
+#: refused outright as unstable -- but of the 57 that produced a number, 28
+#: came out above 1.0. The unmodified path was judged an improvement over
+#: itself roughly half the time it was judged at all, the largest such reading
+#: being 1.00925x. Not one trial reached 1.01x.
+#:
+#: So this sits just above the whole observed null distribution rather than at
+#: its edge, and the rule it implements is "beat the noise", not "be positive".
+#: Without it a generated tuner that proposes the baseline backend verbatim is
+#: verified as an improvement and deployed, which is the one outcome the
+#: referee exists to make impossible.
+MIN_SPEEDUP = 1.01
 
 
 @dataclass(frozen=True)
@@ -54,7 +90,8 @@ class Judgement:
 
     @property
     def improved(self) -> bool:
-        return bool(self.best_timing and self.best_timing.usable and (self.best_timing.speedup or 0) > 1.0)
+        """Faster than the baseline by more than the baseline beats itself."""
+        return bool(self.best_timing and self.best_timing.usable and (self.best_timing.speedup or 0) >= MIN_SPEEDUP)
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/src/kernelforge/gemm_tune/tier3/runner.py
+++ b/src/kernelforge/gemm_tune/tier3/runner.py
@@ -36,6 +36,11 @@ class Tier3Outcome:
     table: str = ""
     script: str = ""
     digest: str = ""
+    #: Where the verified rows are, for a caller that has to land them. Carried
+    #: rather than recomputed from the work root: the layout under it is this
+    #: module's business, and a caller rebuilding the path by convention would
+    #: deploy the wrong file the day the layout changes.
+    output_csv: str = ""
     judgements: list[Judgement] = field(default_factory=list)
     #: Whether an operator has signed this exact script off. Named for the
     #: signature and not for "trusted" because CodeQL's clear-text-storage
@@ -56,6 +61,7 @@ class Tier3Outcome:
             "table": self.table,
             "script": self.script,
             "digest": self.digest,
+            "output_csv": self.output_csv,
             "operator_signed": self.operator_signed,
             "improved_shapes": self.improved_shapes,
             "judgements": [j.to_dict() for j in self.judgements],
@@ -91,6 +97,7 @@ def attempt_generated_tuner(
     shapes = demand_shapes_for(gap)
     mandate = build_mandate(gap, shapes, gpu=gpu, framework=framework)
     mandate.output_csv = str(work_dir / "out.csv")
+    outcome.output_csv = mandate.output_csv
     mandate.candidates_json = str(work_dir / "candidates.json")
     write_mandate(mandate, work_dir / "mandate.json")
 

--- a/src/kernelforge/gemm_tune/tier3/runner.py
+++ b/src/kernelforge/gemm_tune/tier3/runner.py
@@ -89,8 +89,22 @@ def attempt_generated_tuner(
         return outcome
 
     gap = decision.gap
-    outcome.attempted = True
     outcome.table = gap.table
+    if make_baseline is None or make_dispatch is None:
+        # Checked here rather than at the referee, where it used to be. The
+        # verdict does not depend on anything the intervening stages produce, so
+        # deferring it bought nothing and cost an authoring session plus a full
+        # sandbox run -- every one of which was then discarded unread. Any table
+        # without a dispatch adapter reaches this: opening the gate to fused-MoE
+        # demand made that a live path rather than a hypothetical one.
+        outcome.reason = (
+            f"no dispatch was supplied for {gap.table}, so nothing written for it could be "
+            "re-timed; an unverified generated tuner is not emitted, and generating one to "
+            "throw away costs a model call and a sandbox run"
+        )
+        return outcome
+
+    outcome.attempted = True
     work_dir = work_root / "tier3" / gap.table.replace(".", "_")
     work_dir.mkdir(parents=True, exist_ok=True)
 
@@ -139,13 +153,6 @@ def attempt_generated_tuner(
         break
 
     outcome.stage = "referee"
-    if make_baseline is None or make_dispatch is None:
-        outcome.reason = (
-            "no dispatch was supplied, so the candidates cannot be re-timed; "
-            "an unverified generated tuner is not emitted"
-        )
-        return outcome
-
     candidates = load_candidates(mandate.candidates_json, mandate)
     if not candidates:
         outcome.reason = "the script proposed no candidates to re-time"


### PR DESCRIPTION
Stacked on #1452 (M0 + M1). **Review that one first** — this branch is 4 commits on top of it, and the diff below only makes sense against it.

#1452 opened the third gate and proved it on dense bf16. This one takes it to the table the fleet actually loses time on: `tuned_fmoe.csv`, whose owner `fmoe_ck` burns 621–707s per GLM session and hands back `empty_output`.

## What was in the way

Fused-MoE misses were parsed, counted, and then dropped on the floor: `evidence.py` filed them under `dispatch["moe"]` while `coverage_gaps()` reads only `demands`. So `tuned_fmoe.csv` could not become a gap, could not reach the gate, and nothing downstream of it had ever run. Behind that sat a second wall — no adapter for the table, and `runner.py` paid for a generated tuner *before* checking whether one existed, so the miss would have surfaced as a wasted authoring call rather than a refusal.

## The four commits

1. **`da8b98ec6`** — check `adapters_for()` before generating, not after. A table with no adapter now refuses at the gate instead of buying a tuner it cannot time.
2. **`abf9f2f05`** — build a `tuned_fmoe.csv` Demand from `dispatch["moe"]`. Blast radius is real and deliberate: `router.py` will now select `fmoe_ck` from log evidence, and `demand_for_tuner(report, "fmoe_ck")` stops returning `None`. Both are fixes in their own right, which is why they are their own commit behind `FORGE_MOE_DEMAND_DISABLE`.
3. **`c7edadbdd`** — `_FusedMoeAdapter`: baseline, dispatch, correctness, and the two guards below.
4. **`50461a9e2`** — mandate text for the `block_m` constraint. No behaviour change.

## Two ways a fused-MoE candidate lies about winning, both measured

**A row aiter reads and then ignores.** `fused_moe.py:2048-2051` logs the tuned pair *before* asking `if is_flydsl1 or is_flydsl2`. A pair with neither name FlyDSL's falls past the entire tuned branch into the heuristic chain — but the log says it was used. Measured: a candidate naming `nope1`/`nope2` was logged verbatim, ran the default kernels, and timed **1.1% faster than baseline**, over the referee's 1.01 floor. `aiter_honours_kernel_pair()` refuses the pair before any GPU work.

**A `block_m` that does not match the tile.** `block_m` is the granularity tokens are sorted into before either kernel indexes them, so a mismatch does not fault — it reads the wrong rows, fast. Nine measurements at token=512, no exceptions:

| stage1 tile_m | stage2 tile_m | block_m | us | mean err |
|---|---|---|---|---|
| 128 | 128 | 32 | 71.70 | 1.404 ✗ |
| 128 | 128 | **128** | 156.74 | **0.0016 ✓** |
| 32 | 32 | **32** | 121.12 | **0.0002 ✓** |
| 32 | 32 | 128 | 91.10 | 1.096 ✗ |

Baseline 111.67us. The wrong pairs were the *fastest things in the search* — 71.70us, a 1.55x. The adapter's mean-error gate caught every one, but a tuner that pins `block_m` and trusts its clock spends its whole budget ranking nonsense, so the mandate now states the constraint.

## Acceptance, on hardware

MI355X / gfx950, aiter `d9e5ef7ce`. The demand comes from a log aiter itself wrote, not a fixture; the authoring stage uses `--stub-generate` because the box has no provider credential — the same documented substitution #1452's dense acceptance ran under.

```
demand:  tuned_fmoe.csv  tuner=fmoe_ck env=AITER_CONFIG_FMOE  36 misses / 3 keys
gap:     ('tuned_fmoe.csv', 'empty', True)      gate: allowed=True
adapter: _FusedMoeAdapter                       shapes: 3
attempt: stage=referee ok=True  reason="3 of 3 shape(s) improved"
result:  tier3_generated_tuned_fmoe status=ok candidate=True shapes=3/3 best=1.1528x
promote: {'tuner': 'tier3_generated_tuned_fmoe',
          'env': {'AITER_CONFIG_FMOE': '.../out.csv'},
          'best_micro_speedup': 1.1528, 'requires_e2e_validation': True}
```

Per shape, referee-verified under `time_paired` (interleaved, min-of-repeats, best-vs-typical consistency gate):

| token | baseline | candidate | speedup |
|---|---|---|---|
| 512 | 2212.0us | 2170.3us | 1.0192 |
| 1024 | 3051.7us | 2651.4us | **1.1510** |
| 2048 | 4208.6us | 3650.6us | **1.1528** |

Zero candidates discarded on correctness — the search groups by tile_m and sets `block_m` to match, so every pair it can propose is legal. `requires_e2e_validation` stays true: micro is a screen, not the verdict.

## Not in this PR

Three aiter findings, all the same bug class and all worth an upstream issue rather than a patch here:

* a tuned config naming `tile=256` for `inter_dim=384` silently runs 128 — aiter's own tuner picks these, and they fail correctness at 0.14;
* `AITER_CONFIG.get_config_file`'s `lru_cache` key omits the env var its body reads;
* the tuned row logged before the branch that discards it (above).

Also: `MAX_JOBS` must be capped on containers with high `nproc` and a small cgroup memory cap — aiter's JIT picked `ninja -j 188` against a 128 GiB limit and OOMed. One env var, wide blast radius if the fleet shares that shape.

## Tests

`src/kernelforge/gemm_tune`: 862 passed, 7 skipped, 3 pre-existing Windows failures (`os.killpg`). `test_moe_dispatch.py` is new: 26 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
