### PR TITLE
fix(forge): recover the nested forge-loop token ledger, or say it is partial

### DIFF
--- a/src/kernelforge/rewrite_by_flydsl/optimize.py
+++ b/src/kernelforge/rewrite_by_flydsl/optimize.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -21,6 +22,7 @@ from typing import Callable
 from kernelforge.llm.git import git
 from kernelforge.config import Config
 from kernelforge.rewrite_by_flydsl.spec import RewriteSpec
+from kernelforge.tracker import ExperimentTracker
 
 log = logging.getLogger(__name__)
 
@@ -59,6 +61,56 @@ def _result_for_this_run(result_json: str, stdout_text: str) -> dict | None:
     if str(payload.get("experiment_id") or "") != announced:
         return None
     return payload
+
+
+def _experiment_llm_usage(experiments_dir: str, experiment_id: str) -> dict:
+    """The token ledger forge-loop last checkpointed onto its own experiment record.
+
+    forge-loop refreshes that record at every session boundary, while ``--result-json`` is only rewritten on a KEEP
+    and the stdout sentinel is only emitted on a clean exit. The record is therefore what survives a run that is cut
+    off at the optimize deadline, or one that never keeps anything — the two cases where the run's whole spend would
+    otherwise go unreported.
+    """
+    if not experiment_id:
+        return {}
+    try:
+        usage = ExperimentTracker(experiments_dir).get(experiment_id).llm_usage
+    except (OSError, TypeError, ValueError, KeyError):
+        # A missing, unreadable, or malformed record leaves the caller with whatever the result file carried.
+        return {}
+    return dict(usage) if isinstance(usage, dict) else {}
+
+
+def _ledger_progress(record: dict) -> tuple[int, int]:
+    """How far along one cumulative ledger snapshot is, for picking the latest."""
+    calls = 0
+    tokens = 0
+    with contextlib.suppress(TypeError, ValueError):
+        calls = int(record.get("calls") or 0)
+    for key in (
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+    ):
+        with contextlib.suppress(TypeError, ValueError):
+            tokens += int(record.get(key) or 0)
+    return calls, tokens
+
+
+def _latest_ledger(*snapshots: dict | None) -> dict:
+    """Pick the furthest-along snapshot of ONE forge-loop ledger — never a sum.
+
+    Both the result file and the experiment record report the same accumulator's running totals, so combining them
+    would double-count; the later snapshot simply supersedes the earlier one.
+    """
+    latest: dict = {}
+    for snapshot in snapshots:
+        if not isinstance(snapshot, dict) or not snapshot:
+            continue
+        if not latest or _ledger_progress(snapshot) > _ledger_progress(latest):
+            latest = dict(snapshot)
+    return latest
 
 
 def _forge_loop_argv() -> list[str]:
