### PR TITLE
ci: expose test progress and nonfatal hang tracebacks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -450,6 +450,8 @@ fail_under = 90
 # Base trailing argv for ``pytest`` in CI; the workflow appends sharding
 # (``--splits``/``--group``) and ``-n`` from the values below.
 pytest_ci_args = [
+    "-vv",
+    "-o", "faulthandler_timeout=180",
     "-m", "not critic_agent_e2e and not robustness_agent_e2e and not targeted_build_e2e",
     "--cov=.", "--cov-report=",
 ]


### PR DESCRIPTION
## Problem
PR #1476 has an unresolved CI hang. Current output does not provide enough live context to identify the blocked test or stack. This independent PR adds diagnostics only; it is not a root-cause fix.

## Change
Only pyproject.toml changes: add `-vv` and `-o faulthandler_timeout=180` to CI pytest arguments. Keep all existing tests, the 300-pass behavior, coverage options and thresholds, shards and workers unchanged. No timeout-killing plugin, workflow changes, or application changes.

## Validation
- Read installed pytest 9.1.1 faulthandler and pytest-xdist 3.8.0 sources. The timer covers the per-test runtest protocol (setup/call/teardown) and does not terminate the process by default. It does not diagnose collection or session-level shutdown hangs.
- Isolated temporary two-worker probe, plugin autoload disabled and only xdist explicitly loaded: a 3-second call and a 3-second fixture teardown both pass without diagnostics and produce no stack dumps.
- With `-vv -o faulthandler_timeout=1`, both stack dumps arrive live around 3.25 seconds after process startup; both tests still pass around 6 seconds. Concurrent worker stacks can interleave.
- TOML parse and structural comparison confirm only those three argv tokens were added. git diff --check passes; focused Ruff lint/format checks pass. No project suite was run locally and no existing coverage files were touched.

## Follow-up
Monitor this diagnostic CI run. If a long hang recurs, retrieve the available live job logs and stacks immediately rather than waiting hours. If it does not reproduce, report that explicitly; do not claim the root cause is fixed. No existing CI runs are cancelled and this PR does not change the #1476 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)