### PR TITLE
fix(prompts): render locally recorded lessons and pitfalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   **Operator note**: affects the conversation warm-start block and the
   `warm_start` MCP context tool, in both local and remote Recipe modes.
 
+- **Lessons and pitfalls recorded by the Recipe KB reach the specialist again —
+  every one of them was rendering as `(none)`.** Sections 5b and 5c read
+  `point["attrs"]["statement"]` / `point["attrs"]["description"]`, but nothing in
+  the system writes an `attrs`-wrapped experience row. `Recipe.to_dict`,
+  `_normalise_lessons` and `_normalise_str_dicts` all write flat rows, `writeback`
+  appends `{statement, measured_impact}` flat, and
+  `test_t0_anchor_surfaces_pitfalls_and_lessons_from_existing_row` already
+  asserted `state.warm_start_lessons[0]["statement"]`. A flat row therefore
+  resolved `attrs` to `{}`, produced an empty statement, and hit the
+  `if not statement: continue` guard, so both sections fell through to their
+  `(none)` placeholder no matter how much a prior session had learned.
+
+  The wrapped form survived only in hand-written test fixtures, so it is deleted
+  rather than accommodated: the renderers read the flat fields directly, and the
+  one place a legacy wrapped row is unwrapped is `recipe_kb_t0._experience_rows`,
+  where `warm_start_lessons` / `warm_start_pitfalls` are assigned. No reader
+  downstream knows about two shapes.
+
+  That normalisation is also where an unusable row is now dropped, with a
+  warning naming the field and the count. The silence is what let this run for so
+  long: a non-empty list could render as `(none)` with no log and no error, so
+  neither the prompt nor the operator had any signal. Rejecting at the boundary
+  puts the complaint where the shape is known, instead of adding a warning to a
+  renderer that should not be inspecting shapes at all.
+
+  The contract docs that caused the drift are corrected too — the section
+  docstrings ("KB `kind=lesson` points"), `_render_measured_impact`
+  ("`attrs.measured_impact`"), `_format_version_note`'s `lesson_attrs`
+  parameter, and the `SharedState.warm_start_pitfalls` / `warm_start_lessons`
+  field comments ("list of KB point dicts") all described a wrapped row.
+  Fixtures are flat, and two of them are built by calling the writer so the
+  reader and the stored shape cannot drift apart again.<br/>
+  **Operator note**: sessions lost no recorded knowledge, but until now none of
+  it was being shown to the agent.
+
 ### Removed
 
 - **The `learning/` tuning database, the tracker's scoring layer, and the

--- a/src/hyperloom/inference_optimizer/tests/test_recipe_kb_t0_anchor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_recipe_kb_t0_anchor.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -13,6 +14,7 @@ import pytest
 
 from hyperloom.orchestrator.knowledge.recipe_kb_t0 import (
     _cascade_warm_start_search,
+    _experience_rows,
     _warm_recipe_source,
     run_t0_anchor,
 )