@@ -193,6 +245,10 @@ def run_optimize(
     ``on_new_best`` is polled every ``new_best_poll_sec`` with the parsed result of each KEEP, and once more after the
     loop exits so the last one cannot be missed by timing. Anything it raises is logged and swallowed, because the
     rewrite layer publishes from it and publishing is not worth losing an optimization run over.
+
+    ``llm_usage`` on the returned dict is the run's furthest-along token ledger, recovered from the experiment record
+    when the result file could not carry it. ``llm_usage_complete`` is set only when the loop exited cleanly with a
+    result of its own, which is the one case where that ledger is final.
     """
     if result_json is None:
         result_json = str(Path(experiments_dir) / "forge_loop_result.json")
@@ -339,7 +395,17 @@ def run_optimize(
             fallback_content=fallback_content,
             fallback_mode=fallback_mode,
         )
-        return {"terminated_for_deadline": True} if terminated_for_deadline else {}
+        # A loop that started and then lost its supervisor still spent tokens the caller must answer for.
+        failed: dict = {}
+        recovered = _experiment_llm_usage(
+            experiments_dir,
+            _announced_experiment_id("".join(collected)) or "",
+        )
+        if recovered:
+            failed["llm_usage"] = recovered
+        if terminated_for_deadline:
+            failed["terminated_for_deadline"] = True
+        return failed
     stdout_text = "".join(collected)
 
     # Trust --result-json only if it belongs to THIS run, keyed on experiment_id. forge-loop writes the file on every
@@ -374,10 +440,25 @@ def run_optimize(
         fallback_content=fallback_content,
         fallback_mode=fallback_mode,
     )
-    if not result and not terminated_for_deadline:
+
+    # The result file only carries the ledger as of the KEEP that wrote it, so a cut-off or never-keeping run leaves
+    # the experiment record holding more of the run's spend than the result does.
+    nested_usage = _latest_ledger(
+        result.get("llm_usage"),
+        _experiment_llm_usage(experiments_dir, expected_id or ""),
+    )
+    # Only a loop that reported its own result on a clean exit has closed its ledger; every other exit truncates it at
+    # the last session boundary it managed to checkpoint.
+    usage_complete = bool(result) and not terminated_for_deadline and _poll_process(proc) == 0
+
+    if not result and not terminated_for_deadline and not nested_usage:
         return {}
-    return {
-        **result,
+    annotations: dict = {
         "terminated_for_deadline": terminated_for_deadline,
         "best_kernel_restored": restored,
     }
+    if nested_usage:
+        annotations["llm_usage"] = nested_usage
+    if usage_complete:
+        annotations["llm_usage_complete"] = True
+    return {**result, **annotations}

--- a/src/kernelforge/rewrite_by_flydsl/runner.py
+++ b/src/kernelforge/rewrite_by_flydsl/runner.py
@@ -165,11 +165,18 @@ def run_rewrite(
     # Producer-owned scratch the consumer may reclaim.
     temporary_paths: list[str] = []
 
-    def _total_usage(optimize_result: dict | None = None) -> dict:
-        nested = (optimize_result or {}).get("llm_usage")
+    def _total_usage(optimize_result: dict | None = None, *, optimize_ran: bool = False) -> dict:
+        """This run's cumulative spend: the in-process stages plus the nested forge-loop's own ledger.
+
+        A forge-loop that was cut off or killed reports a ledger that stops at its last checkpoint, so the totals are
+        published as partial rather than as a complete provider-priced answer.
+        """
+        opt_result = optimize_result or {}
+        nested = opt_result.get("llm_usage")
         return combine_usage_totals(
             usage.totals(),
             nested if isinstance(nested, dict) else None,
+            incomplete=optimize_ran and not opt_result.get("llm_usage_complete"),
         )
 
     # Emit a clean, scorable failure result (no traceback) on any setup error so the caller can attribute it, instead
@@ -504,7 +511,9 @@ def run_rewrite(
         )
 
     opt: dict = {}
+    optimize_ran = False
     if time.time() < search_stop_unix:
+        optimize_ran = True
         remaining_hours = max(1.0, (deadline_unix - time.time()) / 3600.0)
         opt = run_optimize(
             spec,
@@ -523,6 +532,12 @@ def run_rewrite(
     else:
         print(
             "  [forge-rewrite] 20-minute finalization reserve reached after PORT; skipping forge-loop",
+            flush=True,
+        )
+    if optimize_ran and not opt.get("llm_usage_complete"):
+        print(
+            "  [forge-rewrite] WARNING: forge-loop did not report a final token ledger; the reported llm_usage covers "
+            "only what it checkpointed and is published as partial",
             flush=True,
         )
 
@@ -586,7 +601,7 @@ def run_rewrite(
         optimize_result=opt,
         applyback_result=applyback.to_dict(),
         applyback_required=bool(rewrite_base_commit),
-        llm_usage=_total_usage(opt),
+        llm_usage=_total_usage(opt, optimize_ran=optimize_ran),
         kb_experience={
             "read": kb_read.to_dict(),
             "write": kb_write,

--- a/src/kernelforge/tests/test_rewrite_by_flydsl_pipeline.py
+++ b/src/kernelforge/tests/test_rewrite_by_flydsl_pipeline.py
@@ -25,6 +25,7 @@ from kernelforge.rewrite_by_flydsl.attempt import create_attempt_workspace
 from kernelforge.rewrite_by_flydsl.applyback import ApplybackResult
 from kernelforge.rewrite_by_flydsl.kb import RewriteKbReadResult
 from kernelforge.rewrite_by_flydsl.spec import RewriteSpec
+from kernelforge.tracker import ExperimentTracker
 
 
 @pytest.fixture(autouse=True)
@@ -326,6 +327,99 @@ def test_optimize_survives_a_failing_new_best_handler(tmp_path, monkeypatch):
     )
 
     assert out["best_ms"] == 4.0
+
+
+def _record_loop_usage(experiments_dir, experiment_id, usage):
+    """Stand in for the checkpoint forge-loop writes onto its own experiment record."""
+    tracker = ExperimentTracker(experiments_dir)
+    tracker.create(experiment_id=experiment_id)
+    tracker.set_llm_usage(experiment_id, usage)
+
+
+def test_optimize_recovers_the_loop_ledger_from_its_experiment_record(tmp_path, monkeypatch):
+    """A run that keeps nothing writes no result file, and its whole spend used to go unreported."""
+    _record_loop_usage(
+        str(tmp_path),
+        "EXP-NOKEEP",
+        {"input_tokens": 400, "output_tokens": 60, "total_cost_usd": 2.0, "calls": 4},
+    )
+    monkeypatch.setattr(
+        optimize.subprocess,
+        "Popen",
+        _fake_popen(["Experiment: EXP-NOKEEP\n", "no keep here\n"], returncode=-15),
+    )
+    monkeypatch.setattr(optimize, "_restore_best_kernel", lambda *a, **k: None)
+
+    out = optimize.run_optimize(
+        _spec(tmp_path),
+        "driver.py",
+        Config.from_env(workspace=str(tmp_path)),
+        experiments_dir=str(tmp_path),
+        result_json=str(tmp_path / "never-written.json"),
+    )
+
+    assert out["llm_usage"]["input_tokens"] == 400
+    assert out["llm_usage"]["calls"] == 4
+    assert "llm_usage_complete" not in out
+
+
+def test_optimize_prefers_the_furthest_along_ledger_snapshot(tmp_path, monkeypatch):
+    """The result file stops at the last KEEP; the experiment record keeps going, and the two never sum."""
+    rj = tmp_path / "res.json"
+    rj.write_text(
+        json.dumps(
+            {
+                "experiment_id": "EXP-KEEP",
+                "best_ms": 0.5,
+                "llm_usage": {"input_tokens": 100, "calls": 1},
+            }
+        )
+    )
+    _record_loop_usage(str(tmp_path), "EXP-KEEP", {"input_tokens": 300, "calls": 3})
+    monkeypatch.setattr(
+        optimize.subprocess,
+        "Popen",
+        _fake_popen(["Experiment: EXP-KEEP\n"], returncode=-15),
+    )
+    monkeypatch.setattr(optimize, "_restore_best_kernel", lambda *a, **k: None)
+
+    out = optimize.run_optimize(
+        _spec(tmp_path),
+        "driver.py",
+        Config.from_env(workspace=str(tmp_path)),
+        experiments_dir=str(tmp_path),
+        result_json=str(rj),
+    )
+
+    assert out["llm_usage"] == {"input_tokens": 300, "calls": 3}
+    assert "llm_usage_complete" not in out
+
+
+def test_optimize_marks_a_cleanly_finished_ledger_complete(tmp_path, monkeypatch):
+    rj = tmp_path / "res.json"
+    rj.write_text(
+        json.dumps(
+            {
+                "experiment_id": "EXP-DONE",
+                "best_ms": 0.5,
+                "llm_usage": {"input_tokens": 500, "calls": 5},
+            }
+        )
+    )
+    _record_loop_usage(str(tmp_path), "EXP-DONE", {"input_tokens": 500, "calls": 5})
+    monkeypatch.setattr(optimize.subprocess, "Popen", _fake_popen(["Experiment: EXP-DONE\n"]))
+    monkeypatch.setattr(optimize, "_restore_best_kernel", lambda *a, **k: None)
+
+    out = optimize.run_optimize(
+        _spec(tmp_path),
+        "driver.py",
+        Config.from_env(workspace=str(tmp_path)),
+        experiments_dir=str(tmp_path),
+        result_json=str(rj),
+    )
+
+    assert out["llm_usage"] == {"input_tokens": 500, "calls": 5}
+    assert out["llm_usage_complete"] is True
 
 
 def test_optimize_argv_falls_back_to_console_script(monkeypatch):
@@ -951,6 +1045,7 @@ def test_run_rewrite_reports_total_usage_across_local_and_forge_loop_agents(
                 "cost_source": "provider",
                 "calls": 3,
             },
+            "llm_usage_complete": True,
         },
     )
     monkeypatch.setattr(runner, "generate_applyback_patch", counted_applyback)
@@ -976,6 +1071,106 @@ def test_run_rewrite_reports_total_usage_across_local_and_forge_loop_agents(
         "cost_source": "provider",
         "calls": 5,
     }
+
+
+def test_run_rewrite_publishes_partial_usage_when_the_forge_loop_ledger_is_truncated(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    """A killed forge-loop reports what it checkpointed, so the run must not claim a complete priced total."""
+    src = tmp_path / "softmax.py"
+    src.write_text("def softmax(x):\n    return x\n")
+    driver = tmp_path / "driver.py"
+    driver.write_text("print('drive')\n")
+    _wire_stub_pipeline(monkeypatch, port_ok=True, best_ms=0.5, source_ms=1.0)
+
+    async def counted_port(spec, driver_path, config, **kwargs):
+        del spec, driver_path, config
+        kwargs["usage"].add_usage({"input_tokens": 10, "output_tokens": 2}, total_cost_usd=0.1)
+        return port_loop.PortResult(ok=True, attempts=1, snr_db=143.0)
+
+    monkeypatch.setattr(runner, "run_port_loop", counted_port)
+    monkeypatch.setattr(
+        runner,
+        "run_optimize",
+        # No ``llm_usage_complete``: the ledger below stops at the loop's last checkpoint.
+        lambda *args, **kwargs: {
+            "best_ms": 0.5,
+            "terminated_for_deadline": True,
+            "llm_usage": {
+                "input_tokens": 100,
+                "output_tokens": 30,
+                "total_cost_usd": 1.0,
+                "cost_available": True,
+                "cost_source": "provider",
+                "calls": 3,
+            },
+        },
+    )
+
+    out = runner.run_rewrite(
+        op_name="softmax",
+        source_kernel=str(src),
+        driver=str(driver),
+        workspace=str(tmp_path),
+        experiments_dir=str(tmp_path / "exp"),
+        target_functions=["softmax"],
+        config=Config.from_env(workspace=str(tmp_path)),
+    )
+
+    assert out["llm_usage"]["input_tokens"] == 110
+    assert out["llm_usage"]["calls"] == 4
+    assert out["llm_usage"]["total_cost_usd"] == 1.1
+    assert out["llm_usage"]["cost_available"] is False
+    assert out["llm_usage"]["cost_source"] == "partial"
+    assert "did not report a final token ledger" in capsys.readouterr().out
+
+
+def test_run_rewrite_reports_provider_usage_when_optimize_never_started(
+    tmp_path,
+    monkeypatch,
+):
+    """Skipping forge-loop leaves nothing unaccounted, so the in-process ledger stands on its own."""
+    src = tmp_path / "softmax.py"
+    src.write_text("def softmax(x):\n    return x\n")
+    driver = tmp_path / "driver.py"
+    driver.write_text("print('drive')\n")
+    clock = {"now": 0.0}
+    monkeypatch.setattr(runner.time, "time", lambda: clock["now"])
+    _stub_preflight(monkeypatch)
+
+    async def port_until_cutoff(*args, **kwargs):
+        kwargs["usage"].add_usage({"input_tokens": 10, "output_tokens": 2}, total_cost_usd=0.1)
+        clock["now"] = 101.0
+        return port_loop.PortResult(ok=True, attempts=1, snr_db=100.0)
+
+    def unexpected_optimize(*args, **kwargs):
+        raise AssertionError("forge-loop must not start in the finalization reserve")
+
+    monkeypatch.setattr(runner, "run_port_loop", port_until_cutoff)
+    monkeypatch.setattr(runner, "_ensure_git_committed", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "run_optimize", unexpected_optimize)
+    monkeypatch.setattr(
+        runner,
+        "generate_applyback_patch",
+        lambda *a, **k: ApplybackResult(ok=True, patch_path="/tmp/forge.patch"),
+    )
+
+    out = runner.run_rewrite(
+        op_name="softmax",
+        source_kernel=str(src),
+        driver=str(driver),
+        workspace=str(tmp_path),
+        experiments_dir=str(tmp_path / "exp"),
+        target_functions=["softmax"],
+        config=Config.from_env(workspace=str(tmp_path)),
+        deadline_unix=1300.0,
+    )
+
+    assert out["llm_usage"]["calls"] == 1
+    assert out["llm_usage"]["cost_available"] is True
+    assert out["llm_usage"]["cost_source"] == "provider"
 
 
 def test_run_rewrite_keeps_the_candidate_out_of_the_workspace_root(

--- a/src/kernelforge/tests/test_usage.py
+++ b/src/kernelforge/tests/test_usage.py
@@ -172,6 +172,37 @@ def test_combine_usage_totals_marks_mixed_provider_cost_partial():
     assert combined["cost_source"] == "partial"
 
 
+def test_combine_usage_totals_degrades_to_partial_when_a_ledger_is_missing():
+    """A run that could not recover a contributor's spend must not be billed as a complete provider total."""
+    combined = combine_usage_totals(
+        {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_cost_usd": 0.1,
+            "cost_available": True,
+            "cost_source": "provider",
+            "calls": 1,
+        },
+        incomplete=True,
+    )
+
+    assert combined["input_tokens"] == 10
+    assert combined["calls"] == 1
+    assert combined["total_cost_usd"] == 0.1
+    assert combined["cost_available"] is False
+    assert combined["cost_source"] == "partial"
+
+
+def test_combine_usage_totals_reports_unavailable_when_nothing_was_priced():
+    combined = combine_usage_totals(
+        {"input_tokens": 10, "calls": 1},
+        incomplete=True,
+    )
+
+    assert combined["cost_available"] is False
+    assert combined["cost_source"] == "unavailable"
+
+
 def test_set_llm_usage_persists_to_experiment():
     with tempfile.TemporaryDirectory() as tmpdir:
         tracker = ExperimentTracker(tmpdir)

--- a/src/kernelforge/tracker/usage.py
+++ b/src/kernelforge/tracker/usage.py
@@ -79,8 +79,16 @@ class UsageAccumulator:
         return self.calls > 0
 
 
-def combine_usage_totals(*records: dict[str, Any] | None) -> dict[str, Any]:
-    """Combine independently accumulated usage records without losing cost provenance."""
+def combine_usage_totals(
+    *records: dict[str, Any] | None,
+    incomplete: bool = False,
+) -> dict[str, Any]:
+    """Combine independently accumulated usage records without losing cost provenance.
+
+    ``incomplete`` states that a contributor's ledger is known to be missing from ``records``. The counters below then
+    describe only part of the run, so the combination reports itself as ``partial`` rather than claiming the complete
+    provider-priced answer a reader would otherwise bill against.
+    """
     combined: dict[str, Any] = {key: 0 for key in _TOKEN_KEYS}
     combined["total_cost_usd"] = 0.0
     combined["calls"] = 0
@@ -116,7 +124,7 @@ def combine_usage_totals(*records: dict[str, Any] | None) -> dict[str, Any]:
                 )
 
     combined["total_cost_usd"] = round(combined["total_cost_usd"], 6)
