### PR TITLE
Stop reporting unknown GPU archs as MI300X (baremetal)

### DIFF
--- a/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
+++ b/src/hyperloom/inference_optimizer/assets/install_baremetal.sh
@@ -325,11 +325,12 @@ detect_gpu_label() {
   case "$gfx" in
     gfx942) echo "MI300X" ;;
     gfx950) echo "MI355X" ;;
-    *) echo "MI300X" ;;
+    "") echo "unknown" ;;
+    *) echo "$gfx" ;;
   esac
 }
 
-DETECTED_GPU="MI300X"
+DETECTED_GPU="unknown"
 
 base_preflight() {
   local rc=0


### PR DESCRIPTION
`detect_gpu_label()` in `install_baremetal.sh` fell through to `MI300X` for any
arch outside gfx942/gfx950, so a Strix Halo (gfx1151) host was reported as an
MI300X. The label is substituted into the operator prompt setup
prints as `GPU: <label>`, so the fabricated part number gets pasted into an
optimization request and forwarded as `--gpu-type mi300x`. 

Use the gfx target for unrecognised archs.

The support for Ryzen AI parts itself will come in a follow-up PR.

## Tests: added/updated? commands run?

No automated test: the installer is shell, and exercising `detect_gpu_label`
from pytest means extracting the function out of the script and stubbing
`rocm-smi`, which is more harness than the four-line change warrants. Verified
by hand against the real binary instead (below).

```
shellcheck src/hyperloom/inference_optimizer/assets/install_baremetal.sh
ruff check . && ruff format --check .
```

shellcheck findings on the installer are byte-identical to `main`.

Verified on a Ryzen AI Max+ 395 (rocminfo reports gfx1151):

| `detect_gpu_label <arch>` | `main` | this branch |
|---|---|---|
| `gfx1151` | `MI300X` | `gfx1151` |
| `gfx90a` | `MI300X` | `gfx90a` |
| `""` (nothing probed) | `MI300X` | `unknown` |
| `gfx942` / `gfx950` | `MI300X` / `MI355X` | unchanged |

## Breaking changes: no

Only the fallback arm changes. gfx942/gfx950 and the rocm-smi product-name path
behave exactly as before.

## PR addresses single concern: yes

## Linked issue(s): none

## Root cause is upstream (Magpie/TraceLens/GEAK/IntelliKit/AgentKernelArena): no