### PR TITLE
feat(forge): publish the run's token spend at one fixed path

### DIFF
--- a/src/kernelforge/cli.py
+++ b/src/kernelforge/cli.py
@@ -1182,7 +1182,7 @@ def forge_loop(
         aggregate_regression_detail,
         warm_start_improvement_flags,
     )
-    from kernelforge.tracker import ExperimentTracker, UsageAccumulator
+    from kernelforge.tracker import ExperimentTracker, UsageAccumulator, UsageLedgerFile
     from kernelforge.orchestrator.agent import make_agent_fn
 
     iter_config = IterationConfig(
@@ -1215,7 +1215,11 @@ def forge_loop(
         commit_new_paths=commit_new_paths,
     )
     tracker = ExperimentTracker(config.experiments_dir)
-    usage = UsageAccumulator()
+    # Published at a fixed path from the first call onwards, so a caller that never asked for --result-json, or that
+    # loses this process outright, can still read what the run spent.
+    usage_ledger = UsageLedgerFile(config.experiments_dir)
+    usage = UsageAccumulator(on_update=usage_ledger.publish)
+    usage_ledger.publish(usage.totals())
 
     # The caller-owned experiment ID is an EXTERNAL recovery channel, deliberately independent of the internal
     # per-segment experiment identity (each resume segment gets a fresh ID so the campaign parent/child chain stays

--- a/src/kernelforge/rewrite_by_flydsl/runner.py
+++ b/src/kernelforge/rewrite_by_flydsl/runner.py
@@ -38,7 +38,7 @@ from kernelforge.rewrite_by_flydsl.optimize import run_optimize
 from kernelforge.rewrite_by_flydsl.port_loop import PortResult, run_port_loop
 from kernelforge.rewrite_by_flydsl.budget import DEFAULT_REWRITE_BUDGET
 from kernelforge.loop.scoring import DEFAULT_SNR_THRESHOLD_DB
-from kernelforge.tracker import UsageAccumulator, combine_usage_totals
+from kernelforge.tracker import UsageAccumulator, UsageLedgerFile, combine_usage_totals
 
 log = logging.getLogger(__name__)
 
@@ -140,8 +140,15 @@ def run_rewrite(
     rewrite_kb_enabled: bool = True,
 ) -> dict:
     """Run the full rewrite pipeline; return (and sentinel-print) the result dict."""
+    # The nested forge-loop runs from the workspace and resolves this path against its own working directory, so a
+    # relative one would send the two processes to different directories for the artifacts they share.
+    experiments_dir = str(Path(experiments_dir).resolve())
     Path(experiments_dir).mkdir(parents=True, exist_ok=True)
-    usage = UsageAccumulator()
+    # Only this process's own stages feed the shared ledger: the nested forge-loop publishes its own share to the same
+    # file, so folding the combined total in here would count that share twice.
+    usage_ledger = UsageLedgerFile(experiments_dir)
+    usage = UsageAccumulator(on_update=usage_ledger.publish)
+    usage_ledger.publish(usage.totals())
     started_at = time.time()
     if not deadline_unix or deadline_unix <= 0:
         deadline_unix = started_at + optimize_max_hours * 3600.0

--- a/src/kernelforge/tests/test_usage_ledger.py
+++ b/src/kernelforge/tests/test_usage_ledger.py
@@ -1,0 +1,156 @@
+"""Tests for the fixed-path token ledger shared by a rewrite and the forge-loop it nests."""
+
+import json
+import multiprocessing
+from pathlib import Path
+
+from kernelforge.tracker import (
+    LEDGER_FILENAME,
+    UsageAccumulator,
+    UsageLedgerFile,
+    read_usage_ledger,
+)
+
+
+def _priced(**counters):
+    """One producer's running totals, fully priced by the provider."""
+    return {
+        "input_tokens": counters.get("input_tokens", 0),
+        "output_tokens": counters.get("output_tokens", 0),
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "total_cost_usd": counters.get("total_cost_usd", 0.0),
+        "cost_available": True,
+        "cost_source": "provider",
+        "calls": counters.get("calls", 0),
+    }
+
+
+def test_ledger_lands_at_one_fixed_name_for_every_producer(tmp_path):
+    UsageLedgerFile(tmp_path).publish(_priced(input_tokens=10, calls=1, total_cost_usd=0.5))
+
+    assert (tmp_path / LEDGER_FILENAME).is_file()
+    assert read_usage_ledger(tmp_path)["input_tokens"] == 10
+
+
+def test_ledger_exists_before_the_first_call(tmp_path):
+    """A caller must find the file even when the run has not billed anything yet."""
+    ledger = UsageLedgerFile(tmp_path)
+    ledger.publish(UsageAccumulator().totals())
+
+    recorded = read_usage_ledger(tmp_path)
+    assert recorded["calls"] == 0
+    assert recorded["cost_source"] == "unavailable"
+
+
+def test_ledger_adds_each_producer_share_without_overwriting_the_other(tmp_path):
+    """A rewrite and its nested forge-loop write one file; neither may erase the other's spend."""
+    rewrite = UsageLedgerFile(tmp_path)
+    forge_loop = UsageLedgerFile(tmp_path)
+
+    rewrite.publish(_priced(input_tokens=10, calls=1, total_cost_usd=0.1))
+    forge_loop.publish(_priced(input_tokens=100, calls=2, total_cost_usd=1.0))
+    # Each producer republishes its own running totals, not an increment.
+    rewrite.publish(_priced(input_tokens=25, calls=2, total_cost_usd=0.3))
+    forge_loop.publish(_priced(input_tokens=400, calls=5, total_cost_usd=4.0))
+
+    recorded = read_usage_ledger(tmp_path)
+    assert recorded["input_tokens"] == 425
+    assert recorded["calls"] == 7
+    assert recorded["total_cost_usd"] == 4.3
+    assert recorded["cost_available"] is True
+    assert recorded["cost_source"] == "provider"
+
+
+def test_ledger_republish_without_new_spend_changes_nothing(tmp_path):
+    ledger = UsageLedgerFile(tmp_path)
+    ledger.publish(_priced(input_tokens=10, calls=1, total_cost_usd=0.1))
+    ledger.publish(_priced(input_tokens=10, calls=1, total_cost_usd=0.1))
+
+    assert read_usage_ledger(tmp_path)["calls"] == 1
+
+
+def test_ledger_degrades_provenance_when_one_producer_is_unpriced(tmp_path):
+    """One contributor without provider pricing makes the shared total unbillable, and it never recovers."""
+    priced = UsageLedgerFile(tmp_path)
+    unpriced = UsageLedgerFile(tmp_path)
+
+    priced.publish(_priced(input_tokens=10, calls=1, total_cost_usd=0.1))
+    unpriced.publish(
+        {
+            "input_tokens": 5,
+            "calls": 1,
+            "total_cost_usd": 0.0,
+            "cost_available": False,
+            "cost_source": "unavailable",
+        }
+    )
+    priced.publish(_priced(input_tokens=20, calls=2, total_cost_usd=0.2))
+
+    recorded = read_usage_ledger(tmp_path)
+    assert recorded["input_tokens"] == 25
+    assert recorded["calls"] == 3
+    assert recorded["cost_available"] is False
+    assert recorded["cost_source"] == "partial"
+
+
+def test_ledger_restarts_from_this_producer_when_the_file_is_corrupt(tmp_path):
+    (tmp_path / LEDGER_FILENAME).write_text("{ not json")
+
+    UsageLedgerFile(tmp_path).publish(_priced(input_tokens=7, calls=1, total_cost_usd=0.07))
+
+    assert read_usage_ledger(tmp_path)["input_tokens"] == 7
+
+
+def test_ledger_publish_never_raises_on_an_unwritable_directory(tmp_path):
+    unwritable = tmp_path / "denied"
+    unwritable.mkdir()
+    unwritable.chmod(0o500)
+    try:
+        UsageLedgerFile(unwritable).publish(_priced(input_tokens=1, calls=1))
+    finally:
+        unwritable.chmod(0o700)
+
+
+def test_accumulator_publishes_on_every_counted_call(tmp_path):
+    """The ledger must survive a kill between two calls, so it cannot wait for a coarse checkpoint."""
+    ledger = UsageLedgerFile(tmp_path)
+    usage = UsageAccumulator(on_update=ledger.publish)
+
+    usage.add_usage({"input_tokens": 10, "output_tokens": 1}, total_cost_usd=0.1)
+    assert read_usage_ledger(tmp_path)["calls"] == 1
+
+    usage.add_usage({"input_tokens": 20, "output_tokens": 2}, total_cost_usd=0.2)
+    recorded = read_usage_ledger(tmp_path)
+    assert recorded["calls"] == 2
+    assert recorded["input_tokens"] == 30
+    assert recorded["total_cost_usd"] == 0.3
+
+
+def test_accumulator_survives_a_failing_sink():
+    def explode(_totals):
+        raise RuntimeError("disk gone")
+
+    usage = UsageAccumulator(on_update=explode)
+
+    assert usage.add_usage({"input_tokens": 5}, total_cost_usd=0.1) is True
+    assert usage.totals()["calls"] == 1
+
+
+def _publish_repeatedly(args):
+    """Run one producer's whole publish sequence in its own process."""
+    directory, calls = args
+    ledger = UsageLedgerFile(directory)
+    for call in range(1, calls + 1):
+        ledger.publish(_priced(input_tokens=call, calls=call, total_cost_usd=call / 100))
+
+
+def test_ledger_loses_no_update_across_processes(tmp_path):
+    """The rewrite and its nested loop publish concurrently; the lock is what keeps both shares."""
+    context = multiprocessing.get_context("spawn")
+    with context.Pool(2) as pool:
+        pool.map(_publish_repeatedly, [(str(tmp_path), 20), (str(tmp_path), 20)])
+
+    recorded = json.loads(Path(tmp_path, LEDGER_FILENAME).read_text())
+    assert recorded["calls"] == 40
+    assert recorded["input_tokens"] == 40

--- a/src/kernelforge/tracker/__init__.py
+++ b/src/kernelforge/tracker/__init__.py
@@ -6,11 +6,21 @@
 from kernelforge.tracker.experiment import ExperimentTracker
 from kernelforge.tracker.schema import Experiment, Iteration
 from kernelforge.tracker.usage import UsageAccumulator, combine_usage_totals
+from kernelforge.tracker.usage_ledger import (
+    LEDGER_FILENAME,
+    UsageLedgerFile,
+    ledger_path,
+    read_usage_ledger,
+)
 
 __all__ = [
     "ExperimentTracker",
     "Experiment",
     "Iteration",
+    "LEDGER_FILENAME",
     "UsageAccumulator",
+    "UsageLedgerFile",
     "combine_usage_totals",
+    "ledger_path",
+    "read_usage_ledger",
 ]

--- a/src/kernelforge/tracker/usage.py
+++ b/src/kernelforge/tracker/usage.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import contextlib
 import math
+from collections.abc import Callable
 from typing import Any
 
 # Canonical four-counter set, mirroring the keys the claude-agent-sdk puts on ``ResultMessage.usage`` (and what
@@ -22,7 +23,7 @@ _TOKEN_KEYS: tuple[str, ...] = (
 class UsageAccumulator:
     """Sum normalized LLM token usage and cost across backend calls."""
 
-    def __init__(self) -> None:
+    def __init__(self, on_update: Callable[[dict[str, Any]], None] | None = None) -> None:
         self.input_tokens = 0
         self.output_tokens = 0
         self.cache_creation_input_tokens = 0
@@ -30,6 +31,9 @@ class UsageAccumulator:
         self.total_cost_usd = 0.0
         self.calls = 0
         self._priced_calls = 0
+        # Called with the new totals after every counted call, so an external ledger survives a hard kill between one
+        # call and the next instead of stopping at the run's last coarse checkpoint.
+        self._on_update = on_update
 
     def add_from_message(self, message: Any) -> bool:
         """Fold one SDK message's usage into the running totals."""
@@ -57,6 +61,9 @@ class UsageAccumulator:
                     self.total_cost_usd += cost
                     self._priced_calls += 1
         self.calls += 1
+        if self._on_update is not None:
+            with contextlib.suppress(Exception):
+                self._on_update(self.totals())
         return True
 
     def totals(self) -> dict[str, Any]:

--- a/src/kernelforge/tracker/usage_ledger.py
+++ b/src/kernelforge/tracker/usage_ledger.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Always-current token ledger at one fixed path per experiments directory."""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from kernelforge.durable_io import atomic_write_text
+from kernelforge.tracker.usage import combine_usage_totals
+
+log = logging.getLogger(__name__)
+
+# Fixed for every producer: a caller that knows the experiments directory can read the run's spend without knowing
+# which command produced it, whether a result file was requested, or what the experiment is called.
+LEDGER_FILENAME = "llm_usage.json"
+
+_COUNTER_KEYS: tuple[str, ...] = (
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+    "calls",
+)
+
+
+def ledger_path(experiments_dir: str | Path) -> Path:
+    """Where the shared token ledger for ``experiments_dir`` lives."""
+    return Path(experiments_dir) / LEDGER_FILENAME
+
+
+def read_usage_ledger(experiments_dir: str | Path) -> dict[str, Any]:
+    """The directory's running token total, or ``{}`` when nothing was recorded."""
+    try:
+        payload = json.loads(ledger_path(experiments_dir).read_text())
+    except (OSError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+class UsageLedgerFile:
+    """Fold one process's spend into the ledger the whole run shares.
+
+    A FlyDSL rewrite and the forge-loop it nests are separate processes writing one file, so a publish adds only what
+    this process has spent since its own last publish instead of overwriting the file with its private view. The file
+    is therefore the running total for the directory: reading it needs no knowledge of who contributed to it.
+    """
+
+    def __init__(self, experiments_dir: str | Path) -> None:
+        self.path = ledger_path(experiments_dir)
+        self._lock_path = self.path.with_name(f".{LEDGER_FILENAME}.lock")
+        self._published: dict[str, Any] = {}
+
+    def publish(self, totals: dict[str, Any]) -> None:
+        """Record this process's totals so far. Never raises: accounting must not end a run."""
+        try:
+            self._publish(totals)
+        except Exception as error:  # noqa: BLE001 - a ledger write must never break the caller
+            log.debug("usage ledger publish skipped (%s: %s)", type(error).__name__, error)
+
+    def _publish(self, totals: dict[str, Any]) -> None:
+        delta = self._delta(totals)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if delta is None and self.path.is_file():
+            return
+        with open(self._lock_path, "a") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                merged = combine_usage_totals(self._current(), delta)
+                merged["updated_at"] = datetime.now().isoformat()
+                atomic_write_text(self.path, json.dumps(merged, indent=2))
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        self._published = dict(totals)
+
+    def _current(self) -> dict[str, Any]:
+        """The ledger as it stands, read inside the lock."""
+        try:
+            payload = json.loads(self.path.read_text())
+        except (OSError, ValueError):
+            # A ledger that was never written, or one a crash left unreadable, restarts from this process's own share
+            # rather than costing the run its accounting.
+            return {}
+        return payload if isinstance(payload, dict) else {}
+
+    def _delta(self, totals: dict[str, Any]) -> dict[str, Any] | None:
+        """What this process has spent since its last publish, or None when nothing moved.
+
+        The provenance of the whole record travels with the delta: a producer whose cost stops being complete can
+        only ever turn the shared answer less certain, which is exactly how ``combine_usage_totals`` folds it.
+        """
+        delta: dict[str, Any] = {}
+        moved = False
+        for key in _COUNTER_KEYS:
+            value = _counter(totals, key) - _counter(self._published, key)
+            delta[key] = value
+            moved = moved or value != 0
+        cost = _cost(totals) - _cost(self._published)
+        delta["total_cost_usd"] = round(cost, 6)
+        delta["cost_available"] = totals.get("cost_available") is True
+        delta["cost_source"] = totals.get("cost_source")
+        return delta if moved or cost else None
+
+
+def _counter(record: dict[str, Any], key: str) -> int:
+    with contextlib.suppress(TypeError, ValueError):
+        return int(record.get(key) or 0)
+    return 0
+
+
+def _cost(record: dict[str, Any]) -> float:
+    with contextlib.suppress(TypeError, ValueError):
+        return float(record.get("total_cost_usd") or 0.0)
+    return 0.0
+
+
+__all__ = [
+    "LEDGER_FILENAME",
+    "UsageLedgerFile",
+    "ledger_path",
+    "read_usage_ledger",
+]


### PR DESCRIPTION
## Summary

Reading what a run spent still required knowing something the reader may not have: a `--result-json` path the caller is free not to pass, or an experiment record named after an id you have to discover from stdout first. This adds one fixed artifact, `<experiments-dir>/llm_usage.json`, written by both `forge-loop` and `forge-rewrite-by-flydsl`.

* every producer folds **its own share** into the file after each counted call, under an `flock`-protected read-modify-write, so the FlyDSL rewrite and the forge-loop it nests — two processes sharing one experiments directory — add up to a single running total instead of overwriting each other
* the payload is flat: the eight canonical usage counters plus `updated_at`, no per-producer breakdown to interpret and nothing to sum by hand

```console
$ jq . <experiments-dir>/llm_usage.json
{
  "input_tokens": 1021230,
  "output_tokens": 77120,
  "cache_creation_input_tokens": 12900,
  "cache_read_input_tokens": 658000,
  "total_cost_usd": 12.29,
  "calls": 47,
  "cost_available": true,
  "cost_source": "provider",
  "updated_at": "2026-09-10T19:45:02"
}
```

* `UsageAccumulator` grows an optional `on_update` sink, which is what makes the file current after every call rather than at the run's next coarse checkpoint — the spend of a session that is killed mid-flight is now recorded too
* cost provenance folds the same way it does everywhere else: one contributor without complete provider pricing makes the shared answer `partial`, and it never recovers
* writes are best-effort — a failing ledger logs and is dropped, it never ends a run

Also resolves `experiments_dir` once in `run_rewrite`: the nested forge-loop runs from the workspace and resolves that path against its own working directory, so a relative one sent the two processes to different directories for every artifact they share, this file included.

The ledger is scoped to the experiments directory, not to a process: a resumed campaign keeps accumulating across segments, which is why one run should own one directory.

## Test plan

* `python -m pytest -q src/kernelforge/tests/test_usage_ledger.py` — covers the fixed name, the file existing before the first call, two producers not overwriting each other, provenance degrading and staying degraded, a corrupt file, an unwritable directory, the accumulator sink firing per call and surviving a failing sink, and a spawn-based two-process run that loses no update
* full CI suite

Made with [Cursor](https://cursor.com)