### PR TITLE
fix(profile): recognize SGLang graph capture directories

### DIFF
--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -2199,14 +2199,6 @@ def test_discover_capture_folder_finds_the_unpatched_sglang_layout(tmp_path):
     assert tlr.discover_capture_folder(trace_dir, [real]) == trace_dir / "graph_capture_profile"
 
 
-def test_discover_capture_folder_accepts_capture_directory_as_input(tmp_path):
-    capture_dir = tmp_path / "graph_capture_profile"
-    capture_dir.mkdir()
-    capture = _rank_trace(capture_dir / "cuda_graph_capture-ModelRunner-TP-0.json.gz", kernels=4)
-
-    assert tlr.discover_capture_folder(capture_dir, [capture]) == capture_dir
-
-
 def test_discover_capture_folder_preserves_legacy_priority(tmp_path):
     trace_dir = tmp_path / "torch_trace"
     for name in ("graph_capture", "graph_capture_profile", "capture_traces"):

--- a/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
+++ b/src/hyperloom/agents/kernel/tests/test_tracelens_csv.py
@@ -2199,6 +2199,23 @@ def test_discover_capture_folder_finds_the_unpatched_sglang_layout(tmp_path):
     assert tlr.discover_capture_folder(trace_dir, [real]) == trace_dir / "graph_capture_profile"
 
 
+def test_discover_capture_folder_accepts_capture_directory_as_input(tmp_path):
+    capture_dir = tmp_path / "graph_capture_profile"
+    capture_dir.mkdir()
+    capture = _rank_trace(capture_dir / "cuda_graph_capture-ModelRunner-TP-0.json.gz", kernels=4)
+
+    assert tlr.discover_capture_folder(capture_dir, [capture]) == capture_dir
+
+
+def test_discover_capture_folder_preserves_legacy_priority(tmp_path):
+    trace_dir = tmp_path / "torch_trace"
+    for name in ("graph_capture", "graph_capture_profile", "capture_traces"):
+        (trace_dir / name).mkdir(parents=True)
+    real = _rank_trace(trace_dir / "rank_0.trace.json.gz", kernels=4)
+
+    assert tlr.discover_capture_folder(trace_dir, [real]) == trace_dir / "capture_traces"
+
+
 def test_discover_capture_folder_ignores_a_descriptive_sibling(tmp_path):
     trace_dir = tmp_path / "torch_trace"
     (trace_dir / "torch_profiler_with_graph_capture").mkdir(parents=True)