-    combined["cost_available"] = combined["calls"] > 0 and all_cost_available
+    combined["cost_available"] = combined["calls"] > 0 and all_cost_available and not incomplete
     combined["cost_source"] = (
         "provider" if combined["cost_available"] else "partial" if any_priced_usage else "unavailable"
     )


### PR DESCRIPTION
## Summary

Follow-up to #1474, which reported the FlyDSL rewrite's LLM usage but lost the nested forge-loop's share in exactly the cases where it matters most.

* recover the nested forge-loop's token ledger from the experiment record it checkpoints at every session boundary, so a run that is cut off at the optimize deadline — or that never keeps anything, and therefore never writes a result file — no longer reports zero for the phase that spends the most
* pick the furthest-along snapshot of that single ledger instead of summing the result file and the record, which are two views of the same accumulator
* mark the combined `llm_usage` partial (`cost_available: false`, `cost_source: "partial"`) whenever the loop never closed its ledger, so the payload stops claiming a complete provider-priced total while a session's spend is missing, and print a warning naming the shortfall

`llm_usage_complete` on the optimize result is the new internal signal: it is set only when forge-loop exited cleanly with a result of its own, the one case where its ledger is final.

## Test plan

* `python -m pytest -q src/kernelforge/tests/test_usage.py src/kernelforge/tests/test_rewrite_by_flydsl_pipeline.py src/kernelforge/tests/test_rewrite_by_flydsl.py src/kernelforge/tests/test_tracker.py`
* `python -m pytest -q src/kernelforge/tests` (full suite green; the `test_codex_backend.py` failures on my host are a sandbox permission error on `~/.cache/kernelforge`, and pass unsandboxed)
* `python -m ruff check src/kernelforge`
* full CI suite

Made with [Cursor](https://cursor.com)