### PR TITLE
feat(conc-sweep): grade the ladder on the axis the session keeps on, and report the guard beside it

### DIFF
--- a/src/hyperloom/common/gain_math.py
+++ b/src/hyperloom/common/gain_math.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 from hyperloom.common.coerce import to_float
+from hyperloom.common.perf_metric import GRADED_INTVTY, GRADED_TOTAL, graded_axes_of, passes_tput_guard
 
 
 def gain_pct(new: float | None, base: float) -> float | None:
@@ -37,8 +38,18 @@ def conc_pair_comparison(
     optimized_points: list[dict[str, Any]],
     *,
     metric_key: str = "output_throughput",
+    guard_noise_pct: float | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    """Pair curve points by CONC (outer join), compute per-conc speedup, and aggregate."""
+    """Pair curve points by CONC (outer join), compute per-conc speedup on *metric_key*, and aggregate.
+
+    Under the interactivity objective each pair also reports whether throughput held within the noise band the
+    session grades under. It is reported, not enforced: InferenceX publishes a 2-D frontier with no fixed
+    interactivity target, so a rung that traded throughput for interactivity moved along that frontier rather than
+    violating a constraint -- and a sweep exists to draw the frontier. Gating on the guard here would drop half the
+    curve. The KEEP path enforces it because a stack promotion at one concurrency is a different question.
+    """
+    # The guard belongs to the interactivity objective; on the output axis there is no second axis to hold.
+    guard_axis = GRADED_TOTAL if metric_key == GRADED_INTVTY else ""
 
     def _norm_conc(p: dict[str, Any]) -> int | float | str:
         raw = p.get("conc")
@@ -68,23 +79,42 @@ def conc_pair_comparison(
             successful_pairs += 1
         else:
             failed_pairs += 1
+        # ``graded_axes_of`` is what normalises the sweep's ``total_token_throughput`` onto GRADED_TOTAL, so the
+        # guard cannot read a differently-named axis as an absent one.
+        base_axes = graded_axes_of(b) if guard_axis else {}
+        opt_axes = graded_axes_of(o) if guard_axis else {}
+        guard_holds: bool | None = None
+        if guard_axis and base_axes.get(guard_axis) and opt_axes.get(guard_axis):
+            guard_holds = passes_tput_guard(opt_axes, base_axes, noise_pct=guard_noise_pct)
         rows.append(
             {
                 "conc": c,
-                "baseline_tput": bt,
-                "optimized_tput": ot,
+                # Named for the axis rather than for throughput: under the interactivity objective these hold a
+                # slow-tail percentile, and ``summary.metric`` is what says which.
+                "baseline_value": bt,
+                "optimized_value": ot,
                 "speedup": speedup,
                 "delta_pct": delta_pct,
                 "baseline_status": b.get("status"),
                 "optimized_status": o.get("status"),
+                # The guard axis beside the objective, so the frontier this rung sits on is readable rather than
+                # only the one number it was ranked by. Null off the interactivity objective, and null when a side
+                # did not measure the axis -- which is not the same as a rung that measured it and fell outside.
+                "baseline_guard": base_axes.get(guard_axis) if guard_axis else None,
+                "optimized_guard": opt_axes.get(guard_axis) if guard_axis else None,
+                "guard_holds": guard_holds,
             }
         )
     summary: dict[str, Any] = {
         "metric": metric_key,
+        # The axis held beside the objective, empty off the interactivity objective. Named here so a reader of
+        # ``best_conc_guard_holds`` does not have to infer which axis the verdict is about.
+        "guard_axis": guard_axis,
         "successful_pairs": successful_pairs,
         "failed_pairs": failed_pairs,
         "best_conc": None,
         "best_speedup": None,
+        "best_conc_guard_holds": None,
         "median_speedup": None,
         "mean_speedup": None,
     }
@@ -100,6 +130,9 @@ def conc_pair_comparison(
             {
                 "best_conc": rows[best_idx]["conc"],
                 "best_speedup": round(best_val, 4),
+                # The headline rung is the best on the objective alone. Whether the session's own KEEP rule would
+                # have accepted it is a second fact, and the two disagreeing is worth seeing rather than resolving.
+                "best_conc_guard_holds": rows[best_idx]["guard_holds"],
                 "median_speedup": round(median, 4),
                 "mean_speedup": round(sum(speedups) / len(speedups), 4),
             }

--- a/src/hyperloom/inference_optimizer/breakdown/recorder/conc_sweep_event.py
+++ b/src/hyperloom/inference_optimizer/breakdown/recorder/conc_sweep_event.py
@@ -29,6 +29,7 @@ from typing import Any
 from .event_fields import (
     as_dict as _as_dict,
     as_list as _as_list,
+    bool_or_none as _bool_or_none,
     clip as _clip,
     float_or_none as _float_or_none,
     int_or_none as _int_or_none,
@@ -620,6 +621,13 @@ class ConcSweepEventRecorder:
         concurrency, so a later pass revises a row rather than adding one, and
         a failure reason is settled here because the arm that broke is the only
         one that can say why.
+
+        ``baseline_value``/``optimized_value`` are on the axis named by
+        ``result.metric``, which is an interactivity percentile rather than a
+        throughput whenever the session grades on one. The guard axis rides
+        along beside them, null off the interactivity objective, so a rung that
+        bought interactivity by giving up throughput is visible as such instead
+        of reading as a clean win.
         """
         for row in _as_list(comparison):
             if not isinstance(row, Mapping):
@@ -630,10 +638,13 @@ class ConcSweepEventRecorder:
                 {
                     "task_id": self._action_id,
                     "conc": rung,
-                    "baseline_throughput": _float_or_none(row.get("baseline_tput")),
-                    "optimized_throughput": _float_or_none(row.get("optimized_tput")),
+                    "baseline_value": _float_or_none(row.get("baseline_value")),
+                    "optimized_value": _float_or_none(row.get("optimized_value")),
                     "speedup": _float_or_none(row.get("speedup")),
                     "delta_pct": _float_or_none(row.get("delta_pct")),
+                    "baseline_guard": _float_or_none(row.get("baseline_guard")),
+                    "optimized_guard": _float_or_none(row.get("optimized_guard")),
+                    "guard_holds": _bool_or_none(row.get("guard_holds")),
                     "baseline_status": _text(row.get("baseline_status")),
                     "optimized_status": _text(row.get("optimized_status")),
                     "error": _pair_error(
@@ -650,8 +661,10 @@ class ConcSweepEventRecorder:
             {
                 "result": {
                     "metric": _text(roll_up.get("metric")),
+                    "guard_axis": _text(roll_up.get("guard_axis")),
                     "best_conc": _int_or_none(roll_up.get("best_conc")),
                     "best_speedup": _float_or_none(roll_up.get("best_speedup")),
+                    "best_conc_guard_holds": _bool_or_none(roll_up.get("best_conc_guard_holds")),
                     "successful_pairs": _int_or_none(roll_up.get("successful_pairs")),
                     "failed_pairs": _int_or_none(roll_up.get("failed_pairs")),
                     "median_speedup": _float_or_none(roll_up.get("median_speedup")),
@@ -697,8 +710,10 @@ class ConcSweepEventRecorder:
         result = {
             "status": status,
             "metric": _text(roll_up.get("metric")),
+            "guard_axis": _text(roll_up.get("guard_axis")),
             "best_conc": _int_or_none(roll_up.get("best_conc")),
             "best_speedup": _float_or_none(roll_up.get("best_speedup")),
+            "best_conc_guard_holds": _bool_or_none(roll_up.get("best_conc_guard_holds")),
             "successful_pairs": _int_or_none(roll_up.get("successful_pairs")),
             "failed_pairs": _int_or_none(roll_up.get("failed_pairs")),
             "median_speedup": _float_or_none(roll_up.get("median_speedup")),

--- a/src/hyperloom/inference_optimizer/breakdown/recorder/event_fields.py
+++ b/src/hyperloom/inference_optimizer/breakdown/recorder/event_fields.py
@@ -21,6 +21,7 @@ __all__ = [
     "analysis_detail",
     "as_dict",
     "as_list",
+    "bool_or_none",
     "bounded_block",
     "clip",
     "failure_row",
@@ -87,6 +88,16 @@ def float_or_none(value: Any) -> float | None:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def bool_or_none(value: Any) -> bool | None:
+    """``bool(value)`` when a value was recorded, else ``None``.
+
+    A tri-state flag needs the coercion to stop at ``None`` rather than fold it
+    to ``False``: "the framework never answered" and "the answer was no" are
+    different facts, and ``bool(None)`` erases the difference.
+    """
+    return None if value is None else bool(value)
 
 
 def text_or_none(value: Any) -> str | None:

--- a/src/hyperloom/inference_optimizer/breakdown/recorder/warm_start_event.py
+++ b/src/hyperloom/inference_optimizer/breakdown/recorder/warm_start_event.py
@@ -28,6 +28,7 @@ from typing import Any
 
 from .event_fields import (
     as_dict as _as_dict,
+    bool_or_none as _bool_or_none,
     float_or_none as _float_or_none,
     now_iso_seconds as _now,
     text_or_none as _text_or_none,
@@ -433,11 +434,6 @@ def _origin(recipe: Mapping[str, Any]) -> dict[str, Any] | None:
     if not session_id and gain is None:
         return None
     return {"session_id": session_id, "gain_pct": gain}
-
-
-def _bool_or_none(value: Any) -> bool | None:
-    """``bool(value)`` when a value was recorded, else ``None``."""
-    return None if value is None else bool(value)
 
 
 __all__ = [

--- a/src/hyperloom/inference_optimizer/breakdown/schema.py
+++ b/src/hyperloom/inference_optimizer/breakdown/schema.py
@@ -586,7 +586,7 @@ class V6ConcSweepPoint(TypedDict, total=False):
     request_throughput: float | None
     total_token_throughput: float | None
     input_throughput: float | None
-    intvty_p90: float | None
+    e2e_norm_intvty_p90: float | None
     tpot_p90_ms: float | None
     ttft_mean_ms: float | None
     e2el_mean_ms: float | None
@@ -633,13 +633,25 @@ class V6ConcSweepArm(TypedDict, total=False):
 
 
 class V6ConcSweepPair(TypedDict, total=False):
-    """The two arms joined at one concurrency."""
+    """The two arms joined at one concurrency.
+
+    The pair is ranked on one axis and reports a second. ``*_value`` is on the
+    axis ``result.metric`` names -- a slow-tail interactivity percentile
+    whenever the session grades on one, which is why these are not named for
+    throughput. ``*_guard`` and ``guard_holds`` carry the throughput the
+    session would have held a promotion to, reported rather than enforced: a
+    sweep exists to draw the interactivity/throughput frontier, so a rung that
+    moved along it is a result and not a failure. They are null off the
+    interactivity objective, where there is no second axis to hold."""
 
     conc: int
-    baseline_throughput: float | None
-    optimized_throughput: float | None
+    baseline_value: float | None
+    optimized_value: float | None
     speedup: float | None
     delta_pct: float | None
+    baseline_guard: float | None
+    optimized_guard: float | None
+    guard_holds: bool | None
     baseline_status: str
     optimized_status: str
     error: str | None

--- a/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
+++ b/src/hyperloom/inference_optimizer/tests/test_conc_sweep.py
@@ -28,6 +28,7 @@ from hyperloom.orchestrator.kernel.conc_sweep import (
     _flush_conc_sweep_report,
     _flush_partial_conc_sweep_report,
     _granted_cap_sec,
+    _grading_of,
     _has_optimization,
     _order_concs_desc,
     _point_from_variant,
@@ -175,8 +176,8 @@ def test_build_comparison_mismatched_concs_outer_join():
     ]
     rows, summary = _build_comparison(baseline, optimized)
     assert [r["conc"] for r in rows] == [1, 4, 16]
-    assert rows[0]["optimized_tput"] is None
-    assert rows[2]["baseline_tput"] is None
+    assert rows[0]["optimized_value"] is None
+    assert rows[2]["baseline_value"] is None
     assert summary["successful_pairs"] == 1
 
 
@@ -1324,7 +1325,6 @@ class TestTheSummaryIsTakenOnTheChartsAxis:
         assert graded_metric_key(benchmark_mode="") == "output_throughput"
 
     def test_an_explicit_grading_override_wins_over_the_mode(self, monkeypatch):
-        """The summary follows the axis the KEEP verdicts were taken on."""
         monkeypatch.setenv("HYPERLOOM_PERF_METRIC", "output_throughput")
         assert graded_metric_key(benchmark_mode="agentx") == "output_throughput"
         from hyperloom.common.perf_metric import INTVTY_V1
@@ -1337,6 +1337,112 @@ class TestTheSummaryIsTakenOnTheChartsAxis:
         monkeypatch.delenv("HYPERLOOM_PERF_METRIC", raising=False)
         monkeypatch.setenv("HYPERLOOM_AGENTX", "1")
         assert graded_metric_key(benchmark_mode="") == "e2e_norm_intvty_p90"
+
+
+class TestTheSweepGradesOnTheAxisTheSessionKeepsOn:
+    """A curve drawn on one axis beside promotions decided on another is two answers to one question."""
+
+    @pytest.fixture(autouse=True)
+    def _no_ambient_grading(self, monkeypatch):
+        for name in ("HYPERLOOM_PERF_METRIC", "HYPERLOOM_PERF_NOISE_PCT", "HYPERLOOM_AGENTX"):
+            monkeypatch.delenv(name, raising=False)
+
+    def _state(self, **fields: Any) -> SharedState:
+        state = SharedState()
+        for key, value in fields.items():
+            setattr(state, key, value)
+        return state
+
+    def test_the_recorded_axis_beats_the_environment(self, monkeypatch):
+        """A resume is a new process, and the shell it landed in is not evidence about the axis."""
+        monkeypatch.setenv("HYPERLOOM_PERF_METRIC", "output_throughput")
+        state = self._state(benchmark_mode="agentx", grading={"objective": "e2e_norm_intvty_p90", "noise_pct": 3.5})
+        assert _grading_of(state) == ("e2e_norm_intvty_p90", 3.5)
+
+    def test_the_recorded_band_travels_with_the_axis(self):
+        """A lost band silently widens a 3.5% guard back to the 5% default."""
+        state = self._state(benchmark_mode="agentx", grading={"objective": "e2e_norm_intvty_p90", "noise_pct": 3.5})
+        assert _grading_of(state)[1] == 3.5
+
+    def test_a_session_with_nothing_recorded_falls_back_to_its_mode(self):
+        assert _grading_of(self._state(benchmark_mode="agentx"))[0] == "e2e_norm_intvty_p90"
+        assert _grading_of(self._state(benchmark_mode="synthetic"))[0] == "output_throughput"
+
+    def test_a_scriptable_framework_is_carved_out(self):
+        """An image framework reports no interactivity axis, so ranking every rung on it fails the whole sweep."""
+        state = self._state(benchmark_mode="agentx", framework="xdit")
+        assert _grading_of(state)[0] == "output_throughput"
+
+
+class TestTheGuardAxisIsReportedNotEnforced:
+    """A sweep exists to draw the frontier, so a rung that moved along it is a result and not a failure."""
+
+    def _pts(self, arm: str, *, intvty: float, total: float) -> list[dict[str, Any]]:
+        return [
+            {
+                "arm": arm,
+                "conc": 8,
+                "status": "succeeded",
+                "e2e_norm_intvty_p90": intvty,
+                "total_token_throughput": total,
+            }
+        ]
+
+    def test_a_rung_that_bought_interactivity_with_throughput_still_pairs(self):
+        """It ranks on the objective it gained on, and carries the throughput it gave up beside it."""
+        comparison, summary = _build_comparison(
+            self._pts("baseline", intvty=20.0, total=20000.0),
+            self._pts("optimized", intvty=30.0, total=10000.0),
+            metric_key="e2e_norm_intvty_p90",
+        )
+        row = comparison[0]
+        assert row["speedup"] == pytest.approx(1.5)
+        assert summary["successful_pairs"] == 1
+        assert summary["best_conc"] == 8
+        # Halving throughput is far outside any band, and that is visible without having dropped the rung.
+        assert row["guard_holds"] is False
+        assert summary["best_conc_guard_holds"] is False
+        assert row["baseline_guard"] == 20000.0
+        assert row["optimized_guard"] == 10000.0
+
+    def test_a_rung_that_held_throughput_says_so(self):
+        comparison, summary = _build_comparison(
+            self._pts("baseline", intvty=20.0, total=20000.0),
+            self._pts("optimized", intvty=24.0, total=19800.0),
+            metric_key="e2e_norm_intvty_p90",
+        )
+        assert comparison[0]["guard_holds"] is True
+        assert summary["guard_axis"] == "total_throughput"
+
+    def test_the_recorded_band_decides_the_verdict(self):
+        """The same pair holds under the default band and fails under a tighter one."""
+        arms = (
+            self._pts("baseline", intvty=20.0, total=20000.0),
+            self._pts("optimized", intvty=24.0, total=19200.0),
+        )
+        assert _build_comparison(*arms, metric_key="e2e_norm_intvty_p90")[0][0]["guard_holds"] is True
+        tight, _ = _build_comparison(*arms, metric_key="e2e_norm_intvty_p90", guard_noise_pct=1.0)
+        assert tight[0]["guard_holds"] is False
+
+    def test_the_output_objective_has_no_second_axis_to_hold(self):
+        comparison, summary = _build_comparison(
+            [{"arm": "baseline", "conc": 8, "status": "succeeded", "output_throughput": 100.0}],
+            [{"arm": "optimized", "conc": 8, "status": "succeeded", "output_throughput": 130.0}],
+            metric_key="output_throughput",
+        )
+        assert summary["guard_axis"] == ""
+        assert summary["best_conc_guard_holds"] is None
+        assert comparison[0]["guard_holds"] is None
+
+    def test_an_unmeasured_guard_axis_is_null_not_a_failure(self):
+        """Null says the axis was never measured; False would say it was, and fell outside."""
+        comparison, _summary = _build_comparison(
+            [{"arm": "baseline", "conc": 8, "status": "succeeded", "e2e_norm_intvty_p90": 20.0}],
+            [{"arm": "optimized", "conc": 8, "status": "succeeded", "e2e_norm_intvty_p90": 30.0}],
+            metric_key="e2e_norm_intvty_p90",
+        )
+        assert comparison[0]["guard_holds"] is None
+        assert comparison[0]["baseline_guard"] is None
 
 
 class TestAnUnreportedTotalComesFromItsHalves:

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_v6_conc_sweep_timeline.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_v6_conc_sweep_timeline.py
@@ -87,7 +87,7 @@ def _point(conc: int, *, arm: str = ARM_OPTIMIZED, status: str = "succeeded", **
         "request_throughput": 1.5 * conc,
         "total_token_throughput": 200.0 * conc,
         "input_throughput": 100.0 * conc,
-        "intvty_p90": 42.0,
+        "e2e_norm_intvty_p90": 42.0,
         "tpot_p90_ms": 13.5,
         "ttft_mean_ms": 130.0,
         "e2el_mean_ms": 4000.0,
@@ -406,7 +406,7 @@ def test_a_rung_carries_the_agentic_axis_the_projection_dropped(_bound_session):
     point = _ext(_bound_session)["arms"][ARM_OPTIMIZED]["points"][0]
     assert point["arm"] == ARM_OPTIMIZED
     assert point["total_token_throughput"] == 12800.0
-    assert point["intvty_p90"] == 42.0
+    assert point["e2e_norm_intvty_p90"] == 42.0
     assert point["tpot_p90_ms"] == 13.5
     assert point["request_throughput"] == 96.0
     assert point["input_throughput"] == 6400.0

--- a/src/hyperloom/inference_optimizer/tests/test_sbd_v6_conc_sweep_timeline.py
+++ b/src/hyperloom/inference_optimizer/tests/test_sbd_v6_conc_sweep_timeline.py
@@ -548,8 +548,8 @@ def test_the_pair_table_keeps_the_gain_columns_the_projection_dropped(_bound_ses
         comparison=[
             {
                 "conc": 32,
-                "baseline_tput": 1000.0,
-                "optimized_tput": 1350.0,
+                "baseline_value": 1000.0,
+                "optimized_value": 1350.0,
                 "speedup": 1.35,
                 "delta_pct": 35.0,
                 "baseline_status": "succeeded",
@@ -570,13 +570,18 @@ def test_the_pair_table_keeps_the_gain_columns_the_projection_dropped(_bound_ses
 
     pair = _ext(_bound_session)["comparison"][0]
     assert pair["conc"] == 32
-    assert pair["baseline_throughput"] == 1000.0
-    assert pair["optimized_throughput"] == 1350.0
+    assert pair["baseline_value"] == 1000.0
+    assert pair["optimized_value"] == 1350.0
     assert pair["speedup"] == 1.35
     assert pair["delta_pct"] == 35.0
     assert pair["baseline_status"] == "succeeded"
     assert pair["optimized_status"] == "succeeded"
     assert pair["error"] is None
+    # The output objective has no second axis to hold, so the guard columns stay null rather than reading as a
+    # rung whose throughput was measured and fell outside the band.
+    assert pair["baseline_guard"] is None
+    assert pair["optimized_guard"] is None
+    assert pair["guard_holds"] is None
 
 
 def test_a_failed_pair_is_explained_by_the_arm_that_broke(_bound_session):

--- a/src/hyperloom/orchestrator/kernel/conc_sweep.py
+++ b/src/hyperloom/orchestrator/kernel/conc_sweep.py
@@ -17,7 +17,7 @@ from typing import Any, Mapping
 from hyperloom.common import io as _common_io
 from hyperloom.common.gain_math import conc_pair_comparison
 from hyperloom.common.model_paths import resolve_session_model_path
-from hyperloom.common.perf_metric import graded_metric_key, is_agentx_mode
+from hyperloom.common.perf_metric import GRADED_INTVTY, GRADED_OUTPUT, is_agentx_mode
 from hyperloom.common.timeutil import now_iso, utc_now_compact
 from hyperloom.inference_optimizer.breakdown.recorder.conc_sweep_event import (
     GRID_MODE_DEFAULT,
@@ -50,10 +50,23 @@ from .roofline_ceiling import (
     load_model_meta,
     select_peak_and_bound,
 )
-from ..state.shared_state import SharedState
+from ..state.shared_state import SharedState, resolved_grading
 
 
 log = logging.getLogger(__name__)
+
+
+def _grading_of(state: Any) -> tuple[str, float | None]:
+    """The axis this sweep draws its speedups on, and the noise band its guard reads.
+
+    Resolved through ``resolved_grading`` so the curve and the promotions in one session cannot end up on
+    different axes. The environment-derived ``graded_metric_key`` diverges two ways: it never sees the axis
+    recorded at seed, so a resume whose shell lost ``HYPERLOOM_PERF_METRIC`` redraws the curve on output; and it
+    has no scriptable carve-out, so an image framework -- which reports no interactivity axis at all -- would
+    compare every rung on a field it never measures and report the whole sweep as failed.
+    """
+    on_intvty, noise_pct = resolved_grading(state)
+    return (GRADED_INTVTY if on_intvty else GRADED_OUTPUT), noise_pct
 
 
 SCHEMA_VERSION = "1.0"
@@ -258,6 +271,9 @@ def _build_roofline_ceiling(
                 return None
             return within_roofline_pct(peak=float(t_peak), achieved=float(measured))
 
+        # Output throughput on both arms regardless of the graded axis, and not a bug to be aligned with it: the
+        # peak above is a memory-bandwidth-derived ceiling on output tokens per second, so MBU is only meaningful
+        # against the same quantity.
         bt = (by_conc_b.get(c) or {}).get("output_throughput")
         ot = (by_conc_o.get(c) or {}).get("output_throughput")
         rows.append(
@@ -1158,9 +1174,8 @@ def _flush_partial_conc_sweep_report(  # noqa: PLR0913
         b_pts.sort(key=lambda p: p["conc"])
         o_pts.sort(key=lambda p: p["conc"])
 
-        comparison, summary = conc_pair_comparison(
-            b_pts, o_pts, metric_key=graded_metric_key(benchmark_mode=str(getattr(state, "benchmark_mode", "") or ""))
-        )
+        metric_key, guard_noise_pct = _grading_of(state)
+        comparison, summary = conc_pair_comparison(b_pts, o_pts, metric_key=metric_key, guard_noise_pct=guard_noise_pct)
         if recorder is not None:
             recorder.record_progress(comparison=comparison, summary=summary)
         p: dict[str, Any] = {
@@ -1543,10 +1558,12 @@ async def run_conc_sweep(
     baseline_points.sort(key=lambda p: p["conc"])
     optimized_points.sort(key=lambda p: p["conc"])
 
+    metric_key, guard_noise_pct = _grading_of(state)
     comparison, summary = conc_pair_comparison(
         baseline_points,
         optimized_points,
-        metric_key=graded_metric_key(benchmark_mode=str(getattr(state, "benchmark_mode", "") or "")),
+        metric_key=metric_key,
+        guard_noise_pct=guard_noise_pct,
     )
     budget_limited_no_pair = _budget_limited_without_valid_pair(
         budget_exhausted=budget_exhausted,


### PR DESCRIPTION
Stacked on #1480 (base is `feat/sbd-v6-agentx-grading-axis`; retarget to `main` once that merges).

## The divergence this closes

#1480 made the KEEP path read the graded axis recorded at seed, through `resolved_grading`. The concurrency sweep kept resolving its own axis through `perf_metric.graded_metric_key`, which is the environment-derived form and diverges two ways:

- **A resume is a new process.** `graded_metric_key` never sees `state.grading`, so a session whose shell lost `HYPERLOOM_PERF_METRIC` would redraw the curve on output throughput while the promotions in that same session were decided on interactivity. One `session_breakdown.json` would carry `metadata.grading.objective = e2e_norm_intvty_p90` next to a sweep event reporting `result.metric = output_throughput`.
- **No scriptable carve-out.** `graded_metric_key` calls `intvty_grading_enabled`, not `intvty_serving_grading_enabled`. An image framework reports no interactivity axis at all, so under AgentX every rung would be compared on a field it never measures, every pair would fail, and the whole sweep would report `failed` where it should have drawn an output-axis curve.

Both call sites now go through `resolved_grading`, which is the one place the answer is settled. The recorded noise band travels with the axis, so the guard below grades under the band the session started with rather than whatever the current shell holds.

## The guard is reported, not enforced

A KEEP is two-dimensional: an interactivity gain that clears the threshold *and* throughput holding inside the noise band. The sweep's pair was one-dimensional, so a rung could show `speedup 1.4` on the chart while the session's own rule would have reverted it.

Each pair now carries the throughput axis beside the objective, plus `guard_holds`. Deliberately not a gate: InferenceX publishes a 2-D frontier with interactivity on x and per-chip throughput on y and no fixed interactivity target, so a rung that traded throughput for interactivity **moved along that frontier** rather than violating a constraint — and drawing that frontier is precisely what a sweep is for. Gating here would drop half the curve.

So `successful_pairs`, `best_conc` and `best_speedup` keep their existing meaning (consumers in `report.py` and `record_conc_sweep` already read them, and silently changing a headline number is worse than not changing it). `best_conc_guard_holds` says whether the session's own KEEP rule would have taken the headline rung, and the two disagreeing is worth seeing rather than resolving.

Guard columns are null off the interactivity objective, and null when a side did not measure the axis — which is not the same fact as a rung that measured it and fell outside.

## Renames

`baseline_tput` / `optimized_tput` held an interactivity percentile whenever the session graded on one, and the V6 timeline renamed them *further* into `baseline_throughput` / `optimized_throughput`. They are now `baseline_value` / `optimized_value`, with `result.metric` naming the axis. Contained: the only non-test readers were the producer in `gain_math` and the mapping in `conc_sweep_event`.

Two drive-by fixes in the same area:

- `V6ConcSweepPoint` declared `intvty_p90` where the recorded curve has always written `e2e_norm_intvty_p90`.
- `bool_or_none` moves into the shared `event_fields` leaf instead of leaving a second copy in `warm_start_event`.

## Test plan

- [x] `test_conc_sweep.py`, `test_sbd_v6_conc_sweep_timeline.py`, `test_sbd_v6_conc_sweep_wiring.py`, `test_conc_sweep_ceiling.py`, `test_promote_shared_state_lock.py` — 157 passed
- [x] New `TestTheSweepGradesOnTheAxisTheSessionKeepsOn`: recorded axis beats the environment, the band travels with it, fallback to mode, scriptable carve-out
- [x] New `TestTheGuardAxisIsReportedNotEnforced`: a rung that bought interactivity with throughput still pairs and can be `best_conc` with `guard_holds` false; the recorded band decides the verdict; the output objective has no second axis; an unmeasured guard axis is null rather than false
- [x] Regression over conc_sweep / sbd / breakdown / sweep / gain / warm_start / perf_metric / shared_state / report — 1983 passed
- [x] Full `inference_optimizer` suite — 12777 passed, 18 failed; all 18 reproduce identically on a clean tree (LLM credential and multi-node environment tests) and are untouched by this change
- [x] `ruff check` + `ruff format --check` over 1232 files clean

## Not in scope

`prompts/prompt_builder.py:165` renders `graded_axis` from the same environment-derived `graded_metric_key`, so it can tell the agent the wrong axis on a resume. It is a pure rendering function with no access to `state`, so fixing it means threading the resolved axis in from its callers — a separate change.