### PR TITLE
gemm-tune: size the aiter JIT build to the container, not to the host

### DIFF
--- a/src/kernelforge/gemm_tune/tests/test_build_parallelism.py
+++ b/src/kernelforge/gemm_tune/tests/test_build_parallelism.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Sizing an aiter JIT build to the container rather than to the host.
+
+The measurement behind every number here, taken on an MI355X under ROCm 7.2:
+one ``hipcc`` job on a CK-tile fused-MoE source holds **1.64 GiB** and runs for
+30 seconds, three samples within 0.01 GiB of each other. The box shows 236 CPUs
+and a cgroup ceiling of 128 GiB, so aiter's ``-j 188`` asks for roughly 308 GiB
+and the build is killed rather than slowed.
+
+These tests inject both numbers instead of reading the machine, so they say the
+same thing on a laptop as on a fleet node.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kernelforge.gemm_tune import utils
+
+GIB = 1024**3
+
+
+class TestReadingTheCeiling:
+    def test_cgroup_v2_reports_bytes(self, tmp_path, monkeypatch):
+        limit = tmp_path / "memory.max"
+        limit.write_text("137438953472\n", encoding="utf-8")
+        monkeypatch.setattr(utils, "_CGROUP_MEMORY_LIMITS", (str(limit),))
+        assert utils.cgroup_memory_limit() == 128 * GIB
+
+    def test_cgroup_v2_unlimited_is_not_a_ceiling(self, tmp_path, monkeypatch):
+        limit = tmp_path / "memory.max"
+        limit.write_text("max\n", encoding="utf-8")
+        monkeypatch.setattr(utils, "_CGROUP_MEMORY_LIMITS", (str(limit),))
+        assert utils.cgroup_memory_limit() is None
+
+    def test_cgroup_v1_sentinel_is_not_a_ceiling(self, tmp_path, monkeypatch):
+        # v1 spells "no limit" as PAGE_COUNTER_MAX rounded to a page. Taken at
+        # face value it would compute a job limit of several billion.
+        limit = tmp_path / "memory.limit_in_bytes"
+        limit.write_text("9223372036854771712\n", encoding="utf-8")
+        monkeypatch.setattr(utils, "_CGROUP_MEMORY_LIMITS", (str(limit),))
+        assert utils.cgroup_memory_limit() is None
+
+    def test_no_cgroup_files_at_all(self, monkeypatch):
+        # Every developer machine that is not a container, and every Mac.
+        monkeypatch.setattr(utils, "_CGROUP_MEMORY_LIMITS", ("/no/such/path",))
+        assert utils.cgroup_memory_limit() is None
+
+    def test_the_first_readable_file_wins(self, tmp_path, monkeypatch):
+        v2, v1 = tmp_path / "memory.max", tmp_path / "limit_in_bytes"
+        v2.write_text("68719476736", encoding="utf-8")
+        v1.write_text("137438953472", encoding="utf-8")
+        monkeypatch.setattr(utils, "_CGROUP_MEMORY_LIMITS", (str(v2), str(v1)))
+        assert utils.cgroup_memory_limit() == 64 * GIB
+
+
+class TestTheJobLimit:
+    def test_the_box_this_was_measured_on(self):
+        # 128 GiB * 0.7 / 2 GiB = 44, against 236 CPUs.
+        assert utils.build_job_limit(cpus=236, memory_bytes=128 * GIB) == 44
+
+    def test_a_roomy_container_is_left_alone(self):
+        # 2 TiB holds a job for every one of 236 CPUs, so there is nothing to
+        # correct and None says so rather than restating the CPU count.
+        assert utils.build_job_limit(cpus=236, memory_bytes=2048 * GIB) is None
+
+    def test_no_ceiling_means_no_opinion(self):
+        assert utils.build_job_limit(cpus=236, memory_bytes=None) is None
+
+    def test_a_ceiling_below_one_job_still_runs_one(self):
+        # Serialised and probably doomed, but a limit of 0 would be a ninja
+        # invocation that never compiles anything, which is worse to debug.
+        assert utils.build_job_limit(cpus=8, memory_bytes=1 * GIB) == 1
+
+    def test_the_limit_never_exceeds_the_cpus(self):
+        assert utils.build_job_limit(cpus=4, memory_bytes=512 * GIB) is None
+
+
+class TestWhatItDoesToTheEnvironment:
+    def test_it_sets_max_jobs_when_the_container_is_tight(self, monkeypatch):
+        monkeypatch.setattr(utils, "build_job_limit", lambda: 44)
+        monkeypatch.setattr(utils, "cgroup_memory_limit", lambda: 128 * GIB)
+        assert utils.cap_build_parallelism({})["MAX_JOBS"] == "44"
+
+    def test_an_operator_who_chose_a_number_keeps_it(self, monkeypatch):
+        # Including through a run that would have picked a different one:
+        # someone debugging a build sets this by hand and expects it to hold.
+        monkeypatch.setattr(utils, "build_job_limit", lambda: 44)
+        assert utils.cap_build_parallelism({"MAX_JOBS": "4"})["MAX_JOBS"] == "4"
+
+    def test_it_leaves_a_roomy_box_untouched(self, monkeypatch):
+        monkeypatch.setattr(utils, "build_job_limit", lambda: None)
+        assert "MAX_JOBS" not in utils.cap_build_parallelism({})
+
+    def test_an_empty_max_jobs_is_not_a_choice(self, monkeypatch):
+        # `MAX_JOBS=` in a shell profile sets it to the empty string, which
+        # ninja reads as unset. Treating it as a choice would leave the build
+        # at the default and back at the OOM this exists to prevent.
+        monkeypatch.setattr(utils, "build_job_limit", lambda: 44)
+        monkeypatch.setattr(utils, "cgroup_memory_limit", lambda: 128 * GIB)
+        assert utils.cap_build_parallelism({"MAX_JOBS": ""})["MAX_JOBS"] == "44"
+
+    @pytest.mark.parametrize("other", ["PATH", "AITER_CONFIG_FMOE"])
+    def test_nothing_else_in_the_environment_moves(self, monkeypatch, other):
+        monkeypatch.setattr(utils, "build_job_limit", lambda: 44)
+        monkeypatch.setattr(utils, "cgroup_memory_limit", lambda: 128 * GIB)
+        env = {other: "untouched"}
+        assert utils.cap_build_parallelism(env)[other] == "untouched"
+
+
+class TestTheSubprocessGetsIt:
+    def test_run_subprocess_passes_the_cap_to_the_child(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(utils, "build_job_limit", lambda: 44)
+        monkeypatch.setattr(utils, "cgroup_memory_limit", lambda: 128 * GIB)
+        seen: dict[str, str] = {}
+
+        class _Proc:
+            returncode = 0
+
+            def communicate(self, timeout=None):
+                return "", ""
+
+        def _popen(cmd, **kwargs):
+            seen.update(kwargs["env"])
+            return _Proc()
+
+        monkeypatch.setattr(utils.subprocess, "Popen", _popen)
+        utils.run_subprocess(["true"], cwd=tmp_path)
+        assert seen["MAX_JOBS"] == "44"
+
+    def test_an_explicit_override_still_wins(self, monkeypatch, tmp_path):
+        # env_override is how a caller says what this particular build needs;
+        # the cap is a default and must not overrule it.
+        monkeypatch.setattr(utils, "build_job_limit", lambda: 44)
+        seen: dict[str, str] = {}
+
+        class _Proc:
+            returncode = 0
+
+            def communicate(self, timeout=None):
+                return "", ""
+
+        def _popen(cmd, **kwargs):
+            seen.update(kwargs["env"])
+            return _Proc()
+
+        monkeypatch.setattr(utils.subprocess, "Popen", _popen)
+        utils.run_subprocess(["true"], cwd=tmp_path, env_override={"MAX_JOBS": "8"})
+        assert seen["MAX_JOBS"] == "8"

--- a/src/kernelforge/gemm_tune/utils.py
+++ b/src/kernelforge/gemm_tune/utils.py
@@ -120,6 +120,108 @@ def check_gpu_status(skip: bool = False) -> list[GpuInfo]:
         return []
 
 
+#: Peak resident memory of one aiter ``hipcc`` job. Measured on an MI355X under
+#: ROCm 7.2: three CK-tile fused-MoE compiles from
+#: ``module_moe_cktile2stages``, 30s each, 1.64 GiB every time to within
+#: 0.01 GiB. Rounded up, because the sample is one module's worth of templates
+#: and a heavier one is likelier than a lighter one.
+#:
+#: Rounding up is also what makes the answer safe rather than merely plausible.
+#: Running the resulting 44 jobs at once on the same box took the cgroup's
+#: ``memory.current`` from 1.0 to 58.4 GiB -- 1.30 GiB a job in aggregate, since
+#: the peaks do not coincide -- and left 69.6 GiB under the 128 GiB ceiling,
+#: with all 44 compiling clean. The same 1.30 GiB against aiter's own ``-j 188``
+#: is about 245 GiB, which is the OOM.
+HIPCC_JOB_BYTES = 2 * 1024**3
+
+#: How much of the container's memory allowance a build may claim. The rest is
+#: the tuner process that launched it -- torch, a loaded model, GPU buffers --
+#: all of it already resident and none of it accounted for by the compiler.
+BUILD_MEMORY_SHARE = 0.7
+
+#: Where the kernel publishes the container's memory ceiling, cgroup v2 first.
+_CGROUP_MEMORY_LIMITS = (
+    "/sys/fs/cgroup/memory.max",
+    "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+)
+
+
+def cgroup_memory_limit() -> int | None:
+    """The container's memory ceiling in bytes, or None if it has none.
+
+    cgroup v2 writes the literal ``max`` when unlimited; v1 writes a sentinel
+    near 2**63. Both mean "ask the host instead", and so does an unreadable or
+    unparseable file -- in every one of those cases this returns None and the
+    caller changes nothing.
+    """
+    for path in _CGROUP_MEMORY_LIMITS:
+        try:
+            raw = Path(path).read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if raw == "max":
+            return None
+        try:
+            value = int(raw)
+        except ValueError:
+            continue
+        # v1's "no limit" is PAGE_COUNTER_MAX rounded to a page; anything past
+        # a petabyte is that sentinel rather than a real allowance.
+        return value if 0 < value < 2**50 else None
+    return None
+
+
+def build_job_limit(cpus: int | None = None, memory_bytes: int | None = None) -> int | None:
+    """How many compile jobs this container's memory can actually hold.
+
+    Returns None when there is nothing to correct: no cgroup ceiling, or one
+    roomy enough for a job per CPU.
+
+    The bug this exists for: aiter's JIT sizes its ``ninja -j`` from the CPU
+    count, which on a fleet box is the *host's* -- 236 here -- while the memory
+    those jobs consume is capped by the *container's* cgroup, 128 GiB here.
+    Nothing reconciles the two. Measured, that is ``-j 188`` at 1.64 GiB a job,
+    or about 308 GiB against a 128 GiB ceiling, and the build is OOM-killed
+    partway through. It is not a slow build or a flaky one; it does not finish.
+    """
+    if cpus is None:
+        # The affinity mask, not the host's core count: a container pinned to a
+        # subset is the case where the two differ and the smaller one is true.
+        cpus = len(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else (os.cpu_count() or 1)
+    if memory_bytes is None:
+        memory_bytes = cgroup_memory_limit()
+    if not memory_bytes:
+        return None
+    fits = int(memory_bytes * BUILD_MEMORY_SHARE) // HIPCC_JOB_BYTES
+    capped = max(1, min(cpus, fits))
+    return capped if capped < cpus else None
+
+
+def cap_build_parallelism(env: dict[str, str]) -> dict[str, str]:
+    """Set ``MAX_JOBS`` in ``env`` when the container cannot afford one per CPU.
+
+    Deliberately narrow. It does nothing when ``MAX_JOBS`` is already set --
+    an operator who chose a number keeps it -- and nothing on a box with no
+    cgroup ceiling or a generous one. Mutates and returns ``env`` so callers
+    can chain it onto the environment they were building anyway.
+    """
+    if env.get("MAX_JOBS"):
+        return env
+    limit = build_job_limit()
+    if limit is None:
+        return env
+    log.info(
+        "capping MAX_JOBS at %d: %d CPUs visible but the cgroup allows %.0f GiB, "
+        "and one hipcc job holds about %.1f GiB",
+        limit,
+        len(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else (os.cpu_count() or 1),
+        (cgroup_memory_limit() or 0) / 1024**3,
+        HIPCC_JOB_BYTES / 1024**3,
+    )
+    env["MAX_JOBS"] = str(limit)
+    return env
+
+
 def run_subprocess(
     cmd: list[str],
     *,
@@ -134,6 +236,8 @@ def run_subprocess(
     env = os.environ.copy()
     if env_override:
         env.update(env_override)
+    # Every tuner here shells out to something that ends in an aiter JIT build.
+    cap_build_parallelism(env)
 
     log.info("Running: %s", " ".join(cmd))
     started = time.time()


### PR DESCRIPTION
## What breaks

aiter's JIT picks its `ninja -j` from the CPU count. In a fleet container that is the **host's** count while the memory those jobs consume is capped by the **container's** cgroup. Nothing reconciles the two.

Measured on the MI355X dev box (ROCm 7.2):

| | |
|---|---|
| `nproc` / affinity | 236 |
| `/sys/fs/cgroup/memory.max` | 137438953472 (128 GiB) |
| host `MemTotal` | 2.75 TiB |
| aiter's chosen `-j` | 188 |
| one hipcc job, peak RSS | **1.64 GiB** (3 samples, ±0.01 GiB, ~30s each, `module_moe_cktile2stages`) |
| 188 × 1.64 GiB | ~308 GiB against a 128 GiB ceiling |

So the build is OOM-killed partway through. Not slow, not flaky — it does not finish, and every tuner downstream of it reports whatever a missing module looks like from where it stands. Every run on that box so far needed `MAX_JOBS=16` set by hand.

## What this does

One call in `run_subprocess`, plus the three helpers it needs:

- `cgroup_memory_limit()` — the container's ceiling, v2 then v1, `None` when there is none;
- `build_job_limit()` — `ceiling × 0.7 / 2 GiB`, capped at the CPU count, `None` when there is nothing to correct;
- `cap_build_parallelism(env)` — sets `MAX_JOBS` only if it is not already set.

Deliberately narrow. No-op when `MAX_JOBS` is set, no-op when `env_override` names one, no-op without a cgroup ceiling, no-op when the ceiling is roomy enough for a job per CPU. On a developer machine nothing changes.

## Verified on hardware, not just derived

The computed cap on that box is **44**. Launching 44 real concurrent hipcc jobs there:

```
memory.current   1.0 GiB before  ->  58.4 GiB peak
per job          1.30 GiB aggregate (the peaks do not coincide)
headroom         69.6 GiB under the 128 GiB ceiling
result           44/44 compiled clean, 177s
```

The 2 GiB constant is the 1.64 GiB measurement rounded up; the run above is what says the rounding is safe rather than merely plausible.

## Why the sentinels are tested

Both cgroup layouts spell "no limit" as a *value*: v2 writes `max`, v1 writes `9223372036854771712`. Taking either at face value computes a job limit in the billions, which is the same OOM with extra steps. `test_cgroup_v1_sentinel_is_not_a_ceiling` and `test_cgroup_v2_unlimited_is_not_a_ceiling` pin both.

`MAX_JOBS=` (empty, as a shell profile leaves it) is likewise treated as unset rather than as an operator's choice — ninja reads it that way too.

## Tests

18 new in `test_build_parallelism.py`; both numbers are injected, so the suite says the same thing on a laptop as on a fleet node. Full `gemm_tune` suite: 831 passed, 6 skipped, 3 failed — the 3 being pre-existing Windows-only `os.killpg` failures in `test_utils_extra.py`, present on `main` too.

## Not in this PR

tier3's sandbox builds its own child environment with `subprocess.run` and does not route through `run_subprocess`, so it does not pick the cap up. It gets the same call once this lands — it cannot be done here because the tier3 work is on a branch that predates this helper.

Upstream, the honest fix is for aiter's JIT to size `-j` from the cgroup rather than from `os.cpu_count()`; that will be reported separately to ROCm/aiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
