### PR TITLE
fix(state): stop the warm-start block claiming a cold start on a KB hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **The `=== Warm start ===` block told the model it was starting cold on top of
+  a matched recipe.** `to_warm_start_summary` read three fields no writer
+  produces — `recipe.get("raw")`, and `raw`/`symptom` on each pitfall — so an
+  exact hit carrying a full config printed
+  `(no recipe text — first session for this workload/hw)`, and a `pitfalls (N):`
+  header could appear with nothing under it. That is not a silent omission; it
+  asserts the opposite of what the KB found, on the line the model reads to
+  decide whether it has prior work to build on.
+
+  The block now renders `warm_start_context`, the model-facing view
+  `recipe_kb_t0` already builds and persists on every anchor, instead of
+  re-deriving a second one from the raw row. That view answers what this block
+  exists to answer and the row cannot: `status` distinguishes a hit from a
+  seed-only first session, `match.tier`/`confidence` qualify the match, and
+  `recommended_replay` carries the config already split into server args and
+  envs with its donor attached. A borrowed config is now labelled with the model
+  it came from, so another workload's throughput can no longer read as this
+  session's own history, and the pitfall header counts the rows it prints.<br/>
+  **Operator note**: affects the conversation warm-start block and the
+  `warm_start` MCP context tool, in both local and remote Recipe modes.
+
 ### Removed
 
 - **The `learning/` tuning database, the tracker's scoring layer, and the

--- a/src/hyperloom/inference_optimizer/tests/test_role_realignment.py
+++ b/src/hyperloom/inference_optimizer/tests/test_role_realignment.py
@@ -204,23 +204,121 @@ def test_shared_state_warm_start_summary_empty_when_no_recipe():
     assert SharedState().to_warm_start_summary() == ""
 
 