--- a/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
@@ -301,6 +301,7 @@ def discover_capture_folder(trace_input: Path, trace_files: list[Path]) -> Path 
         Path | None: The capture folder if one exists nearby, else ``None``.
     """
 
+    capture_dir_priority = ("capture_traces", "graph_capture_profile", "graph_capture")
     search_roots: list[Path] = []
     if trace_input.is_dir():
         search_roots.append(trace_input)
@@ -311,12 +312,18 @@ def discover_capture_folder(trace_input: Path, trace_files: list[Path]) -> Path 
         if root in seen or not root.is_dir():
             continue
         seen.add(root)
+        if is_capture_dir_name(root.name):
+            return root
         try:
-            children = sorted(root.iterdir())
+            children = [child for child in root.iterdir() if child.is_dir()]
         except OSError:
             continue
-        for child in children:
-            if child.is_dir() and is_capture_dir_name(child.name):
+        children_by_name = {child.name.lower(): child for child in children}
+        for name in capture_dir_priority:
+            if child := children_by_name.get(name):
+                return child
+        for child in sorted(children):
+            if is_capture_dir_name(child.name):
                 return child
     return None
 

--- a/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
+++ b/src/hyperloom/agents/kernel/tools/tracelens_skill_runner.py
@@ -312,8 +312,6 @@ def discover_capture_folder(trace_input: Path, trace_files: list[Path]) -> Path 
         if root in seen or not root.is_dir():
             continue
         seen.add(root)
-        if is_capture_dir_name(root.name):
-            return root
         try:
             children = [child for child in root.iterdir() if child.is_dir()]
         except OSError:

--- a/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
+++ b/src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py
@@ -2260,12 +2260,18 @@ async def test_profile_executor_extracts_vllm_capture_traces(tmp_path):
     db.close()
 
 
-def _capture_trace_dir(tmp_path, *, cpu_ops: int, with_input_dims: int) -> object:
+def _capture_trace_dir(
+    tmp_path,
+    *,
+    cpu_ops: int,
+    with_input_dims: int,
+    dirname: str = "capture_traces",
+) -> object:
     """Write a capture file carrying a chosen number of cpu_op events."""
     import gzip
     import json as _json
 
-    capture = tmp_path / "capture_traces"
+    capture = tmp_path / dirname
     capture.mkdir()
     events = [{"name": "cpu_op", "cat": "cpu_op"} for _ in range(cpu_ops)]
     for index in range(with_input_dims):
@@ -2314,6 +2320,24 @@ def test_a_healthy_input_dims_fraction_passes_the_check(tmp_path):
     health = pf._validate_trace_structure(tmp_path, "sglang")
 
     assert _check_row(health, pf.CHECK_CAPTURE_INPUT_DIMS)["status"] == "passed"
+
+
+def test_upstream_sglang_capture_directory_passes_health_check(tmp_path):
+    from hyperloom.orchestrator.actions.executors import profile as pf
+
+    capture = _capture_trace_dir(
+        tmp_path,
+        cpu_ops=10,
+        with_input_dims=10,
+        dirname="graph_capture_profile",
+    )
+    health = pf._validate_trace_structure(tmp_path, "sglang")
+
+    row = _check_row(health, pf.CHECK_CAPTURE_TRACES_PRESENT)
+    assert row["status"] == "passed"
+    assert row["detail"]["capture_dir"] == str(capture)
+    assert health["capture_traces_present"] is True
+    assert not any("subdirectory missing" in issue for issue in health["issues"])
 
 
 # kernel_request_handlers — direct unit

--- a/src/hyperloom/orchestrator/actions/executors/profile.py
+++ b/src/hyperloom/orchestrator/actions/executors/profile.py
@@ -312,8 +312,13 @@ def _validate_trace_structure(
     framework = str(framework or os.environ.get("FRAMEWORK", "") or "")
     scriptable = _fw_reg.is_scriptable(framework)
 
-    # --- Check 1: capture_traces/ presence (LLM/serving only) ---
-    capture = trace_dir / "capture_traces"
+    # --- Check 1: graph-capture directory presence (LLM/serving only) ---
+    capture_dirs = [
+        trace_dir / "capture_traces",
+        trace_dir / "graph_capture_profile",
+        trace_dir / "graph_capture",
+    ]
+    capture = next((path for path in capture_dirs if path.is_dir()), None)
     capture_files: list[Path] = []
     if scriptable:
         _note_check(
@@ -322,9 +327,9 @@ def _validate_trace_structure(
             skip_reason="scriptable framework writes a plain torch-profiler trace",
         )
     else:
-        if not capture.is_dir():
+        if capture is None:
             issues.append(
-                "[1] capture_traces/ subdirectory missing — graph capture "
+                "[1] graph-capture subdirectory missing — graph capture "
                 "didn't fire. Verify EXTRA_VLLM_ARGS / EXTRA_SGLANG_ARGS "
                 "include the TraceLens flag and the server-side patch landed."
             )
@@ -334,12 +339,13 @@ def _validate_trace_structure(
             capture_traces_present = bool(capture_files)
             if not capture_files:
                 issues.append(
-                    "[1] capture_traces/ exists but is empty — graph capture path fired but produced no files."
+                    f"[1] {capture.name}/ exists but is empty — graph capture path fired but produced no files."
                 )
             _note_check(
                 CHECK_CAPTURE_TRACES_PRESENT,
                 status="passed" if capture_files else "failed",
                 capture_dir_present=True,
+                capture_dir=str(capture),
                 file_count=len(capture_files),
             )
 


### PR DESCRIPTION
## Summary
- keep nearby capture-directory selection deterministic as `capture_traces/` → `graph_capture_profile/` → `graph_capture/`
- accept SGLang's upstream `graph_capture_profile/` directory in profile health checks instead of reporting a false missing-capture warning
- preserve the intentional capture-only preflight: capture sidecars remain auxiliary input passed with `--capture-folder` alongside a real Replay `--trace-input`
- add regression coverage for directory priority and SGLang profile health

## SGLang definition

[SGLang PR #24370](https://github.com/sgl-project/sglang/pull/24370) defines `GRAPH_CAPTURE_PROFILE_DIRNAME = \"graph_capture_profile\"` under `${SGLANG_TORCH_PROFILER_DIR}` and uses that directory for both supported capture exports:

- `SGLANG_ENABLE_CUDA_GRAPH_CAPTURE_TRACE=1` writes one combined trace per tensor-parallel rank as `cuda_graph_capture-{runner}-TP-{tp_rank}.json.gz`.
- `SGLANG_GRAPH_BATCH_CAPTURE=1` writes one trace per captured batch size and rank as `{runner}_bs_{bs}_rank{tp_rank}.json.gz`.
- If both environment variables are set, the combined `SGLANG_ENABLE_CUDA_GRAPH_CAPTURE_TRACE` mode takes precedence.

Hyperloom's shared sidecar classifier and nearby-folder discovery already understand `graph_capture_profile`, but profile health still checked only `capture_traces/`. The explicit priority keeps legacy vLLM/AMD layouts preferred when multiple recognized directories coexist, while valid upstream SGLang output is no longer reported as missing.

A `graph_capture_profile/` directory by itself is deliberately not a valid `--trace-input`: it contains auxiliary Capture sidecars, not the Replay trace required for analysis. It must be passed as `--capture-folder` beside a real Replay input.

## Test plan
- `python -m pytest src/hyperloom/agents/kernel/tests/test_tracelens_csv.py -k 'discover_capture_folder'` (3 passed)
- `python -m pytest src/hyperloom/inference_optimizer/tests/test_profile_and_kernel_handlers.py -k 'input_dims_fraction or upstream_sglang_capture_directory or zero_cpu_op'` (4 passed)
- `ruff check` and `ruff format --check` on all four modified files