### PR TITLE
fix(forge): report complete FlyDSL rewrite LLM usage

### DIFF
--- a/src/kernelforge/rewrite_by_flydsl/applyback.py
+++ b/src/kernelforge/rewrite_by_flydsl/applyback.py
@@ -33,6 +33,7 @@ from kernelforge.rewrite_by_flydsl.budget import DEFAULT_REWRITE_BUDGET
 from kernelforge.rewrite_by_flydsl.protocol import validate_applyback_manifest
 from kernelforge.rewrite_by_flydsl.spec import RewriteSpec
 from kernelforge.durable_io import atomic_write_text
+from kernelforge.tracker import UsageAccumulator
 
 # Framework apply-back artifacts live beside, never inside, the artifact paths the nested standalone FlyDSL forge-loop
 # owns (``forge_experiments/best*``).
@@ -326,6 +327,7 @@ async def _run_agent(
     timeout_sec: int,
     progress_log: list[str],
     prior_failure: str = "",
+    usage: UsageAccumulator | None = None,
 ) -> tuple[str, str]:
     runtime = config.agent_runtime()
     backend = create_registered_backend(
@@ -366,7 +368,7 @@ async def _run_agent(
         ),
     )
     result = await asyncio.wait_for(
-        backend.run(run_spec),
+        backend.run(run_spec, usage=usage),
         timeout=watchdog_timeout_sec(timeout_sec),
     )
     # A turn cap or SDK error leaves a half-rewired integration that passes host validation and every gate after it,
@@ -723,6 +725,7 @@ def generate_applyback_patch(
     deadline_unix: float | None = None,
     import_modules: list[str] | tuple[str, ...] = (),
     max_attempts: int = 2,
+    usage: UsageAccumulator | None = None,
 ) -> ApplybackResult:
     """Run bounded clean-room agent attempts and publish a validated patch."""
     workspace = Path(spec.workspace).resolve()
@@ -855,6 +858,7 @@ def generate_applyback_patch(
                         timeout_sec=timeout_sec,
                         progress_log=progress_log,
                         prior_failure=prior_failure,
+                        usage=usage,
                     )
                 )
 

--- a/src/kernelforge/rewrite_by_flydsl/flydsl_rewrite_driver_preparation.py
+++ b/src/kernelforge/rewrite_by_flydsl/flydsl_rewrite_driver_preparation.py
@@ -29,6 +29,7 @@ from kernelforge.rewrite_by_flydsl import driver_contract, protocol
 from kernelforge.rewrite_by_flydsl.budget import DEFAULT_REWRITE_BUDGET
 from kernelforge.rewrite_by_flydsl.spec import RewriteSpec
 from kernelforge.durable_io import atomic_write_bytes
+from kernelforge.tracker import UsageAccumulator
 
 
 DRIVER_PREPARATION_FAILED = "driver_preparation_failed"
@@ -315,6 +316,7 @@ async def _run_agent(
     prompt: str,
     timeout_sec: int,
     progress_log: list[str],
+    usage: UsageAccumulator | None = None,
 ) -> str:
     runtime = with_writable_sandbox(config.agent_runtime())
     backend = create_registered_backend(runtime)
@@ -342,7 +344,7 @@ async def _run_agent(
         progress_log=progress_log,
     )
     result = await asyncio.wait_for(
-        backend.run(run_spec),
+        backend.run(run_spec, usage=usage),
         timeout=watchdog_timeout_sec(timeout_sec),
     )
     return result.text.strip()
@@ -500,6 +502,7 @@ async def prepare_rewrite_driver(
     invocation_spec_file: str = "",
     initial_preflight: DriverPreflight | None = None,
     max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    usage: UsageAccumulator | None = None,
 ) -> DriverPreparationResult:
     """Author or repair one driver without exposing the caller's tree to writes."""
 
@@ -594,6 +597,7 @@ async def prepare_rewrite_driver(
                         prompt=prompt,
                         timeout_sec=timeout_sec,
                         progress_log=progress_log,
+                        usage=usage,
                     )
                     _audit_text(audit, f"{attempt_dir}/agent_output.txt", output)
                 except asyncio.TimeoutError:

--- a/src/kernelforge/rewrite_by_flydsl/port_loop.py
+++ b/src/kernelforge/rewrite_by_flydsl/port_loop.py
@@ -15,6 +15,7 @@ from kernelforge.config import Config
 from kernelforge.loop.validation import run_validation_pipeline
 from kernelforge.rewrite_by_flydsl.prompts import build_port_program_md
 from kernelforge.rewrite_by_flydsl.spec import RewriteSpec