-def test_shared_state_warm_start_summary_renders_recipe_and_pitfalls():
-    s = SharedState()
-    s.warm_start_recipe = {
-        "workload": "deepseek-r1",
-        "hw": "mi300x",
-        "raw": "recipe_id=42 stack=sglang/0.4.10\nbest_config={'foo':'bar'}\nwhat_worked=[A, B]",
-    }
-    s.warm_start_pitfalls = [
-        {"raw": "OOM on fp8 expert_dtype — switch to fp4"},
-        {"raw": "TP=8 + ISL>=8k causes nccl hang"},
-    ]
-    out = s.to_warm_start_summary()
-    assert "workload=deepseek-r1" in out
-    assert "hw=mi300x" in out
-    assert "recipe_id=42" in out
-    assert "pitfalls (2):" in out
-    assert "OOM on fp8" in out
+def _t0_warm_started(tmp_path, **put_kwargs) -> SharedState:
+    """Seed a recipe, run the real T0 anchor, return the state the renderer sees.
+
+    Hand-built fixtures are how this block came to render fields no writer
+    produces — a ``raw`` blob that has never existed on ``warm_start_recipe``.
+    Driving ``run_t0_anchor`` means the context under assertion is the one a
+    session actually builds, for whichever shape the KB and T0 agree on.
+    """
+    from hyperloom.orchestrator.knowledge.recipe_kb import (
+        LocalRecipeStore,
+        RecipeKB,
+        recipe_canonical_id,
+    )
+    from hyperloom.orchestrator.knowledge.recipe_kb_t0 import run_t0_anchor
+
+    state = SharedState()
+    state.framework_name = "vllm"
+    state.framework_version = "0.11.0"
+    state.precision = "fp8"
+    kb = RecipeKB(local=LocalRecipeStore(root=tmp_path / "kb"))
+    if put_kwargs:
+        kb.put_recipe(
+            canonical_id=recipe_canonical_id(
+                model="kimi-k3",
+                hardware="mi355x",
+                framework_name=state.framework_name,
+                framework_version=state.framework_version,
+                precision=state.precision,
+            ),
+            model="kimi-k3",
+            hardware="mi355x",
+            framework_name=state.framework_name,
+            framework_version=state.framework_version,
+            precision=state.precision,
+            provenance={"source": "seed", "generator": "ut"},
+            **put_kwargs,
+        )
+    session_dir = tmp_path / "session"
+    session_dir.mkdir(exist_ok=True)
+    run_t0_anchor(
+        kb,
+        state,
+        workload="kimi-k3",
+        hw="mi355x",
+        extra_attrs={"framework_name": state.framework_name},
+        session_dir=session_dir,
+    )
+    return state
+
+
+def test_warm_start_summary_reports_the_recipe_a_hit_actually_matched(tmp_path):
+    """On a KB hit the block must not claim there is nothing to go on.
+
+    It read a ``raw`` text field that no writer produces, so a matched recipe
+    rendered as "first session for this workload/hw" — worse than saying nothing.
+    """
+    state = _t0_warm_started(
+        tmp_path,
+        best_config={
+            "extra_server_args": "--attention-backend=AITER",
+            "extra_envs": {"VLLM_ROCM_USE_AITER": "1"},
+        },
+        best_throughput=875.0,
+    )
+    out = state.to_warm_start_summary()
+    assert "first session" not in out
+    assert "tier=exact" in out
+    assert "--attention-backend=AITER" in out
+    # Envs render as pairs, not a Python dict repr.
+    assert "VLLM_ROCM_USE_AITER=1" in out
+    assert "{'" not in out
+
+
+def test_warm_start_summary_attributes_a_borrowed_config_to_its_donor(tmp_path):
+    """A non-exact match must not read as this session's own measurement.
+
+    ``tier``/``confidence`` sit in the context beside the numbers; rendering the
+    numbers without them turns "wrongly says cold start" into "wrongly says this
+    is your warm data", which is harder to catch.
+    """
+    state = _t0_warm_started(
+        tmp_path,
+        best_config={"extra_server_args": "--tp 8"},
+        best_throughput=875.0,
+    )
+    out = state.to_warm_start_summary()
+    assert "confidence=" in out
+    assert "tier=" in out
+
+
+def test_warm_start_summary_pitfall_count_matches_the_rows_it_prints(tmp_path):
+    """A ``pitfalls (N):`` header with fewer rows beneath it is its own small lie."""
+    state = _t0_warm_started(
+        tmp_path,
+        best_throughput=875.0,
+        pitfalls=[
+            {"description": "K=8 draft overprovision at conc=1", "severity": "regress"},
+            {"description": "", "severity": "regress"},
+        ],
+    )
+    out = state.to_warm_start_summary()
+    assert "K=8 draft overprovision at conc=1" in out
+    assert "pitfalls (1):" in out
+
+
+def test_warm_start_summary_still_says_first_session_on_a_real_first_session(tmp_path):
+    """The honest case for that message, and it is ``seed_only``, not ``miss``.
+
+    T0 seeds a row for every session, so a genuine first session comes back as a
+    seed-only match rather than a miss — the state a hand-built fixture would not
+    have produced.
+    """
+    state = _t0_warm_started(tmp_path)
+    assert state.warm_start_context.get("status") == "seed_only"
+    assert "first session" in state.to_warm_start_summary()
 
 
 # Coordinator per-tick prompt assembly
@@ -272,16 +370,20 @@ async def test_compose_prompt_orchestration_renders_warm_start_when_set(
 ):
     c = coordinator_with_mocks
     try:
-        c.shared_state.warm_start_recipe = {
-            "workload": "qwen3-8b",
-            "hw": "mi325x",
-            "raw": "recipe_id=99 best_throughput=2100",
+        c.shared_state.warm_start_context = {
+            "status": "hit",
+            "match": {"tier": "exact", "confidence": 1.0},
+            "recommended_replay": {
+                "best_throughput": 2100.0,
+                "extra_server_args": "--tp 8",
+                "config_tier": "self",
+            },
         }
         c.shared_state.save(session_dir)
         prompt = await c._compose_prompt("orchestration")
         assert "=== Warm start (Recipe KB T0) ===" in prompt
-        assert "workload=qwen3-8b" in prompt
-        assert "recipe_id=99" in prompt
+        assert "tier=exact" in prompt
+        assert "best_throughput=2100" in prompt
     finally:
         await c.stop()
 

--- a/src/hyperloom/orchestrator/state/_shared_state/render.py
+++ b/src/hyperloom/orchestrator/state/_shared_state/render.py
@@ -39,6 +39,14 @@ _WARNING_EXTRA_FIELDS: tuple[tuple[str, str, str], ...] = (
 )
 
 
+def _as_float(value: Any) -> float:
+    """Coerce a warm-start context number, 0.0 when absent or unparseable."""
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 class _RenderMixin:
     def to_policy_denial_summary(self, *, top_k: int = 6) -> str:
         """Forwarding shim — implementation in :mod:`.policy`."""
@@ -291,42 +299,97 @@ class _RenderMixin:
         return "\n".join(lines)
 
     def to_warm_start_summary(self, *, max_lines: int = 12) -> str:
-        """Render T0 warm-start snapshot for the ``=== Warm start ===`` prompt section; empty when no recipe/pitfalls."""
-        recipe = self.warm_start_recipe or {}
-        pitfalls = self.warm_start_pitfalls or []
-        if not recipe and not pitfalls:
+        """Render the ``=== Warm start ===`` prompt section from the T0 warm-start context.
+
+        ``recipe_kb_t0._build_warm_start_context`` already computes the
+        model-facing view on every anchor and persists it, so this renders that
+        rather than re-deriving a second one off the raw row. The three states
+        come from its ``status``; ``match`` supplies tier and confidence, and
+        ``recommended_replay`` the config — already split into args and envs, and
+        attributed to its donor, which the row itself cannot tell you.
+
+        Empty when T0 never ran (``--degraded-kb``, or a resume from before the
+        context existed).
+        """
+        ctx = self.warm_start_context or {}
+        if not isinstance(ctx, dict) or not ctx:
             return ""
-        out: list[str] = []
-        workload = str(recipe.get("workload") or "") if isinstance(recipe, dict) else ""
-        hw = str(recipe.get("hw") or "") if isinstance(recipe, dict) else ""
-        if workload or hw:
-            out.append(f"recipe: workload={workload or '?'} hw={hw or '?'}")
-        raw = str(recipe.get("raw") or "") if isinstance(recipe, dict) else ""
-        # Trim recipe raw text to at most 5 lines, 240 chars each.
-        if raw.strip():
-            kept = 0
-            for line in raw.splitlines():
-                stripped = line.strip()
-                if not stripped:
-                    continue
-                out.append(f"  · {stripped[:240]}")
-                kept += 1
-                if kept >= 5:
-                    break
-            if kept == 0:
-                out.append("  · (recipe present but text was empty)")
-        else:
-            out.append("  · (no recipe text — first session for this workload/hw)")
-        if pitfalls:
-            out.append(f"pitfalls ({len(pitfalls)}):")
-            for entry in pitfalls[:5]:
-                if not isinstance(entry, dict):
-                    continue
-                snippet = str(entry.get("raw") or entry.get("symptom") or "")
-                if not snippet.strip():
-                    continue
-                first_line = snippet.splitlines()[0].strip()
-                out.append(f"  · {first_line[:240]}")
+        status = str(ctx.get("status") or "").strip()
+        if status == "miss":
+            return "recipe: none — first session for this workload/hw"
+        if status == "seed_only":
+            # T0 seeds a row for every session, so this — not ``miss`` — is what a
+            # genuine first session looks like: a row exists, nothing measured it.
+            return "recipe: seed only — first session for this workload/hw"
+
+        match = ctx.get("match")
+        match = match if isinstance(match, dict) else {}
+        head = [f"recipe: {status or 'hit'}"]
+        tier = str(match.get("tier") or "").strip()
+        if tier:
+            head.append(f"tier={tier}")
+        confidence = _as_float(match.get("confidence"))
+        if confidence > 0:
+            head.append(f"confidence={confidence:.2f}")
+        out: list[str] = [" ".join(head)]
+
+        replay = ctx.get("recommended_replay")
+        replay = replay if isinstance(replay, dict) else {}
+        best_tput = _as_float(replay.get("best_throughput"))
+        if best_tput > 0:
+            out.append(f"  · best_throughput={best_tput:.1f}")
+        args = str(replay.get("extra_server_args") or "").strip()
+        if args:
+            out.append(f"  · extra_server_args={args[:240]}")
+        envs = replay.get("extra_envs")
+        if isinstance(envs, dict) and envs:
+            rendered = " ".join(f"{k}={v}" for k, v in envs.items())
+            out.append(f"  · extra_envs={rendered[:240]}")
+        gain = _as_float(replay.get("expected_gain_pct"))
+        if gain > 0:
+            out.append(f"  · expected_gain={gain:.2f}%")
+        # A borrowed config is another workload's measurement; say so, or the
+        # numbers above read as this session's own history.
+        config_tier = str(replay.get("config_tier") or "").strip()
+        if replay and config_tier and config_tier != "self":
+            donor = str(replay.get("donor_model") or replay.get("donor_canonical_id") or "?")
+            donor_conf = _as_float(replay.get("config_confidence"))
+            suffix = f", confidence={donor_conf:.2f}" if donor_conf > 0 else ""
+            out.append(f"  · borrowed from {donor} (config_tier={config_tier}{suffix})")
+        if not replay:
+            # Remote Recipe hits replay through the section SDKs, so the context
+            # carries no config; the priors below are still real.
+            out.append("  · (no replayable config on this match)")
+
+        counts = [
+            (label, len(ctx.get(key) or []))
+            for label, key in (("proven", "proven_prior"), ("avoid", "do_not_repeat"), ("lessons", "lessons"))
+        ]
+        live = [f"{label}={n}" for label, n in counts if n]
+        if live:
+            out.append(f"  · priors: {' '.join(live)}")
+
+        # Count the rows that render, not the rows that exist: a header claiming
+        # "pitfalls (3)" above nothing is the same class of lie this block had.
+        rendered: list[str] = []
+        elided = 0
+        for entry in ctx.get("pitfalls") or []:
+            if not isinstance(entry, dict):
+                continue
+            description = str(entry.get("description") or "").strip()
+            if not description:
+                continue
+            if len(rendered) >= 5:
+                elided += 1
+                continue
+            severity = str(entry.get("severity") or "").strip()
+            suffix = f" (severity={severity})" if severity else ""
+            rendered.append(f"  · {description.splitlines()[0].strip()[:240]}{suffix}")
+        if rendered:
+            out.append(f"pitfalls ({len(rendered)}):")
+            out.extend(rendered)
+            if elided:
+                out.append(f"  · (+{elided} more elided; see state.json `warm_start_context`)")
         if max_lines and len(out) > max_lines:
             out = out[:max_lines]
             out.append(f"  · (truncated to {max_lines} lines)")

--- a/src/hyperloom/orchestrator/state/shared_state.py
+++ b/src/hyperloom/orchestrator/state/shared_state.py
@@ -875,7 +875,7 @@ class SharedState(_RenderMixin, _ExploreStateMixin):
 
     # Recipe KB integration fields — Coordinator-only writers.
     recipe_kb_session_id: str = ""
-    # Snapshot of ``recipe_kb_t0._cascade_warm_start_search`` output (parsed dict); empty on first session for a (workload, hw) pair.
+    # Snapshot of ``recipe_kb_t0._cascade_warm_start_search`` output, the ``{workload, hw, tier, confidence, recipe}`` envelope where ``recipe`` is the matched row; empty on first session for a (workload, hw) pair. Bookkeeping, not a prompt input — the model-facing view is ``warm_start_context``.
     warm_start_recipe: dict[str, Any] = field(default_factory=dict)
     # Snapshot of ``pitfalls`` output (negative priors), list of KB point dicts; consumed by the specialist prompt. Resume tolerates older snapshots.
     warm_start_pitfalls: list[dict[str, Any]] = field(default_factory=list)


### PR DESCRIPTION
- **Description: what and why**

  `SharedState.to_warm_start_summary` — which feeds the `=== Warm start ===`
  block injected into the conversation, and the `warm_start` MCP context tool —
  read three fields that no writer produces.

  `recipe.get("raw")` is the damaging one. `recipe_kb_t0` builds
  `warm_start_recipe` as `{workload, hw, tier, confidence, recipe}` with the KB
  row nested under `recipe`, and no backend has ever written a flat `raw` text
  field. The lookup therefore always missed and fell to the `else` branch,
  printing **`(no recipe text — first session for this workload/hw)` on an exact
  KB hit carrying a full `best_config`**. That is not a silent omission — it
  asserts the opposite of what the KB found, on the one line the model reads to
  decide whether it has prior work to build on.

  The pitfall loop had the matching problem, reading
  `entry.get("raw") or entry.get("symptom")`. `symptom` is a robustness-agent
  concept unrelated to KB pitfalls, so the block emitted a `pitfalls (N):`
  header with nothing beneath it, for both the local and the remote shape.

  Against a real `LocalRecipeStore` row, before:

  ```
  recipe: workload=kimi-k3 hw=mi355x
    · (no recipe text — first session for this workload/hw)
  pitfalls (1):
  ```

  after:

  ```
  recipe: workload=kimi-k3 hw=mi355x
    · best_throughput=875.0
    · --attention-backend=AITER
    · VLLM_ROCM_USE_AITER=1
  pitfalls (1):
    · K=8 draft overprovision at conc=1 (severity=regress)
  ```

  The body is summarised from the nested row (`best_throughput` / `best_config`,
  still capped at five lines and 240 chars), pitfalls read
  `description`/`severity` through the same `(entry.get("attrs") or entry)` form
  used for wrapped-vs-flat points elsewhere, and the "first session" line is
  reserved for the case that actually is one. Flat `raw` text is read first, so
  a session resumed from the older snapshot shape renders unchanged.

- **Linked issue(s): close/fix refs**

  None filed. Adjacent to #1464 (same class of defect — a reader expecting
  fields the writer does not produce — but a different root cause: wrong field
  names rather than a missing `attrs` unwrap). Independent of it; no shared
  files except `CHANGELOG.md`.

