### PR TITLE
fix(orchestrator): run long executor subprocesses off the event loop

### DIFF
--- a/src/hyperloom/inference_optimizer/tests/test_integrate_patch_executor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_integrate_patch_executor.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -1433,6 +1434,51 @@ async def test_enablement_replays_setup_commands_before_boot(tmp_path: Path, mon
     assert result["status"] == "kept"
     assert result["setup_commands_applied"] == ["pip install -U transformers"]
     assert replayed["commands"] == ["pip install -U transformers"]
+
+
+@pytest.mark.asyncio
+async def test_setup_replay_runs_off_the_event_loop_thread(tmp_path: Path, monkeypatch):
+    """Enablement setup replay must not occupy the coordinator event-loop thread.
+
+    ``_run_setup_commands`` is a blocking ``subprocess.run`` loop. If it ran on
+    the loop thread, concurrent in-flight LLM streams, the dispatcher's re-scan
+    poll, and cancel grace would freeze until the installs finished.
+    """
+    from hyperloom.orchestrator.actions.executors import integrate_patch as ip_mod
+
+    seen: dict[str, int] = {}
+    loop_ident = threading.get_ident()
+
+    def _spy_run_setup(commands, *, cwd, log_dir):
+        seen["ident"] = threading.get_ident()
+        return {"applied": [], "skipped": [], "failed": []}
+
+    monkeypatch.setattr(ip_mod, "_run_setup_commands", _spy_run_setup)
+
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    executor = IntegratePatchExecutor(session_dir=session_dir)
+    ctx = _make_ctx("t-int-setup-thread", {"enablement": True})
+    ctx._ip_specialist_workspace = workspace  # type: ignore[attr-defined]
+
+    result = await executor._stage_apply(
+        ctx,
+        {
+            "enablement": True,
+            "enablement_setup_commands": ["pip install -U transformers"],
+        },
+        {},
+        "t-spec-setup-thread",
+        None,
+        None,
+    )
+
+    assert "ident" in seen
+    assert seen["ident"] != loop_ident
+    assert result is not None
+    assert result["status"] == "no_patches"
 
 
 def test_integrate_patch_executor_imports_clean():

--- a/src/hyperloom/inference_optimizer/tests/test_integrate_patch_executor.py
+++ b/src/hyperloom/inference_optimizer/tests/test_integrate_patch_executor.py
@@ -1299,6 +1299,30 @@ def test_run_setup_commands_skips_non_allowlisted(tmp_path: Path, monkeypatch):
     assert (tmp_path / "logs" / "enablement_setup.log").exists()
 
 
+def test_run_setup_commands_stops_between_commands_on_cancel(tmp_path: Path, monkeypatch):
+    """Cancel is cooperative between commands; an in-flight subprocess.run is not killed."""
+    from hyperloom.orchestrator.actions.cancel_channel import CancelScope, use_cancel_scope
+
+    ran: list[str] = []
+    scope = CancelScope()
+
+    def _fake_run(cmd, *args, **kwargs):
+        ran.append(cmd)
+        scope.cancel(reason="test")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    with use_cancel_scope(scope):
+        out = _run_setup_commands(
+            ["pip install -U transformers", "pip install -U torch"],
+            cwd=tmp_path,
+            log_dir=tmp_path / "logs",
+        )
+    assert ran == ["pip install -U transformers"]
+    assert out["applied"] == ["pip install -U transformers"]
+    assert out["failed"] == []
+
+
 def test_skipped_setup_commands_are_named_in_the_round_reason():
     """A rejected command must reach the conclusion, not just a log line.
 

--- a/src/hyperloom/inference_optimizer/tests/test_integrate_patch_provision.py
+++ b/src/hyperloom/inference_optimizer/tests/test_integrate_patch_provision.py
@@ -129,6 +129,30 @@ async def test_provision_ok_sets_ctx(_executor, monkeypatch):
     assert ctx._ip_attempt_venv_root == venv
 
 
+@pytest.mark.asyncio
+async def test_provision_runs_off_the_event_loop_thread(_executor, monkeypatch):
+    """Adapter provision (venv/pip, 1800s) must not occupy the event-loop thread."""
+    import threading
+
+    seen: dict[str, int] = {}
+    loop_ident = threading.get_ident()
+    venv = str(_executor.session_dir / "enablement" / "stacks" / "vllm" / "t-1" / "venv")
+    adapter = _FakeAdapter(_ok_result(venv))
+    orig = adapter.provision
+
+    def _spy_provision(action, attempt_dir):
+        seen["ident"] = threading.get_ident()
+        return orig(action, attempt_dir)
+
+    adapter.provision = _spy_provision
+    monkeypatch.setattr("hyperloom.orchestrator.framework.adapters.get_adapter", lambda _fw: adapter)
+    ctx = _ctx()
+    out = await _executor._stage_provision_attempt_runtime(ctx, {"runtime_candidate": _candidate()}, "t-1")
+    assert out is None
+    assert "ident" in seen
+    assert seen["ident"] != loop_ident
+
+
 async def test_provision_fail_returns_reverted_and_gcs(_executor, monkeypatch):
     adapter = _FakeAdapter(ProvisionResult(ok=False, error="pip failed"))
     monkeypatch.setattr("hyperloom.orchestrator.framework.adapters.get_adapter", lambda _fw: adapter)

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_runner_helpers_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_runner_helpers_unit.py
@@ -8,7 +8,10 @@ the prompt/transcript/heartbeat/done writers."""
 from __future__ import annotations
 
 import json
+import threading
 from types import SimpleNamespace
+
+import pytest
 
 from hyperloom.orchestrator.specialists import runner as sr
 from hyperloom.orchestrator.specialists.runner import (
@@ -234,7 +237,7 @@ def test_write_specialist_done_partial(tmp_path):
     assert "ts" in payload
 
 
-def _finalize(r, tmp_path, payload):
+async def _finalize(r, tmp_path, payload):
     """Drive ``_finalize`` far enough to inspect the artifact it writes."""
     prep = sr._PreparedRun(
         domain=SimpleNamespace(key="serving_specialist"),
@@ -242,7 +245,7 @@ def _finalize(r, tmp_path, payload):
         workspace=tmp_path,
     )
     ctx = SimpleNamespace(task=SimpleNamespace(task_id="t1", params={}), extra={})
-    result = r._finalize(
+    result = await r._finalize(
         ctx=ctx,
         prep=prep,
         specialist_done_payload=payload,
@@ -255,11 +258,12 @@ def _finalize(r, tmp_path, payload):
     return result, json.loads((tmp_path / "specialist_done.json").read_text(encoding="utf-8"))
 
 
-def test_finalize_strips_forbidden_fields_before_the_critic_can_see_them(tmp_path):
+@pytest.mark.asyncio
+async def test_finalize_strips_forbidden_fields_before_the_critic_can_see_them(tmp_path):
     """The Critic is told to reject a proposal_set carrying self-reported gain
     fields, which costs the round every idea in it. Dropping them makes that
     verdict unreachable; the audit note still records what was there."""
-    result, written = _finalize(
+    result, written = await _finalize(
         _runner(),
         tmp_path,
         {
@@ -277,14 +281,32 @@ def test_finalize_strips_forbidden_fields_before_the_critic_can_see_them(tmp_pat
     assert "expected_gain" in joined and "score" in joined
 
 
-def test_finalize_keeps_the_round_level_confidence_the_audit_records(tmp_path):
-    _, written = _finalize(
+@pytest.mark.asyncio
+async def test_finalize_keeps_the_round_level_confidence_the_audit_records(tmp_path):
+    _, written = await _finalize(
         _runner(),
         tmp_path,
         {"proposal_set": [{"name": "v1"}], "confidence": 0.6},
     )
 
     assert written["confidence"] == 0.6
+
+
+@pytest.mark.asyncio
+async def test_patch_vetting_runs_off_the_event_loop_thread(tmp_path, monkeypatch):
+    """``vet_patches`` serialises ``git apply --check``; that must not freeze the loop."""
+    seen: dict[str, int] = {}
+    loop_ident = threading.get_ident()
+    orig = sr._patch_safety.vet_patches
+
+    def _spy_vet(*args, **kwargs):
+        seen["ident"] = threading.get_ident()
+        return orig(*args, **kwargs)
+
+    monkeypatch.setattr(sr._patch_safety, "vet_patches", _spy_vet)
+    await _finalize(_runner(), tmp_path, {"proposal_set": [{"name": "v1"}], "summary": "s"})
+    assert "ident" in seen
+    assert seen["ident"] != loop_ident
 
 
 def test_write_specialist_done_partial_noop_none_workspace():

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_runner_helpers_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_runner_helpers_unit.py
@@ -7,6 +7,7 @@ the prompt/transcript/heartbeat/done writers."""
 
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 from types import SimpleNamespace
@@ -237,7 +238,7 @@ def test_write_specialist_done_partial(tmp_path):
     assert "ts" in payload
 
 
-async def _finalize(r, tmp_path, payload):
+def _finalize(r, tmp_path, payload):
     """Drive ``_finalize`` far enough to inspect the artifact it writes."""
     prep = sr._PreparedRun(
         domain=SimpleNamespace(key="serving_specialist"),
@@ -245,7 +246,7 @@ async def _finalize(r, tmp_path, payload):
         workspace=tmp_path,
     )
     ctx = SimpleNamespace(task=SimpleNamespace(task_id="t1", params={}), extra={})
-    result = await r._finalize(
+    result = r._finalize(
         ctx=ctx,
         prep=prep,
         specialist_done_payload=payload,
@@ -258,12 +259,11 @@ async def _finalize(r, tmp_path, payload):
     return result, json.loads((tmp_path / "specialist_done.json").read_text(encoding="utf-8"))
 
 
-@pytest.mark.asyncio
-async def test_finalize_strips_forbidden_fields_before_the_critic_can_see_them(tmp_path):
+def test_finalize_strips_forbidden_fields_before_the_critic_can_see_them(tmp_path):
     """The Critic is told to reject a proposal_set carrying self-reported gain
     fields, which costs the round every idea in it. Dropping them makes that
     verdict unreachable; the audit note still records what was there."""
-    result, written = await _finalize(
+    result, written = _finalize(
         _runner(),
         tmp_path,
         {
@@ -281,9 +281,8 @@ async def test_finalize_strips_forbidden_fields_before_the_critic_can_see_them(t
     assert "expected_gain" in joined and "score" in joined
 
 
-@pytest.mark.asyncio
-async def test_finalize_keeps_the_round_level_confidence_the_audit_records(tmp_path):
-    _, written = await _finalize(
+def test_finalize_keeps_the_round_level_confidence_the_audit_records(tmp_path):
+    _, written = _finalize(
         _runner(),
         tmp_path,
         {"proposal_set": [{"name": "v1"}], "confidence": 0.6},
@@ -294,7 +293,7 @@ async def test_finalize_keeps_the_round_level_confidence_the_audit_records(tmp_p
 
 @pytest.mark.asyncio
 async def test_patch_vetting_runs_off_the_event_loop_thread(tmp_path, monkeypatch):
-    """``vet_patches`` serialises ``git apply --check``; that must not freeze the loop."""
+    """Production wraps ``_finalize`` in ``asyncio.to_thread``; vetting must not freeze the loop."""
     seen: dict[str, int] = {}
     loop_ident = threading.get_ident()
     orig = sr._patch_safety.vet_patches
@@ -304,7 +303,24 @@ async def test_patch_vetting_runs_off_the_event_loop_thread(tmp_path, monkeypatc
         return orig(*args, **kwargs)
 
     monkeypatch.setattr(sr._patch_safety, "vet_patches", _spy_vet)
-    await _finalize(_runner(), tmp_path, {"proposal_set": [{"name": "v1"}], "summary": "s"})
+    r = _runner()
+    prep = sr._PreparedRun(
+        domain=SimpleNamespace(key="serving_specialist"),
+        gap="gap-1",
+        workspace=tmp_path,
+    )
+    ctx = SimpleNamespace(task=SimpleNamespace(task_id="t1", params={}), extra={})
+    await asyncio.to_thread(
+        r._finalize,
+        ctx=ctx,
+        prep=prep,
+        specialist_done_payload={"proposal_set": [{"name": "v1"}], "summary": "s"},
+        turns_used=1,
+        tool_violations=[],
+        backend_error="",
+        extra_notes=[],
+        patches_written=[],
+    )
     assert "ident" in seen
     assert seen["ident"] != loop_ident
 

--- a/src/hyperloom/inference_optimizer/tests/test_specialist_runner_helpers_unit.py
+++ b/src/hyperloom/inference_optimizer/tests/test_specialist_runner_helpers_unit.py
@@ -7,13 +7,15 @@ the prompt/transcript/heartbeat/done writers."""
 
 from __future__ import annotations
 
-import asyncio
 import json
 import threading
 from types import SimpleNamespace
 
 import pytest
 
+from hyperloom.inference_optimizer.protocol.intent import Intent, IntentType
+from hyperloom.orchestrator.loop.sub_agent_runner import RunnerContext
+from hyperloom.orchestrator.roles.mock_backend import MockBackend, MockTurn, ScriptedPlan
 from hyperloom.orchestrator.specialists import runner as sr
 from hyperloom.orchestrator.specialists.runner import (
     SpecialistFailureType,
@@ -21,6 +23,7 @@ from hyperloom.orchestrator.specialists.runner import (
     build_empty_specialist_done,
     classify_specialist_failure,
 )
+from hyperloom.orchestrator.state.task_registry import Task
 
 
 def _runner(**over):
@@ -293,7 +296,7 @@ def test_finalize_keeps_the_round_level_confidence_the_audit_records(tmp_path):
 
 @pytest.mark.asyncio
 async def test_patch_vetting_runs_off_the_event_loop_thread(tmp_path, monkeypatch):
-    """Production wraps ``_finalize`` in ``asyncio.to_thread``; vetting must not freeze the loop."""
+    """In-process ``run`` wraps ``_finalize`` in ``to_thread``; vetting must not freeze the loop."""
     seen: dict[str, int] = {}
     loop_ident = threading.get_ident()
     orig = sr._patch_safety.vet_patches
@@ -303,24 +306,33 @@ async def test_patch_vetting_runs_off_the_event_loop_thread(tmp_path, monkeypatc
         return orig(*args, **kwargs)
 
     monkeypatch.setattr(sr._patch_safety, "vet_patches", _spy_vet)
-    r = _runner()
-    prep = sr._PreparedRun(
-        domain=SimpleNamespace(key="serving_specialist"),
-        gap="gap-1",
-        workspace=tmp_path,
+    done = {
+        "gap_canonical_id": "gap-1",
+        "domain": "serving_specialist",
+        "proposal_set": [{"name": "v1"}],
+        "summary": "s",
+        "reason": "test",
+        "confidence": 0.0,
+        "new_findings": [],
+        "residual_questions": [],
+    }
+    plan = ScriptedPlan(
+        turns=[MockTurn(intents=[Intent(type=IntentType.SPECIALIST_DONE, payload=done)])],
     )
-    ctx = SimpleNamespace(task=SimpleNamespace(task_id="t1", params={}), extra={})
-    await asyncio.to_thread(
-        r._finalize,
-        ctx=ctx,
-        prep=prep,
-        specialist_done_payload={"proposal_set": [{"name": "v1"}], "summary": "s"},
-        turns_used=1,
-        tool_violations=[],
-        backend_error="",
-        extra_notes=[],
-        patches_written=[],
+    runner = SpecialistRunner(
+        backend_factory=lambda d: MockBackend(plan, name="mock"),
+        session_dir=tmp_path,
+        default_max_turns=2,
     )
+    task = Task(
+        task_id="t1",
+        kind="specialist",
+        state="queued",
+        params={"domain": "serving_specialist", "gap_canonical_id": "gap-1", "max_turns": 1},
+        idempotency_key="t1",
+        requires_lanes=tuple(),
+    )
+    await runner.run(RunnerContext(task=task, lease=None, extra={}))
     assert "ident" in seen
     assert seen["ident"] != loop_ident
 

--- a/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
+++ b/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
@@ -53,6 +53,7 @@ from ...bringup import load_boot_observation, observation_summary, verdict_of, w
 from ...delivery import file_digest, load_records
 from ..stop_attribution import stopped_by_the_run_class
 from ...policy.gate import INTEGRATE_PATCH_PERMISSIVE_VERDICTS
+from ..cancel_channel import cancel_scope_listener, stop_was_asked_for
 from ._accuracy_gate import (
     DEFAULT_ENABLEMENT_ACCURACY_FLOOR,
     accuracy_keep_block,
@@ -377,6 +378,11 @@ def _resolve_setup_commands(
 def _run_setup_commands(commands: list[str], *, cwd: Path, log_dir: Path) -> dict[str, Any]:
     """Replay allowlisted enablement setup commands (installs) before boot.
 
+    Blocking (serial ``subprocess.run``, 1800s cap); call via ``asyncio.to_thread``.
+    Cancel is checked between commands; a command already in ``subprocess.run``
+    is not killed. Cancelling the await unwinds integrate and does not continue
+    to apply patches.
+
     Runs each allowlisted command non-interactively with a per-command timeout,
     appending combined output to ``<log_dir>/enablement_setup.log``. Commands
     that fail the allowlist are skipped (never executed). A non-zero install is
@@ -406,48 +412,52 @@ def _run_setup_commands(commands: list[str], *, cwd: Path, log_dir: Path) -> dic
     env = dict(os.environ)
     env.setdefault("DEBIAN_FRONTEND", "noninteractive")
     env.setdefault("PIP_DISABLE_PIP_VERSION_CHECK", "1")
-    for cmd in commands:
-        if not _is_allowlisted_setup_command(cmd):
-            # Sanitised HERE, not at the reporting sites. This list is copied
-            # verbatim into every result payload that carries
-            # ``setup_commands_skipped``, and a rejected command is LLM-written
-            # text that can hold a bearer token or a credentialed URL. Doing it
-            # at the four call sites protects those four; doing it at the source
-            # protects the fifth as well.
-            safe_cmd = _sanitize_setup_command(cmd)
-            skipped.append(safe_cmd)
-            # Also carried into the round's ``reason`` by
-            # _with_skipped_setup_reason: a warning alone left the caller with an
-            # outcome and no link to the cause, so the same proposal was
-            # re-authored and re-dropped until the budget ran out. The log is a
-            # disk-backed surface too, so it gets the sanitised form as well.
-            log.warning("integrate_patch: skipping non-allowlisted enablement setup command: %s", safe_cmd)
-            continue
-        log.info("integrate_patch: enablement setup replay: %s", cmd)
-        try:
-            proc = subprocess.run(  # noqa: S602  # nosec B602 - allowlisted install-only shell command.
-                cmd,
-                shell=True,
-                cwd=str(cwd),
-                env=env,
-                capture_output=True,
-                text=True,
-                timeout=_SETUP_CMD_TIMEOUT_SEC,
-            )
+    with cancel_scope_listener():
+        for cmd in commands:
+            if stop_was_asked_for():
+                log.info("integrate_patch: enablement setup replay stopped after cancel")
+                break
+            if not _is_allowlisted_setup_command(cmd):
+                # Sanitised HERE, not at the reporting sites. This list is copied
+                # verbatim into every result payload that carries
+                # ``setup_commands_skipped``, and a rejected command is LLM-written
+                # text that can hold a bearer token or a credentialed URL. Doing it
+                # at the four call sites protects those four; doing it at the source
+                # protects the fifth as well.
+                safe_cmd = _sanitize_setup_command(cmd)
+                skipped.append(safe_cmd)
+                # Also carried into the round's ``reason`` by
+                # _with_skipped_setup_reason: a warning alone left the caller with an
+                # outcome and no link to the cause, so the same proposal was
+                # re-authored and re-dropped until the budget ran out. The log is a
+                # disk-backed surface too, so it gets the sanitised form as well.
+                log.warning("integrate_patch: skipping non-allowlisted enablement setup command: %s", safe_cmd)
+                continue
+            log.info("integrate_patch: enablement setup replay: %s", cmd)
             try:
-                with open(log_path, "a", encoding="utf-8") as fh:
-                    fh.write(f"$ {cmd}\n{proc.stdout}\n{proc.stderr}\n(rc={proc.returncode})\n\n")
-            except OSError:
-                # Logging is best-effort.
-                pass
-            if proc.returncode == 0:
-                applied.append(cmd)
-            else:
+                proc = subprocess.run(  # noqa: S602  # nosec B602 - allowlisted install-only shell command.
+                    cmd,
+                    shell=True,
+                    cwd=str(cwd),
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                    timeout=_SETUP_CMD_TIMEOUT_SEC,
+                )
+                try:
+                    with open(log_path, "a", encoding="utf-8") as fh:
+                        fh.write(f"$ {cmd}\n{proc.stdout}\n{proc.stderr}\n(rc={proc.returncode})\n\n")
+                except OSError:
+                    # Logging is best-effort.
+                    pass
+                if proc.returncode == 0:
+                    applied.append(cmd)
+                else:
+                    failed.append(cmd)
+                    log.warning("integrate_patch: enablement setup rc=%d for: %s", proc.returncode, cmd)
+            except (subprocess.TimeoutExpired, OSError) as exc:
                 failed.append(cmd)
-                log.warning("integrate_patch: enablement setup rc=%d for: %s", proc.returncode, cmd)
-        except (subprocess.TimeoutExpired, OSError) as exc:
-            failed.append(cmd)
-            log.warning("integrate_patch: enablement setup errored (%s) for: %s", type(exc).__name__, cmd)
+                log.warning("integrate_patch: enablement setup errored (%s) for: %s", type(exc).__name__, cmd)
     return {"applied": applied, "skipped": skipped, "failed": failed}
 
 
@@ -1970,6 +1980,8 @@ class IntegratePatchExecutor:
 
         No-op when no candidate is present or in multi-node mode.
         Runs a disk preflight, delegates provision+probe to the framework
+        adapter (off the event loop; an in-flight pip install is not killed
+        if the await is cancelled), and on success stores the resolved runtime on
         adapter, and on success stores the resolved runtime on
         ``ctx._ip_provision_result`` / ``ctx._ip_stack_action`` for the gate to
         activate via the YAML-layer ``runtime_override``. Returns an early-exit
@@ -2019,12 +2031,17 @@ class IntegratePatchExecutor:
             log.warning("integrate_patch: disk preflight raised (%r); continuing", exc)
 
         adapter = get_adapter(action.framework)
-        try:
-            result = adapter.provision(action, attempt_dir)
-            if result.ok and not adapter.probe(result, action):
+
+        def _provision_and_probe():
+            provisioned = adapter.provision(action, attempt_dir)
+            if provisioned.ok and not adapter.probe(provisioned, action):
                 from ...framework.stack_actions import ProvisionResult as _PR
 
-                result = _PR(ok=False, log_path=result.log_path, error="adapter probe failed after provision")
+                return _PR(ok=False, log_path=provisioned.log_path, error="adapter probe failed after provision")
+            return provisioned
+
+        try:
+            result = await asyncio.to_thread(_provision_and_probe)
         except Exception as exc:  # noqa: BLE001 — provision failure is a clean revert, not a crash
             log.exception("integrate_patch: attempt-runtime provision raised")
             self._gc_attempt_dir(attempt_dir)
@@ -2123,7 +2140,8 @@ class IntegratePatchExecutor:
             }
 
         try:
-            diff_text, touched_paths, verdict = build_localization_diff(
+            diff_text, touched_paths, verdict = await asyncio.to_thread(
+                build_localization_diff,
                 action,
                 fetch_pr_patches=lambda slug, num: _gh.pr_patches(slug, num),
                 fetch_raw_file=lambda slug, ref, path: _gh.fetch_raw_file(slug, ref, path),
@@ -3148,6 +3166,8 @@ class IntegratePatchExecutor:
         provision_result: Any,
     ) -> dict[str, Any]:
         """Editable-refresh a localized closure and snapshot its manifest.
+
+        Blocking (editable-refresh up to 600s); call via ``asyncio.to_thread``.
 
         Runs the framework adapter's editable-refresh argv against the attempt
         interpreter (best-effort; skipped when there is no attempt runtime or no

--- a/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
+++ b/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
@@ -1982,7 +1982,6 @@ class IntegratePatchExecutor:
         Runs a disk preflight, delegates provision+probe to the framework
         adapter (off the event loop; an in-flight pip install is not killed
         if the await is cancelled), and on success stores the resolved runtime on
-        adapter, and on success stores the resolved runtime on
         ``ctx._ip_provision_result`` / ``ctx._ip_stack_action`` for the gate to
         activate via the YAML-layer ``runtime_override``. Returns an early-exit
         ``reverted`` dict on any provision failure (no patch side effects yet),

--- a/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
+++ b/src/hyperloom/orchestrator/actions/executors/integrate_patch.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import csv
 import functools
 import json
@@ -2197,7 +2198,8 @@ class IntegratePatchExecutor:
         if bool(params.get("enablement")):
             setup_cmds = _resolve_setup_commands(params=params, done_payload=done_payload)
             if setup_cmds:
-                setup_result = _run_setup_commands(
+                setup_result = await asyncio.to_thread(
+                    _run_setup_commands,
                     setup_cmds,
                     cwd=self.session_dir,
                     log_dir=runs_dir(self.session_dir, "integrate_patch", ctx.task.task_id),
@@ -3089,7 +3091,8 @@ class IntegratePatchExecutor:
             kept_result["installed_versions"] = dict(getattr(provision_result, "installed_versions", {}) or {})
         # Editable-refresh the localized closure + snapshot a manifest that
         # survives rearm so the closure is recorded and not re-fetched.
-        manifest = self._finalize_localization_keep(
+        manifest = await asyncio.to_thread(
+            self._finalize_localization_keep,
             ctx,
             framework_root=framework_root,
             specialist_task_id=specialist_task_id,

--- a/src/hyperloom/orchestrator/framework/adapters.py
+++ b/src/hyperloom/orchestrator/framework/adapters.py
@@ -147,7 +147,11 @@ class BaseAdapter:
         return None
 
     def provision(self, action: EnablementStackAction, attempt_dir: Path) -> ProvisionResult:
-        """Provision ``action`` into an attempt-local venv under ``attempt_dir``."""
+        """Provision ``action`` into an attempt-local venv under ``attempt_dir``.
+
+        Blocking (venv/pip, 1800s cap); call via ``asyncio.to_thread``.
+        Cancel of the await is fire-and-forget for an in-flight pip install.
+        """
         return ProvisionResult(ok=False, error=f"{self.framework or 'null'} adapter does not provision")
 
     def probe(self, result: ProvisionResult, action: EnablementStackAction) -> bool:
@@ -341,7 +345,10 @@ class VllmRocmAdapter(_VenvProvisionMixin):
         )
 
     def provision(self, action: EnablementStackAction, attempt_dir: Path) -> ProvisionResult:
-        """Create an attempt venv, pip-install the vLLM wheel, verify ROCm."""
+        """Create an attempt venv, pip-install the vLLM wheel, verify ROCm.
+
+        Blocking (venv/pip, 1800s cap); call via ``asyncio.to_thread``.
+        """
         log_path = str(attempt_dir / "provision.log")
         try:
             attempt_dir.mkdir(parents=True, exist_ok=True)
@@ -474,7 +481,10 @@ class SglangAdapter(_VenvProvisionMixin):
         )
 
     def provision(self, action: EnablementStackAction, attempt_dir: Path) -> ProvisionResult:
-        """Create an attempt venv, install SGLang (editable ref or wheel)."""
+        """Create an attempt venv, install SGLang (editable ref or wheel).
+
+        Blocking (venv/pip, 1800s cap); call via ``asyncio.to_thread``.
+        """
         log_path = str(attempt_dir / "provision.log")
         try:
             attempt_dir.mkdir(parents=True, exist_ok=True)

--- a/src/hyperloom/orchestrator/framework/localization.py
+++ b/src/hyperloom/orchestrator/framework/localization.py
@@ -127,7 +127,10 @@ def build_localization_diff(
     fetch_raw_file: Callable[[str, str, str], str],
     framework_root: object = None,
 ) -> tuple[str, list[str], ClosureVerdict]:
-    """Fetch/synthesize the localization diff and classify its closure."""
+    """Fetch/synthesize the localization diff and classify its closure.
+
+    Blocking (synchronous HTTP); call via ``asyncio.to_thread``.
+    """
     kind = str(getattr(action, "kind", "") or "")
     repo_url = str(getattr(action, "repo_url", "") or "")
     slug = _repo_slug_safe(repo_url)

--- a/src/hyperloom/orchestrator/specialists/patch_safety.py
+++ b/src/hyperloom/orchestrator/specialists/patch_safety.py
@@ -969,6 +969,8 @@ def vet_patches(
 ) -> tuple[list[str], list[dict[str, str]], dict[str, str], bool]:
     """Ground each patch against the candidate checkouts, one root per patch.
 
+    Blocking (``git apply --check`` per patch); call via ``asyncio.to_thread``.
+
     Structural rejects, task-owned work artifacts and grounded Python
     comment-only patches are dropped. Each survivor resolves its own root.
     Unresolved or ambiguous roots and stale-but-valid patches are kept with

--- a/src/hyperloom/orchestrator/specialists/runner.py
+++ b/src/hyperloom/orchestrator/specialists/runner.py
@@ -579,7 +579,8 @@ class SpecialistRunner:
             notes.append(f"domain={domain.key!r} is outside the domain catalogue; using generic prompt template")
 
         # Worktree — created only under subprocess dispatch; surfaced via ``workspace_path``.
-        worktree, worktree_base, worktree_err = self._maybe_setup_worktree(
+        worktree, worktree_base, worktree_err = await asyncio.to_thread(
+            self._maybe_setup_worktree,
             ctx,
             workspace=workspace,
             profile=profile,
@@ -1079,7 +1080,8 @@ class SpecialistRunner:
             status="finished",
         )
 
-        return await self._finalize(
+        return await asyncio.to_thread(
+            self._finalize,
             ctx=ctx,
             prep=prep,
             specialist_done_payload=(
@@ -1247,7 +1249,8 @@ class SpecialistRunner:
         elif sub_result.exit_code not in (None, 0) and sub_result.done_payload is None:
             backend_error = f"subprocess_exit_code:{sub_result.exit_code}"
 
-        return await self._finalize(
+        return await asyncio.to_thread(
+            self._finalize,
             ctx=ctx,
             prep=prep,
             specialist_done_payload=sub_result.done_payload,
@@ -1260,7 +1263,7 @@ class SpecialistRunner:
         )
 
     # Finalize phase (shared)
-    async def _finalize(
+    def _finalize(
         self,
         *,
         ctx: RunnerContext,
@@ -1274,6 +1277,8 @@ class SpecialistRunner:
         patch_roots: dict[str, str] | None = None,
     ) -> SpecialistRunResult:
         """Persist the ``specialist_done`` artifact and build the result.
+
+        Blocking (``git apply --check`` per patch); call via ``asyncio.to_thread``.
 
         Synthesises an empty payload when none was produced, sanitises the
         proposal set, merges discovered patches and writes the on-disk
@@ -1412,8 +1417,7 @@ class SpecialistRunner:
             patches=deduped,
             patch_roots=collected_roots,
         )
-        kept, ungrounded, grounding, spans_roots = await asyncio.to_thread(
-            _patch_safety.vet_patches,
+        kept, ungrounded, grounding, spans_roots = _patch_safety.vet_patches(
             deduped,
             base_checkout=base_checkout,
             candidate_roots=candidate_roots,
@@ -1479,6 +1483,8 @@ class SpecialistRunner:
         profile: SpecialistProfile | None = None,
     ) -> tuple[Path | None, Path | None, str]:
         """Provision a per-task git worktree when in subprocess mode.
+
+        Blocking (``git worktree add``, 60s); call via ``asyncio.to_thread``.
 
         Best-effort: the specialist still dispatches without isolation and the
         reason lands in ``notes``.

--- a/src/hyperloom/orchestrator/specialists/runner.py
+++ b/src/hyperloom/orchestrator/specialists/runner.py
@@ -13,6 +13,7 @@ outcome for the audit trail.
 
 from __future__ import annotations
 
+import asyncio
 import enum
 import json
 import logging
@@ -1078,7 +1079,7 @@ class SpecialistRunner:
             status="finished",
         )
 
-        return self._finalize(
+        return await self._finalize(
             ctx=ctx,
             prep=prep,
             specialist_done_payload=(
@@ -1246,7 +1247,7 @@ class SpecialistRunner:
         elif sub_result.exit_code not in (None, 0) and sub_result.done_payload is None:
             backend_error = f"subprocess_exit_code:{sub_result.exit_code}"
 
-        return self._finalize(
+        return await self._finalize(
             ctx=ctx,
             prep=prep,
             specialist_done_payload=sub_result.done_payload,
@@ -1259,7 +1260,7 @@ class SpecialistRunner:
         )
 
     # Finalize phase (shared)
-    def _finalize(
+    async def _finalize(
         self,
         *,
         ctx: RunnerContext,
@@ -1411,7 +1412,8 @@ class SpecialistRunner:
             patches=deduped,
             patch_roots=collected_roots,
         )
-        kept, ungrounded, grounding, spans_roots = _patch_safety.vet_patches(
+        kept, ungrounded, grounding, spans_roots = await asyncio.to_thread(
+            _patch_safety.vet_patches,
             deduped,
             base_checkout=base_checkout,
             candidate_roots=candidate_roots,


### PR DESCRIPTION
## Problem

The coordinator is a single-threaded asyncio event loop. Concurrent tasks share that thread and only yield at await. Several executor helpers called blocking subprocess.run (and urllib) on that thread: enablement setup replay (up to twelve installs, 30 minutes each), attempt-runtime provision (venv + pip, 1800s), specialist patch vetting (serial git apply --check), localization HTTP fetch, localization editable-refresh (10 minutes), and specialist git worktree add (60s).

While the loop is frozen, wall-clock timeouts keep ticking. asyncio.wait_for records an absolute deadline when the await starts; when the loop resumes, the timer has already fired.

This does not stall the same tick's own model call: integrate_patch is joined. The work that is concurrent on the loop is what breaks: another in-flight action's streaming LLM call (per-chunk idle timeout), the dispatcher's re-scan poll, shutdown cancel-grace, and the kernel-step heartbeat.

The dispatcher assumes every executor spends blocking time inside asyncio.to_thread so cooperative cancel can run. These paths violated that.

## Fix

Keep the helpers synchronous. At the coroutine boundary, wrap each one in asyncio.to_thread and wait until it finishes. Same convention as the magpie grid path. Provision+probe (including the probe-fail downgrade) is one hop, not two.

Do not use the existing offload helper. That helper waits with a budget, then returns a default while the worker keeps running. On setup replay or provision that would mean pip is still mutating the environment while integrate continues to apply patches and bench.

Setup replay polls the action CancelScope between commands (the ContextVar is copied into the worker). A command already inside subprocess.run is not killed. Cancelling the await unwinds integrate and does not apply patches. That is the opposite of an offload timeout, where the caller continues. Provision's single 1800s pip is fire-and-forget the same way.

Helpers that must stay off the loop are marked Blocking (...); call via asyncio.to_thread.

## Out of scope

The many short git helpers on the integrate path stay on the loop. Each call is bounded (two-minute default) and usually sub-second. Moving them would force a cascade of sync helpers to become coroutines.

Loop-lag detection, and writing the "upper bound shorter than the shortest timeout concurrent on the loop" criterion next to the dispatcher cancel invariant, remain a follow-up. A failed attempt venv rmtree on the loop (tens of seconds on shared storage) is exactly what that criterion would catch.

The localization editable-refresh except Exception swallow is pre-existing and untouched.

## Tests

- Setup replay and provision each assert the sync helper's thread id is not the event-loop thread, by driving the real async stages.
- Patch vetting is driven through the in-process specialist run path (the production wrap around finalize).
- Setup replay stops between commands when the cancel scope is set.
- Existing allowlist and patch-vetting unit tests are unchanged: helper signatures did not change.

## Limitations

Threads started by asyncio.to_thread cannot be cancelled. Setup replay cooperates between commands; mid-command pip and provision pip are fire-and-forget. A long install occupies one slot in the default executor pool (min(32, cpu+4)). The magpie path already does this; this change does not introduce a dedicated pool.