@@ -188,8 +190,102 @@ def test_t0_anchor_surfaces_pitfalls_and_lessons_from_existing_row(
     assert state.warm_start_pitfalls[0]["description"] == "watch for X"
     assert len(state.warm_start_lessons) == 1
     assert state.warm_start_lessons[0]["statement"] == "Y is the answer"
+    # The snapshot is the contract the prompt renderers read; it is flat.
+    assert "attrs" not in state.warm_start_pitfalls[0]
+    assert "attrs" not in state.warm_start_lessons[0]
     assert state.warm_start_recipe["tier"] == "exact"
     assert state.warm_start_recipe["confidence"] == 1.0
+
+
+def test_t0_anchor_drops_an_unparseable_row_on_disk_and_says_so(
+    kb: RecipeKB,
+    session_dir: Path,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A row the schema cannot parse is dropped loudly, not rendered as nothing.
+
+    ``Recipe.from_dict`` reads ``statement`` off each lesson, so a row on disk in
+    any other shape comes back empty rather than wrapped — the local store cannot
+    hand T0 something to unwrap. What matters here is the difference from before:
+    the empty row is dropped with a log naming the field, instead of reaching the
+    prompt and rendering as ``(none)`` with no signal anywhere.
+    """
+    state = _FakeSharedState()
+    cid = _expected_cid(state, "M", "MI300X")
+    kb.put_recipe(
+        canonical_id=cid,
+        model="M",
+        hardware="MI300X",
+        framework_name="sglang",
+        framework_version="0.4.5",
+        precision="fp8",
+        lessons=[{"statement": "placeholder", "measured_impact": "+1%"}],
+        provenance={"source": "seed", "generator": "ut"},
+    )
+    recipe_path = next((tmp_path / "kb").rglob("recipe.json"))
+    row = json.loads(recipe_path.read_text(encoding="utf-8"))
+    row["lessons"] = [{"attrs": {"statement": "wrapped", "measured_impact": "+9%"}}]
+    recipe_path.write_text(json.dumps(row), encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        run_t0_anchor(
+            kb,
+            state,
+            workload="M",
+            hw="MI300X",
+            extra_attrs={"framework_name": "sglang"},
+            session_dir=session_dir,
+        )
+    assert state.warm_start_lessons == []
+    assert "warm_start_lessons: dropped 1 row(s) missing 'statement'" in caplog.text
+
+
+def test_experience_rows_passes_through_the_stored_flat_shape() -> None:
+    """The stored shape is flat; normalisation must not restructure it."""
+    rows = _experience_rows(
+        [{"statement": "Y is the answer", "measured_impact": "+15%"}],
+        "statement",
+        "lessons",
+    )
+    assert rows == [{"statement": "Y is the answer", "measured_impact": "+15%"}]
+
+
+def test_experience_rows_unwraps_a_wrapped_row_once() -> None:
+    """The remote projection passes rows through unnormalised, so unwrap here.
+
+    ``knowledge_to_warm_recipe`` copies ``lessons`` straight out of the remote
+    record without going through ``Recipe.from_dict``, which is the one way a
+    wrapped row reaches T0. Unwrapping at this boundary keeps every downstream
+    reader on a single shape.
+    """
+    rows = _experience_rows(
+        [{"canonical_id": "lesson:x", "attrs": {"statement": "wrapped", "measured_impact": "+1%"}}],
+        "statement",
+        "lessons",
+    )
+    assert rows == [{"statement": "wrapped", "measured_impact": "+1%"}]
+
+
+def test_experience_rows_drops_unusable_rows_loudly(caplog: pytest.LogCaptureFixture) -> None:
+    """A row the renderer could not have used is dropped here, with a log.
+
+    The renderer used to emit "(none)" off a non-empty list with no log and no
+    error, which is why a wrong shape went unnoticed for so long.
+    """
+    with caplog.at_level("WARNING"):
+        rows = _experience_rows(
+            [
+                {"statement": "kept"},
+                {"measured_impact": "no statement"},
+                "not-a-row",
+            ],
+            "statement",
+            "lessons",
+        )
+    assert rows == [{"statement": "kept"}]
+    assert "dropped 2 row(s)" in caplog.text
+    assert "warm_start_lessons" in caplog.text
 
 
 def test_t0_anchor_no_prior_recipe_means_warm_miss(

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_lessons_section.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_lessons_section.py
@@ -11,6 +11,10 @@ from typing import Any
 
 import pytest
 
+from hyperloom.orchestrator.knowledge.recipe_kb.local_store import (
+    _normalise_lessons,
+    _normalise_str_dicts,
+)
 from hyperloom.orchestrator.loop.coordinator import Coordinator
 from hyperloom.orchestrator.specialists.domains import (
     get_domain,
@@ -58,11 +62,9 @@ async def test_warm_specialist_params_populates_warm_start_lessons(tmp_path: Pat
             "canonical_id": "lesson:abc",
             "kind": "lesson",
             "confidence": 0.9,
-            "attrs": {
-                "statement": "--attention-backend AITER → +12.3%",
-                "measured_impact": "gain_pct=12.30",
-                "source_session_id": "session-A",
-            },
+            "statement": "--attention-backend AITER → +12.3%",
+            "measured_impact": "gain_pct=12.30",
+            "source_session_id": "session-A",
         },
     ]
     coord = _make_coord(tmp_path, state=_BareState(warm_start_lessons=lessons))
@@ -107,19 +109,15 @@ def test_section_lessons_renders_each_lesson_with_metadata():
         {
             "canonical_id": "lesson:abc",
             "confidence": 0.85,
-            "attrs": {
-                "statement": "--attention-backend AITER → +12.3%",
-                "measured_impact": "gain_pct=12.30 throughput_after=875.0",
-                "source_session_id": "session-A",
-            },
+            "statement": "--attention-backend AITER → +12.3%",
+            "measured_impact": "gain_pct=12.30 throughput_after=875.0",
+            "source_session_id": "session-A",
         },
         {
             "canonical_id": "lesson:def",
             "confidence": 0.5,
-            "attrs": {
-                "statement": "VLLM_ROCM_USE_AITER=1 → +9.5%",
-                "measured_impact": "gain_pct=9.50",
-            },
+            "statement": "VLLM_ROCM_USE_AITER=1 → +9.5%",
+            "measured_impact": "gain_pct=9.50",
         },
     ]
     rows = _section_lessons(_make_inp(lessons))
@@ -140,14 +138,12 @@ def test_section_lessons_renders_dict_measured_impact_as_human_readable_line():
         {
             "canonical_id": "lesson:dict",
             "confidence": 0.85,
-            "attrs": {
-                "statement": "--attention-backend AITER → +12.3%",
-                "measured_impact": {
-                    "gain_pct": 12.3,
-                    "throughput_after": 678.0,
-                    "stack_depth_at_apply": 2,
-                    "measured_at": "2026-05-26T08:48:00Z",
-                },
+            "statement": "--attention-backend AITER → +12.3%",
+            "measured_impact": {
+                "gain_pct": 12.3,
+                "throughput_after": 678.0,
+                "stack_depth_at_apply": 2,
+                "measured_at": "2026-05-26T08:48:00Z",
             },
         },
     ]
@@ -165,12 +161,10 @@ def test_section_lessons_renders_validated_count_when_above_1():
         {
             "canonical_id": "lesson:multi",
             "confidence": 0.85,
-            "attrs": {
-                "statement": "AITER+TileLang → +15%",
-                "measured_impact": "gain_pct=15",
-                "validated_count": 5,
-                "source_session_ids": ["s-a", "s-b", "s-c", "s-d", "s-e"],
-            },
+            "statement": "AITER+TileLang → +15%",
+            "measured_impact": "gain_pct=15",
+            "validated_count": 5,
+            "source_session_ids": ["s-a", "s-b", "s-c", "s-d", "s-e"],
         },
     ]
     rows = _section_lessons(_make_inp(lessons))
@@ -186,11 +180,9 @@ def test_section_lessons_singleton_validation_omits_validated_tag():
         {
             "canonical_id": "lesson:single",
             "confidence": 0.7,
-            "attrs": {
-                "statement": "x → +5%",
-                "validated_count": 1,
-                "source_session_ids": ["s-only"],
-            },
+            "statement": "x → +5%",
+            "validated_count": 1,
+            "source_session_ids": ["s-only"],
         },
     ]
     rows = _section_lessons(_make_inp(lessons))
@@ -203,8 +195,8 @@ def test_section_lessons_singleton_validation_omits_validated_tag():
 def test_section_lessons_skips_lessons_with_empty_statement():
     """Defensive: a KB row with empty ``statement`` is skipped."""
     lessons = [
-        {"canonical_id": "lesson:empty", "attrs": {"statement": ""}},
-        {"canonical_id": "lesson:real", "attrs": {"statement": "real one"}},
+        {"canonical_id": "lesson:empty", "statement": ""},
+        {"canonical_id": "lesson:real", "statement": "real one"},
     ]
     rows = _section_lessons(_make_inp(lessons))
     text = "\n".join(rows)
@@ -213,11 +205,47 @@ def test_section_lessons_skips_lessons_with_empty_statement():
     assert "**** " not in text
 
 
+def test_section_lessons_renders_the_shape_the_local_kb_actually_writes():
+    """A lesson stored by the local KB has to survive the trip back into the prompt.
+
+    The fixture is built by the writer rather than by hand, so the reader and the
+    stored shape cannot drift apart silently again — reading a field
+    ``_normalise_lessons`` does not write turned every recorded lesson into
+    ``(none)``.
+    """
+    stored = _normalise_lessons(
+        [
+            {
+                "statement": "raise the MLA decode KV-split cap at conc=1",
+                "measured_impact": "gain_pct=30.00",
+            }
+        ]
+    )
+    rows = _section_lessons(_make_inp(stored))
+    text = "\n".join(rows)
+    assert "raise the MLA decode KV-split cap at conc=1" in text
+    assert "gain_pct=30.00" in text
+    assert "(none" not in text
+
+
+def test_section_pitfalls_renders_the_shape_the_local_kb_actually_writes():
+    """The same writer/reader contract for pitfalls, which flatten the same way."""
+    stored = _normalise_str_dicts(
+        [{"description": "--max-num-seqs 1024 on MoE regressed 8%", "severity": "regress"}],
+        ("description", "severity"),
+    )
+    rows = _section_pitfalls(_make_inp(pitfalls=stored))
+    text = "\n".join(rows)
+    assert "--max-num-seqs 1024 on MoE regressed 8%" in text
+    assert "severity=regress" in text
+    assert "(none" not in text
+
+
 def test_build_specialist_prompts_inserts_5b_between_recipe_and_pr_monitor():
     """End-to-end: section 5b is inserted between section 5 (recipe) and 5c (pitfalls)."""
     inp = _make_inp(
         [
-            {"canonical_id": "lesson:x", "attrs": {"statement": "x → +1%"}},
+            {"canonical_id": "lesson:x", "statement": "x → +1%"},
         ]
     )
     _system, user = build_specialist_prompts(inp)
@@ -242,19 +270,15 @@ def test_section_pitfalls_renders_each_pitfall_with_metadata():
         {
             "canonical_id": "pitfall:abc",
             "confidence": 0.7,
-            "attrs": {
-                "description": "VLLM_ROCM_USE_AITER_FP4BMM=1 → crash on gfx942",
-                "severity": "crash",
-                "source_session_id": "session-A",
-            },
+            "description": "VLLM_ROCM_USE_AITER_FP4BMM=1 → crash on gfx942",
+            "severity": "crash",
+            "source_session_id": "session-A",
         },
         {
             "canonical_id": "pitfall:def",
             "confidence": 0.4,
-            "attrs": {
-                "description": "--max-num-seqs 1024 on MoE → -8% regress",
-                "severity": "regress",
-            },
+            "description": "--max-num-seqs 1024 on MoE → -8% regress",
+            "severity": "regress",
         },
     ]
     rows = _section_pitfalls(_make_inp(pitfalls=pitfalls))
@@ -268,12 +292,12 @@ def test_section_pitfalls_renders_each_pitfall_with_metadata():
 
 
 def test_section_pitfalls_skips_pitfalls_with_empty_description():
-    """Defensive against partial / legacy rows lacking ``attrs.description``."""
+    """Defensive against partial / legacy rows lacking ``description``."""
     pitfalls = [
-        {"canonical_id": "pitfall:empty", "attrs": {"description": ""}},
-        # Legacy row shape lacking attrs.description.
+        {"canonical_id": "pitfall:empty", "description": ""},
+        # Legacy row shape carrying no description at all.
         {"raw": '{"points":[...legacy json blob...]}'},
-        {"canonical_id": "pitfall:real", "attrs": {"description": "real one", "severity": "crash"}},
+        {"canonical_id": "pitfall:real", "description": "real one", "severity": "crash"},
     ]
     rows = _section_pitfalls(_make_inp(pitfalls=pitfalls))
     text = "\n".join(rows)

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_prompt_builder_coverage_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_prompt_builder_coverage_unit.py
@@ -107,32 +107,28 @@ def _rich_inputs(**overrides):
         warm_start_lessons=[
             {
                 "confidence": 0.9,
-                "attrs": {
-                    "statement": "enable cudagraph",
-                    "measured_impact": {
-                        "gain_pct": 5.0,
-                        "throughput_after": 100.0,
-                        "stack_depth_at_apply": 2,
-                        "measured_at": "2026-01-02T00:00:00",
-                    },
-                    "validated_count": 3,
-                    "source_session_ids": ["s1", "s2"],
-                    "framework_version": "0.6.1",
+                "statement": "enable cudagraph",
+                "measured_impact": {
+                    "gain_pct": 5.0,
+                    "throughput_after": 100.0,
+                    "stack_depth_at_apply": 2,
+                    "measured_at": "2026-01-02T00:00:00",
                 },
+                "validated_count": 3,
+                "source_session_ids": ["s1", "s2"],
+                "framework_version": "0.6.1",
             },
-            {"attrs": {}},  # filtered
+            {},  # filtered
         ],
         warm_start_pitfalls=[
             {
                 "confidence": 0.8,
-                "attrs": {
-                    "description": "do not enforce eager",
-                    "severity": "high",
-                    "validated_count": 2,
-                    "source_session_id": "s9",
-                },
+                "description": "do not enforce eager",
+                "severity": "high",
+                "validated_count": 2,
+                "source_session_id": "s9",
             },
-            {"attrs": {}},  # filtered
+            {},  # filtered
         ],
         framework_source_roots=("/src/vllm",),
         source_hint_directories=("/src/vllm/v1",),

--- a/src/hyperloom/orchestrator/knowledge/recipe_kb_t0.py
+++ b/src/hyperloom/orchestrator/knowledge/recipe_kb_t0.py
@@ -72,6 +72,51 @@ def _warm_recipe_source(row: Mapping[str, Any] | None, kb: Any) -> str:
     return str(getattr(kb, "backend_name", "") or "recipe-kb")
 
 
+def _experience_rows(raw: Any, required_key: str, label: str) -> list[dict[str, Any]]:
+    """Normalise a recipe row's ``lessons`` / ``pitfalls`` into flat rows.
+
+    The stored shape is flat — ``Recipe.to_dict`` and the ``_normalise_*``
+    helpers write ``{statement, ...}`` / ``{description, ...}``. The remote
+    projection (``knowledge_to_warm_recipe``) copies rows out of the record
+    without going through ``Recipe.from_dict``, so a wrapped row can still arrive
+    that way; this is the single place it is unwrapped, and no reader downstream
+    has to know about two shapes.
+
+    Rows missing *required_key* are dropped here rather than silently vanishing
+    in the prompt renderer, which is what let a wrong shape pass unnoticed: the
+    section rendered "(none)" off a non-empty list with no log and no error.
+
+    Args:
+        raw: The row list as read off the recipe.
+        required_key: The field a usable row must carry.
+        label: Field name for the warning.
+
+    Returns:
+        The flat rows that carry *required_key*.
+    """
+    out: list[dict[str, Any]] = []
+    dropped = 0
+    for item in raw or []:
+        if not isinstance(item, Mapping):
+            dropped += 1
+            continue
+        wrapped = item.get("attrs")
+        row = dict(wrapped) if isinstance(wrapped, Mapping) and wrapped else dict(item)
+        if not str(row.get(required_key) or "").strip():
+            dropped += 1
+            continue
+        out.append(row)
+    if dropped:
+        log.warning(
+            "warm_start_%s: dropped %d row(s) missing %r; kept %d",
+            label,
+            dropped,
+            required_key,
+            len(out),
+        )
+    return out
+
+
 def _recipe_is_actionable(row: Mapping[str, Any]) -> bool:
     """True when a warm recipe carries something worth replaying or priors."""
     if not isinstance(row, Mapping):
@@ -1219,8 +1264,8 @@ def run_t0_anchor(
     # warm_start_pitfalls / warm_start_lessons are embedded recipe-row fields.
     exact_history = warm_point.get("exact_history")
     history_source = exact_history if isinstance(exact_history, Mapping) else warm_point
-    pitfalls_list: list[dict[str, Any]] = list(history_source.get("pitfalls") or [])
-    lessons_list: list[dict[str, Any]] = list(history_source.get("lessons") or [])
+    pitfalls_list = _experience_rows(history_source.get("pitfalls"), "description", "pitfalls")
+    lessons_list = _experience_rows(history_source.get("lessons"), "statement", "lessons")
     try:
         pit_path = recipe_kb_pitfalls_json(sd)
         pit_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/hyperloom/orchestrator/prompts/specialist_prompt_builder.py
+++ b/src/hyperloom/orchestrator/prompts/specialist_prompt_builder.py
@@ -1766,8 +1766,12 @@ def _section_recipe(inp: SpecialistPromptInputs) -> list[str]:
 
 # Section 5b — Related lessons (positive priors from prior KEEPs)
 def _section_lessons(inp: SpecialistPromptInputs) -> list[str]:
-    """Render KB ``kind=lesson`` points from prior KEEPs, compactly
+    """Render the recipe row's ``lessons`` from prior KEEPs, compactly
     (statement + measured_impact).
+
+    Rows are the flat shape ``Recipe.to_dict`` / ``_normalise_lessons`` write —
+    ``{statement, measured_impact, ...}`` — normalised by ``recipe_kb_t0``
+    before they land on ``warm_start_lessons``.
 
     Args:
         inp: The specialist prompt inputs (reads ``warm_start_lessons``).
@@ -1789,29 +1793,28 @@ def _section_lessons(inp: SpecialistPromptInputs) -> list[str]:
             continue
         if not isinstance(point, dict):
             continue
-        attrs = point.get("attrs") or {}
-        statement = str(attrs.get("statement") or "").strip()
+        statement = str(point.get("statement") or "").strip()
         if not statement:
             continue
-        impact_str = _render_measured_impact(attrs.get("measured_impact"))
+        impact_str = _render_measured_impact(point.get("measured_impact"))
         conf = point.get("confidence")
         meta_bits: list[str] = []
         if isinstance(conf, (int, float)) and conf > 0:
             meta_bits.append(f"conf={float(conf):.2f}")
         # validated_count is the strongest cross-session signal; fall back to source_session_id.
-        vc = attrs.get("validated_count")
+        vc = point.get("validated_count")
         if isinstance(vc, int) and vc > 1:
             meta_bits.append(f"validated={vc}")
-        recent_ids = attrs.get("source_session_ids")
+        recent_ids = point.get("source_session_ids")
         if isinstance(recent_ids, list) and recent_ids:
             meta_bits.append(f"recent={recent_ids[-1]}")
         else:
-            src_sid = str(attrs.get("source_session_id") or "").strip()
+            src_sid = str(point.get("source_session_id") or "").strip()
             if src_sid:
                 meta_bits.append(f"src={src_sid}")
         meta = f" ({', '.join(meta_bits)})" if meta_bits else ""
         # Version-mismatch annotation; the LLM gets the final call.
-        version_note = _format_version_note(inp, attrs)
+        version_note = _format_version_note(inp, point)
         rows.append(f"- **{defang_prompt_structure(statement)}**{meta}{version_note}")
         if impact_str:
             rows.append(f"    impact: {impact_str}")
@@ -1822,21 +1825,21 @@ def _section_lessons(inp: SpecialistPromptInputs) -> list[str]:
 
 def _format_version_note(
     inp: SpecialistPromptInputs,
-    lesson_attrs: dict[str, Any],
+    row: dict[str, Any],
 ) -> str:
     """Render a ``[from sglang@X.Y, you're on A.B]`` annotation when
-    the lesson's framework_version differs; empty when either side is
+    the row's framework_version differs; empty when either side is
     unknown or they match.
 
     Args:
         inp: The specialist prompt inputs (reads ``framework`` /
             ``framework_version``).
-        lesson_attrs: The lesson's attrs (reads ``framework_version``).
+        row: The lesson or pitfall row (reads ``framework_version``).
 
     Returns:
         The version-mismatch annotation, or "" when unknown or matching.
     """
-    lesson_fv = str(lesson_attrs.get("framework_version") or "").strip()
+    lesson_fv = str(row.get("framework_version") or "").strip()
     current_fv = (inp.framework_version or "").strip()
     if not lesson_fv or not current_fv:
         return ""
@@ -1847,7 +1850,7 @@ def _format_version_note(
 
 
 def _render_measured_impact(raw: Any) -> str:
-    """Back-compat renderer for ``attrs.measured_impact`` (dict, legacy
+    """Back-compat renderer for a row's ``measured_impact`` (dict, legacy
     string, or other).
 
     Args:
@@ -1880,8 +1883,11 @@ def _render_measured_impact(raw: Any) -> str:
 
 # Section 5c — Known pitfalls (anti-priors from prior REVERTs)
 def _section_pitfalls(inp: SpecialistPromptInputs) -> list[str]:
-    """Render KB ``kind=pitfall`` points from prior REVERTs (description +
+    """Render the recipe row's ``pitfalls`` from prior REVERTs (description +
     severity); framed as forbidden paths, not suggestions.
+
+    Rows are the flat ``{description, severity, ...}`` shape ``Recipe.to_dict`` /
+    ``_normalise_str_dicts`` write, normalised by ``recipe_kb_t0``.
 
     Args:
         inp: The specialist prompt inputs (reads ``warm_start_pitfalls``).
@@ -1902,29 +1908,28 @@ def _section_pitfalls(inp: SpecialistPromptInputs) -> list[str]:
             continue
         if not isinstance(point, dict):
             continue
-        attrs = point.get("attrs") or {}
-        description = str(attrs.get("description") or "").strip()
+        description = str(point.get("description") or "").strip()
         if not description:
             continue
-        severity = str(attrs.get("severity") or "").strip()
+        severity = str(point.get("severity") or "").strip()
         conf = point.get("confidence")
         meta_bits: list[str] = []
         if severity:
             meta_bits.append(f"severity={severity}")
         if isinstance(conf, (int, float)) and conf > 0:
             meta_bits.append(f"conf={float(conf):.2f}")
-        vc = attrs.get("validated_count")
+        vc = point.get("validated_count")
         if isinstance(vc, int) and vc > 1:
             meta_bits.append(f"observed={vc}")
-        recent_ids = attrs.get("source_session_ids")
+        recent_ids = point.get("source_session_ids")
         if isinstance(recent_ids, list) and recent_ids:
             meta_bits.append(f"recent={recent_ids[-1]}")
         else:
-            src_sid = str(attrs.get("source_session_id") or "").strip()
+            src_sid = str(point.get("source_session_id") or "").strip()
             if src_sid:
                 meta_bits.append(f"src={src_sid}")
         meta = f" ({', '.join(meta_bits)})" if meta_bits else ""
-        version_note = _format_version_note(inp, attrs)
+        version_note = _format_version_note(inp, point)
         rows.append(f"- **{description}**{meta}{version_note}")
     if len(rows) == 2:  # only the header + blank line, all pitfalls filtered out
         rows.append(_NONE_PLACEHOLDER)

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -877,9 +877,9 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
     recipe_kb_session_id: str = ""
     # Snapshot of ``recipe_kb_t0._cascade_warm_start_search`` output, the ``{workload, hw, tier, confidence, recipe}`` envelope where ``recipe`` is the matched row; empty on first session for a (workload, hw) pair. Bookkeeping, not a prompt input — the model-facing view is ``warm_start_context``.
     warm_start_recipe: dict[str, Any] = field(default_factory=dict)
-    # Snapshot of ``pitfalls`` output (negative priors), list of KB point dicts; consumed by the specialist prompt. Resume tolerates older snapshots.
+    # Snapshot of the recipe row's ``pitfalls`` (negative priors), flat ``{description, severity, ...}`` rows as written by ``Recipe.to_dict``; consumed by the specialist prompt. Resume tolerates older snapshots.
     warm_start_pitfalls: list[dict[str, Any]] = field(default_factory=list)
-    # T0 snapshot of ``lessons`` output (positive priors), symmetric with warm_start_pitfalls; consumed by the specialist prompt. Empty under --degraded-kb or T0 failure.
+    # T0 snapshot of the recipe row's ``lessons`` (positive priors), flat ``{statement, measured_impact, ...}`` rows, symmetric with warm_start_pitfalls; consumed by the specialist prompt. Empty under --degraded-kb or T0 failure.
     warm_start_lessons: list[dict[str, Any]] = field(default_factory=list)
     # ISO UTC timestamp of the T0 snapshot; empty under --degraded-kb or T0 failure.
     warm_start_ts: str = ""


### PR DESCRIPTION
- **Description: what and why**

  Sections 5b (`RELATED LESSONS`) and 5c (`KNOWN PITFALLS`) of the specialist
  prompt read `point["attrs"]["statement"]` / `point["attrs"]["description"]`,
  which is the shape a *remote* KB point arrives in. The local store flattens
  both on the way to disk — `_normalise_lessons` writes
  `{statement, measured_impact}` and
  `_normalise_str_dicts(pitfalls, ("description", "severity"))` writes
  `{description, severity}`, neither wrapped in `attrs`.

  A flat row therefore resolved `attrs` to `{}`, produced an empty statement,
  hit the `if not statement: continue` guard, and both sections fell through to
  their `(none)` placeholder. **Every lesson and pitfall a local-mode session
  recorded was invisible to the next session** — both halves of the KB's memory,
  what worked and what to avoid.

  Both readers now use the `(point.get("attrs") or point)` form already used for
  this same wrapped-vs-flat split at three sites in `phases/prelude.py`, so
  remote points and local rows both render. Fixing the reader rather than the
  writer keeps the on-disk format and the remote path untouched, and that
  renderer is already the designated tolerance point — it carries an explicit
  "tolerate shape drift" comment for bare-string rows and simply missed this
  shape.

  Nothing failed loudly, which is why it survived: the sections are advisory
  prose, and every existing test built its fixture in the wrapped shape *by
  hand*, so the writer was never on the other end of an assertion.

- **Linked issue(s): close/fix refs**

  None filed.

- **Tests: added/updated? commands run?**

  Two added, both in `test_specialist_lessons_section.py`. They build their
  input by calling the writer (`_normalise_lessons` / `_normalise_str_dicts`)
  instead of hand-writing a dict, which is what stops the two sides drifting
  apart silently again. Both fail on `main` with the section rendering `(none)`.

  ```
  pytest src/hyperloom/inference_optimizer/tests/test_specialist_lessons_section.py
      14 passed   (includes the pre-existing guard that legacy {"raw": ...}
                   rows still do not leak, now that the fallback exposes them)

  pytest src/hyperloom -k "lesson or pitfall or warm or specialist or prompt"
      1323 passed

  pytest src/hyperloom scripts
      15745 passed, 8 failed — all 8 reproduce identically on a clean tree with
      this change stashed (pre-existing, subprocess "No module named 'hyperloom'"
      in this environment)

  ruff check / ruff format --check   clean
  ```

  Also verified as a real round trip: written through `LocalRecipeStore.put_recipe`,
  read back off disk, rendered into the prompt.

  ```
  --- 5b lessons, as the agent now sees it ---
  - **raise the MLA decode KV-split cap at conc=1**
      impact: gain_pct=30.00
  --- 5c pitfalls ---
  - **K=8 draft tokens overprovision at conc=1** (severity=regress)
  ```

- **Breaking changes: yes/no (details if yes)**

  No. Remote (wrapped) points render exactly as before; this only adds a
  fallback for rows that previously rendered as nothing.

- **PR addresses single concern: yes/no (details if no)**

  Yes — one defect, in the two renderers that share it.

  Noting one adjacent bug found while tracing this, deliberately *not* fixed
  here: `SharedState.to_warm_start_summary` renders the `=== Warm start ===`
  section by reading `entry.get("raw") or entry.get("symptom")`, field names no
  writer produces. It is broken for the flat *and* wrapped shapes, so the root
  cause is different (wrong field names, not the wrapper), and it emits a
  misleading `pitfalls (1):` header with nothing beneath it. Worth its own
  change.

- **Root cause is upstream (Magpie/TraceLens/GEAK/IntelliKit/AgentKernelArena), ticket filed:**

  No — root cause is in this repo.