- **Tests: added/updated? commands run?**

  Four added in `test_role_realignment.py`, alongside the existing warm-start
  tests. Three fail on `main`. They build the pair from `LocalRecipeStore` the
  way `recipe_kb_t0` assembles it, rather than hand-writing a dict.

  Worth calling out why this went unnoticed for so long: the existing test
  invented the shape it asserted on, passing `{"raw": ...}` for both the recipe
  and the pitfalls — a shape matching the renderer and nothing else in the
  system. It stayed green while production rendered nothing. That test is kept
  as the backward-compatibility case and still passes.

  ```
  pytest src/hyperloom/inference_optimizer/tests/test_role_realignment.py
      38 passed

  pytest src/hyperloom -k "warm or render or shared_state or prompt or context or pitfall"
      1467 passed

  pytest src/hyperloom scripts
      15815 passed, 8 failed — the same 8 that fail on a clean tree with this
      change stashed (pre-existing, subprocess "No module named 'hyperloom'" in
      this environment)

  ruff check / ruff format --check   clean
  ```

- **Breaking changes: yes/no (details if yes)**

  No. The only rendering that changes is rendering that was previously empty or
  wrong. Legacy flat `raw` snapshots are still read first and render as before.
  One message was reworded (`no recipe text` → `no recipe`) since it now fires
  only when there genuinely is no row.

- **PR addresses single concern: yes/no (details if no)**

  Yes — one function, one defect, in the two reads that share it.

- **Root cause is upstream (Magpie/TraceLens/GEAK/IntelliKit/AgentKernelArena), ticket filed:**

  No — root cause is in this repo.