+from kernelforge.tracker import UsageAccumulator
 
 log = logging.getLogger(__name__)
 
@@ -122,7 +123,7 @@ async def run_port_loop(
     max_attempts: int = 3,
     permission_mode: str | None = None,
     validate_stage_timeout_sec: int = 1800,
-    usage=None,
+    usage: UsageAccumulator | None = None,
     stop_at_unix: float | None = None,
     pre_task_context: str = "",
 ) -> PortResult:

--- a/src/kernelforge/rewrite_by_flydsl/report.py
+++ b/src/kernelforge/rewrite_by_flydsl/report.py
@@ -32,6 +32,7 @@ class RewriteResult:
     flydsl_best_ms: float | None
     speedup: float | None
     experiment_id: str | None
+    llm_usage: dict
     port_attempts: int
     # Forge-loop-compatible result view consumed by Hyperloom.
     success: bool
@@ -78,6 +79,7 @@ def build_result(
     optimize_result: dict,
     applyback_result: dict | None = None,
     applyback_required: bool = False,
+    llm_usage: dict | None = None,
     kb_experience: dict | None = None,
     failure_class: str = "",
     failure_detail: str = "",
@@ -111,6 +113,7 @@ def build_result(
         flydsl_best_ms=flydsl_best_ms,
         speedup=speedup,
         experiment_id=experiment_id,
+        llm_usage=dict(llm_usage if llm_usage is not None else (optimize_result.get("llm_usage") or {})),
         port_attempts=port_attempts,
         success=bool(
             port_ok and (not applyback_required or (applyback.get("ok") if applyback_result is not None else False))

--- a/src/kernelforge/rewrite_by_flydsl/runner.py
+++ b/src/kernelforge/rewrite_by_flydsl/runner.py
@@ -38,6 +38,7 @@ from kernelforge.rewrite_by_flydsl.optimize import run_optimize
 from kernelforge.rewrite_by_flydsl.port_loop import PortResult, run_port_loop
 from kernelforge.rewrite_by_flydsl.budget import DEFAULT_REWRITE_BUDGET
 from kernelforge.loop.scoring import DEFAULT_SNR_THRESHOLD_DB
+from kernelforge.tracker import UsageAccumulator, combine_usage_totals
 
 log = logging.getLogger(__name__)
 
@@ -140,6 +141,7 @@ def run_rewrite(
 ) -> dict:
     """Run the full rewrite pipeline; return (and sentinel-print) the result dict."""
     Path(experiments_dir).mkdir(parents=True, exist_ok=True)
+    usage = UsageAccumulator()
     started_at = time.time()
     if not deadline_unix or deadline_unix <= 0:
         deadline_unix = started_at + optimize_max_hours * 3600.0
@@ -163,6 +165,13 @@ def run_rewrite(
     # Producer-owned scratch the consumer may reclaim.
     temporary_paths: list[str] = []
 
+    def _total_usage(optimize_result: dict | None = None) -> dict:
+        nested = (optimize_result or {}).get("llm_usage")
+        return combine_usage_totals(
+            usage.totals(),
+            nested if isinstance(nested, dict) else None,
+        )
+
     # Emit a clean, scorable failure result (no traceback) on any setup error so the caller can attribute it, instead
     # of the process dying opaquely.
     def _setup_failed(reason: str, failure_class: str) -> dict:
@@ -173,6 +182,7 @@ def run_rewrite(
             port_attempts=0,
             source_ms=None,
             optimize_result={},
+            llm_usage=_total_usage(),
             failure_class=failure_class,
             failure_detail=reason,
             temporary_paths=temporary_paths,
@@ -253,6 +263,7 @@ def run_rewrite(
                 deadline_unix=search_stop_unix,
                 invocation_spec_file=invocation_spec_file,
                 initial_preflight=preflight,
+                usage=usage,
             )
         )
         if not prepared.ok or prepared.preflight is None:
@@ -342,6 +353,7 @@ def run_rewrite(
                 permission_mode=permission_mode,
                 stop_at_unix=search_stop_unix,
                 pre_task_context=kb_read.reference_context,
+                usage=usage,
             )
         )
     if not port.ok:
@@ -352,6 +364,7 @@ def run_rewrite(
             port_attempts=port.attempts,
             source_ms=source_ms,
             optimize_result={},
+            llm_usage=_total_usage(),
             kb_experience={
                 "read": kb_read.to_dict(),
                 "write": {"written": False, "reason": "port_failed"},
@@ -433,6 +446,7 @@ def run_rewrite(
         optimize_result={"best_ms": flydsl_baseline_ms},
         applyback_result={"ok": False, "error": "apply-back pending"},
         applyback_required=bool(rewrite_base_commit),
+        llm_usage=_total_usage(),
         kb_experience={
             "read": kb_read.to_dict(),
             "write": port_kb_write,
@@ -552,6 +566,7 @@ def run_rewrite(
         deadline_unix=deadline_unix,
         import_modules=applyback_import_modules,
         max_attempts=max_applyback_attempts,
+        usage=usage,
     )
     if applyback.ok:
         print(
@@ -571,6 +586,7 @@ def run_rewrite(
         optimize_result=opt,
         applyback_result=applyback.to_dict(),
         applyback_required=bool(rewrite_base_commit),
+        llm_usage=_total_usage(opt),
         kb_experience={
             "read": kb_read.to_dict(),
             "write": kb_write,

--- a/src/kernelforge/tests/test_flydsl_rewrite_driver_preparation.py
+++ b/src/kernelforge/tests/test_flydsl_rewrite_driver_preparation.py
@@ -15,6 +15,7 @@ from kernelforge.rewrite_by_flydsl import (
     flydsl_rewrite_driver_preparation as driver_preparation,
 )
 from kernelforge.rewrite_by_flydsl.spec import RewriteSpec
+from kernelforge.tracker import UsageAccumulator
 
 
 def _spec(tmp_path: Path) -> RewriteSpec:
@@ -74,8 +75,9 @@ def test_authoring_spec_does_not_declare_the_driver_protected(tmp_path, monkeypa
     captured: dict[str, object] = {}
 
     class _Backend:
-        async def run(self, spec):
+        async def run(self, spec, usage=None):
             captured["spec"] = spec
+            captured["usage"] = usage
             raise RuntimeError("stop after capturing the spec")
 
     monkeypatch.setattr(
@@ -87,6 +89,7 @@ def test_authoring_spec_does_not_declare_the_driver_protected(tmp_path, monkeypa
     stage.mkdir()
     stage_driver = stage / ".forge_driver_probe.py"
     stage_driver.write_text("# placeholder\n", encoding="utf-8")
+    usage = UsageAccumulator()
 
     try:
         asyncio.run(
@@ -98,6 +101,7 @@ def test_authoring_spec_does_not_declare_the_driver_protected(tmp_path, monkeypa
                 prompt="author it",
                 timeout_sec=30,
                 progress_log=[],
+                usage=usage,
             )
         )
     except RuntimeError:
@@ -106,6 +110,7 @@ def test_authoring_spec_does_not_declare_the_driver_protected(tmp_path, monkeypa
     spec = captured["spec"]
     assert str(stage_driver) in spec.target_files
     assert not spec.driver_script
+    assert captured["usage"] is usage
 
 
 def test_rewrite_preflight_accepts_source_timing_and_unready_candidate(tmp_path):

--- a/src/kernelforge/tests/test_rewrite_by_flydsl.py
+++ b/src/kernelforge/tests/test_rewrite_by_flydsl.py
@@ -335,6 +335,31 @@ def test_speedup_only_when_port_ok_and_both_times():
     assert failed.speedup is None and not failed.correct
 
 
+def test_rewrite_result_includes_cumulative_llm_usage():
+    usage = {
+        "input_tokens": 123,
+        "output_tokens": 45,
+        "cache_creation_input_tokens": 6,
+        "cache_read_input_tokens": 78,
+        "total_cost_usd": 0.5,
+        "cost_available": True,
+        "cost_source": "provider",
+        "calls": 2,
+    }
+
+    result = report.build_result(
+        op_name="op",
+        port_ok=True,
+        port_attempts=1,
+        source_ms=2.0,
+        optimize_result={"best_ms": 1.0},
+        llm_usage=usage,
+    )
+
+    assert result.llm_usage == usage
+    assert result.to_dict()["llm_usage"] == usage
+
+
 def test_applyback_is_required_only_for_framework_repositories():
     legacy = report.build_result(
         op_name="op",

--- a/src/kernelforge/tests/test_rewrite_by_flydsl_applyback.py
+++ b/src/kernelforge/tests/test_rewrite_by_flydsl_applyback.py
@@ -541,7 +541,8 @@ class _StoppedBackend:
         self._end_reason = end_reason
         self.runtime = type("_Runtime", (), {"model": "fake-model"})()
 
-    async def run(self, _run_spec):
+    async def run(self, _run_spec, usage=None):
+        del usage
         from kernelforge.agent_backends.base import AgentRunResult
 
         return AgentRunResult(end_reason=self._end_reason)

--- a/src/kernelforge/tests/test_rewrite_by_flydsl_pipeline.py
+++ b/src/kernelforge/tests/test_rewrite_by_flydsl_pipeline.py
@@ -903,6 +903,81 @@ def test_run_rewrite_happy_path_reports_speedup(tmp_path, monkeypatch, capsys):
     assert rj.exists()
 
 
+def test_run_rewrite_reports_total_usage_across_local_and_forge_loop_agents(
+    tmp_path,
+    monkeypatch,
+):
+    src = tmp_path / "softmax.py"
+    src.write_text("def softmax(x):\n    return x\n")
+    driver = tmp_path / "driver.py"
+    driver.write_text("print('drive')\n")
+    _wire_stub_pipeline(monkeypatch, port_ok=True, best_ms=0.5, source_ms=1.0)
+    seen_usage = []
+
+    async def counted_port(spec, driver_path, config, **kwargs):
+        del spec, driver_path, config
+        usage = kwargs["usage"]
+        seen_usage.append(usage)
+        usage.add_usage(
+            {"input_tokens": 10, "output_tokens": 2},
+            total_cost_usd=0.1,
+        )
+        return port_loop.PortResult(ok=True, attempts=1, snr_db=143.0)
+
+    def counted_applyback(*args, **kwargs):
+        del args
+        usage = kwargs["usage"]
+        seen_usage.append(usage)
+        usage.add_usage(
+            {"input_tokens": 20, "output_tokens": 4},
+            total_cost_usd=0.2,
+        )
+        return ApplybackResult(ok=True)
+
+    monkeypatch.setattr(runner, "run_port_loop", counted_port)
+    monkeypatch.setattr(
+        runner,
+        "run_optimize",
+        lambda *args, **kwargs: {
+            "best_ms": 0.5,
+            "experiment_id": "E",
+            "llm_usage": {
+                "input_tokens": 100,
+                "output_tokens": 30,
+                "cache_creation_input_tokens": 8,
+                "cache_read_input_tokens": 40,
+                "total_cost_usd": 1.0,
+                "cost_available": True,
+                "cost_source": "provider",
+                "calls": 3,
+            },
+        },
+    )
+    monkeypatch.setattr(runner, "generate_applyback_patch", counted_applyback)
+
+    out = runner.run_rewrite(
+        op_name="softmax",
+        source_kernel=str(src),
+        driver=str(driver),
+        workspace=str(tmp_path),
+        experiments_dir=str(tmp_path / "exp"),
+        target_functions=["softmax"],
+        config=Config.from_env(workspace=str(tmp_path)),
+    )
+
+    assert seen_usage[0] is seen_usage[1]
+    assert out["llm_usage"] == {
+        "input_tokens": 130,
+        "output_tokens": 36,
+        "cache_creation_input_tokens": 8,
+        "cache_read_input_tokens": 40,
+        "total_cost_usd": 1.3,
+        "cost_available": True,
+        "cost_source": "provider",
+        "calls": 5,
+    }
+
+
 def test_run_rewrite_keeps_the_candidate_out_of_the_workspace_root(
     tmp_path,
     monkeypatch,

--- a/src/kernelforge/tests/test_usage.py
+++ b/src/kernelforge/tests/test_usage.py
@@ -4,7 +4,11 @@ import tempfile
 from dataclasses import dataclass
 from typing import Any
 
-from kernelforge.tracker import ExperimentTracker, UsageAccumulator
+from kernelforge.tracker import (
+    ExperimentTracker,
+    UsageAccumulator,
+    combine_usage_totals,
+)
 
 
 # Minimal stand-ins for the claude-agent-sdk message types.
@@ -106,6 +110,66 @@ def test_accumulator_rejects_boolean_provider_cost():
     assert totals["total_cost_usd"] == 0.0
     assert totals["cost_available"] is False
     assert totals["cost_source"] == "unavailable"
+
+
+def test_combine_usage_totals_preserves_tokens_calls_and_provider_cost():
+    combined = combine_usage_totals(
+        {
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_creation_input_tokens": 10,
+            "cache_read_input_tokens": 5,
+            "total_cost_usd": 0.25,
+            "cost_available": True,
+            "cost_source": "provider",
+            "calls": 1,
+        },
+        {
+            "input_tokens": 200,
+            "output_tokens": 40,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 50,
+            "total_cost_usd": 0.75,
+            "cost_available": True,
+            "cost_source": "provider",
+            "calls": 2,
+        },
+    )
+
+    assert combined == {
+        "input_tokens": 300,
+        "output_tokens": 60,
+        "cache_creation_input_tokens": 10,
+        "cache_read_input_tokens": 55,
+        "total_cost_usd": 1.0,
+        "cost_available": True,
+        "cost_source": "provider",
+        "calls": 3,
+    }
+
+
+def test_combine_usage_totals_marks_mixed_provider_cost_partial():
+    combined = combine_usage_totals(
+        {
+            "input_tokens": 10,
+            "total_cost_usd": 0.1,
+            "cost_available": True,
+            "cost_source": "provider",
+            "calls": 1,
+        },
+        {
+            "output_tokens": 5,
+            "total_cost_usd": 0.0,
+            "cost_available": False,
+            "cost_source": "unavailable",
+            "calls": 1,
+        },
+    )
+
+    assert combined["calls"] == 2
+    assert combined["total_cost_usd"] == 0.1
+    assert combined["cost_available"] is False
+    assert combined["cost_source"] == "partial"
 
 
 def test_set_llm_usage_persists_to_experiment():

--- a/src/kernelforge/tracker/__init__.py
+++ b/src/kernelforge/tracker/__init__.py
@@ -5,6 +5,12 @@
 
 from kernelforge.tracker.experiment import ExperimentTracker
 from kernelforge.tracker.schema import Experiment, Iteration
-from kernelforge.tracker.usage import UsageAccumulator
+from kernelforge.tracker.usage import UsageAccumulator, combine_usage_totals
 
-__all__ = ["ExperimentTracker", "Experiment", "Iteration", "UsageAccumulator"]
+__all__ = [
+    "ExperimentTracker",
+    "Experiment",
+    "Iteration",
+    "UsageAccumulator",
+    "combine_usage_totals",
+]

--- a/src/kernelforge/tracker/usage.py
+++ b/src/kernelforge/tracker/usage.py
@@ -79,4 +79,48 @@ class UsageAccumulator:
         return self.calls > 0
 
 
-__all__ = ["UsageAccumulator"]
+def combine_usage_totals(*records: dict[str, Any] | None) -> dict[str, Any]:
+    """Combine independently accumulated usage records without losing cost provenance."""
+    combined: dict[str, Any] = {key: 0 for key in _TOKEN_KEYS}
+    combined["total_cost_usd"] = 0.0
+    combined["calls"] = 0
+    all_cost_available = True
+    any_priced_usage = False
+
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        for key in (*_TOKEN_KEYS, "calls"):
+            with contextlib.suppress(TypeError, ValueError):
+                value = int(record.get(key) or 0)
+                if value >= 0:
+                    combined[key] += value
+        with contextlib.suppress(TypeError, ValueError):
+            cost = float(record.get("total_cost_usd") or 0.0)
+            if math.isfinite(cost) and cost >= 0:
+                combined["total_cost_usd"] += cost
+
+        calls = record.get("calls")
+        with contextlib.suppress(TypeError, ValueError):
+            if int(calls or 0) > 0:
+                available = record.get("cost_available") is True
+                all_cost_available = all_cost_available and available
+                any_priced_usage = (
+                    any_priced_usage
+                    or available
+                    or record.get("cost_source")
+                    in {
+                        "provider",
+                        "partial",
+                    }
+                )
+
+    combined["total_cost_usd"] = round(combined["total_cost_usd"], 6)
+    combined["cost_available"] = combined["calls"] > 0 and all_cost_available
+    combined["cost_source"] = (
+        "provider" if combined["cost_available"] else "partial" if any_priced_usage else "unavailable"
+    )
+    return combined
+
+
+__all__ = ["UsageAccumulator", "combine_usage_totals"]


### PR DESCRIPTION
## Summary
- thread a shared usage accumulator through FlyDSL driver preparation, PORT, and apply-back agent calls
- combine in-process usage with the nested forge-loop usage while preserving token, call, cost, and cost-availability semantics
- expose the cumulative `llm_usage` block in all final FlyDSL rewrite result payloads, including failure results

## Test plan
- [x] `python -m pytest -q src/kernelforge/tests/test_usage.py src/kernelforge/tests/test_rewrite_by_flydsl.py src/kernelforge/tests/test_rewrite_by_flydsl_pipeline.py`
- [x] `python -m pytest -q src/kernelforge/tests/test_flydsl_rewrite_driver_preparation.py src/kernelforge/tests/test_rewrite_by_flydsl_applyback.py`
- [x] `python -m ruff check` on all modified Python files
- [ ] full CI suite

Made with [Cursor](https://cursor.com)